### PR TITLE
Add traditional chinese locale

### DIFF
--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -13,6 +13,7 @@ import nl from "vuetify/es5/locale/nl";
 import pl from "vuetify/es5/locale/pl";
 import sv from "vuetify/es5/locale/sv";
 import zhHans from "vuetify/es5/locale/zh-Hans";
+import zhHant from "vuetify/es5/locale/zh-Hant";
 
 const vuetify = new Vuetify({
   theme: {
@@ -53,6 +54,7 @@ const vuetify = new Vuetify({
       "pl-PL": pl,
       "sv-SE": sv,
       "zh-CN": zhHans,
+      "zh-TW": zhHant,
     },
     current: "en-US",
   },

--- a/frontend/src/store/modules/language.js
+++ b/frontend/src/store/modules/language.js
@@ -45,6 +45,10 @@ const state = {
       name: "简体中文 (Chinese simplified)",
       value: "zh-CN",
     },
+    {
+      name: "繁體中文 (Chinese traditional)",
+      value: "zh-TW",
+    },
   ],
 };
 


### PR DESCRIPTION
Traditional chinese is now fully translated on Crowdin. Opening this PR to add `zh-TW` to the locale settings.