### PR TITLE
feat: Add basic support for Web Share Target API

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -78,5 +78,13 @@
   "start_url": ".",
   "display": "standalone",
   "background_color": "#FFFFFF",
-  "theme_color": "#E58325"
+  "theme_color": "#E58325",
+  "share_target": {
+    "action": "/",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "recipe_import_url"
+    }
+  }
 }

--- a/frontend/src/components/UI/TheRecipeFab.vue
+++ b/frontend/src/components/UI/TheRecipeFab.vue
@@ -166,10 +166,12 @@ export default {
   },
 
   mounted() {
-    if (this.$route.query.recipe_import_url) {
-      this.addRecipe = true;
-      this.createRecipe();
-    }
+    this.$router.onReady(() => {
+      if (this.$route.query.recipe_import_url) {
+        this.addRecipe = true;
+        this.createRecipe();
+      }
+    });
   },
 
   computed: {


### PR DESCRIPTION
This is a simple change that allows an installed PWA to receive recipe links for import via the Web Share Target API

https://user-images.githubusercontent.com/3818002/135656533-23a5abfa-53d0-4239-b12e-9f350d67d5ce.mp4
