### PR TITLE
Fix docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # Use root/example as user/password credentials
-version: "3.1"
+version: "3.4"
 services:
   # Vue Frontend
   mealie-frontend:
@@ -7,7 +7,7 @@ services:
     image: mealie-frontend:dev
     build:
       context: ./frontend
-      dockerfile: Dockerfile.frontend
+      dockerfile: Dockerfile
     restart: always
     ports:
       - 9920:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "3.4"
 services:
   mealie-frontend:
     container_name: mealie-frontend


### PR DESCRIPTION
Frontend-Dockerfile is now simply called `Dockerfile`, the [build/target parameter](https://docs.docker.com/compose/compose-file/compose-file-v3/#target) has been added in compose file version 3.4.