### PR TITLE
Fix issue with parsing scraped nutrition

### DIFF
--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -112,7 +112,7 @@ class RecipeModel(SqlAlchemyBase, BaseMixins):
         self.image = image
         self.recipeCuisine = recipeCuisine
 
-        self.nutrition = Nutrition(**nutrition) if self.nutrition else Nutrition()
+        self.nutrition = Nutrition(**nutrition) if nutrition else Nutrition()
 
         self.tools = [Tool(tool=x) for x in tools] if tools else []
 

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -69,17 +69,26 @@ def clean_html(raw_html):
 
 def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
     # Assumes that all units are supplied in grams, except sodium which may be in mg.
-    if nutrition is None:
-        return {}
 
     # Fn only expects a dict[str,str]. Other structures should not be parsed.
-    try:
-        # Allow for commas as decimals
-        nutrition = {key: val.replace(",", ".") for key, val in nutrition.items()}
-        # Remove strings
-        output_nutrition = {key: re.sub("[^0-9.]", "", val) for key, val in nutrition.items()}
-    except Exception:
+    if not isinstance(nutrition, dict):
         return {}
+    
+    # Allow for commas as decimals (common in Europe)
+    # Compile once for efficiency
+    re_match_digits = re.compile(r"\d+([.,]\d+)?")
+
+    output_nutrition = {}
+    for key, val in nutrition.items():
+        # If the val contains digits matching the regex, add the first match to the output dict.
+        # Handle unexpected datastructures safely.
+        try:
+            if matched_digits := re_match_digits.search(val):
+                output_nutrition[key] = matched_digits.group(0)
+        except Exception:
+            continue
+
+    output_nutrition = {key: val.replace(",", ".") for key, val in output_nutrition.items()}
 
     if "sodiumContent" in nutrition and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
         # Sodium is in grams. Parse its value, multiple by 1k and return to string.

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -70,7 +70,7 @@ def clean_html(raw_html):
 def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
     # Assumes that all units are supplied in grams, except sodium which may be in mg.
     if nutrition is None:
-        return None
+        return {}
 
     # Fn only expects a dict[str,str]. Other structures should not be parsed.
     try:
@@ -78,7 +78,7 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
         nutrition = {key: val.replace(",", ".") for key, val in nutrition.items()}
         # Remove strings
         output_nutrition = {key: re.sub("[^0-9.]", "", val) for key, val in nutrition.items()}
-    except TypeError:
+    except Exception:
         return {}
 
     if "sodiumContent" in nutrition and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -74,6 +74,9 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
 
     # Fn only expects a dict[str,str]. Other structures should not be parsed.
     try:
+        # Allow for commas as decimals
+        nutrition = {key: val.replace(",", ".") for key, val in nutrition.items()}
+        # Remove strings
         output_nutrition = {key: re.sub("[^0-9.]", "", val) for key, val in nutrition.items()}
     except TypeError:
         return {}

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -73,7 +73,7 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
     # Fn only expects a dict[str,str]. Other structures should not be parsed.
     if not isinstance(nutrition, dict):
         return {}
-    
+
     # Allow for commas as decimals (common in Europe)
     # Compile once for efficiency
     re_match_digits = re.compile(r"\d+([.,]\d+)?")

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -98,8 +98,7 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
             # Could not parse sodium content as float, so don't touch it.
             pass
 
-    # Don't return empty strings
-    return {key: val for key, val in output_nutrition.items() if val != ""}
+    return output_nutrition
 
 
 def image(image=None) -> str:

--- a/mealie/services/scraper/scraper.py
+++ b/mealie/services/scraper/scraper.py
@@ -137,7 +137,7 @@ def clean_scraper(scraped_data: SchemaScraperFactory.SchemaScraper, url: str) ->
         slug="",
         image=try_get_default(scraped_data.image, "image", None),
         description=try_get_default(None, "description", "", cleaner.clean_string),
-        nutrition=try_get_default(None, "nutrition", None),
+        nutrition=try_get_default(None, "nutrition", None, cleaner.clean_nutrition),
         recipe_yield=try_get_default(scraped_data.yields, "recipeYield", "1", cleaner.clean_string),
         recipe_ingredient=try_get_default(scraped_data.ingredients, "recipeIngredient", [""], cleaner.ingredient),
         recipe_instructions=get_instructions(),

--- a/mealie/services/scraper/scraper.py
+++ b/mealie/services/scraper/scraper.py
@@ -137,6 +137,7 @@ def clean_scraper(scraped_data: SchemaScraperFactory.SchemaScraper, url: str) ->
         slug="",
         image=try_get_default(scraped_data.image, "image", None),
         description=try_get_default(None, "description", "", cleaner.clean_string),
+        nutrition=try_get_default(None, "nutrition", None),
         recipe_yield=try_get_default(scraped_data.yields, "recipeYield", "1", cleaner.clean_string),
         recipe_ingredient=try_get_default(scraped_data.ingredients, "recipeIngredient", [""], cleaner.ingredient),
         recipe_instructions=get_instructions(),

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -61,7 +61,7 @@ def test_clean_image():
 @pytest.mark.parametrize(
     "nutrition,expected",
     [
-        (None, None),
+        (None, {}),
         ({"calories": "105 kcal"}, {"calories": "105"}),
         ({"calories": ""}, {}),
         ({"calories": ["not just a string"]}, {}),

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -65,7 +65,7 @@ def test_clean_image():
         ({"calories": "105 kcal"}, {"calories": "105"}),
         ({"calories": "105 kcal 104 sugar"}, {"calories": "105"}),
         ({"calories": ""}, {}),
-        ({"calories": ["not just a string"], "sugarContent":"but still tries 555.321"}, {"sugarContent":"555.321"}),
+        ({"calories": ["not just a string"], "sugarContent": "but still tries 555.321"}, {"sugarContent": "555.321"}),
         ({"sodiumContent": "5.1235g"}, {"sodiumContent": "5123.5"}),
         ({"sodiumContent": "5mg"}, {"sodiumContent": "5"}),
         ({"sodiumContent": "10oz"}, {"sodiumContent": "10"}),

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -59,6 +59,23 @@ def test_clean_image():
 
 
 @pytest.mark.parametrize(
+    "nutrition,expected",
+    [
+        (None, None),
+        ({"calories": "105 kcal"}, {"calories": "105"}),
+        ({"calories": ""}, {}),
+        ({"calories": ["not just a string"]}, {}),
+        ({"sodiumContent": "5.1235g"}, {"sodiumContent": "5123.5"}),
+        ({"sodiumContent": "5mg"}, {"sodiumContent": "5"}),
+        ({"sodiumContent": "10oz"}, {"sodiumContent": "10"}),
+        ({"sodiumContent": "10.1.2g"}, {"sodiumContent": "10.1.2"}),
+    ],
+)
+def test_clean_nutrition(nutrition, expected):
+    assert cleaner.clean_nutrition(nutrition) == expected
+
+
+@pytest.mark.parametrize(
     "instructions",
     [
         "A\n\nB\n\nC\n\n",

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -63,12 +63,13 @@ def test_clean_image():
     [
         (None, {}),
         ({"calories": "105 kcal"}, {"calories": "105"}),
+        ({"calories": "105 kcal 104 sugar"}, {"calories": "105"}),
         ({"calories": ""}, {}),
-        ({"calories": ["not just a string"]}, {}),
+        ({"calories": ["not just a string"], "sugarContent":"but still tries 555.321"}, {"sugarContent":"555.321"}),
         ({"sodiumContent": "5.1235g"}, {"sodiumContent": "5123.5"}),
         ({"sodiumContent": "5mg"}, {"sodiumContent": "5"}),
         ({"sodiumContent": "10oz"}, {"sodiumContent": "10"}),
-        ({"sodiumContent": "10.1.2g"}, {"sodiumContent": "10.1.2"}),
+        ({"sodiumContent": "10.1.2g"}, {"sodiumContent": "10100.0"}),
     ],
 )
 def test_clean_nutrition(nutrition, expected):


### PR DESCRIPTION
The scraper often contains the nutrition information, this should be populated by default (then could be hidden if not needed)

Found a small bug in mealie/db/models/recipe/recipe.py