### PR TITLE
Fix issues parsing times not in "PT.*H.*M" format

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -179,9 +179,6 @@ def clean_time(time_entry):
         return str(time_entry)
 
 
-# ! TODO: Cleanup Code Below
-
-
 def parse_duration(iso_duration):
     """Parses an ISO 8601 duration string into a datetime.timedelta instance.
     Args:
@@ -189,14 +186,13 @@ def parse_duration(iso_duration):
     Returns:
         a datetime.timedelta instance
     """
-    m = re.match(r"^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:.\d+)?)S)?$", iso_duration)
+    m = re.match(
+        r"^P((\d+)Y)?((\d+)M)?((?P<days>\d+)D)?"
+        r"T((?P<hours>\d+)H)?((?P<minutes>\d+)M)?((?P<seconds>\d+(?:\.\d+)?)S)?$",
+        iso_duration,
+    )
     if m is None:
         raise ValueError("invalid ISO 8601 duration string")
-
-    days = 0
-    hours = 0
-    minutes = 0
-    seconds = 0.0
 
     # Years and months are not being utilized here, as there is not enough
     # information provided to determine which year and which month.
@@ -204,16 +200,12 @@ def parse_duration(iso_duration):
     # microseconds internally, and therefore we'd have to
     # convert parsed years and months to specific number of days.
 
-    if m[3]:
-        days = int(m[3])
-    if m[4]:
-        hours = int(m[4])
-    if m[5]:
-        minutes = int(m[5])
-    if m[6]:
-        seconds = float(m[6])
+    times = {"days": 0, "hours": 0, "minutes": 0, "seconds": 0}
+    for unit, value in times.items():
+        if m.group(unit):
+            times[unit] = int(float(m.group(unit)))
 
-    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    return timedelta(**times)
 
 
 def pretty_print_timedelta(t, max_components=None, max_decimal_places=2):

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -211,7 +211,7 @@ def parse_duration(iso_duration):
 def pretty_print_timedelta(t, max_components=None, max_decimal_places=2):
     """
     Print a pretty string for a timedelta.
-    For example datetime.timedelta(days=2, seconds=17280) will be printed as '2 days, 4 hours, 48 minutes'. Setting max_components to e.g. 1 will change this to '2.2 days', where the
+    For example datetime.timedelta(days=2, seconds=17280) will be printed as '2 days 4 Hours 48 Minutes'. Setting max_components to e.g. 1 will change this to '2.2 days', where the
     number of decimal points can also be set.
     """
 

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -214,15 +214,7 @@ def pretty_print_timedelta(t, max_components=None, max_decimal_places=2):
     For example datetime.timedelta(days=2, seconds=17280) will be printed as '2 days, 4 hours, 48 minutes'. Setting max_components to e.g. 1 will change this to '2.2 days', where the
     number of decimal points can also be set.
     """
-    time_scales = [
-        timedelta(days=365),
-        timedelta(days=1),
-        timedelta(hours=1),
-        timedelta(minutes=1),
-        timedelta(seconds=1),
-        timedelta(microseconds=1000),
-        timedelta(microseconds=1),
-    ]
+
     time_scale_names_dict = {
         timedelta(days=365): "year",
         timedelta(days=1): "day",
@@ -233,9 +225,8 @@ def pretty_print_timedelta(t, max_components=None, max_decimal_places=2):
         timedelta(microseconds=1): "microsecond",
     }
     count = 0
-    txt = ""
-    first = True
-    for scale in time_scales:
+    out_list = []
+    for scale, scale_name in time_scale_names_dict.items():
         if t >= scale:
             count += 1
             n = t / scale if count == max_components else int(t / scale)
@@ -244,15 +235,9 @@ def pretty_print_timedelta(t, max_components=None, max_decimal_places=2):
             n_txt = str(round(n, max_decimal_places))
             if n_txt[-2:] == ".0":
                 n_txt = n_txt[:-2]
-            txt += "{}{} {}{}".format(
-                "" if first else " ",
-                n_txt,
-                time_scale_names_dict[scale],
-                "s" if n > 1 else "",
-            )
-            if first:
-                first = False
 
-    if len(txt) == 0:
-        txt = "none"
-    return txt
+            out_list.append(f"{n_txt} {scale_name}{'s' if n > 1 else ''}")
+
+    if out_list == []:
+        return "none"
+    return " ".join(out_list)

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -5,6 +5,9 @@ from datetime import datetime, timedelta
 from typing import List
 
 from slugify import slugify
+from mealie.core.root_logger import get_logger
+
+logger = get_logger()
 
 
 def clean(recipe_data: dict, url=None) -> dict:
@@ -167,9 +170,11 @@ def clean_time(time_entry):
     elif isinstance(time_entry, datetime):
         print(time_entry)
     elif isinstance(time_entry, str):
-        if re.match("PT.*H.*M", time_entry):
+        try:
             time_delta_object = parse_duration(time_entry)
             return pretty_print_timedelta(time_delta_object)
+        except ValueError:
+            logger.error(f"Could not parse time_entry `{time_entry}`")
     else:
         return str(time_entry)
 

--- a/mealie/services/scraper/scraper.py
+++ b/mealie/services/scraper/scraper.py
@@ -132,6 +132,10 @@ def clean_scraper(scraped_data: SchemaScraperFactory.SchemaScraper, url: str) ->
         except TypeError:
             return []
 
+    cook_time = try_get_default(None, "performTime", None, cleaner.clean_time) or try_get_default(
+        None, "cookTime", None, cleaner.clean_time
+    )
+
     return Recipe(
         name=try_get_default(scraped_data.title, "name", "No Name Found", cleaner.clean_string),
         slug="",
@@ -142,7 +146,7 @@ def clean_scraper(scraped_data: SchemaScraperFactory.SchemaScraper, url: str) ->
         recipe_instructions=get_instructions(),
         total_time=try_get_default(None, "totalTime", None, cleaner.clean_time),
         prep_time=try_get_default(None, "prepTime", None, cleaner.clean_time),
-        perform_time=try_get_default(None, "performTime", None, cleaner.clean_time),
+        perform_time=cook_time,
         org_url=url,
     )
 

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -96,6 +96,7 @@ def test_html_with_recipe_data():
         ("PT30M", "30 Minutes"),
         ("PT3H", "3 Hours"),
         ("P1DT1H1M1S", "1 day 1 Hour 1 Minute 1 Second"),
+        ("P1DT1H1M1.53S", "1 day 1 Hour 1 Minute 1 Second"),
         ("PT-3H", None),
     ],
 )

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -89,9 +89,14 @@ def test_html_with_recipe_data():
     assert url_validation_regex.match(recipe_data["image"])
 
 
-def test_time_cleaner():
-
-    my_time_delta = "PT2H30M"
-    return_delta = cleaner.clean_time(my_time_delta)
-
-    assert return_delta == "2 Hours 30 Minutes"
+@pytest.mark.parametrize(
+    "time_delta,expected",
+    [
+        ("PT2H30M", "2 Hours 30 Minutes"),
+        ("PT30M", "30 Minutes"),
+        ("PT3H", "3 Hours"),
+        ("PT-3H", None)
+    ],
+)
+def test_time_cleaner(time_delta, expected):
+    assert cleaner.clean_time(time_delta) == expected

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -2,6 +2,7 @@ import json
 import re
 
 import pytest
+from datetime import timedelta
 from mealie.services.scraper import cleaner
 from mealie.services.scraper.scraper import open_graph
 from tests.test_config import TEST_RAW_HTML, TEST_RAW_RECIPES
@@ -103,3 +104,15 @@ def test_html_with_recipe_data():
 )
 def test_time_cleaner(time_delta, expected):
     assert cleaner.clean_time(time_delta) == expected
+
+
+@pytest.mark.parametrize(
+    "t,max_components,max_decimal_places,expected",
+    [
+        (timedelta(days=2, seconds=17280), None, 2, "2 days 4 Hours 48 Minutes"),
+        (timedelta(days=2, seconds=17280), 1, 2, "2.2 days"),
+        (timedelta(days=365), None, 2, "1 year"),
+    ],
+)
+def test_pretty_print_timedelta(t, max_components, max_decimal_places, expected):
+    assert cleaner.pretty_print_timedelta(t, max_components, max_decimal_places) == expected

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -98,6 +98,7 @@ def test_html_with_recipe_data():
         ("P1DT1H1M1S", "1 day 1 Hour 1 Minute 1 Second"),
         ("P1DT1H1M1.53S", "1 day 1 Hour 1 Minute 1 Second"),
         ("PT-3H", None),
+        ("PT", "none"),
     ],
 )
 def test_time_cleaner(time_delta, expected):

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -95,6 +95,7 @@ def test_html_with_recipe_data():
         ("PT2H30M", "2 Hours 30 Minutes"),
         ("PT30M", "30 Minutes"),
         ("PT3H", "3 Hours"),
+        ("P1DT1H1M1S", "1 day 1 Hour 1 Minute 1 Second"),
         ("PT-3H", None)
     ],
 )

--- a/tests/unit_tests/test_cleaner.py
+++ b/tests/unit_tests/test_cleaner.py
@@ -96,7 +96,7 @@ def test_html_with_recipe_data():
         ("PT30M", "30 Minutes"),
         ("PT3H", "3 Hours"),
         ("P1DT1H1M1S", "1 day 1 Hour 1 Minute 1 Second"),
-        ("PT-3H", None)
+        ("PT-3H", None),
     ],
 )
 def test_time_cleaner(time_delta, expected):


### PR DESCRIPTION
Added more tests for the time cleaner. 
Allow parsing of a wider range of times by reusing regex in `parse_duration` (I was seeing issues for <1h)

I wasn't sure what to do about invalid times, so I logged them as an error. 
Happy to pass instead if you think that would be better