### PR TITLE
Feature: Pick best image from list

### DIFF
--- a/mealie/services/image/image.py
+++ b/mealie/services/image/image.py
@@ -61,7 +61,7 @@ def scrape_image(image_url: str, slug: str) -> Path:
             if r.status_code == 200:
                 all_image_requests.append((url, r))
 
-        image_url, _ = max(all_image_requests, key=lambda url_r: len(url_r[1].content), default=("",0))
+        image_url, _ = max(all_image_requests, key=lambda url_r: len(url_r[1].content), default=("", 0))
 
     if isinstance(image_url, dict):  # Handles Dictionary Types
         for key in image_url:

--- a/mealie/services/image/image.py
+++ b/mealie/services/image/image.py
@@ -61,7 +61,7 @@ def scrape_image(image_url: str, slug: str) -> Path:
             if r.status_code == 200:
                 all_image_requests.append((url, r))
 
-        image_url, _ = max(all_image_requests, key=lambda url_r: len(url_r[1].content))
+        image_url, _ = max(all_image_requests, key=lambda url_r: len(url_r[1].content), default=("",0))
 
     if isinstance(image_url, dict):  # Handles Dictionary Types
         for key in image_url:

--- a/mealie/services/scraper/scraper.py
+++ b/mealie/services/scraper/scraper.py
@@ -135,7 +135,7 @@ def clean_scraper(scraped_data: SchemaScraperFactory.SchemaScraper, url: str) ->
     return Recipe(
         name=try_get_default(scraped_data.title, "name", "No Name Found", cleaner.clean_string),
         slug="",
-        image=try_get_default(scraped_data.image, "image", None),
+        image=try_get_default(None, "image", None),
         description=try_get_default(None, "description", "", cleaner.clean_string),
         recipe_yield=try_get_default(scraped_data.yields, "recipeYield", "1", cleaner.clean_string),
         recipe_ingredient=try_get_default(scraped_data.ingredients, "recipeIngredient", [""], cleaner.ingredient),


### PR DESCRIPTION
[Google's recipe properties](https://developers.google.com/search/docs/advanced/structured-data/recipe) allow for multiple images to be defined such that the best one can be chosen for a given resolution screen.

Currently, the first image is chosen. This can lead to very low quality images being captured (e.g. `https://www.sbs.com.au/food/recipes/filipino-chicken-adobo`)
This PR checks all the images within the list and returns the largest one.

Also, some sites require a `UserAgent` header when fetching images (e.g. `https://www.gonnawantseconds.com/sloppy-joe-casserole/`), otherwise giving a 403.
From the websites I've tried, it doesn't matter if this is empty - but some may care.
It would be good if some people were willing to beta test this on a wider range of websites.