### PR TITLE
Allow arrow keys to function when SearchDialog is not open

### DIFF
--- a/frontend/src/components/UI/Dialogs/SearchDialog.vue
+++ b/frontend/src/components/UI/Dialogs/SearchDialog.vue
@@ -136,16 +136,18 @@ export default {
       this.$emit(SELECTED_EVENT, recipe);
     },
     onUpDown(e) {
-      if (e.keyCode === 38) {
-        e.preventDefault();
-        this.selectedIndex--;
-      } else if (e.keyCode === 40) {
-        e.preventDefault();
-        this.selectedIndex++;
-      } else {
-        return;
+      if (this.dialog) {
+        if (e.keyCode === 38) {
+          e.preventDefault();
+          this.selectedIndex--;
+        } else if (e.keyCode === 40) {
+          e.preventDefault();
+          this.selectedIndex++;
+        } else {
+          return;
+        }
+        this.selectRecipe();
       }
-      this.selectRecipe();
     },
     resetSelected() {
       this.searchString = "";


### PR DESCRIPTION
Proposed fix for #776.  I have tested this with a custom Docker build and it seems to work for me, both in recipe editor and within the search dialog to select recipes from search results.