### PR TITLE
Use firefox user agent when making requests

### DIFF
--- a/mealie/services/image/image.py
+++ b/mealie/services/image/image.py
@@ -43,6 +43,7 @@ def write_image(recipe_slug: str, file_data: bytes, extension: str) -> Path:
 
 def scrape_image(image_url: str, slug: str) -> Path:
     logger.info(f"Image URL: {image_url}")
+    _FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
     if isinstance(image_url, str):  # Handles String Types
         pass
 
@@ -54,7 +55,7 @@ def scrape_image(image_url: str, slug: str) -> Path:
         all_image_requests = []
         for url in image_url:
             try:
-                r = requests.get(url, stream=True, headers={"User-Agent": ""})
+                r = requests.get(url, stream=True, headers={"User-Agent": _FIREFOX_UA})
             except Exception:
                 logger.exception("Image {url} could not be requested")
                 continue
@@ -72,7 +73,7 @@ def scrape_image(image_url: str, slug: str) -> Path:
     filename = Recipe(slug=slug).image_dir.joinpath(filename)
 
     try:
-        r = requests.get(image_url, stream=True)
+        r = requests.get(image_url, stream=True, headers={"User-Agent": _FIREFOX_UA})
     except Exception:
         logger.exception("Fatal Image Request Exception")
         return None


### PR DESCRIPTION
Some sites (e.g. https://food52.com/recipes/38745-vermont-spice-pumpkin-cake) do not like the blank UA used in #745
Firefox UA shall be used instead, in line with [what recipe-scrapers does](https://github.com/hhursev/recipe-scrapers/blob/8a9672166b67d91986bca3e58fceb863cecb37bb/recipe_scrapers/_abstract.py#L14)