### PR TITLE
Improve the SWAG Community Guide

### DIFF
--- a/docs/docs/documentation/community-guide/swag.md
+++ b/docs/docs/documentation/community-guide/swag.md
@@ -10,7 +10,7 @@ SWAG - Secure Web Application Gateway (formerly known as letsencrypt, no relatio
 ## Step 1: Get a domain
 
 The first step is to grab a dynamic DNS if you don't have your own subdomain already. You can get this from for example [DuckDNS](https://www.duckdns.org).
-If you already own a domain, you'll need to create an <code>A</code> record that points to the machine that SWAG is running on. See 
+If you already own a domain, you'll need to create an `A` record that points to the machine that SWAG is running on. See 
 the [SWAG documentation](https://docs.linuxserver.io/general/swag#create-container-via-http-validation) for more details.
 
 ## Step 2: Set-up SWAG
@@ -50,19 +50,19 @@ services:
 
 ```
 
-Don't forget to change the <code>mydomain.duckns</code> into your personal domain and the <code>duckdnstoken</code> into your token and remove the brackets.
+Don't forget to change the `mydomain.duckns` into your personal domain and the `duckdnstoken` into your token and remove the brackets.
 
 You can also include the contents of the [mealie docker-compose](mealie/documentation/getting-started/install/#docker-compose-with-sqlite) in the SWAG
-docker-compose, without the <code>ports</code> section under mealie. This allows SWAG and mealie to communicate on the same docker network, without
+docker-compose, without the `ports` section under mealie. This allows SWAG and mealie to communicate on the same docker network, without
 making mealie visible to other applications on your machine.
 
 ## Step 3: Change the config files
 
-Navigate to the config folder of SWAG and head to <code>proxy-confs</code>. If you used the example above, you should navigate to: <code>/etc/config/swag/nginx/proxy-confs/</code>.
+Navigate to the config folder of SWAG and head to `proxy-confs`. If you used the example above, you should navigate to: `/etc/config/swag/nginx/proxy-confs/`.
 There are a lot of preconfigured files to use for different apps such as radarr, sonarr, overseerr, ...
 
-To use the bundled configuration file, simply rename <code>mealie.subdomain.conf.sample</code> in the proxy-confs folder to <code>mealie.subdomain.conf</code>.
-Alternatively, you can create a new file <code>mealie.subdomain.conf</code> in proxy-confs with the following configuration:
+To use the bundled configuration file, simply rename `mealie.subdomain.conf.sample` in the proxy-confs folder to `mealie.subdomain.conf`.
+Alternatively, you can create a new file `mealie.subdomain.conf` in proxy-confs with the following configuration:
 
 !!! example "mealie.subdomain.conf"
 ```yaml
@@ -94,5 +94,5 @@ Since SWAG allows you to set up a secure connection, you will need to open port 
 
 ## Step 5: Restart SWAG
 
-When you change anything in the config of Nginx, you will need to restart the container using <code>docker restart swag</code>.
-If everything went well, you can now access mealie on the subdomain you configured: mealie.mydomain.duckdns.org
+When you change anything in the config of Nginx, you will need to restart the container using `docker restart swag`.
+If everything went well, you can now access mealie on the subdomain you configured: `mealie.mydomain.duckdns.org`

--- a/docs/docs/documentation/community-guide/swag.md
+++ b/docs/docs/documentation/community-guide/swag.md
@@ -30,7 +30,8 @@ services:
         environment:
             - PUID=1000
             - PGID=1000
-            - TZ=Europe/Brussels # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for other time zones
+            # valid TZs at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+            - TZ=Europe/Brussels 
             - URL=<mydomain.duckdns>
             - SUBDOMAINS=wildcard
             - VALIDATION=duckdns
@@ -45,7 +46,8 @@ services:
             - /etc/config/swag:/config
         ports:
             - 443:443
-	    - 80:80 # this is required if you are using SWAG's http authorization to get a TLS cert
+            # required if VALIDATION=http above, if you aren't using DuckDNS
+            - 80:80 
         restart: unless-stopped
 
 ```
@@ -65,27 +67,26 @@ To use the bundled configuration file, simply rename `mealie.subdomain.conf.samp
 Alternatively, you can create a new file `mealie.subdomain.conf` in proxy-confs with the following configuration:
 
 !!! example "mealie.subdomain.conf"
-```yaml
-    server {
+```nginx
+server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    	server_name mealie.*;
+    server_name mealie.*;
 
-    	include /config/nginx/ssl.conf;
+    include /config/nginx/ssl.conf;
 
-    	client_max_body_size 0;
+    client_max_body_size 0;
 
-    	location / {
-        	include /config/nginx/proxy.conf;
-        	include /config/nginx/resolver.conf;
-        	set $upstream_app mealie;
-        	set $upstream_port 80;
-        	set $upstream_proto http;
-        	proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    		}
-
-	}	
+    location / {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app mealie;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}	
 ```
 
 ## Step 4: Port-forward port 443

--- a/docs/docs/documentation/community-guide/swag.md
+++ b/docs/docs/documentation/community-guide/swag.md
@@ -16,7 +16,7 @@ the [SWAG documentation](https://docs.linuxserver.io/general/swag#create-contain
 ## Step 2: Set-up SWAG
 
 Then you will need to set up SWAG, the variables of the docker-compose are explained on the Github page of [SWAG](https://github.com/linuxserver/docker-swag).
-This is an example of how to set it up using duckdns and docker-compose.
+This is an example of how to set it up using DuckDNS and docker-compose.
 
 !!! example "docker-compose.yml"
 ```yaml


### PR DESCRIPTION
I setup SWAG with on a mealie instance today, and this guide was super useful (thanks @zierbeek!) I figured I could fix up a few things about the page while I was using it:
* There were a few missing points about DNS setup and Let's Encrypt certs that stumped be a bit when installing (likely because I wasn't using DuckDNS), so I expanded some points and added comments in the docker-compose file.
* replaced `<code>`s with backticks, for conciseness. 
* Fixed some formatting issues with the nginx reverse proxy config (tabs -> spaces, and nginx syntax on the code block) and docker-compose (indentation) files