### PR TITLE
[1.0.0b] Fix titles of category, tag, tool pages

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCategoryTagToolPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeCategoryTagToolPage.vue
@@ -67,10 +67,10 @@ export default defineComponent({
         state.headline = i18n.t("tag.tags") as string;
         break;
       case ItemTypes.category:
-        state.headline = i18n.t("recipe.categories") as string;
+        state.headline = i18n.t("category.categories") as string;
         break;
       case ItemTypes.tool:
-        state.headline = "Tools";
+        state.headline = i18n.t("tool.tools") as string;
         state.icon = $globals.icons.potSteam;
         break;
       default:
@@ -99,8 +99,10 @@ export default defineComponent({
       itemsSorted,
     };
   },
-  head: {
-    title: "vbase-nuxt",
+  head() {
+    return {
+      title: this.headline as string,
+    }
   },
 });
 </script>

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -33,6 +33,7 @@
     "show-assets": "Show Assets"
   },
   "category": {
+    "categories": "Categories",
     "category-created": "Category created",
     "category-creation-failed": "Category creation failed",
     "category-deleted": "Category Deleted",
@@ -435,6 +436,9 @@
     "tag-updated": "Tag updated",
     "tags": "Tags",
     "untagged-count": "Untagged {count}"
+  },
+  "tool":{
+    "tools": "Tools"
   },
   "user": {
     "admin": "Admin",

--- a/frontend/pages/recipes/categories/_slug.vue
+++ b/frontend/pages/recipes/categories/_slug.vue
@@ -51,7 +51,7 @@
     </RecipeCardSection>
   </v-container>
 </template>
-    
+
 <script lang="ts">
 import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
@@ -109,7 +109,7 @@ export default defineComponent({
   },
   head() {
     return {
-      title: this.$t("sidebar.categories") as string,
+      title: this.$t("category.categories") as string,
     };
   },
   methods: {
@@ -122,4 +122,3 @@ export default defineComponent({
   },
 });
 </script>
-    

--- a/frontend/pages/recipes/categories/index.vue
+++ b/frontend/pages/recipes/categories/index.vue
@@ -27,9 +27,5 @@ export default defineComponent({
       categories,
     };
   },
-  // head: {
-  //   // @ts-ignore
-  //   title: this.$t("sidebar.categories") as string,
-  // },
 });
 </script>

--- a/frontend/pages/recipes/tags/_slug.vue
+++ b/frontend/pages/recipes/tags/_slug.vue
@@ -51,7 +51,7 @@
     </RecipeCardSection>
   </v-container>
 </template>
-    
+
 <script lang="ts">
 import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
@@ -109,7 +109,7 @@ export default defineComponent({
   },
   head() {
     return {
-      title: this.$t("sidebar.categories") as string,
+      title: this.$t("tag.tags") as string,
     };
   },
   methods: {
@@ -122,4 +122,3 @@ export default defineComponent({
   },
 });
 </script>
-    

--- a/frontend/pages/recipes/tags/index.vue
+++ b/frontend/pages/recipes/tags/index.vue
@@ -26,9 +26,5 @@ export default defineComponent({
       tools,
     };
   },
-  // head: {
-  //   // @ts-ignore
-  //   title: this.$t("sidebar.tags") as string,
-  // },
 });
 </script>

--- a/frontend/pages/recipes/tools/_slug.vue
+++ b/frontend/pages/recipes/tools/_slug.vue
@@ -45,7 +45,7 @@
     </RecipeCardSection>
   </v-container>
 </template>
-    
+
 <script lang="ts">
 import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
@@ -103,7 +103,7 @@ export default defineComponent({
   },
   head() {
     return {
-      title: this.$t("sidebar.categories") as string,
+      title: this.$t("tool.tools") as string,
     };
   },
   methods: {
@@ -116,4 +116,3 @@ export default defineComponent({
   },
 });
 </script>
-    

--- a/frontend/pages/recipes/tools/index.vue
+++ b/frontend/pages/recipes/tools/index.vue
@@ -26,8 +26,5 @@ export default defineComponent({
       tools,
     };
   },
-  head: {
-    title: "Tools",
-  },
 });
 </script>


### PR DESCRIPTION
Until now, some of the titles were either non-existent or mixed-up. I also made them all localizable.