### PR TITLE
Change the height style to min-height

### DIFF
--- a/frontend/pages/recipe/_slug/index.vue
+++ b/frontend/pages/recipe/_slug/index.vue
@@ -33,7 +33,7 @@
         <v-img
           :key="imageKey"
           :max-width="enableLandscape ? null : '50%'"
-          :height="hideImage ? '50' : imageHeight"
+          :min-height="hideImage ? '50' : imageHeight"
           :src="recipeImage(recipe.slug, imageKey)"
           class="d-print-none"
           @error="hideImage = true"


### PR DESCRIPTION
This is a small change change to the recipe view. Currently if you have a no image it defaults the height to 50px to give a border, but the "times" are children of that div. This means if you have no image but also have total/cook/prep times filled in it cuts off on the mobile view.

To see the bug, create a new recipe with no image but type "long" times into the three time fields (i.e. 1 Hour 30 Minutes). Open it in your browser and switch to a mobile view in the dev console. You'll see it cuts off.

This change means it'll always have the 50px border but if there are children that extend past it it'll expand the div to fill the content.