### PR TITLE
Trims URL when importing a recipe

### DIFF
--- a/frontend/src/components/UI/TheRecipeFab.vue
+++ b/frontend/src/components/UI/TheRecipeFab.vue
@@ -177,6 +177,7 @@ export default {
   computed: {
     recipeURL: {
       set(recipe_import_url) {
+        recipe_import_url = recipe_import_url.trim()
         this.$router.replace({ query: { ...this.$route.query, recipe_import_url } });
       },
       get() {
@@ -234,7 +235,7 @@ export default {
       this.processing = false;
     },
     isValidWebUrl(url) {
-      let regEx = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,256}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/gm;
+      let regEx = /^\s*https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,256}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)\s*$/gm;
       return regEx.test(url) ? true : this.$t('new-recipe.must-be-a-valid-url');
     },
   },


### PR DESCRIPTION
Import URLs don't trim the beginning and end space, nor recognize it as a valid URL. This change makes the regex recognize arbitrary whitespace before and after the URL and trims it when it's set.