### PR TITLE
Trims urls before importing

### DIFF
--- a/frontend/pages/recipe/create.vue
+++ b/frontend/pages/recipe/create.vue
@@ -505,6 +505,7 @@ export default defineComponent({
     recipeUrl: {
       set(recipe_import_url) {
         // @ts-ignore
+        recipe_import_url = recipe_import_url.trim()
         this.$router.replace({ query: { ...this.$route.query, recipe_import_url } });
       },
       get() {


### PR DESCRIPTION
Same as the dev change, but without the regex change (since mealie-next doesn't verify URLs). Trims the whitespace from start and end of a URL.