### PR TITLE
Update the mealie.core.config to have the current version

### DIFF
--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Union
 import dotenv
 from pydantic import BaseSettings, Field, PostgresDsn, validator
 
-APP_VERSION = "v0.5.3"
+APP_VERSION = "v0.5.4"
 DB_VERSION = "v0.5.0"
 
 CWD = Path(__file__).parent


### PR DESCRIPTION
The info box in the corner / the about page of the server is a version behind, claiming that there's a newer release, even though it's the most up to date version.

Not sure how much it'll help given that 0.5.4 is already released, but might as well bump it anyway. `¯\_(ツ)_/¯`