### PR TITLE
Fix version number for 0.5.4

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,7 +94,8 @@ nav:
           - Style Guide: "contributors/developers-guide/style-guide.md"
   - Development Road Map: "roadmap.md"
   - Change Log:
-      - v0.5.3 - Bug Fixes: "changelog/v0.5.3.md"
+      - v0.5.4 Bug Fixes: "changelog/v0.5.4.md"
+      - v0.5.3 Bug Fixes: "changelog/v0.5.3.md"
       - v0.5.2 Misc Updates: "changelog/v0.5.2.md"
       - v0.5.1 Bug Fixes: "changelog/v0.5.1.md"
       - v0.5.0 General Upgrades: "changelog/v0.5.0.md"

--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Union
 import dotenv
 from pydantic import BaseSettings, Field, PostgresDsn, validator
 
-APP_VERSION = "v0.5.3"
+APP_VERSION = "v0.5.4"
 DB_VERSION = "v0.5.0"
 
 CWD = Path(__file__).parent


### PR DESCRIPTION
This PR adds the changelog for v0.5.4 to the docs and also bumps the version in the config file to the correct version which fixes #926 