### PR TITLE
Fix TypeError in clean_nutrition function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = [
+extend-ignore = [
     E501 # Line Length - See Black Config in pyproject.toml
     E402 # Import Not at Top of File
 ]

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -93,7 +93,7 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
 
     output_nutrition = {key: val.replace(",", ".") for key, val in output_nutrition.items()}
 
-    if "sodiumContent" in nutrition and nutrition["sodiumContent"] is not None and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
+    if "sodiumContent" in nutrition and type(nutrition["sodiumContent"]) == str and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
         # Sodium is in grams. Parse its value, multiple by 1k and return to string.
         try:
             output_nutrition["sodiumContent"] = str(float(output_nutrition["sodiumContent"]) * 1000)

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -93,7 +93,12 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
 
     output_nutrition = {key: val.replace(",", ".") for key, val in output_nutrition.items()}
 
-    if "sodiumContent" in nutrition and type(nutrition["sodiumContent"]) == str and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
+    if (
+        "sodiumContent" in nutrition
+        and type(nutrition["sodiumContent"]) == str
+        and "m" not in nutrition["sodiumContent"]
+        and "g" in nutrition["sodiumContent"]
+    ):
         # Sodium is in grams. Parse its value, multiple by 1k and return to string.
         try:
             output_nutrition["sodiumContent"] = str(float(output_nutrition["sodiumContent"]) * 1000)

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -93,7 +93,7 @@ def clean_nutrition(nutrition: Optional[dict]) -> dict[str, str]:
 
     output_nutrition = {key: val.replace(",", ".") for key, val in output_nutrition.items()}
 
-    if "sodiumContent" in nutrition and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
+    if "sodiumContent" in nutrition and nutrition["sodiumContent"] is not None and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
         # Sodium is in grams. Parse its value, multiple by 1k and return to string.
         try:
             output_nutrition["sodiumContent"] = str(float(output_nutrition["sodiumContent"]) * 1000)


### PR DESCRIPTION
Fixes #1033
Using this recipe: https://www.marthastewart.com/336792/breaded-chicken-breasts
## Changes
 - If sodiumContent is `None`, it blows up when trying to check if `m` or `g` are in the string.
   - Fixed by checking that it's a string before checking if it has substrings.
 - Flake8 and black incompatability
   - fixed with setting `igntore` to `extend-ignore` in `.flake8` file [Source](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-extend-ignore)
   - With ignore used it was enabling all the default ignored rules, include the ones below: 
     - [W503](https://www.flake8rules.com/rules/W503.html) line break before binary operator
     - [W504](https://www.flake8rules.com/rules/W504.html) line break after binary operator
 - CodeFactor issues are not from my changes.


## Testing Artifacts:

### Before code fix:
Error:
```
mealie-api       |   File "/app/mealie/services/scraper/cleaner.py", line 96, in clean_nutrition
mealie-api       |     if "sodiumContent" in nutrition and "m" not in nutrition["sodiumContent"] and "g" in nutrition["sodiumContent"]:
mealie-api       | TypeError: argument of type 'NoneType' is not iterable
```
### After code fix:
Adds recipe.

### Before flake8 fix
```python
  if (
      "sodiumContent" in nutrition
      and type(nutrition["sodiumContent"]) == str
      and "m" not in nutrition["sodiumContent"]
      and "g" in nutrition["sodiumContent"]
  ):

```

```
mealie/services/scraper/cleaner.py:98:9: W503 line break before binary operator
mealie/services/scraper/cleaner.py:99:9: W503 line break before binary operator
mealie/services/scraper/cleaner.py:100:9: W503 line break before binary operator
```

Changed to this to fix W503
```python
    if (
        "sodiumContent" in nutrition and
        type(nutrition["sodiumContent"]) == str and
        "m" not in nutrition["sodiumContent"] and 
        "g" in nutrition["sodiumContent"]
    ):
```
```
mealie/services/scraper/cleaner.py:102:38: W504 line break after binary operator
mealie/services/scraper/cleaner.py:103:49: W504 line break after binary operator
mealie/services/scraper/cleaner.py:104:47: W504 line break after binary operator
```
Then recieved 504.

After flake8 fix:
```bash
❯ make lint
poetry run black .
All done! ✨ 🍰 ✨
154 files left unchanged.
poetry run black . --check
All done! ✨ 🍰 ✨
154 files would be left unchanged.
poetry run flake8 mealie tests
```
