### PR TITLE
Fix JSON edit not saving

### DIFF
--- a/frontend/src/pages/Recipe/NewRecipe.vue
+++ b/frontend/src/pages/Recipe/NewRecipe.vue
@@ -13,19 +13,19 @@
       <RecipePageActionMenu
         logged-in
         :value="true"
-        @json="jsonEditor = true"
-        @edit="jsonEditor = false"
+        @json="jsonEditor = !jsonEditor"
+        @edit="jsonEditor = !jsonEditor"
         @save="createRecipe"
       />
 
-      <div v-if="jsonEditor">
+      <div v-show="jsonEditor">
         <!-- Probably not the best way, but it works! -->
         <br />
         <br />
         <VJsoneditor v-model="recipeDetails" height="1500px" :options="jsonEditorOptions" />
       </div>
 
-      <RecipeEditor ref="recipeEditor" v-else v-model="recipeDetails" @upload="getImage" />
+      <RecipeEditor ref="recipeEditor" v-show="!jsonEditor" v-model="recipeDetails" @upload="getImage" />
     </v-card>
   </v-container>
 </template>


### PR DESCRIPTION
Fixes https://github.com/hay-kot/mealie/issues/1044.
Put the `ref` code in a `v-show`, otherwise Vue was not picking it up on mount and trying to use the `ref` would result in an `undefined`.

Fixes https://github.com/hay-kot/mealie/issues/891.
Have the action button toggle `jsonEditor` state, so clicking JSON again will close the JSON editor.