### PR TITLE
Fix docker-compose.dev.yml reference

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     image: mealie-frontend:dev
     build:
       context: ./frontend
-      dockerfile: Dockerfile.frontend
+      dockerfile: Dockerfile
     restart: always
     ports:
       - 9920:8080


### PR DESCRIPTION
The command `make docker-dev` for setting up the development environment is failing on the next branch because `docker-compose.dev.yml` is pointing to an unexisting Dockerfile on the frontend folder, probably because it was renamed at some point but this dockerfile was not updated.
This PR updates the reference.