### PR TITLE
Feature/auto increment recipe name

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -2,6 +2,7 @@ from random import randint
 from typing import Any, Optional
 from uuid import UUID
 
+from slugify import slugify
 from sqlalchemy import and_, func
 from sqlalchemy.orm import joinedload
 
@@ -17,6 +18,17 @@ from .repository_generic import RepositoryGeneric
 
 
 class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
+    def create(self, document: Recipe) -> Recipe:  # type: ignore
+        def valid_name(slug: str) -> bool:
+            return self.get_one(slug) is None
+
+        loop = 1
+        while not valid_name(document.slug):
+            document.name = f"{document.name} ({loop})"
+            document.slug = slugify(document.name)
+
+        return super().create(document)
+
     def by_group(self, group_id: UUID) -> "RepositoryRecipes":
         return super().by_group(group_id)  # type: ignore
 

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from slugify import slugify
 from sqlalchemy import and_, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from mealie.db.models.recipe.category import Category
@@ -19,15 +20,19 @@ from .repository_generic import RepositoryGeneric
 
 class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
     def create(self, document: Recipe) -> Recipe:  # type: ignore
-        def valid_name(slug: str) -> bool:
-            return self.get_one(slug) is None
+        max_retries = 10
+        original_name: str = document.name  # type: ignore
 
-        loop = 1
-        while not valid_name(document.slug):
-            document.name = f"{document.name} ({loop})"
-            document.slug = slugify(document.name)
+        for i in range(1, 11):
+            try:
+                return super().create(document)
+            except IntegrityError:
+                self.session.rollback()
+                document.name = f"{original_name} ({i})"
+                document.slug = slugify(document.name)
 
-        return super().create(document)
+                if i >= max_retries:
+                    raise
 
     def by_group(self, group_id: UUID) -> "RepositoryRecipes":
         return super().by_group(group_id)  # type: ignore

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -15,6 +15,7 @@ from mealie.services.recipe.recipe_data_service import RecipeDataService
 from mealie.services.scraper.scraper_strategies import RecipeScraperOpenGraph
 from tests import utils
 from tests.utils.app_routes import AppRoutes
+from tests.utils.factories import random_string
 from tests.utils.fixture_schemas import TestUser
 from tests.utils.recipe_data import RecipeSiteTestCase, get_recipe_test_cases
 
@@ -167,3 +168,15 @@ def test_recipe_crud_404(api_client: TestClient, api_routes: AppRoutes, unique_u
 
     response = api_client.patch(api_routes.recipes_create_url, json={"test": "stest"}, headers=unique_user.token)
     assert response.status_code == 404
+
+
+def test_create_recipe_same_name(api_client: TestClient, api_routes: AppRoutes, unique_user: TestUser):
+    slug = random_string(10)
+
+    response = api_client.post("/api/recipes", json={"name": slug}, headers=unique_user.token)
+    assert response.status_code == 201
+    assert json.loads(response.text) == slug
+
+    response = api_client.post("/api/recipes", json={"name": slug}, headers=unique_user.token)
+    assert response.status_code == 201
+    assert json.loads(response.text) == f"{slug}-1"

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -180,3 +180,14 @@ def test_create_recipe_same_name(api_client: TestClient, api_routes: AppRoutes, 
     response = api_client.post("/api/recipes", json={"name": slug}, headers=unique_user.token)
     assert response.status_code == 201
     assert json.loads(response.text) == f"{slug}-1"
+
+
+def test_create_recipe_too_many_time(api_client: TestClient, api_routes: AppRoutes, unique_user: TestUser):
+    slug = random_string(10)
+
+    for _ in range(10):
+        response = api_client.post("/api/recipes", json={"name": slug}, headers=unique_user.token)
+        assert response.status_code == 201
+
+    response = api_client.post("/api/recipes", json={"name": slug}, headers=unique_user.token)
+    assert response.status_code == 400

--- a/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
@@ -62,9 +62,10 @@ def test_unique_slug_by_group(api_client: TestClient, unique_user: TestUser, g2_
     response = api_client.post(Routes.base, json=create_data, headers=g2_user.token)
     assert response.status_code == 201
 
-    # Try to create a recipe again with the same name
+    # Try to create a recipe again with the same name and check that the name was incremented
     response = api_client.post(Routes.base, json=create_data, headers=g2_user.token)
-    assert response.status_code == 400
+    assert response.status_code == 201
+    assert response.json() == create_data["name"] + "-1"
 
 
 def test_user_locked_recipe(api_client: TestClient, user_tuple: list[TestUser]) -> None:


### PR DESCRIPTION
When creating a recipe with a name that already exists Mealie will increment the the name by 1 until it finds a valid name. This action always add an additional query to the create method but the difference isn't noticable. An alternative would be to wrap in a try/except and recall the function if it fails.

Example:

Create: Tortilla Soup
Create Again: Tortilla Soup (1)