### PR TITLE
Fix clear url action in recipe creation

### DIFF
--- a/frontend/pages/recipe/create.vue
+++ b/frontend/pages/recipe/create.vue
@@ -394,9 +394,11 @@ export default defineComponent({
     });
 
     const recipeUrl = computed({
-      set(recipe_import_url: string) {
-        recipe_import_url = recipe_import_url.trim();
-        router.replace({ query: { ...route.value.query, recipe_import_url } });
+      set(recipe_import_url: string | null) {
+        if (recipe_import_url !== null) {
+          recipe_import_url = recipe_import_url.trim();
+          router.replace({ query: { ...route.value.query, recipe_import_url } });
+        }
       },
       get() {
         return route.value.query.recipe_import_url as string;


### PR DESCRIPTION
# Related
I have not created an issue to report this bug. I could not find an existing one either. 

# Fixes:

- Clicking on the clear button when creating a recipe with a url will not result in a 404 error anymore

# Does this affect code?

The route is not changed anymore when the vuetify text field component sets the v-model variable to null. This previously caused an error in the console.