### PR TITLE
Keep Original Text on Ingredient Parse

### DIFF
--- a/alembic/versions/2022-03-27-19.30.28_f1a2dbee5fe9_add_original_text_column_to_recipes_.py
+++ b/alembic/versions/2022-03-27-19.30.28_f1a2dbee5fe9_add_original_text_column_to_recipes_.py
@@ -1,7 +1,7 @@
 """Add original_text column to recipes_ingredients
 
 Revision ID: f1a2dbee5fe9
-Revises: 6b0f5f32d602
+Revises: 263dd6707191
 Create Date: 2022-03-27 19:30:28.545846
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f1a2dbee5fe9"
-down_revision = "6b0f5f32d602"
+down_revision = "263dd6707191"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/2022-03-27-19.30.28_f1a2dbee5fe9_add_original_text_column_to_recipes_.py
+++ b/alembic/versions/2022-03-27-19.30.28_f1a2dbee5fe9_add_original_text_column_to_recipes_.py
@@ -1,0 +1,24 @@
+"""Add original_text column to recipes_ingredients
+
+Revision ID: f1a2dbee5fe9
+Revises: 6b0f5f32d602
+Create Date: 2022-03-27 19:30:28.545846
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2dbee5fe9"
+down_revision = "6b0f5f32d602"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("recipes_ingredients", sa.Column("original_text", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("recipes_ingredients", "original_text")

--- a/frontend/api/class-interfaces/recipes/types.ts
+++ b/frontend/api/class-interfaces/recipes/types.ts
@@ -23,6 +23,7 @@ export interface Ingredient {
 }
 
 export interface ParsedIngredient {
+  input: string
   confidence: Confidence;
   ingredient: Ingredient;
 }

--- a/frontend/pages/recipe/_slug/ingredient-parser.vue
+++ b/frontend/pages/recipe/_slug/ingredient-parser.vue
@@ -88,6 +88,7 @@ import { CreateIngredientFood, CreateIngredientUnit, IngredientFood, IngredientU
 import RecipeIngredientEditor from "~/components/Domain/Recipe/RecipeIngredientEditor.vue";
 import { useUserApi } from "~/composables/api";
 import { useFoods, useRecipe, useUnits } from "~/composables/recipes";
+import { RecipeIngredient } from "~/types/api-types/admin";
 
 interface Error {
   ingredientIndex: number;
@@ -218,7 +219,8 @@ export default defineComponent({
       let ingredients = parsedIng.value.map((ing) => {
         return {
           ...ing.ingredient,
-        };
+          originalText: ing.input
+        } as RecipeIngredient;
       });
 
       ingredients = ingredients.map((ing) => {

--- a/frontend/types/api-types/recipe.ts
+++ b/frontend/types/api-types/recipe.ts
@@ -155,6 +155,7 @@ export interface RecipeIngredient {
   food?: IngredientFood | CreateIngredientFood;
   disableAmount?: boolean;
   quantity?: number;
+  originalText?: string;
   referenceId?: string;
 }
 export interface Recipe {

--- a/mealie/db/models/recipe/ingredient.py
+++ b/mealie/db/models/recipe/ingredient.py
@@ -63,6 +63,8 @@ class RecipeIngredient(SqlAlchemyBase, BaseMixins):
     food = orm.relationship(IngredientFoodModel, uselist=False)
     quantity = Column(Float)
 
+    original_text = Column(String)
+
     reference_id = Column(GUID)  # Reference Links
 
     @auto_init()

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -54,6 +54,7 @@ class RecipeIngredient(MealieModel):
     food: Optional[Union[IngredientFood, CreateIngredientFood]]
     disable_amount: bool = True
     quantity: float = 1
+    original_text: Optional[str]
 
     # Ref is used as a way to distinguish between an individual ingredient on the frontend
     # It is required for the reorder and section titles to function properly because of how

--- a/tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py
+++ b/tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py
@@ -4,7 +4,7 @@ from mealie.core.config import get_app_settings
 from mealie.services.backups_v2.alchemy_exporter import AlchemyExporter
 
 ALEMBIC_VERSIONS = [
-    {"version_num": "263dd6707191"},
+    {"version_num": "f1a2dbee5fe9"},
 ]
 
 


### PR DESCRIPTION
# Related
https://github.com/hay-kot/mealie/issues/1094 - Keep Original Text on Ingredient Parse

# Fixes:

- Ingredient parse used to be a destructive operation, now the original text is stored in the database.
- I have taken the liberty to add the missing _input_ property on the ParsedInrgedient interface definition. This probably should have triggered a warning somewhere that the property did not exist when it was referenced in the template.

# Does this affect code?

- A column named original_text has been added to the table recipes_ingredients.
- There is one database migration file to add/remove the original_text column from the above mentioned table.
- The button to save all parsed ingredients now sends the original text in the request to be saved in the database.

### Note

The original_text field has yet to be used somewhere to get the value out of it.