### PR TITLE
Fix failed tests when env default email/password were changed

### DIFF
--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -76,7 +76,7 @@ class UserBase(MealieModel):
         schema_extra = {
             "username": "ChangeMe",
             "fullName": "Change Me",
-            "email": settings.DEFAULT_EMAIL,
+            "email": "changeme@email.com",
             "group": settings.DEFAULT_GROUP,
             "admin": "false",
         }

--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -76,7 +76,7 @@ class UserBase(MealieModel):
         schema_extra = {
             "username": "ChangeMe",
             "fullName": "Change Me",
-            "email": "changeme@email.com",
+            "email": settings.DEFAULT_EMAIL,
             "group": settings.DEFAULT_GROUP,
             "admin": "false",
         }

--- a/tests/fixtures/fixture_admin.py
+++ b/tests/fixtures/fixture_admin.py
@@ -9,7 +9,7 @@ from tests import utils
 def admin_token(api_client: TestClient, api_routes: utils.AppRoutes):
     settings = get_app_settings()
 
-    form_data = {"username": "changeme@email.com", "password": settings.DEFAULT_PASSWORD}
+    form_data = {"username": settings.DEFAULT_EMAIL, "password": settings.DEFAULT_PASSWORD}
     return utils.login(form_data, api_client, api_routes)
 
 
@@ -17,7 +17,7 @@ def admin_token(api_client: TestClient, api_routes: utils.AppRoutes):
 def admin_user(api_client: TestClient, api_routes: utils.AppRoutes):
     settings = get_app_settings()
 
-    form_data = {"username": "changeme@email.com", "password": settings.DEFAULT_PASSWORD}
+    form_data = {"username": settings.DEFAULT_EMAIL, "password": settings.DEFAULT_PASSWORD}
 
     token = utils.login(form_data, api_client, api_routes)
 

--- a/tests/integration_tests/admin_tests/test_admin_user_actions.py
+++ b/tests/integration_tests/admin_tests/test_admin_user_actions.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 
+from mealie.core.config import get_app_settings
 from tests import utils
 from tests.utils import routes
 from tests.utils.app_routes import AppRoutes
@@ -24,6 +25,8 @@ def generate_create_data() -> dict:
 
 
 def test_init_superuser(api_client: TestClient, admin_user: TestUser):
+    settings = get_app_settings()
+
     response = api_client.get(routes.RoutesAdminUsers.item(admin_user.user_id), headers=admin_user.token)
     assert response.status_code == 200
 
@@ -33,7 +36,7 @@ def test_init_superuser(api_client: TestClient, admin_user: TestUser):
     assert admin_data["groupId"] == admin_user.group_id
 
     assert admin_data["fullName"] == "Change Me"
-    assert admin_data["email"] == "changeme@email.com"
+    assert admin_data["email"] == settings.DEFAULT_EMAIL
 
 
 def test_create_user(api_client: TestClient, api_routes: AppRoutes, admin_token):
@@ -80,10 +83,12 @@ def test_update_user(api_client: TestClient, admin_user: TestUser):
 
 
 def test_update_other_user_as_not_admin(api_client: TestClient, unique_user: TestUser, g2_user: TestUser):
+    settings = get_app_settings()
+
     update_data = {
         "id": unique_user.user_id,
         "fullName": "Updated Name",
-        "email": "changeme@email.com",
+        "email": settings.DEFAULT_EMAIL,
         "group": "Home",
         "admin": True,
     }

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -2,19 +2,24 @@ import json
 
 from fastapi.testclient import TestClient
 
+from mealie.core.config import get_app_settings
 from tests.utils.app_routes import AppRoutes
 from tests.utils.fixture_schemas import TestUser
 
 
 def test_failed_login(api_client: TestClient, api_routes: AppRoutes):
-    form_data = {"username": "changeme@email.com", "password": "WRONG_PASSWORD"}
+    settings = get_app_settings()
+
+    form_data = {"username": settings.DEFAULT_EMAIL, "password": "WRONG_PASSWORD"}
     response = api_client.post(api_routes.auth_token, form_data)
 
     assert response.status_code == 401
 
 
 def test_superuser_login(api_client: TestClient, api_routes: AppRoutes, admin_token):
-    form_data = {"username": "changeme@email.com", "password": "MyPassword"}
+    settings = get_app_settings()
+
+    form_data = {"username": settings.DEFAULT_EMAIL, "password": settings.DEFAULT_PASSWORD}
     response = api_client.post(api_routes.auth_token, form_data)
 
     assert response.status_code == 200


### PR DESCRIPTION
A lot of tests would fail when running in a dev environment with non default DEFAULT_EMAIL and DEFAULT_PASSWORD environment variables.

This PR **does not** fix https://github.com/hay-kot/mealie/issues/1156, this issue will need extra attention.