### PR TITLE
typo: replace scrapper with scraper

### DIFF
--- a/docs/docs/overrides/home.html
+++ b/docs/docs/overrides/home.html
@@ -254,7 +254,7 @@
             Import Recipes
         </h2>
         <p>
-            Quickly and easily import recipes from sites around the web using the built in <b>recipe scrapper</b>.
+            Quickly and easily import recipes from sites around the web using the built in <b>recipe scraper</b>.
         </p>
     </div>
     <div class="feature-item">


### PR DESCRIPTION
i'm assuming that you mean `scraping` as in [web scraping](https://en.wikipedia.org/wiki/Web_scraping), which is spelled with one `p` instead of two.