### PR TITLE
mealie/run: only modify the uid and gid if necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV PYTHONUNBUFFERED=1 \
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 
 # create user account
-RUN useradd -u 911 -U -d $MEALIE_HOME -s /bin/bash abc \
+RUN groupadd  -g 911 abc \
+    && useradd -u 911 -g 911 -d $MEALIE_HOME -s /bin/bash abc \
     && usermod -G users abc \
     && mkdir $MEALIE_HOME
 

--- a/mealie/run.sh
+++ b/mealie/run.sh
@@ -10,14 +10,23 @@ PUID=${PUID:-911}
 PGID=${PGID:-911}
 
 add_user() {
-    groupmod -o -g "$PGID" abc
-    usermod -o -u "$PUID" abc
+    local chown=false
+    if [ "$PGID" != "$(id -g abc || true)" ]; then
+        groupmod -o -g "$PGID" abc
+        chown=true
+    fi
+    if [ "$PUID" != "$(id -u abc || true)" ]; then
+        usermod -o -u "$PUID" abc
+        chown=true
+    fi
 
     echo "
     User uid:    $(id -u abc)
     User gid:    $(id -g abc)
     "
-    chown -R abc:abc /app
+    if $chown; then
+        chown -R abc:abc /app
+    fi
 }
 
 init() {


### PR DESCRIPTION
This allows the Docker image to run without write access to its image in
the default case.

Also manually create the group in the Docker image to avoid auto
assignment of a different id.