### PR TITLE
fix: error on duplicate username/email registration

### DIFF
--- a/mealie/lang/messages/af-ZA.json
+++ b/mealie/lang/messages/af-ZA.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ar-SA.json
+++ b/mealie/lang/messages/ar-SA.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ca-ES.json
+++ b/mealie/lang/messages/ca-ES.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/cs-CZ.json
+++ b/mealie/lang/messages/cs-CZ.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/da-DK.json
+++ b/mealie/lang/messages/da-DK.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/de-DE.json
+++ b/mealie/lang/messages/de-DE.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/el-GR.json
+++ b/mealie/lang/messages/el-GR.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/en-GB.json
+++ b/mealie/lang/messages/en-GB.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/en-US.json
+++ b/mealie/lang/messages/en-US.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/es-ES.json
+++ b/mealie/lang/messages/es-ES.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/fi-FI.json
+++ b/mealie/lang/messages/fi-FI.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/fr-CA.json
+++ b/mealie/lang/messages/fr-CA.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "Ce nom d'utilisateur est déjà pris",
+        "email-conflict-error": "Cet email existe déjà"
     }
 }

--- a/mealie/lang/messages/fr-FR.json
+++ b/mealie/lang/messages/fr-FR.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "Ce nom d'utilisateur est déjà pris",
+        "email-conflict-error": "Cet email existe déjà"
     }
 }

--- a/mealie/lang/messages/he-IL.json
+++ b/mealie/lang/messages/he-IL.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/hu-HU.json
+++ b/mealie/lang/messages/hu-HU.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/it-IT.json
+++ b/mealie/lang/messages/it-IT.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ja-JP.json
+++ b/mealie/lang/messages/ja-JP.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ko-KR.json
+++ b/mealie/lang/messages/ko-KR.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/nl-NL.json
+++ b/mealie/lang/messages/nl-NL.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/no-NO.json
+++ b/mealie/lang/messages/no-NO.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/pl-PL.json
+++ b/mealie/lang/messages/pl-PL.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/pt-BR.json
+++ b/mealie/lang/messages/pt-BR.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/pt-PT.json
+++ b/mealie/lang/messages/pt-PT.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ro-RO.json
+++ b/mealie/lang/messages/ro-RO.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/ru-RU.json
+++ b/mealie/lang/messages/ru-RU.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/sk-SK.json
+++ b/mealie/lang/messages/sk-SK.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/sr-SP.json
+++ b/mealie/lang/messages/sr-SP.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/sv-SE.json
+++ b/mealie/lang/messages/sv-SE.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/tr-TR.json
+++ b/mealie/lang/messages/tr-TR.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/uk-UA.json
+++ b/mealie/lang/messages/uk-UA.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/vi-VN.json
+++ b/mealie/lang/messages/vi-VN.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/zh-CN.json
+++ b/mealie/lang/messages/zh-CN.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/lang/messages/zh-TW.json
+++ b/mealie/lang/messages/zh-TW.json
@@ -8,6 +8,8 @@
     "exceptions": {
         "permission_denied": "You do not have permission to perform this action",
         "no-entry-found": "The requested resource was not found",
-        "integrity-error": "Database integrity error"
+        "integrity-error": "Database integrity error",
+        "username-conflict-error": "This username is already taken",
+        "email-conflict-error": "This email is already in use"
     }
 }

--- a/mealie/services/user_services/registration_service.py
+++ b/mealie/services/user_services/registration_service.py
@@ -59,7 +59,7 @@ class RegistrationService:
         if self.repos.users.get_by_username(registration.username):
             raise HTTPException(status.HTTP_409_CONFLICT, {"message": self.t.t("exceptions.username-conflict-error")})
         elif self.repos.users.get(registration.email, "email"):
-            raise HTTPException(status.HTTP_409_CONFLICT, {"message": self.t.t(key="exceptions.email-conflict-error")})
+            raise HTTPException(status.HTTP_409_CONFLICT, {"message": self.t.t("exceptions.email-conflict-error")})
 
         self.logger.info(f"Registering user {registration.username}")
         token_entry = None

--- a/mealie/services/user_services/registration_service.py
+++ b/mealie/services/user_services/registration_service.py
@@ -55,9 +55,9 @@ class RegistrationService:
         self.registration = registration
 
         if self.repos.users.get_by_username(registration.username):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "A user with this username already exists"})
+            raise HTTPException(status.HTTP_409_CONFLICT, {"message": "A user with this username already exists"})
         elif self.repos.users.get(registration.email, "email"):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "A user with this email already exists"})
+            raise HTTPException(status.HTTP_409_CONFLICT, {"message": "A user with this email already exists"})
 
         self.logger.info(f"Registering user {registration.username}")
         token_entry = None
@@ -74,8 +74,6 @@ class RegistrationService:
             group = self.repos.groups.get_one(token_entry.group_id)
         else:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "Missing group"})
-
-        self.logger.info(self.repos.users.get_by_username(registration.username))
 
         user = self._create_new_user(group, new_group)
 

--- a/mealie/services/user_services/registration_service.py
+++ b/mealie/services/user_services/registration_service.py
@@ -54,6 +54,11 @@ class RegistrationService:
     def register_user(self, registration: CreateUserRegistration) -> PrivateUser:
         self.registration = registration
 
+        if self.repos.users.get_by_username(registration.username):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "A user with this username already exists"})
+        elif self.repos.users.get(registration.email, "email"):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "A user with this email already exists"})
+
         self.logger.info(f"Registering user {registration.username}")
         token_entry = None
         new_group = False
@@ -69,6 +74,8 @@ class RegistrationService:
             group = self.repos.groups.get_one(token_entry.group_id)
         else:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "Missing group"})
+
+        self.logger.info(self.repos.users.get_by_username(registration.username))
 
         user = self._create_new_user(group, new_group)
 

--- a/mealie/services/user_services/registration_service.py
+++ b/mealie/services/user_services/registration_service.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 
 from mealie.core.security import hash_password
+from mealie.lang import local_provider
 from mealie.repos.repository_factory import AllRepositories
 from mealie.schema.group.group_preferences import CreateGroupPreferences
 from mealie.schema.user.registration import CreateUserRegistration
@@ -18,6 +19,7 @@ class RegistrationService:
     def __init__(self, logger: Logger, db: AllRepositories):
         self.logger = logger
         self.repos = db
+        self.t = local_provider()
 
     def _create_new_user(self, group: GroupInDB, new_group: bool) -> PrivateUser:
         new_user = UserIn(
@@ -55,9 +57,9 @@ class RegistrationService:
         self.registration = registration
 
         if self.repos.users.get_by_username(registration.username):
-            raise HTTPException(status.HTTP_409_CONFLICT, {"message": "A user with this username already exists"})
+            raise HTTPException(status.HTTP_409_CONFLICT, {"message": self.t.t("exceptions.username-conflict-error")})
         elif self.repos.users.get(registration.email, "email"):
-            raise HTTPException(status.HTTP_409_CONFLICT, {"message": "A user with this email already exists"})
+            raise HTTPException(status.HTTP_409_CONFLICT, {"message": self.t.t(key="exceptions.email-conflict-error")})
 
         self.logger.info(f"Registering user {registration.username}")
         token_entry = None


### PR DESCRIPTION
# Related
#814 - Error 500 when information for new user is not unique

# Fixes
Trying to register with an already used username or email was not handled and resulted in the frontend being unresponsive.
Now, the registration is done only if the username and email are unique records in the database and a feedback is sent to the user trying to register. 

# Note(s)
- I understand the error message is coming from the backend and is therefore not localized.
- **More important in my opinion**, duplicate records should return the http error code 409. I could unfortunately not find where I could define it. 