### PR TITLE
Fix typos and wording in v1.0.0 docs

### DIFF
--- a/docs/docs/changelog/v1.0.0.md
+++ b/docs/docs/changelog/v1.0.0.md
@@ -73,8 +73,8 @@
 
 #### 📢 Apprise Integration
 
-- Server based Apprise notifications have been depreciated. An effort has been made to improve logging overall in the application and make it easier to monitor/debug through the logs.
-- The Apprise integration has been updated to the latest version and is not used asynchronously.
+- Server based Apprise notifications have been deprecated. An effort has been made to improve logging overall in the application and make it easier to monitor/debug through the logs.
+- The Apprise integration has been updated to the latest version and is now used asynchronously.
 - Notifiers now support a wider variety of events.
 - Notifiers can now be managed by-group instead of by the server.
 
@@ -95,17 +95,17 @@
 
 ##### 🍴 Recipe General
 
-- Recipe Pages not implement a screen lock on supported devices to keep the screen from going to sleep.
+- Recipe Pages now implement a screen lock on supported devices to keep the screen from going to sleep.
 - Recipes are now only viewable by group members
 - Recipes can be shared with share links
 - Shared recipes can now render previews for the recipe on sites like Twitter, Facebook, and Discord.
-- Recipes now have a `tools` attributes that contains a list of required tools/equipment for the recipe. Tools can be set with a state to determine if you have that tool or not. If it's marked as on hand it will show checked by default.
-- Recipe Extras now only show when advanced mode it toggled on
+- Recipes now have a `tools` attribute that contains a list of required tools/equipment for the recipe. Tools can be set with a state to determine if you have that tool or not. If it's marked as on hand it will show checked by default.
+- Recipe Extras now only show when advanced mode is toggled on
 - You can now import multiple URLs at a time pre-tagged using the bulk importer. This task runs in the background so no need to wait for it to finish.
 - Foods/Units for Ingredients are now supported (toggle inside your recipe settings)
 - Common Food and Units come pre-packaged with Mealie
-- Landscape and Portrait views is now available
-- Users with the advanced flag turned on will not be able to manage recipe data in bulk and perform the following actions:
+- Landscape and Portrait views are now available
+- Users with the advanced flag turned on will now be able to manage recipe data in bulk and perform the following actions:
     - Set Categories
     - Set Tags
     - Delete Recipes
@@ -119,9 +119,9 @@
 ##### 🍞 Recipe Ingredients
 
 - Recipe ingredients can now be scaled when the food/unit is defined
-- Recipe ingredients can no be copied as markdown lists
+- Recipe ingredients can now be copied as markdown lists
     - example `- [ ] 1 cup of flour`
-- You can no use Natural Language Processing (NLP) to process ingredients and attempt to parse them into amounts, units, and foods. There additional is a "Brute Force" processor that can be used to use a pattern matching parser to try and determine ingredients. **Note** if you are processing a Non-English language you will have terrible results with the NLP and will likely need to use the Bruce Force processor.
+- You can now use Natural Language Processing (NLP) to process ingredients and attempt to parse them into amounts, units, and foods. There is an additional "Brute Force" processor that can be used as pattern matching parser to try and determine ingredients. **Note** if you are processing a Non-English language you will have terrible results with the NLP and will likely need to use the Bruce Force processor.
 
 ##### 📜 Recipe Instructions
 
@@ -132,7 +132,7 @@
 
 #### ⚠️ Other things to know...
 
-- Themes have been depreciated for specific users. You can still set specific themes for your site through ENV variables. This approach should yield much better results for performance and some weirdness users have experienced.
+- Themes have been deprecated for specific users. You can still set specific themes for your site through ENV variables. This approach should yield much better results for performance and some weirdness users have experienced.
 - If you've experienced slowness in the past, you may notice a significant improvement in the "All Recipes" and "Search" pages, or wherever large payloads of recipes are being displayed. This is due to not validating responses from the database, as such if you are consuming these API's you may get extra values that are unexpected.
 
 #### 👨‍💻 Backend/Development Goodies


### PR DESCRIPTION
This fixes some typos and wording  in the v1.0.0 docs.