### PR TITLE
fix:Error when scraper returns None

### DIFF
--- a/mealie/services/scraper/recipe_scraper.py
+++ b/mealie/services/scraper/recipe_scraper.py
@@ -28,9 +28,9 @@ class RecipeScraper:
 
         for scraper_type in self.scrapers:
             scraper = scraper_type(url)
-            recipe, extras = scraper.parse()
+            result = scraper.parse()
 
-            if recipe is not None:
-                return recipe, extras
+            if result is not None:
+                return result
 
         return None, None


### PR DESCRIPTION
When the scraper would send back a None object, the following error would occur:`TypeError: cannot unpack non-iterable NoneType object`.

There was no reason to unpack the object in this function anyway since it is returned as is.