### PR TITLE
Improve ingredient sections editing behavior

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipeIngredientEditor.vue
@@ -163,13 +163,10 @@ export default defineComponent({
     });
 
     function toggleTitle() {
-      if (value.title) {
-        state.showTitle = false;
+      if (state.showTitle) {
         value.title = "";
-      } else {
-        state.showTitle = true;
-        value.title = "Section Title";
       }
+      state.showTitle = !state.showTitle
     }
 
     function toggleOriginalText() {


### PR DESCRIPTION
# Fixes
1. value.title (v-model value) was set to the string "Section Title" by default which was annoying to remove and completely unnecessary since "Section Title" is already a placeholder in the v-text-field component.
2. Cleaned up the logic to toggle the section display

## Notes
Some (if not all) of this component is not translated. For example the placeholder "Section Title"