### PR TITLE
docs: docker-compose.dev.yml is currently not functional

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,4 @@
+# WARNING: currently not functional, see #756, #1072
 # Use root/example as user/password credentials
 version: "3.4"
 services:

--- a/docs/docs/contributors/developers-guide/starting-dev-server.md
+++ b/docs/docs/contributors/developers-guide/starting-dev-server.md
@@ -110,7 +110,7 @@ frontend             🎬 Start Mealie Frontend Development Server
 frontend-build       🏗  Build Frontend in frontend/dist
 frontend-generate    🏗  Generate Code for Frontend
 frontend-lint        🧺 Run yarn lint
-docker-dev           🐳 Build and Start Docker Development Stack
+docker-dev           🐳 Build and Start Docker Development Stack (currently not functional, see #756, #1072)
 docker-prod          🐳 Build and Start Docker Production Stack
 
 ```


### PR DESCRIPTION
Adds documentation that `docker-compose.dev.yml` is currently not functional and references associated issues. Prevents confusion for people that did not search for existing issues (like me).