### PR TITLE
fix: update issue links in v1.0.0beta-2 changelog

### DIFF
--- a/docs/docs/changelog/v1.0.0beta-2.md
+++ b/docs/docs/changelog/v1.0.0beta-2.md
@@ -1,29 +1,29 @@
 ### Bug Fixes
 
-- Bump isomorphic-dompurify from 0.18.0 to 0.19.0 in /frontend ([#1257](https://github.com/orhun/git-cliff/issues/1257))
-- Bump @nuxtjs/auth-next in /frontend ([#1265](https://github.com/orhun/git-cliff/issues/1265))
-- Bad dev dependency ([#1281](https://github.com/orhun/git-cliff/issues/1281))
-- Add touch support for mealplanner delete ([#1298](https://github.com/orhun/git-cliff/issues/1298))
+- Bump isomorphic-dompurify from 0.18.0 to 0.19.0 in /frontend ([#1257](https://github.com/hay-kot/mealie/issues/1257))
+- Bump @nuxtjs/auth-next in /frontend ([#1265](https://github.com/hay-kot/mealie/issues/1265))
+- Bad dev dependency ([#1281](https://github.com/hay-kot/mealie/issues/1281))
+- Add touch support for mealplanner delete ([#1298](https://github.com/hay-kot/mealie/issues/1298))
 
 ### Documentation
 
-- Add references for VSCode dev containers ([#1299](https://github.com/orhun/git-cliff/issues/1299))
-- Docker-compose.dev.yml is currently not functional ([#1300](https://github.com/orhun/git-cliff/issues/1300))
+- Add references for VSCode dev containers ([#1299](https://github.com/hay-kot/mealie/issues/1299))
+- Docker-compose.dev.yml is currently not functional ([#1300](https://github.com/hay-kot/mealie/issues/1300))
 
 ### Features
 
-- Add reports to bulk recipe import (url) ([#1294](https://github.com/orhun/git-cliff/issues/1294))
-- Rewrite print implementation to support new ing ([#1305](https://github.com/orhun/git-cliff/issues/1305))
+- Add reports to bulk recipe import (url) ([#1294](https://github.com/hay-kot/mealie/issues/1294))
+- Rewrite print implementation to support new ing ([#1305](https://github.com/hay-kot/mealie/issues/1305))
 
 ### Miscellaneous Tasks
 
-- Github stalebot changes ([#1271](https://github.com/orhun/git-cliff/issues/1271))
-- Bump eslint-plugin-nuxt in /frontend ([#1258](https://github.com/orhun/git-cliff/issues/1258))
-- Bump @vue/runtime-dom in /frontend ([#1259](https://github.com/orhun/git-cliff/issues/1259))
-- Bump nuxt-vite from 0.1.3 to 0.3.5 in /frontend ([#1260](https://github.com/orhun/git-cliff/issues/1260))
-- Bump vue2-script-setup-transform in /frontend ([#1263](https://github.com/orhun/git-cliff/issues/1263))
-- Update dev dependencies ([#1282](https://github.com/orhun/git-cliff/issues/1282))
+- Github stalebot changes ([#1271](https://github.com/hay-kot/mealie/issues/1271))
+- Bump eslint-plugin-nuxt in /frontend ([#1258](https://github.com/hay-kot/mealie/issues/1258))
+- Bump @vue/runtime-dom in /frontend ([#1259](https://github.com/hay-kot/mealie/issues/1259))
+- Bump nuxt-vite from 0.1.3 to 0.3.5 in /frontend ([#1260](https://github.com/hay-kot/mealie/issues/1260))
+- Bump vue2-script-setup-transform in /frontend ([#1263](https://github.com/hay-kot/mealie/issues/1263))
+- Update dev dependencies ([#1282](https://github.com/hay-kot/mealie/issues/1282))
 
 ### Refactor
 
-- Split up recipe create page ([#1283](https://github.com/orhun/git-cliff/issues/1283))
+- Split up recipe create page ([#1283](https://github.com/hay-kot/mealie/issues/1283))


### PR DESCRIPTION
Seems like `git-cliff` was misconfigured and pointed to non-existent issues.