### PR TITLE
docs update postgres documentation to use most recent version

### DIFF
--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -10,7 +10,7 @@
 version: "3.7"
 services:
   mealie-frontend:
-    image: hkotel/mealie:frontend-v1.0.0-beta-1
+    image: hkotel/mealie:frontend-v1.0.0beta-2
     container_name: mealie-frontend
     depends_on:
       - mealie-api
@@ -23,7 +23,7 @@ services:
     volumes:
       - mealie-data:/app/data/ # (3)
   mealie-api:
-    image: hkotel/mealie:api-v1.0.0-beta-1
+    image: hkotel/mealie:api-v1.0.0beta-2
     container_name: mealie-api
     depends_on:
       - postgres


### PR DESCRIPTION
Sorry for two PRs, edited through github web editor did not allow both in one :/