### PR TITLE
Fixed alpha sort in RecipeOrganizerPage

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
@@ -84,19 +84,13 @@ export default defineComponent({
 
       if (!props.items) return byLetter;
 
-      props.items.forEach((item) => {
+      props.items.sort((a, b) => a.name.localeCompare(b.name)).forEach((item) => {
         const letter = item.name[0].toUpperCase();
         if (!byLetter[letter]) {
           byLetter[letter] = [];
         }
         byLetter[letter].push(item);
       });
-
-      for (const key in byLetter) {
-        byLetter[key] = byLetter[key].sort((a, b) => {
-          return a.name.localeCompare(b.name);
-        });
-      }
 
       return byLetter;
     });


### PR DESCRIPTION
The recipe organizer page template wasn't properly sorting items alphabetically due to an ordering issue, as reported in [issue #1226](https://github.com/hay-kot/mealie/discussions/1226).

Root cause: the view was grouping items by first letter _first_, then sorting each item group, but never sorting the groups themselves.

Resolution: sort the items first, then group them.