### PR TITLE
Extend Apprise JSON notification functionality with programmatic data

### DIFF
--- a/mealie/lang/messages/af-ZA.json
+++ b/mealie/lang/messages/af-ZA.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/ar-SA.json
+++ b/mealie/lang/messages/ar-SA.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/bg-BG.json
+++ b/mealie/lang/messages/bg-BG.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/ca-ES.json
+++ b/mealie/lang/messages/ca-ES.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/cs-CZ.json
+++ b/mealie/lang/messages/cs-CZ.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/da-DK.json
+++ b/mealie/lang/messages/da-DK.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} blev opdateret",
         "generic-created-with-url": "{name} er oprettet, {url}",
         "generic-updated-with-url": "{name} er blevet opdateret, {url}",
-        "generic-deleted": "{name} er oprettet"
+        "generic-deleted": "{name} er slettet"
     }
 }

--- a/mealie/lang/messages/de-DE.json
+++ b/mealie/lang/messages/de-DE.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} wurde aktualisiert",
         "generic-created-with-url": "{name} wurde erstellt, {url}",
         "generic-updated-with-url": "{name} wurde aktualisiert, {url}",
-        "generic-deleted": "{name} wurde erstellt"
+        "generic-deleted": "{name} wurde gelöscht"
     }
 }

--- a/mealie/lang/messages/el-GR.json
+++ b/mealie/lang/messages/el-GR.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/en-GB.json
+++ b/mealie/lang/messages/en-GB.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/en-US.json
+++ b/mealie/lang/messages/en-US.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/es-ES.json
+++ b/mealie/lang/messages/es-ES.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/fi-FI.json
+++ b/mealie/lang/messages/fi-FI.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/fr-CA.json
+++ b/mealie/lang/messages/fr-CA.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/fr-FR.json
+++ b/mealie/lang/messages/fr-FR.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/he-IL.json
+++ b/mealie/lang/messages/he-IL.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/hu-HU.json
+++ b/mealie/lang/messages/hu-HU.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/it-IT.json
+++ b/mealie/lang/messages/it-IT.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} è stato aggiornato",
         "generic-created-with-url": "{name} è stato creato, {url}",
         "generic-updated-with-url": "{name} è stato aggiornato, {url}",
-        "generic-deleted": "{name} è stato creato"
+        "generic-deleted": "{name} è stato cancellato"
     }
 }

--- a/mealie/lang/messages/ja-JP.json
+++ b/mealie/lang/messages/ja-JP.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/ko-KR.json
+++ b/mealie/lang/messages/ko-KR.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/nl-NL.json
+++ b/mealie/lang/messages/nl-NL.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/no-NO.json
+++ b/mealie/lang/messages/no-NO.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/pl-PL.json
+++ b/mealie/lang/messages/pl-PL.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/pt-BR.json
+++ b/mealie/lang/messages/pt-BR.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/pt-PT.json
+++ b/mealie/lang/messages/pt-PT.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/ro-RO.json
+++ b/mealie/lang/messages/ro-RO.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/ru-RU.json
+++ b/mealie/lang/messages/ru-RU.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/sk-SK.json
+++ b/mealie/lang/messages/sk-SK.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/sr-SP.json
+++ b/mealie/lang/messages/sr-SP.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/sv-SE.json
+++ b/mealie/lang/messages/sv-SE.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/tr-TR.json
+++ b/mealie/lang/messages/tr-TR.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/uk-UA.json
+++ b/mealie/lang/messages/uk-UA.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} оновлено",
         "generic-created-with-url": "{name} створено, {url}",
         "generic-updated-with-url": "{name} оновлено, {url}",
-        "generic-deleted": "{name} створено"
+        "generic-deleted": "{name} видалено"
     }
 }

--- a/mealie/lang/messages/vi-VN.json
+++ b/mealie/lang/messages/vi-VN.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/zh-CN.json
+++ b/mealie/lang/messages/zh-CN.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/lang/messages/zh-TW.json
+++ b/mealie/lang/messages/zh-TW.json
@@ -17,6 +17,6 @@
         "generic-updated": "{name} was updated",
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
-        "generic-deleted": "{name} has been created"
+        "generic-deleted": "{name} has been deleted"
     }
 }

--- a/mealie/routes/groups/controller_cookbooks.py
+++ b/mealie/routes/groups/controller_cookbooks.py
@@ -1,3 +1,4 @@
+import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -53,6 +54,9 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_created,
                 msg=self.t("notifications.generic-created", name=val.name),
+                event_source=json.dumps(
+                    {"event_type": "create", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
+                ),
             )
         return val
 
@@ -94,6 +98,9 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_updated,
                 msg=self.t("notifications.generic-updated", name=val.name),
+                event_source=json.dumps(
+                    {"event_type": "update", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
+                ),
             )
 
         return val
@@ -106,5 +113,8 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_deleted,
                 msg=self.t("notifications.generic-deleted", name=val.name),
+                event_source=json.dumps(
+                    {"event_type": "delete", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
+                ),
             )
         return val

--- a/mealie/routes/groups/controller_cookbooks.py
+++ b/mealie/routes/groups/controller_cookbooks.py
@@ -1,4 +1,3 @@
-import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -54,9 +53,12 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_created,
                 msg=self.t("notifications.generic-created", name=val.name),
-                event_source=json.dumps(
-                    {"event_type": "create", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "cookbook",
+                    "item_id": str(val.id),
+                    "slug": val.slug,
+                },
             )
         return val
 
@@ -98,9 +100,12 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_updated,
                 msg=self.t("notifications.generic-updated", name=val.name),
-                event_source=json.dumps(
-                    {"event_type": "update", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "cookbook",
+                    "item_id": str(val.id),
+                    "slug": val.slug,
+                },
             )
 
         return val
@@ -113,8 +118,11 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_deleted,
                 msg=self.t("notifications.generic-deleted", name=val.name),
-                event_source=json.dumps(
-                    {"event_type": "delete", "item_type": "cookbook", "item_id": str(val.id), "slug": val.slug}
-                ),
+                event_source={
+                    "event_type": "delete",
+                    "item_type": "cookbook",
+                    "item_id": str(val.id),
+                    "slug": val.slug,
+                },
             )
         return val

--- a/mealie/routes/groups/controller_cookbooks.py
+++ b/mealie/routes/groups/controller_cookbooks.py
@@ -8,7 +8,7 @@ from mealie.routes._base import BaseUserController, controller
 from mealie.routes._base.mixins import HttpRepo
 from mealie.schema import mapper
 from mealie.schema.cookbook import CreateCookBook, ReadCookBook, RecipeCookBook, SaveCookBook, UpdateCookBook
-from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_bus_service import EventBusService, EventSource
 from mealie.services.event_bus_service.message_types import EventTypes
 
 router = APIRouter(prefix="/groups/cookbooks", tags=["Groups: Cookbooks"])
@@ -53,12 +53,7 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_created,
                 msg=self.t("notifications.generic-created", name=val.name),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "cookbook",
-                    "item_id": str(val.id),
-                    "slug": val.slug,
-                },
+                event_source=EventSource(event_type="create", item_type="cookbook", item_id=val.id, slug=val.slug),
             )
         return val
 
@@ -100,12 +95,7 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_updated,
                 msg=self.t("notifications.generic-updated", name=val.name),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "cookbook",
-                    "item_id": str(val.id),
-                    "slug": val.slug,
-                },
+                event_source=EventSource(event_type="update", item_type="cookbook", item_id=val.id, slug=val.slug),
             )
 
         return val
@@ -118,11 +108,6 @@ class GroupCookbookController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.cookbook_deleted,
                 msg=self.t("notifications.generic-deleted", name=val.name),
-                event_source={
-                    "event_type": "delete",
-                    "item_type": "cookbook",
-                    "item_id": str(val.id),
-                    "slug": val.slug,
-                },
+                event_source=EventSource(event_type="delete", item_type="cookbook", item_id=val.id, slug=val.slug),
             )
         return val

--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -19,7 +19,7 @@ from mealie.schema.group.group_shopping_list import (
 from mealie.schema.mapper import cast
 from mealie.schema.query import GetAll
 from mealie.schema.response.responses import SuccessResponse
-from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_bus_service import EventBusService, EventSource
 from mealie.services.event_bus_service.message_types import EventTypes
 from mealie.services.group_services.shopping_lists import ShoppingListService
 
@@ -85,12 +85,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-created",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "shopping-list-item",
-                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                    "shopping_list_item_ids": [str(shopping_list_item.id)],
-                },
+                event_source=EventSource(
+                    event_type="create",
+                    item_type="shopping-list-item",
+                    item_id=shopping_list_item.id,
+                    shopping_list_id=shopping_list_item.shopping_list_id,
+                ),
             )
 
         return shopping_list_item
@@ -111,12 +111,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-updated",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "shopping-list-item",
-                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                    "shopping_list_item_ids": [str(shopping_list_item.id)],
-                },
+                event_source=EventSource(
+                    event_type="update",
+                    item_type="shopping-list-item",
+                    item_id=shopping_list_item.id,
+                    shopping_list_id=shopping_list_item.shopping_list_id,
+                ),
             )
 
         return shopping_list_item
@@ -133,12 +133,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-deleted",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source={
-                    "event_type": "delete",
-                    "item_type": "shopping-list-item",
-                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                    "shopping_list_item_ids": [str(shopping_list_item.id)],
-                },
+                event_source=EventSource(
+                    event_type="delete",
+                    item_type="shopping-list-item",
+                    item_id=shopping_list_item.id,
+                    shopping_list_id=shopping_list_item.shopping_list_id,
+                ),
             )
 
         return shopping_list_item
@@ -180,11 +180,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_created,
                 msg=self.t("notifications.generic-created", name=val.name),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "shopping-list",
-                    "item_id": str(val.id),
-                },
+                event_source=EventSource(
+                    event_type="create",
+                    item_type="shopping-list",
+                    item_id=val.id,
+                ),
             )
 
         return val
@@ -201,11 +201,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_updated,
                 msg=self.t("notifications.generic-updated", name=data.name),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "shopping-list",
-                    "item_id": str(data.id),
-                },
+                event_source=EventSource(
+                    event_type="update",
+                    item_type="shopping-list",
+                    item_id=data.id,
+                ),
             )
         return data
 
@@ -217,11 +217,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source={
-                    "event_type": "delete",
-                    "item_type": "shopping-list",
-                    "item_id": str(data.id),
-                },
+                event_source=EventSource(
+                    event_type="delete",
+                    item_type="shopping-list",
+                    item_id=data.id,
+                ),
             )
         return data
 
@@ -240,12 +240,12 @@ class ShoppingListController(BaseUserController):
                     "notifications.generic-updated",
                     name=shopping_list.name,
                 ),
-                event_source={
-                    "event_type": "create-and-update",
-                    "item_type": "shopping-list-item",
-                    "shopping_list_id": str(shopping_list.id),
-                    "shopping_list_item_ids": shopping_list_ids,
-                },
+                event_source=EventSource(
+                    event_type="bulk-updated-items",
+                    item_type="shopping-list",
+                    item_id=shopping_list.id,
+                    shopping_list_item_ids=shopping_list_ids,
+                ),
             )
 
         return shopping_list
@@ -262,12 +262,12 @@ class ShoppingListController(BaseUserController):
                     "notifications.generic-updated",
                     name=shopping_list.name,
                 ),
-                event_source={
-                    "event_type": "delete-and-update",
-                    "item_type": "shopping-list-item",
-                    "shopping_list_id": str(shopping_list.id),
-                    "shopping_list_item_ids": shopping_list_ids,
-                },
+                event_source=EventSource(
+                    event_type="bulk-updated-items",
+                    item_type="shopping-list",
+                    item_id=shopping_list.id,
+                    shopping_list_item_ids=shopping_list_ids,
+                ),
             )
 
         return shopping_list

--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -232,7 +232,6 @@ class ShoppingListController(BaseUserController):
     def add_recipe_ingredients_to_list(self, item_id: UUID4, recipe_id: UUID4):
         shopping_list = self.service.add_recipe_ingredients_to_list(item_id, recipe_id)
         if shopping_list:
-            shopping_list_ids = [str(shopping_list_item.id) for shopping_list_item in shopping_list.list_items]
             self.event_bus.dispatch(
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_updated,
@@ -244,7 +243,6 @@ class ShoppingListController(BaseUserController):
                     event_type="bulk-updated-items",
                     item_type="shopping-list",
                     item_id=shopping_list.id,
-                    shopping_list_item_ids=shopping_list_ids,
                 ),
             )
 
@@ -254,7 +252,6 @@ class ShoppingListController(BaseUserController):
     def remove_recipe_ingredients_from_list(self, item_id: UUID4, recipe_id: UUID4):
         shopping_list = self.service.remove_recipe_ingredients_from_list(item_id, recipe_id)
         if shopping_list:
-            shopping_list_ids = [str(shopping_list_item.id) for shopping_list_item in shopping_list.list_items]
             self.event_bus.dispatch(
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_updated,
@@ -266,7 +263,6 @@ class ShoppingListController(BaseUserController):
                     event_type="bulk-updated-items",
                     item_type="shopping-list",
                     item_id=shopping_list.id,
-                    shopping_list_item_ids=shopping_list_ids,
                 ),
             )
 

--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -1,3 +1,4 @@
+import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, Query
@@ -126,6 +127,13 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_created,
                 msg=self.t("notifications.generic-created", name=val.name),
+                event_source=json.dumps(
+                    {
+                        "event_type": "create",
+                        "item_type": "shopping-list",
+                        "item_id": str(val.id),
+                    }
+                ),
             )
 
         return val
@@ -142,6 +150,13 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_updated,
                 msg=self.t("notifications.generic-updated", name=data.name),
+                event_source=json.dumps(
+                    {
+                        "event_type": "update",
+                        "item_type": "shopping-list",
+                        "item_id": str(data.id),
+                    }
+                ),
             )
         return data
 
@@ -151,8 +166,15 @@ class ShoppingListController(BaseUserController):
         if data:
             self.event_bus.dispatch(
                 self.deps.acting_user.group_id,
-                EventTypes.shopping_list_updated,
+                EventTypes.shopping_list_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
+                event_source=json.dumps(
+                    {
+                        "event_type": "delete",
+                        "item_type": "shopping-list",
+                        "item_id": str(data.id),
+                    }
+                ),
             )
         return data
 

--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -1,4 +1,3 @@
-import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, Query
@@ -86,14 +85,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-created",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "create",
-                        "item_type": "shopping-list-item",
-                        "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                        "shopping_list_item_ids": [str(shopping_list_item.id)],
-                    }
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "shopping-list-item",
+                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
+                    "shopping_list_item_ids": [str(shopping_list_item.id)],
+                },
             )
 
         return shopping_list_item
@@ -114,14 +111,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-updated",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "update",
-                        "item_type": "shopping-list-item",
-                        "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                        "shopping_list_item_ids": [str(shopping_list_item.id)],
-                    }
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "shopping-list-item",
+                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
+                    "shopping_list_item_ids": [str(shopping_list_item.id)],
+                },
             )
 
         return shopping_list_item
@@ -138,14 +133,12 @@ class ShoppingListItemController(BaseUserController):
                     "notifications.generic-deleted",
                     name=f"An item on shopping list {shopping_list_item.shopping_list_id}",
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "delete",
-                        "item_type": "shopping-list-item",
-                        "shopping_list_id": str(shopping_list_item.shopping_list_id),
-                        "shopping_list_item_ids": [str(shopping_list_item.id)],
-                    }
-                ),
+                event_source={
+                    "event_type": "delete",
+                    "item_type": "shopping-list-item",
+                    "shopping_list_id": str(shopping_list_item.shopping_list_id),
+                    "shopping_list_item_ids": [str(shopping_list_item.id)],
+                },
             )
 
         return shopping_list_item
@@ -187,13 +180,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_created,
                 msg=self.t("notifications.generic-created", name=val.name),
-                event_source=json.dumps(
-                    {
-                        "event_type": "create",
-                        "item_type": "shopping-list",
-                        "item_id": str(val.id),
-                    }
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "shopping-list",
+                    "item_id": str(val.id),
+                },
             )
 
         return val
@@ -210,13 +201,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_updated,
                 msg=self.t("notifications.generic-updated", name=data.name),
-                event_source=json.dumps(
-                    {
-                        "event_type": "update",
-                        "item_type": "shopping-list",
-                        "item_id": str(data.id),
-                    }
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "shopping-list",
+                    "item_id": str(data.id),
+                },
             )
         return data
 
@@ -228,13 +217,11 @@ class ShoppingListController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.shopping_list_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source=json.dumps(
-                    {
-                        "event_type": "delete",
-                        "item_type": "shopping-list",
-                        "item_id": str(data.id),
-                    }
-                ),
+                event_source={
+                    "event_type": "delete",
+                    "item_type": "shopping-list",
+                    "item_id": str(data.id),
+                },
             )
         return data
 
@@ -253,14 +240,12 @@ class ShoppingListController(BaseUserController):
                     "notifications.generic-updated",
                     name=shopping_list.name,
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "create-and-update",
-                        "item_type": "shopping-list-item",
-                        "shopping_list_id": str(shopping_list.id),
-                        "shopping_list_item_ids": shopping_list_ids,
-                    }
-                ),
+                event_source={
+                    "event_type": "create-and-update",
+                    "item_type": "shopping-list-item",
+                    "shopping_list_id": str(shopping_list.id),
+                    "shopping_list_item_ids": shopping_list_ids,
+                },
             )
 
         return shopping_list
@@ -277,14 +262,12 @@ class ShoppingListController(BaseUserController):
                     "notifications.generic-updated",
                     name=shopping_list.name,
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "delete-and-update",
-                        "item_type": "shopping-list-item",
-                        "shopping_list_id": str(shopping_list.id),
-                        "shopping_list_item_ids": shopping_list_ids,
-                    }
-                ),
+                event_source={
+                    "event_type": "delete-and-update",
+                    "item_type": "shopping-list-item",
+                    "shopping_list_id": str(shopping_list.id),
+                    "shopping_list_item_ids": shopping_list_ids,
+                },
             )
 
         return shopping_list

--- a/mealie/routes/organizers/controller_categories.py
+++ b/mealie/routes/organizers/controller_categories.py
@@ -10,7 +10,7 @@ from mealie.schema.recipe import CategoryIn, RecipeCategoryResponse
 from mealie.schema.recipe.recipe import RecipeCategory
 from mealie.schema.recipe.recipe_category import CategoryBase, CategorySave
 from mealie.services import urls
-from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_bus_service import EventBusService, EventSource
 from mealie.services.event_bus_service.message_types import EventTypes
 
 router = APIRouter(prefix="/categories", tags=["Organizer: Categories"])
@@ -59,12 +59,7 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "category",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="create", item_type="category", item_id=data.id, slug=data.slug),
             )
         return data
 
@@ -90,12 +85,7 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "category",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="update", item_type="category", item_id=data.id, slug=data.slug),
             )
         return data
 
@@ -111,12 +101,7 @@ class RecipeCategoryController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.category_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source={
-                    "event_type": "delete",
-                    "item_type": "category",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="delete", item_type="category", item_id=data.id, slug=data.slug),
             )
 
     # =========================================================================

--- a/mealie/routes/organizers/controller_categories.py
+++ b/mealie/routes/organizers/controller_categories.py
@@ -1,3 +1,4 @@
+import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends
@@ -59,6 +60,9 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
+                event_source=json.dumps(
+                    {"event_type": "create", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
+                ),
             )
         return data
 
@@ -84,6 +88,9 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
+                event_source=json.dumps(
+                    {"event_type": "update", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
+                ),
             )
         return data
 
@@ -99,6 +106,9 @@ class RecipeCategoryController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.category_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
+                event_source=json.dumps(
+                    {"event_type": "delete", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
+                ),
             )
 
     # =========================================================================

--- a/mealie/routes/organizers/controller_categories.py
+++ b/mealie/routes/organizers/controller_categories.py
@@ -1,4 +1,3 @@
-import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends
@@ -60,9 +59,12 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "create", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "category",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
         return data
 
@@ -88,9 +90,12 @@ class RecipeCategoryController(BaseUserController):
                     name=data.name,
                     url=urls.category_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "update", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "category",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
         return data
 
@@ -106,9 +111,12 @@ class RecipeCategoryController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.category_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source=json.dumps(
-                    {"event_type": "delete", "item_type": "category", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "delete",
+                    "item_type": "category",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
 
     # =========================================================================

--- a/mealie/routes/organizers/controller_tags.py
+++ b/mealie/routes/organizers/controller_tags.py
@@ -1,3 +1,4 @@
+import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -58,6 +59,9 @@ class TagController(BaseUserController):
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
                 ),
+                event_source=json.dumps(
+                    {"event_type": "create", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
+                ),
             )
         return data
 
@@ -74,6 +78,9 @@ class TagController(BaseUserController):
                     "notifications.generic-updated-with-url",
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
+                ),
+                event_source=json.dumps(
+                    {"event_type": "update", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
                 ),
             )
         return data
@@ -94,6 +101,9 @@ class TagController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.tag_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
+                event_source=json.dumps(
+                    {"event_type": "delete", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
+                ),
             )
 
     @router.get("/slug/{tag_slug}", response_model=RecipeTagResponse)

--- a/mealie/routes/organizers/controller_tags.py
+++ b/mealie/routes/organizers/controller_tags.py
@@ -1,4 +1,3 @@
-import json
 from functools import cached_property
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -59,9 +58,7 @@ class TagController(BaseUserController):
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "create", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={"event_type": "create", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
             )
         return data
 
@@ -79,9 +76,7 @@ class TagController(BaseUserController):
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "update", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={"event_type": "update", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
             )
         return data
 
@@ -101,9 +96,7 @@ class TagController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.tag_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source=json.dumps(
-                    {"event_type": "delete", "item_type": "tag", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={"event_type": "delete", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
             )
 
     @router.get("/slug/{tag_slug}", response_model=RecipeTagResponse)

--- a/mealie/routes/organizers/controller_tags.py
+++ b/mealie/routes/organizers/controller_tags.py
@@ -10,7 +10,7 @@ from mealie.schema.recipe import RecipeTagResponse, TagIn
 from mealie.schema.recipe.recipe import RecipeTag
 from mealie.schema.recipe.recipe_category import TagSave
 from mealie.services import urls
-from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_bus_service import EventBusService, EventSource
 from mealie.services.event_bus_service.message_types import EventTypes
 
 router = APIRouter(prefix="/tags", tags=["Organizer: Tags"])
@@ -58,7 +58,7 @@ class TagController(BaseUserController):
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={"event_type": "create", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
+                event_source=EventSource(event_type="create", item_type="tag", item_id=data.id, slug=data.slug),
             )
         return data
 
@@ -76,7 +76,7 @@ class TagController(BaseUserController):
                     name=data.name,
                     url=urls.tag_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={"event_type": "update", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
+                event_source=EventSource(event_type="update", item_type="tag", item_id=data.id, slug=data.slug),
             )
         return data
 
@@ -96,7 +96,7 @@ class TagController(BaseUserController):
                 self.deps.acting_user.group_id,
                 EventTypes.tag_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source={"event_type": "delete", "item_type": "tag", "item_id": str(data.id), "slug": data.slug},
+                event_source=EventSource(event_type="delete", item_type="tag", item_id=data.id, slug=data.slug),
             )
 
     @router.get("/slug/{tag_slug}", response_model=RecipeTagResponse)

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -28,7 +28,7 @@ from mealie.schema.recipe.recipe_scraper import ScrapeRecipeTest
 from mealie.schema.recipe.request_helpers import RecipeZipTokenResponse, UpdateImageResponse
 from mealie.schema.response.responses import ErrorResponse
 from mealie.services import urls
-from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_bus_service import EventBusService, EventSource
 from mealie.services.event_bus_service.message_types import EventTypes
 from mealie.services.recipe.recipe_data_service import RecipeDataService
 from mealie.services.recipe.recipe_service import RecipeService
@@ -162,12 +162,9 @@ class RecipeController(BaseRecipeController):
                     name=new_recipe.name,
                     url=urls.recipe_url(new_recipe.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "recipe",
-                    "item_id": str(new_recipe.id),
-                    "slug": new_recipe.slug,
-                },
+                event_source=EventSource(
+                    event_type="create", item_type="recipe", item_id=new_recipe.id, slug=new_recipe.slug
+                ),
             )
 
         return new_recipe.slug
@@ -247,12 +244,9 @@ class RecipeController(BaseRecipeController):
                     name=new_recipe.name,
                     url=urls.recipe_url(new_recipe.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "create",
-                    "item_type": "recipe",
-                    "item_id": str(new_recipe.id),
-                    "slug": new_recipe.slug,
-                },
+                event_source=EventSource(
+                    event_type="create", item_type="recipe", item_id=new_recipe.id, slug=new_recipe.slug
+                ),
             )
 
         return new_recipe.slug
@@ -274,12 +268,7 @@ class RecipeController(BaseRecipeController):
                     name=data.name,
                     url=urls.recipe_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "recipe",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="update", item_type="recipe", item_id=data.id, slug=data.slug),
             )
 
         return data
@@ -301,12 +290,7 @@ class RecipeController(BaseRecipeController):
                     name=data.name,
                     url=urls.recipe_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source={
-                    "event_type": "update",
-                    "item_type": "recipe",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="update", item_type="recipe", item_id=data.id, slug=data.slug),
             )
 
         return data
@@ -324,12 +308,7 @@ class RecipeController(BaseRecipeController):
                 self.deps.acting_user.group_id,
                 EventTypes.recipe_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source={
-                    "event_type": "delete",
-                    "item_type": "recipe",
-                    "item_id": str(data.id),
-                    "slug": data.slug,
-                },
+                event_source=EventSource(event_type="delete", item_type="recipe", item_id=data.id, slug=data.slug),
             )
 
         return data

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,4 +1,3 @@
-import json
 from functools import cached_property
 from shutil import copyfileobj
 from zipfile import ZipFile
@@ -163,14 +162,12 @@ class RecipeController(BaseRecipeController):
                     name=new_recipe.name,
                     url=urls.recipe_url(new_recipe.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "create",
-                        "item_type": "recipe",
-                        "item_id": str(new_recipe.id),
-                        "slug": new_recipe.slug,
-                    }
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "recipe",
+                    "item_id": str(new_recipe.id),
+                    "slug": new_recipe.slug,
+                },
             )
 
         return new_recipe.slug
@@ -243,14 +240,12 @@ class RecipeController(BaseRecipeController):
                     name=new_recipe.name,
                     url=urls.recipe_url(new_recipe.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {
-                        "event_type": "create",
-                        "item_type": "recipe",
-                        "item_id": str(new_recipe.id),
-                        "slug": new_recipe.slug,
-                    }
-                ),
+                event_source={
+                    "event_type": "create",
+                    "item_type": "recipe",
+                    "item_id": str(new_recipe.id),
+                    "slug": new_recipe.slug,
+                },
             )
 
         return new_recipe.slug
@@ -272,9 +267,12 @@ class RecipeController(BaseRecipeController):
                     name=data.name,
                     url=urls.recipe_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "update", "item_type": "recipe", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "recipe",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
 
         return data
@@ -296,9 +294,12 @@ class RecipeController(BaseRecipeController):
                     name=data.name,
                     url=urls.recipe_url(data.slug, self.deps.settings.BASE_URL),
                 ),
-                event_source=json.dumps(
-                    {"event_type": "update", "item_type": "recipe", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "update",
+                    "item_type": "recipe",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
 
         return data
@@ -316,9 +317,12 @@ class RecipeController(BaseRecipeController):
                 self.deps.acting_user.group_id,
                 EventTypes.recipe_deleted,
                 msg=self.t("notifications.generic-deleted", name=data.name),
-                event_source=json.dumps(
-                    {"event_type": "delete", "item_type": "recipe", "item_id": str(data.id), "slug": data.slug}
-                ),
+                event_source={
+                    "event_type": "delete",
+                    "item_type": "recipe",
+                    "item_id": str(data.id),
+                    "slug": data.slug,
+                },
             )
 
         return data

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -72,7 +72,8 @@ class EventBusService:
 
                 self.publisher.publish(EventBusMessage.from_type(event_type, body=msg), urls)
 
-        self.bg.add_task(_dispatch(event_source=event_source))
+        if dispatch_task := _dispatch(event_source=event_source):
+            self.bg.add_task(dispatch_task)
 
     def test_publisher(self, url: str) -> None:
         self.bg.add_task(

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -17,7 +17,7 @@ class EventBusService:
         self._publisher = ApprisePublisher
         self.session = session
         self.group_id = None
-        self.event_source = None
+        self.event_source = ""
 
     @property
     def publisher(self) -> PublisherLike:
@@ -26,14 +26,14 @@ class EventBusService:
     def get_urls(self, event_type: EventTypes) -> list[str]:
         repos = AllRepositories(self.session)
 
-        notifiers: list[GroupEventNotifierPrivate] = repos.group_event_notifier.by_group(self.group_id).multi_query(
-            {"enabled": True}, override_schema=GroupEventNotifierPrivate
-        )
+        notifiers: list[GroupEventNotifierPrivate] = repos.group_event_notifier.by_group(  # type: ignore
+            self.group_id
+        ).multi_query({"enabled": True}, override_schema=GroupEventNotifierPrivate)
 
         return [notifier.apprise_url for notifier in notifiers if getattr(notifier.options, event_type.name)]
 
     def dispatch(self, group_id: UUID4, event_type: EventTypes, msg: str = "", event_source: str = "") -> None:
-        self.group_id = group_id
+        self.group_id = group_id  # type: ignore
         self.event_source = event_source
 
         def _dispatch():

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -17,7 +17,7 @@ class EventBusService:
         self._publisher = ApprisePublisher
         self.session = session
         self.group_id = None
-        self.event_source = ""
+        self.event_source: dict = {}
 
     @property
     def publisher(self) -> PublisherLike:
@@ -32,15 +32,22 @@ class EventBusService:
 
         return [notifier.apprise_url for notifier in notifiers if getattr(notifier.options, event_type.name)]
 
-    def dispatch(self, group_id: UUID4, event_type: EventTypes, msg: str = "", event_source: str = "") -> None:
+    def dispatch(self, group_id: UUID4, event_type: EventTypes, msg: str = "", event_source: dict = None) -> None:
         self.group_id = group_id  # type: ignore
+
+        if event_source is None:
+            event_source = {}
+
         self.event_source = event_source
 
         def _dispatch():
             if urls := self.get_urls(event_type):
                 if self.event_source:
                     urls = [
-                        EventBusService.merge_query_parameters(url, {"+mealie-event-source": self.event_source})
+                        # We use query params to add custom key: value pairs to the Apprise payload by prepending the key with ":".
+                        # As of 2022-11-06 this is undocumented, but discussed in this pull request:
+                        # https://github.com/caronc/apprise/pull/547
+                        EventBusService.merge_query_parameters(url, {f":{k}": v for k, v in self.event_source.items()})
                         for url in urls
                         if EventBusService.is_json_url(url)
                     ]

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -45,11 +45,10 @@ class EventBusService:
                 if self.event_source:
                     urls = [
                         # We use query params to add custom key: value pairs to the Apprise payload by prepending the key with ":".
-                        # As of 2022-11-06 this is undocumented, but discussed in this pull request:
-                        # https://github.com/caronc/apprise/pull/547
-                        EventBusService.merge_query_parameters(url, {f":{k}": v for k, v in self.event_source.items()})
+                        EventBusService.merge_query_parameters(url, {f":{k}": v for k, v in event_source.items()})
+                        # only JSON, XML, and HTTP Form endpoints support the custom key: value pairs, so we only apply them to those endpoints
+                        if EventBusService.is_custom_url(url) else url
                         for url in urls
-                        if EventBusService.is_json_url(url)
                     ]
 
                 self.publisher.publish(EventBusMessage.from_type(event_type, body=msg), urls)
@@ -75,5 +74,5 @@ class EventBusService:
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
 
     @staticmethod
-    def is_json_url(url: str):
-        return url.split(":", 1)[0].lower() in ["json", "jsons"]
+    def is_custom_url(url: str):
+        return url.split(":", 1)[0].lower() in ["form", "forms", "json", "jsons", "xml", "xmls"]

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -16,6 +16,10 @@ def random_bool() -> bool:
     return bool(random.getrandbits(1))
 
 
+def random_int(min=-4294967296, max=4294967296) -> int:
+    return random.randint(min, max)
+
+
 def user_registration_factory(advanced=None, private=None) -> CreateUserRegistration:
     return CreateUserRegistration(
         group=random_string(),


### PR DESCRIPTION
Overview
---
While the existing Apprise notification implementation works great for general use, it's not as useful for programmatic use. This PR adds programmatic data to the [Apprise custom JSON notification](https://github.com/caronc/apprise/wiki/Notify_Custom_JSON) implementation. This was done to solve for [feature request #1350](https://github.com/hay-kot/mealie/discussions/1350).

Functional changes
---
When a user creates a notification using either the `json://` or `jsons://` endpoint, the message contains a custom `mealie-event-source` header. As an example, here is the `mealie-event-source` header for when a new recipe is created:
```json
{
   "event_type":"create",
   "item_type":"recipe",
   "item_id":"b13a63a1-66a1-46f6-941d-544bcd87f950",
   "slug":"pasta-fagioli"
}
```

This is implemented for all existing CRUD events (recipies, cookbooks, categories, tags, and shopping lists).

---

The event listener for shopping lists has been extended to include CRUD operations for shopping list items. The event source header is a bit more customized to accommodate this:
```json
{
   "event_type":"update",
   "item_type":"shopping-list-item",
   "shopping_list_id":"bca4bb04-0d6a-490f-84ad-09627d3a0a1f",
   "shopping_list_item_ids":[
      "9c81e510-9935-4742-899e-823ce9f7c5c2"
   ]
}
```

In order to avoid reworking the API for adding and removing recipe ingredients to a shopping list, the shopping list id and all shopping list item ids are added to the header, _**not just the ones that were modified**_. A different event type is used to convey this:
```json
{
   "event_type":"create-and-update",
   "item_type":"shopping-list-item",
   "shopping_list_id":"bca4bb04-0d6a-490f-84ad-09627d3a0a1f",
   "shopping_list_item_ids":[
      "9c81e510-9935-4742-899e-823ce9f7c5c2",
      "b9f3c293-0ac8-4c72-8c94-27593ad2ce77",
      "9055eabb-0141-4e95-b112-01fe0ccf3739"
   ]
}
```

Implementation
---
To achieve this, a new `event_source` arg was added to the `event_bus.dispatch` function. The dispatch function is updated to add the event source JSON data to the headers as a URL param (per the Apprise docs):
```python
def dispatch(self, group_id: UUID4, event_type: EventTypes, msg: str = "", event_source: str = "") -> None:
    self.group_id = group_id
    self.event_source = event_source

    def _dispatch():
        if urls := self.get_urls(event_type):

            # this is where we add the mealie-event-source header
            if self.event_source:
                urls = [
                    EventBusService.merge_query_parameters(url, {"+mealie-event-source": self.event_source})
                    for url in urls
                    if EventBusService.is_json_url(url)
                ]

            self.publisher.publish(EventBusMessage.from_type(event_type, body=msg), urls)

    self.bg.add_task(_dispatch)
```

What's Next?
---
The shopping list items are a bit of a hack; ideally the user is able to subscribe to just shopping list events, just shopping list item events, or both. However, this would require a database change and some frontend changes.

When a full recipe is added or removed to/from a shopping list, the API doesn't return the details of which items were impacted, it just returns the shopping list in its new state (including all items). A more proper solution would be to either send a mixed header (items a/b/c were created and items d/e/f were updated) or send two events: one for each CRUD operation. This requires a re-write of the relevant bits of the shopping list API and its dependencies. 

