### PR TITLE
Implemented "order by" API parameters for recipe, food, and unit queries

### DIFF
--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -67,7 +67,8 @@ class RepositoryGeneric(Generic[Schema, Model]):
         q = self._query().filter_by(**fltr)
 
         if order_by:
-            if order_attr := getattr(self.model, str(order_by)):
+            try:
+                order_attr = getattr(self.model, str(order_by))
                 if order_descending:
                     order_attr = order_attr.desc()
 
@@ -75,6 +76,9 @@ class RepositoryGeneric(Generic[Schema, Model]):
                     order_attr = order_attr.asc()
 
                 q = q.order_by(order_attr)
+
+            except AttributeError:
+                self.logger.info(f'Attempted to sort by unknown sort property "{order_by}"; ignoring')
 
         return [eff_schema.from_orm(x) for x in q.offset(start).limit(limit).all()]
 

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -56,7 +56,9 @@ class RepositoryGeneric(Generic[Schema, Model]):
 
         return {**dct, **kwargs}
 
-    def get_all(self, limit: int = None, order_by: str = None, start=0, override=None) -> list[Schema]:
+    def get_all(
+        self, limit: int = None, order_by: str = None, order_descending: bool = True, start=0, override=None
+    ) -> list[Schema]:
         # sourcery skip: remove-unnecessary-cast
         eff_schema = override or self.schema
 
@@ -66,7 +68,12 @@ class RepositoryGeneric(Generic[Schema, Model]):
 
         if order_by:
             if order_attr := getattr(self.model, str(order_by)):
-                order_attr = order_attr.desc()
+                if order_descending:
+                    order_attr = order_attr.desc()
+
+                else:
+                    order_attr = order_attr.asc()
+
                 q = q.order_by(order_attr)
 
         return [eff_schema.from_orm(x) for x in q.offset(start).limit(limit).all()]

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -90,7 +90,9 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
             override_schema=override_schema,
         )
 
-    def summary(self, group_id, start=0, limit=99999, load_foods=False) -> Any:
+    def summary(
+        self, group_id, start=0, limit=99999, load_foods=False, order_by="date_added", order_descending=True
+    ) -> Any:
         args = [
             joinedload(RecipeModel.recipe_category),
             joinedload(RecipeModel.tags),
@@ -100,11 +102,23 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
         if load_foods:
             args.append(joinedload(RecipeModel.recipe_ingredient).options(joinedload(RecipeIngredient.food)))
 
+        try:
+            order_attr = getattr(RecipeModel, order_by)
+        except AttributeError:
+            self.logger.info(f'Attempted to sort by unknown sort property "{order_by}"')
+            order_attr = RecipeModel.date_added
+
+        if order_descending:
+            order_attr = order_by.desc()
+
+        else:
+            order_attr = order_by.asc()
+
         return (
             self.session.query(RecipeModel)
             .options(*args)
             .filter(RecipeModel.group_id == group_id)
-            .order_by(RecipeModel.date_added.desc())
+            .order_by(order_attr)
             .offset(start)
             .limit(limit)
             .all()

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -103,9 +103,13 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
             args.append(joinedload(RecipeModel.recipe_ingredient).options(joinedload(RecipeIngredient.food)))
 
         try:
-            order_attr = getattr(RecipeModel, order_by)
+            if order_by:
+                order_attr = getattr(RecipeModel, order_by)
+            else:
+                order_attr = RecipeModel.date_added
+
         except AttributeError:
-            self.logger.info(f'Attempted to sort by unknown sort property "{order_by}"')
+            self.logger.info(f'Attempted to sort by unknown sort property "{order_by}"; ignoring')
             order_attr = RecipeModel.date_added
 
         if order_descending:

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -109,10 +109,10 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
             order_attr = RecipeModel.date_added
 
         if order_descending:
-            order_attr = order_by.desc()
+            order_attr = order_attr.desc()
 
         else:
-            order_attr = order_by.asc()
+            order_attr = order_attr.asc()
 
         return (
             self.session.query(RecipeModel)

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -194,7 +194,14 @@ class RecipeController(BaseRecipeController):
 
     @router.get("", response_model=list[RecipeSummary])
     def get_all(self, q: RecipeGetAll = Depends(RecipeGetAll)):
-        items = self.repo.summary(self.user.group_id, start=q.start, limit=q.limit, load_foods=q.load_food)
+        items = self.repo.summary(
+            self.user.group_id,
+            start=q.start,
+            limit=q.limit,
+            load_foods=q.load_food,
+            order_by=q.order_by,
+            order_descending=q.order_descending,
+        )
 
         new_items = []
         for item in items:

--- a/mealie/routes/unit_and_foods/foods.py
+++ b/mealie/routes/unit_and_foods/foods.py
@@ -39,7 +39,7 @@ class IngredientFoodsController(BaseUserController):
 
     @router.get("", response_model=list[IngredientFood])
     def get_all(self, q: GetAll = Depends(GetAll)):
-        return self.repo.get_all(start=q.start, limit=q.limit)
+        return self.repo.get_all(start=q.start, limit=q.limit, order_by=q.order_by, order_descending=q.order_descending)
 
     @router.post("", response_model=IngredientFood, status_code=201)
     def create_one(self, data: CreateIngredientFood):

--- a/mealie/routes/unit_and_foods/units.py
+++ b/mealie/routes/unit_and_foods/units.py
@@ -39,7 +39,7 @@ class IngredientUnitsController(BaseUserController):
 
     @router.get("", response_model=list[IngredientUnit])
     def get_all(self, q: GetAll = Depends(GetAll)):
-        return self.repo.get_all(start=q.start, limit=q.limit)
+        return self.repo.get_all(start=q.start, limit=q.limit, order_by=q.order_by, order_descending=q.order_descending)
 
     @router.post("", response_model=IngredientUnit, status_code=201)
     def create_one(self, data: CreateIngredientUnit):

--- a/mealie/schema/query.py
+++ b/mealie/schema/query.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from mealie.schema._mealie import MealieModel
 
 
 class GetAll(MealieModel):
     start: int = 0
     limit: int = 999
-    order_by: str = "date_added"
-    order_descending: bool = True
+    order_by: Optional[str]
+    order_descending: Optional[bool] = True

--- a/mealie/schema/query.py
+++ b/mealie/schema/query.py
@@ -4,3 +4,5 @@ from mealie.schema._mealie import MealieModel
 class GetAll(MealieModel):
     start: int = 0
     limit: int = 999
+    order_by: str = "date_added"
+    order_descending: bool = True


### PR DESCRIPTION
Added two new parameters for `get_all` queries:
`orderBy` - allows for sorting by any valid property name (e.g. `name` or `description`)
`orderDescending` - boolean toggle for the order direction

I figure someone can utilize these to implement sorting & paging on the frontend. This also enables incremental syncs by sorting by "dateUpdated".