### PR TITLE
Fix for erroneously-translated datetime config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,8 +2,6 @@ preserve_hierarchy: false
 files:
   - source: /frontend/lang/messages/en-US.json
     translation: /frontend/lang/messages/%locale%.json
-  - source: /frontend/lang/dateTimeFormats/en-US.json
-    translation: /frontend/lang/dateTimeFormats/%locale%.json
   - source: /mealie/lang/messages/en-US.json
     translation: /mealie/lang/messages/%locale%.json
   - source: /mealie/repos/seed/resources/foods/locales/en-US.json

--- a/frontend/lang/dateTimeFormats/da-DK.json
+++ b/frontend/lang/dateTimeFormats/da-DK.json
@@ -1,21 +1,21 @@
 {
   "short": {
-    "month": "kort",
-    "day": "numerisk",
-    "weekday": "lang"
+    "month": "short",
+    "day": "numeric",
+    "weekday": "long"
   },
   "medium": {
-    "month": "lang",
-    "day": "numerisk",
-    "weekday": "lang",
-    "year": "numerisk"
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "year": "numeric"
   },
   "long": {
-    "year": "numerisk",
-    "month": "lang",
-    "day": "numerisk",
-    "weekday": "lang",
-    "hour": "numerisk",
-    "minute": "numerisk"
+    "year": "numeric",
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "hour": "numeric",
+    "minute": "numeric"
   }
 }

--- a/frontend/lang/dateTimeFormats/de-DE.json
+++ b/frontend/lang/dateTimeFormats/de-DE.json
@@ -1,21 +1,21 @@
 {
   "short": {
-    "month": "kurz",
-    "day": "numerisch",
-    "weekday": "lang"
+    "month": "short",
+    "day": "numeric",
+    "weekday": "long"
   },
   "medium": {
-    "month": "lang",
-    "day": "numerisch",
-    "weekday": "lang",
-    "year": "numerisch"
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "year": "numeric"
   },
   "long": {
-    "year": "numerisch",
-    "month": "lang",
-    "day": "numerisch",
-    "weekday": "lang",
-    "hour": "numerisch",
-    "minute": "numerisch"
+    "year": "numeric",
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "hour": "numeric",
+    "minute": "numeric"
   }
 }

--- a/frontend/lang/dateTimeFormats/it-IT.json
+++ b/frontend/lang/dateTimeFormats/it-IT.json
@@ -1,21 +1,21 @@
 {
   "short": {
-    "month": "breve",
-    "day": "numerico",
-    "weekday": "lungo"
+    "month": "short",
+    "day": "numeric",
+    "weekday": "long"
   },
   "medium": {
-    "month": "lungo",
-    "day": "numerico",
-    "weekday": "lungo",
-    "year": "numerico"
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "year": "numeric"
   },
   "long": {
     "year": "numeric",
-    "month": "lungo",
-    "day": "numerico",
-    "weekday": "lungo",
-    "hour": "numerico",
-    "minute": "numerico"
+    "month": "long",
+    "day": "numeric",
+    "weekday": "long",
+    "hour": "numeric",
+    "minute": "numeric"
   }
 }

--- a/frontend/lang/dateTimeFormats/uk-UA.json
+++ b/frontend/lang/dateTimeFormats/uk-UA.json
@@ -1,21 +1,21 @@
 {
   "short": {
     "month": "short",
-    "day": "числовий",
+    "day": "numeric",
     "weekday": "long"
   },
   "medium": {
     "month": "long",
-    "day": "числовий",
+    "day": "numeric",
     "weekday": "long",
-    "year": "числовий"
+    "year": "numeric"
   },
   "long": {
-    "year": "числовий",
+    "year": "numeric",
     "month": "long",
-    "day": "числовий",
+    "day": "numeric",
     "weekday": "long",
-    "hour": "числовий",
-    "minute": "числовий"
+    "hour": "numeric",
+    "minute": "numeric"
   }
 }


### PR DESCRIPTION
Following up on issue #1361, it looks like some vue datetime formats were translated by accident. These are config options so they need to be in English (they still render the text in their respective languages).