### PR TITLE
Fix: increased float rounding precision for CRF parser

### DIFF
--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -74,7 +74,7 @@ class RecipeIngredient(MealieModel):
         empty string.
         """
         if isinstance(value, float):
-            return value
+            return round(value, 3)
         if value is None or value == "":
             return None
         return value

--- a/mealie/services/parser_services/crfpp/processor.py
+++ b/mealie/services/parser_services/crfpp/processor.py
@@ -37,7 +37,7 @@ class CRFIngredient(BaseModel):
             # Check if other contains a fraction
             try:
                 if values["other"] is not None and values["other"].find("/") != -1:
-                    return float(Fraction(values["other"])).__round__(1)
+                    return round(float(Fraction(values["other"])), 3)
                 else:
                     return 1
             except Exception:

--- a/mealie/services/parser_services/ingredient_parser.py
+++ b/mealie/services/parser_services/ingredient_parser.py
@@ -74,7 +74,7 @@ class NLPParser(ABCIngredientParser):
                 unit=CreateIngredientUnit(name=crf_model.unit),
                 food=CreateIngredientFood(name=crf_model.name),
                 disable_amount=False,
-                quantity=float(sum(Fraction(s) for s in crf_model.qty.split())),
+                quantity=float(sum(Fraction(s).limit_denominator(32) for s in crf_model.qty.split())),
             )
         except Exception as e:
             logger.error(f"Failed to parse ingredient: {crf_model}: {e}")

--- a/tests/unit_tests/test_ingredient_parser.py
+++ b/tests/unit_tests/test_ingredient_parser.py
@@ -26,8 +26,12 @@ def crf_exists() -> bool:
 test_ingredients = [
     TestIngredient("½ cup all-purpose flour", 0.5, "cup", "all-purpose flour", ""),
     TestIngredient("1 ½ teaspoons ground black pepper", 1.5, "teaspoon", "black pepper", "ground"),
-    TestIngredient("⅔ cup unsweetened flaked coconut", 0.7, "cup", "coconut", "unsweetened flaked"),
-    TestIngredient("⅓ cup panko bread crumbs", 0.3, "cup", "panko bread crumbs", ""),
+    TestIngredient("⅔ cup unsweetened flaked coconut", 0.667, "cup", "coconut", "unsweetened flaked"),
+    TestIngredient("⅓ cup panko bread crumbs", 0.333, "cup", "panko bread crumbs", ""),
+    # Small Fraction Tests - PR #1369
+    # Reported error is was for 1/8 - new lowest expected threshold is 1/32
+    TestIngredient("1/8 cup all-purpose flour", 0.125, "cup", "all-purpose flour", ""),
+    TestIngredient("1/32 cup all-purpose flour", 0.03125, "cup", "all-purpose flour", ""),
 ]
 
 


### PR DESCRIPTION
Issue raised in #1358: the CRF parser rounds the float value to the nearest 1/10; this causes issues for smaller fractions. I increased the precision to 3, which is accurate down to increments of 1/32.

I also limited the denominator to a max of 32 to prevent float precision artifacts like 5980780305148019/72057594037927936 (which is really just 1/12).

Full disclosure: I'm having trouble getting the CRF parser running in dev, so I instead emulated the process locally. Since it's all built-in decimal handling it shouldn't matter, but it's worth checking a few test cases in dev before merging (such as the one mentioned in #1358).