### PR TITLE
Avoid page breaks in sections when printing recipes and other CSS tweaks

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -20,10 +20,7 @@
       <div v-for="(ingredientSection, sectionIndex) in ingredientSections" :key="`ingredient-section-${sectionIndex}`" class="print-section">
         <div class="ingredient-grid">
           <template v-for="(ingredient, ingredientIndex) in ingredientSection.ingredients">
-            <div v-if="ingredient.title" :key="`ingredient-title-${ingredientIndex}`" class="ingredient-title mt-2">
-              <h4>{{ ingredient.title }}</h4>
-              <hr />
-            </div>
+            <h4 v-if="ingredient.title" :key="`ingredient-title-${ingredientIndex}`" class="ingredient-title mt-2">{{ ingredient.title }}</h4>
             <p :key="`ingredient-${ingredientIndex}`" v-html="parseText(ingredient)" class="ingredient-body" />
           </template>
         </div>
@@ -36,11 +33,8 @@
       <div v-for="(instructionSection, sectionIndex) in instructionSections" :key="`instruction-section-${sectionIndex}`" :class="{ 'print-section': instructionSection.sectionName }">
         <div v-for="(step, stepIndex) in instructionSection.instructions" :key="`instruction-${stepIndex}`">
           <div class="print-section">
-            <div v-if="step.title" :key="`instruction-title-${stepIndex}`" class="mb-2">
-              <h3>{{ step.title }}</h3>
-              <hr />
-            </div>
-            <h4>{{ $t("recipe.step-index", { step: stepIndex + instructionSection.stepOffset + 1 }) }}</h4>
+            <h4 v-if="step.title" :key="`instruction-title-${stepIndex}`" class="instruction-title mb-2">{{ step.title }}</h4>
+            <h5>{{ $t("recipe.step-index", { step: stepIndex + instructionSection.stepOffset + 1 }) }}</h5>
             <VueMarkdown :source="step.text" class="recipe-step-body" />
           </div>
         </div>
@@ -235,8 +229,15 @@ p {
 }
 
 .ingredient-title,
-.ingredient-title >>> * {
+.instruction-title {
   grid-column: 1 / span 2;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+ {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .ingredient-body, .recipe-step-body, .note-body {

--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -235,11 +235,6 @@ p {
   text-underline-offset: 4px;
 }
 
- {
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
 .ingredient-body, .recipe-step-body, .note-body {
   font-size: 14px;
 }

--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -17,31 +17,45 @@
     <!-- Ingredients -->
     <section>
       <v-card-title class="headline pl-0"> {{ $t("recipe.ingredients") }} </v-card-title>
+      <div v-for="(ingredientSection, sectionIndex) in ingredientSections" :key="`ingredient-section-${sectionIndex}`" class="print-section">
       <div class="ingredient-grid">
-        <template v-for="(ingredient, index) in recipe.recipeIngredient">
-          <h4 v-if="ingredient.title" :key="`title-${index}`" class="ingredient-title mt-2">{{ ingredient.title }}</h4>
-          <p :key="`ingredient-${index}`" v-html="parseText(ingredient)" />
+          <template v-for="(ingredient, ingredientIndex) in ingredientSection.ingredients">
+            <div v-if="ingredient.title" :key="`ingredient-title-${ingredientIndex}`" class="ingredient-title mt-2">
+              <h4>{{ ingredient.title }}</h4>
+              <hr />
+            </div>
+            <p :key="`ingredient-${ingredientIndex}`" v-html="parseText(ingredient)" class="ingredient-body" />
         </template>
+      </div>
       </div>
     </section>
 
+    <!-- Instructions -->
     <section>
       <v-card-title class="headline pl-0">{{ $t("recipe.instructions") }}</v-card-title>
-      <div v-for="(step, index) in recipe.recipeInstructions" :key="index">
-        <h3 v-if="step.title" class="mb-2">{{ step.title }}</h3>
-        <div class="ml-5">
-          <h4>{{ $t("recipe.step-index", { step: index + 1 }) }}</h4>
-          <VueMarkdown :source="step.text" />
+      <div v-for="(instructionSection, sectionIndex) in instructionSections" :key="`instruction-section-${sectionIndex}`" :class="{ 'print-section': instructionSection.sectionName }">
+        <div v-for="(step, stepIndex) in instructionSection.instructions" :key="`instruction-${stepIndex}`">
+          <div class="print-section">
+            <div v-if="step.title" :key="`instruction-title-${stepIndex}`" class="mb-2">
+              <h3>{{ step.title }}</h3>
+              <hr />
+            </div>
+            <h4>{{ $t("recipe.step-index", { step: stepIndex + instructionSection.stepOffset + 1 }) }}</h4>
+            <VueMarkdown :source="step.text" class="recipe-step-body" />
+          </div>
         </div>
       </div>
     </section>
 
+    <!-- Notes -->
     <v-divider v-if="hasNotes" class="grey my-4"></v-divider>
 
     <section>
       <div v-for="(note, index) in recipe.notes" :key="index + 'note'">
+        <div class="print-section">
         <h4>{{ note.title }}</h4>
-        <VueMarkdown :source="note.text" />
+          <VueMarkdown :source="note.text" class="note-body" />
+        </div>
       </div>
     </section>
   </div>
@@ -215,7 +229,8 @@ p {
   grid-gap: 0.5rem;
 }
 
-.ingredient-title {
+.ingredient-title,
+.ingredient-title >>> * {
   grid-column: 1 / span 2;
 }
 

--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -55,6 +55,17 @@ import RecipeTimeCard from "~/components/Domain/Recipe/RecipeTimeCard.vue";
 import { Recipe, RecipeIngredient } from "~/types/api-types/recipe";
 import { parseIngredientText } from "~/composables/recipes";
 
+type IngredientSection = {
+  sectionName: string;
+  ingredients: RecipeIngredient[];
+};
+
+type InstructionSection = {
+  sectionName: string;
+  stepOffset: number;
+  instructions: RecipeStep[];
+};
+
 export default defineComponent({
   components: {
     RecipeTimeCard,
@@ -67,6 +78,72 @@ export default defineComponent({
     },
   },
   setup(props) {
+
+    // Group ingredients by section so we can style them independently
+    const ingredientSections = computed<IngredientSection[]>(() => {
+      const ingredientSections:IngredientSection[] = [];
+      const sectionIndexes:number[] = [];
+
+      // Store indexes of each new section
+      for (let i = 0; i < props.recipe.recipeIngredient.length; i++) {
+        if (props.recipe.recipeIngredient[i].title) {
+          sectionIndexes.push(i);
+        }
+      }
+      sectionIndexes.push(props.recipe.recipeIngredient.length);
+
+      // Make sure the first element is 0, otherwise we lose the first section of ingredients
+      if (sectionIndexes[0] !== 0) {
+        sectionIndexes.unshift(0);
+      }
+
+      // Create sections by slicing between section indexes
+      for (let i = 0; i < sectionIndexes.length - 1; i++) {
+        const startIndex:number = sectionIndexes[i];
+        const endIndex:number = sectionIndexes[i + 1];
+        const ingredientSection:IngredientSection = {
+          sectionName: props.recipe.recipeIngredient[startIndex].title,
+          ingredients: props.recipe.recipeIngredient.slice(startIndex, endIndex)
+        };
+        ingredientSections.push(ingredientSection);
+      }
+
+      return ingredientSections;
+    });
+
+    // Group instructions by section so we can style them independently
+    const instructionSections = computed<InstructionSection[]>(() => {
+      const instructionSections:InstructionSection[] = [];
+      const sectionIndexes:number[] = [];
+
+      // Store indexes of each new section
+      for (let i = 0; i < props.recipe.recipeInstructions.length; i++) {
+        if (props.recipe.recipeInstructions[i].title) {
+          sectionIndexes.push(i);
+        }
+      }
+      sectionIndexes.push(props.recipe.recipeInstructions.length);
+
+      // Make sure the first element is 0, otherwise we lose the first section of instructions
+      if (sectionIndexes[0] !== 0) {
+        sectionIndexes.unshift(0);
+      }
+
+      // Create sections by slicing between section indexes
+      for (let i = 0; i < sectionIndexes.length - 1; i++) {
+        const startIndex:number = sectionIndexes[i];
+        const endIndex:number = sectionIndexes[i + 1];
+        const instructionSection:InstructionSection = {
+          sectionName: props.recipe.recipeInstructions[startIndex].title,
+          stepOffset: startIndex,
+          instructions: props.recipe.recipeInstructions.slice(startIndex, endIndex)
+        };
+        instructionSections.push(instructionSection);
+      }
+
+      return instructionSections;
+    });
+
     const hasNotes = computed(() => {
       return props.recipe.notes && props.recipe.notes.length > 0;
     });
@@ -79,6 +156,8 @@ export default defineComponent({
       hasNotes,
       parseText,
       parseIngredientText,
+      ingredientSections,
+      instructionSections,
     };
   },
 });

--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -52,7 +52,7 @@ import { defineComponent, computed } from "@nuxtjs/composition-api";
 // @ts-ignore vue-markdown has no types
 import VueMarkdown from "@adapttive/vue-markdown";
 import RecipeTimeCard from "~/components/Domain/Recipe/RecipeTimeCard.vue";
-import { Recipe, RecipeIngredient } from "~/types/api-types/recipe";
+import { Recipe, RecipeIngredient, RecipeStep } from "~/types/api-types/recipe";
 import { parseIngredientText } from "~/composables/recipes";
 
 type IngredientSection = {

--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -18,15 +18,15 @@
     <section>
       <v-card-title class="headline pl-0"> {{ $t("recipe.ingredients") }} </v-card-title>
       <div v-for="(ingredientSection, sectionIndex) in ingredientSections" :key="`ingredient-section-${sectionIndex}`" class="print-section">
-      <div class="ingredient-grid">
+        <div class="ingredient-grid">
           <template v-for="(ingredient, ingredientIndex) in ingredientSection.ingredients">
             <div v-if="ingredient.title" :key="`ingredient-title-${ingredientIndex}`" class="ingredient-title mt-2">
               <h4>{{ ingredient.title }}</h4>
               <hr />
             </div>
             <p :key="`ingredient-${ingredientIndex}`" v-html="parseText(ingredient)" class="ingredient-body" />
-        </template>
-      </div>
+          </template>
+        </div>
       </div>
     </section>
 
@@ -53,7 +53,7 @@
     <section>
       <div v-for="(note, index) in recipe.notes" :key="index + 'note'">
         <div class="print-section">
-        <h4>{{ note.title }}</h4>
+          <h4>{{ note.title }}</h4>
           <VueMarkdown :source="note.text" class="note-body" />
         </div>
       </div>
@@ -201,16 +201,21 @@ export default defineComponent({
 </style>
 
 <style scoped>
+/* Makes all text solid black */
 .print-container {
   display: none;
   background-color: white;
 }
 
-/* Makes all text solid black */
 .print-container,
 .print-container >>> * {
   opacity: 1 !important;
   color: black !important;
+}
+
+/* Prevents sections from being broken up between pages */
+.print-section {
+  page-break-inside: avoid;
 }
 
 p {
@@ -232,6 +237,10 @@ p {
 .ingredient-title,
 .ingredient-title >>> * {
   grid-column: 1 / span 2;
+}
+
+.ingredient-body, .recipe-step-body, .note-body {
+  font-size: 14px;
 }
 
 ul {


### PR DESCRIPTION
A user posted a delicious looking vegan ramen recipe to the discord, so I imported it into Mealie. It's a monster of a recipe, with 35 ingredients and 16 steps.

After parsing it and categorizing everything, I was unhappy with the print view at this scale. It was readable, but sections were broken up between pages (and some steps were cut in half) and overall it was pretty unwieldly if I were to try to cook it.

With this recipe as a base I made the following broad changes:
- brought back the sections computed property from PR #1351 that we cut as it was no longer needed
- wrapped each ingredient section, instruction section in a new class that avoids being split between two pages
- visually grouped each section with stronger headers
- tweaked the CSS to fit a bit more content on a page

And I'm pretty happy with the results. There's probably still room to improve some things, but the `page-break-inside: avoid;` CSS attribute makes printing much more consistent.

Here's a before and after on the recipe in question:
[Current View - Ultimate Vegan Ramen Recipe With Miso Broth.pdf](https://github.com/hay-kot/mealie/files/8886239/Current.View.-.Ultimate.Vegan.Ramen.Recipe.With.Miso.Broth.pdf)
[New View - Ultimate Vegan Ramen Recipe With Miso Broth.pdf](https://github.com/hay-kot/mealie/files/8886240/New.View.-.Ultimate.Vegan.Ramen.Recipe.With.Miso.Broth.pdf)

And I checked a couple of more basic recipes to make sure it still looks good. If there is no section title for the instructions, it treats each step as its own section (otherwise longer recipes with no instruction sections would always start on page 2).
[New View - Simple Honey Glazed Baby Carrots Recipe.pdf](https://github.com/hay-kot/mealie/files/8886249/New.View.-.Simple.Honey.Glazed.Baby.Carrots.Recipe.pdf)

