### PR TITLE
fix: squashed bug with infinite scroll

### DIFF
--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -12,7 +12,7 @@
     </v-fade-transition>
   </v-container>
 </template>
-  
+
 <script lang="ts">
 import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 import { useThrottleFn } from "@vueuse/core";
@@ -23,8 +23,9 @@ export default defineComponent({
   components: { RecipeCardSection },
   setup() {
     const start = ref(0);
-    const limit = ref(30);
     const increment = ref(30);
+    const offset = ref(increment.value);
+    const limit = ref(increment.value);
     const ready = ref(false);
     const loading = ref(false);
 
@@ -40,8 +41,8 @@ export default defineComponent({
         return;
       }
       loading.value = true;
-      start.value = limit.value + 1;
-      limit.value = limit.value + increment.value;
+      start.value = offset.value + 1;
+      offset.value = offset.value + increment.value;
       fetchMore(start.value, limit.value);
       loading.value = false;
     }, 500);
@@ -64,4 +65,3 @@ export default defineComponent({
   },
 });
 </script>
-  

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -24,6 +24,7 @@ export default defineComponent({
   components: { RecipeCardSection },
   setup() {
     const start = ref(0);
+    const offset = ref(30);
     const limit = ref(30);
     const increment = ref(30);
     const ready = ref(false);
@@ -41,8 +42,8 @@ export default defineComponent({
         return;
       }
       loading.value = true;
-      start.value = limit.value + 1;
-      limit.value = limit.value + increment.value;
+      start.value = offset.value + 1;
+      offset.value = offset.value + increment.value;
       fetchMore(start.value, limit.value);
       loading.value = false;
     }, 500);

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -24,9 +24,9 @@ export default defineComponent({
   components: { RecipeCardSection },
   setup() {
     const start = ref(0);
-    const offset = ref(30);
-    const limit = ref(30);
     const increment = ref(30);
+    const offset = ref(increment.value);
+    const limit = ref(increment.value);
     const ready = ref(false);
     const loading = ref(false);
 

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -19,6 +19,7 @@ import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 import { useThrottleFn } from "@vueuse/core";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useLazyRecipes } from "~/composables/recipes";
+import { Recipe } from "~/types/api-types/recipe";
 
 export default defineComponent({
   components: { RecipeCardSection },

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -4,6 +4,7 @@
       :icon="$globals.icons.primary"
       :title="$t('page.all-recipes')"
       :recipes="recipes"
+      @sort="assignSorted"
       @delete="removeRecipe"
     ></RecipeCardSection>
     <v-card v-intersect="infiniteScroll"></v-card>
@@ -12,7 +13,7 @@
     </v-fade-transition>
   </v-container>
 </template>
-  
+
 <script lang="ts">
 import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
 import { useThrottleFn } from "@vueuse/core";
@@ -62,6 +63,10 @@ export default defineComponent({
       title: this.$t("page.all-recipes") as string,
     };
   },
+  methods: {
+    assignSorted(val: Array<Recipe>) {
+      this.recipes = val;
+    },
+  },
 });
 </script>
-  


### PR DESCRIPTION
Bug
---
The infinite scroll was incorrectly repeating recipes as it paged through all the results. This bug was only present on instances with greater than 60 recipes (since this is the increment size). You can reproduce this in nightly if you have more than 60 recipes - notice that the 61st recipe will always be the same as the 91st recipe, 62 --> 92, 63 --> 93, and so on until it continues after 120.

Because the default sort is by updated date, it was less noticeable that recipes were duplicated, however the further down the list you go (in sets of 30) the more apparent the issue becomes (as it repeats 30 recipes, then 60, then 90, etc.). However, as soon as you sort by alphabetical, the issue becomes immediately obvious (you can't do this in nightly, but I restored that feature here).

Fix
---
The bug is subtle, but thankfully the fix is easy. The limit was being used as the offset, which creates paging overlap; the fix is to introduce an offset and keep the limit constant.

Tangentially related, I noticed that the infinite scroll doesn't stop calling the backend even when you've reached the end of your list. However, this doesn't impact the frontend, so I figure it's not worth fixing this since the fetching/sorting is going to be redone eventually anyway.
```python
"GET /api/recipes?start=121&limit=30 HTTP/1.1" 200  # <-- I ran out of recipes here
"GET /api/recipes?start=151&limit=30 HTTP/1.1" 200
"GET /api/recipes?start=181&limit=30 HTTP/1.1" 200
...  # this continues forever if you keep scrolling, though users probably won't do that
```