### PR TITLE
Added gosu & updated run.sh to switch to the dedicated user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ENV GIT_COMMIT_HASH=$COMMIT
 # curl for used by healthcheck
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-    curl \
+    curl gosu \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR allows the system administrator to provide an PUID and PGID to the container.

If container is run without --user PUID:PGID then it uses the default 911 values (or the values specified in env PUID/PGID) and switch to this user and continue startup.

If --user PUID:PGID is specified then it will just start the rest of the container; skipping user creation as another user is defined. The administrator should make sure the mounted folder has the required permissions (this should make sense if you would run it with --user).