### PR TITLE
fix: bulk URL imports give up if one URL fails

### DIFF
--- a/frontend/pages/recipe/create/debug.vue
+++ b/frontend/pages/recipe/create/debug.vue
@@ -6,7 +6,7 @@
         <v-card-text>
           Grab the URL of the recipe you want to debug and paste it here. The URL will be scraped by the recipe scraper
           and the results will be displayed. If you don't see any data returned, the site you are trying to scrape is
-          not supported by Mealie or it's scraper library.
+          not supported by Mealie or its scraper library.
           <v-text-field
             v-model="recipeUrl"
             :label="$t('new-recipe.recipe-url')"

--- a/mealie/services/scraper/recipe_bulk_scraper.py
+++ b/mealie/services/scraper/recipe_bulk_scraper.py
@@ -77,7 +77,7 @@ class RecipeBulkScraperService(BaseService):
                 self.service.logger.error(f"failed to scrape url during bulk url import {b.url}")
                 self.service.logger.exception(e)
                 self._add_error_entry(f"failed to scrape url {b.url}", str(e))
-                break
+                continue
 
             if b.tags:
                 recipe.tags = b.tags
@@ -91,6 +91,7 @@ class RecipeBulkScraperService(BaseService):
                 self.service.logger.error(f"Failed to save recipe to database during bulk url import {b.url}")
                 self.service.logger.exception(e)
                 self._add_error_entry("Failed to save recipe to database during bulk url import", str(e))
+                continue
 
             self.report_entries.append(
                 ReportEntryCreate(


### PR DESCRIPTION
As raised in #1387, if you supply the bulk URL importer a list of URLs, and one fails, it doesn't try to import the rest of them. This changes the behavior to log the failed URL and continue parsing the remaining URLs.