### PR TITLE
fix: add missing types for API token deletion

### DIFF
--- a/frontend/types/api-types/user.ts
+++ b/frontend/types/api-types/user.ts
@@ -66,6 +66,8 @@ export interface UserOut {
 }
 export interface LongLiveTokenOut {
   token: string;
+  name: string;
+  id: number;
 }
 export interface ReadGroupPreferences {
   privateGroup?: boolean;

--- a/mealie/routes/users/api_tokens.py
+++ b/mealie/routes/users/api_tokens.py
@@ -33,7 +33,7 @@ class UserApiTokensController(BaseUserController):
         new_token_in_db = self.repos.api_tokens.create(token_model)
 
         if new_token_in_db:
-            return LongLiveTokenOut(token=token)
+            return new_token_in_db
 
     @router.delete("/api-tokens/{token_id}", response_model=DeleteTokenResponse)
     def delete_api_token(self, token_id: int):

--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -23,6 +23,8 @@ class LongLiveTokenIn(MealieModel):
 
 class LongLiveTokenOut(MealieModel):
     token: str
+    name: str
+    id: int
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This fixes #1389. The token properties `name` and `id` were not returned by the API, so the frontend didn't know the ID and thus didn't make it possible to delete any tokens.