### PR TITLE
feature: added route for deleting a recipe reference from a shopping list without modifying the list items

### DIFF
--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -231,7 +231,7 @@ class ShoppingListController(BaseUserController):
         return data
 
     # =======================================================================
-    # Other Operations
+    # Recipe References
 
     @router.post("/{item_id}/recipe/{recipe_id}", response_model=ShoppingListOut)
     def add_recipe_ingredients_to_list(self, item_id: UUID4, recipe_id: UUID4):
@@ -256,6 +256,24 @@ class ShoppingListController(BaseUserController):
     @router.delete("/{item_id}/recipe/{recipe_id}", response_model=ShoppingListOut)
     def remove_recipe_ingredients_from_list(self, item_id: UUID4, recipe_id: UUID4):
         shopping_list = self.service.remove_recipe_ingredients_from_list(item_id, recipe_id)
+        if shopping_list:
+            self.event_bus.dispatch(
+                self.deps.acting_user.group_id,
+                EventTypes.shopping_list_updated,
+                msg=self.t(
+                    "notifications.generic-updated",
+                    name=shopping_list.name,
+                ),
+                event_source=EventSource(
+                    event_type="bulk-updated-items",
+                    item_type="shopping-list",
+                    item_id=shopping_list.id,
+                ),
+            )
+
+    @router.delete("/{item_id}/recipe-references/{recipe_reference_id}", response_model=ShoppingListOut)
+    def remove_recipe_reference_from_list(self, item_id: UUID4, recipe_reference_id: UUID4):
+        shopping_list = self.service.remove_recipe_reference_from_list(item_id, recipe_reference_id)
         if shopping_list:
             self.event_bus.dispatch(
                 self.deps.acting_user.group_id,

--- a/mealie/services/group_services/shopping_lists.py
+++ b/mealie/services/group_services/shopping_lists.py
@@ -47,9 +47,9 @@ class ShoppingListService:
 
     def consolidate_list_items(self, item_list: list[ShoppingListItemOut]) -> list[ShoppingListItemOut]:
         """
-        itterates through the shopping list provided and returns
+        iterates through the shopping list provided and returns
         a consolidated list where all items that are matched against multiple values are
-        de-duplicated and only the first item is kept where the quantity is updated accoridngly.
+        de-duplicated and only the first item is kept where the quantity is updated accordingly.
         """
 
         consolidated_list: list[ShoppingListItemOut] = []
@@ -197,6 +197,15 @@ class ShoppingListService:
                 else:
                     self.list_refs.update(ref.id, ref)
                 break
+
+        # Save Changes
+        return self.shopping_lists.get_one(shopping_list.id)
+
+    def remove_recipe_reference_from_list(self, list_id: UUID4, recipe_reference_id: UUID4) -> ShoppingListOut:
+        shopping_list = self.shopping_lists.get_one(list_id)
+        for ref in shopping_list.recipe_references:
+            if ref.id == recipe_reference_id:
+                self.list_refs.delete(ref.id)
 
         # Save Changes
         return self.shopping_lists.get_one(shopping_list.id)


### PR DESCRIPTION
Added a simple route to delete the entire recipe reference from a shopping list. This allows you to remove the reference without changing the items (which is useful when trying to clear a shopping list without deleting it)