### PR TITLE
Fix/mealplan pagination

### DIFF
--- a/frontend/composables/use-group-mealplan.ts
+++ b/frontend/composables/use-group-mealplan.ts
@@ -26,11 +26,11 @@ export const useMealplans = function (range: Ref<DateRange>) {
       loading.value = true;
       const units = useAsync(async () => {
         const query = {
-          start: format(range.value.start, "yyyy-MM-dd"),
-          limit: format(range.value.end, "yyyy-MM-dd"),
+          start_date: format(range.value.start, "yyyy-MM-dd"),
+          end_date: format(range.value.end, "yyyy-MM-dd"),
         };
         // @ts-ignore TODO Modify typing to allow for string start+limit for mealplans
-        const { data } = await api.mealplans.getAll(1, -1, { start: query.start, limit: query.limit });
+        const { data } = await api.mealplans.getAll(1, -1, { start_date: query.start_date, end_date: query.end_date });
 
         if (data) {
           return data.items;
@@ -45,11 +45,11 @@ export const useMealplans = function (range: Ref<DateRange>) {
     async refreshAll(this: void) {
       loading.value = true;
       const query = {
-        start: format(range.value.start, "yyyy-MM-dd"),
-        limit: format(range.value.end, "yyyy-MM-dd"),
+        start_date: format(range.value.start, "yyyy-MM-dd"),
+        end_date: format(range.value.end, "yyyy-MM-dd"),
       };
       // @ts-ignore TODO Modify typing to allow for string start+limit for mealplans
-      const { data } = await api.mealplans.getAll(1, -1, { start: query.start, limit: query.limit });
+      const { data } = await api.mealplans.getAll(1, -1, { start_date: query.start_date, end_date: query.end_date });
 
       if (data && data.items) {
         mealplans.value = data.items;

--- a/mealie/repos/repository_meals.py
+++ b/mealie/repos/repository_meals.py
@@ -1,8 +1,13 @@
 from datetime import date
+from math import ceil
 from uuid import UUID
 
+from sqlalchemy import func
+from sqlalchemy.sql import sqltypes
+
 from mealie.db.models.group import GroupMealPlan
-from mealie.schema.meal_plan.new_meal import ReadPlanEntry
+from mealie.schema.meal_plan.new_meal import PlanEntryPagination, ReadPlanEntry
+from mealie.schema.response.pagination import OrderDirection, PaginationQuery
 
 from .repository_generic import RepositoryGeneric
 
@@ -11,15 +16,67 @@ class RepositoryMeals(RepositoryGeneric[ReadPlanEntry, GroupMealPlan]):
     def by_group(self, group_id: UUID) -> "RepositoryMeals":
         return super().by_group(group_id)  # type: ignore
 
-    def get_slice(self, start: date, end: date, group_id: UUID) -> list[ReadPlanEntry]:
-        start_str = start.strftime("%Y-%m-%d")
-        end_str = end.strftime("%Y-%m-%d")
-        qry = self.session.query(GroupMealPlan).filter(
+    def get_slice(
+        self, pagination: PaginationQuery, start_date: date, end_date: date, group_id: UUID
+    ) -> PlanEntryPagination:
+        start_str = start_date.strftime("%Y-%m-%d")
+        end_str = end_date.strftime("%Y-%m-%d")
+
+        # get the total number of documents
+        q = self.session.query(GroupMealPlan).filter(
             GroupMealPlan.date.between(start_str, end_str),
             GroupMealPlan.group_id == group_id,
         )
 
-        return [self.schema.from_orm(x) for x in qry.all()]
+        count = q.count()
+
+        # interpret -1 as "get_all"
+        if pagination.per_page == -1:
+            pagination.per_page = count
+
+        try:
+            total_pages = ceil(count / pagination.per_page)
+
+        except ZeroDivisionError:
+            total_pages = 0
+
+        # interpret -1 as "last page"
+        if pagination.page == -1:
+            pagination.page = total_pages
+
+        # failsafe for user input error
+        if pagination.page < 1:
+            pagination.page = 1
+
+        if pagination.order_by:
+            if order_attr := getattr(self.model, pagination.order_by, None):
+                # queries handle uppercase and lowercase differently, which is undesirable
+                if isinstance(order_attr.type, sqltypes.String):
+                    order_attr = func.lower(order_attr)
+
+                if pagination.order_direction == OrderDirection.asc:
+                    order_attr = order_attr.asc()
+                elif pagination.order_direction == OrderDirection.desc:
+                    order_attr = order_attr.desc()
+
+                q = q.order_by(order_attr)
+
+        q = q.limit(pagination.per_page).offset((pagination.page - 1) * pagination.per_page)
+
+        try:
+            data = [self.schema.from_orm(x) for x in q.all()]
+        except Exception as e:
+            self._log_exception(e)
+            self.session.rollback()
+            raise e
+
+        return PlanEntryPagination(
+            page=pagination.page,
+            per_page=pagination.per_page,
+            total=count,
+            total_pages=total_pages,
+            items=data,
+        )
 
     def get_today(self, group_id: UUID) -> list[ReadPlanEntry]:
         today = date.today()

--- a/mealie/schema/meal_plan/new_meal.py
+++ b/mealie/schema/meal_plan/new_meal.py
@@ -7,6 +7,7 @@ from pydantic import validator
 
 from mealie.schema._mealie import MealieModel
 from mealie.schema.recipe.recipe import RecipeSummary
+from mealie.schema.response.pagination import PaginationBase
 
 
 class PlanEntryType(str, Enum):
@@ -54,3 +55,7 @@ class ReadPlanEntry(UpdatePlanEntry):
 
     class Config:
         orm_mode = True
+
+
+class PlanEntryPagination(PaginationBase):
+    items: list[ReadPlanEntry]


### PR DESCRIPTION
This fixes the issue raised in Discord where meal plans weren't populating on /mealplan/planner. The frontend uses the `get_slice` route which wasn't returning paginated data.

This fix is a little bit of a band-aid; I had to modify the custom `get_slice` method to slice the dates. Once we implement a standard schema for filtering queries we can replace the `state_date` and `end_date` params with filters:
`object.date >= start_date, object.date <= end_date`