### PR TITLE
Restore frontend sorting for all recipes

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -35,6 +35,48 @@
           </v-btn>
         </template>
         <v-list>
+          <v-list-item @click="sortRecipesFrontend(EVENTS.az)">
+            <v-icon left>
+              {{ $globals.icons.orderAlphabeticalAscending }}
+            </v-icon>
+            <v-list-item-title>{{ $t("general.sort-alphabetically") }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="sortRecipesFrontend(EVENTS.rating)">
+            <v-icon left>
+              {{ $globals.icons.star }}
+            </v-icon>
+            <v-list-item-title>{{ $t("general.rating") }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="sortRecipesFrontend(EVENTS.created)">
+            <v-icon left>
+              {{ $globals.icons.newBox }}
+            </v-icon>
+            <v-list-item-title>{{ $t("general.created") }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="sortRecipesFrontend(EVENTS.updated)">
+            <v-icon left>
+              {{ $globals.icons.update }}
+            </v-icon>
+            <v-list-item-title>{{ $t("general.updated") }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="sortRecipesFrontend(EVENTS.shuffle)">
+            <v-icon left>
+              {{ $globals.icons.shuffleVariant }}
+            </v-icon>
+            <v-list-item-title>{{ $t("general.shuffle") }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+      <v-menu v-if="$listeners.sortRecipes" offset-y left>
+        <template #activator="{ on, attrs }">
+          <v-btn text :icon="$vuetify.breakpoint.xsOnly" v-bind="attrs" :loading="sortLoading" v-on="on">
+            <v-icon :left="!$vuetify.breakpoint.xsOnly">
+              {{ $globals.icons.sort }}
+            </v-icon>
+            {{ $vuetify.breakpoint.xsOnly ? null : $t("general.sort") }}
+          </v-btn>
+        </template>
+        <v-list>
           <v-list-item @click="sortRecipes(EVENTS.az)">
             <v-icon left>
               {{ $globals.icons.orderAlphabeticalAscending }}
@@ -58,12 +100,6 @@
               {{ $globals.icons.update }}
             </v-icon>
             <v-list-item-title>{{ $t("general.updated") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="sortRecipes(EVENTS.shuffle)">
-            <v-icon left>
-              {{ $globals.icons.shuffleVariant }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.shuffle") }}</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>
@@ -110,17 +146,27 @@
         </v-col>
       </v-row>
     </div>
+    <div v-if="usePagination">
+      <v-card v-intersect="infiniteScroll"></v-card>
+      <v-fade-transition>
+        <AppLoader v-if="loading" :loading="loading" />
+      </v-fade-transition>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, toRefs, useContext, useRouter, ref } from "@nuxtjs/composition-api";
+import { computed, defineComponent, onMounted, reactive, ref, toRefs, useAsync, useContext, useRouter } from "@nuxtjs/composition-api";
+import { useAsyncKey } from "~/composables/use-utils";
+import { useThrottleFn } from "@vueuse/core";
 import RecipeCard from "./RecipeCard.vue";
 import RecipeCardMobile from "./RecipeCardMobile.vue";
-import { useSorter } from "~/composables/recipes";
+import { useLazyRecipes, useSorter } from "~/composables/recipes";
 import { Recipe } from "~/types/api-types/recipe";
 
 const SORT_EVENT = "sort";
+const REPLACE_RECIPES_EVENT = "replaceRecipes";
+const APPEND_RECIPES_EVENT = "appendRecipes";
 
 export default defineComponent({
   components: {
@@ -148,6 +194,10 @@ export default defineComponent({
       type: Array as () => Recipe[],
       default: () => [],
     },
+    usePagination: {
+      type: Boolean,
+      default: false,
+    }
   },
   setup(props, context) {
     const mobileCards = ref(false);
@@ -184,7 +234,123 @@ export default defineComponent({
       }
     }
 
+    const page = ref(1);
+    const perPage = ref(30);
+    const orderBy = ref("name");
+    const orderDirection = ref("asc");
+    const hasMore = ref(true);
+
+    const ready = ref(false);
+    const loading = ref(false);
+
+    const { recipes, fetchMore } = useLazyRecipes();
+
+    onMounted(async () => {
+      if (props.usePagination) {
+        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+        ready.value = true;
+      }
+    });
+
+    const infiniteScroll = useThrottleFn(() => {
+      useAsync(async () => {
+        if (!ready.value || !hasMore.value || loading.value) {
+          return;
+        }
+
+        loading.value = true;
+        page.value = page.value + 1;
+
+        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        if (!newRecipes.length) {
+          hasMore.value = false;
+        }
+
+        else {
+          context.emit(APPEND_RECIPES_EVENT, newRecipes);
+        }
+
+        loading.value = false;
+      }, useAsyncKey());
+    }, 500);
+
+    /*
+    sortRecipes helps filter using the API. This will eventually replace the sortRecipesFrontend function which pulls all recipes
+    (without pagination) and does the sorting in the frontend.
+
+    TODO: remove sortRecipesFrontend and remove duplicate "sortRecipes" section in the template (above)
+    */
+
     function sortRecipes(sortType: string) {
+      if (state.sortLoading || loading.value) {
+        return;
+      }
+
+      switch (sortType) {
+        case EVENTS.az:
+          if (orderBy.value != "name") {
+            orderBy.value = "name";
+            orderDirection.value = "asc";
+          }
+
+          else {
+            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+          }
+          break;
+        case EVENTS.rating:
+          if (orderBy.value != "rating") {
+            orderBy.value = "rating";
+            orderDirection.value = "desc";
+          }
+
+          else {
+            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+          }
+          break;
+        case EVENTS.created:
+          if (orderBy.value != "created_at") {
+            orderBy.value = "created_at";
+            orderDirection.value = "desc";
+          }
+
+          else {
+            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+          }
+          break;
+        case EVENTS.updated:
+          if (orderBy.value != "update_at") {
+            orderBy.value = "update_at";
+            orderDirection.value = "desc";
+          }
+
+          else {
+            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+          }
+          break;
+        default:
+          console.log("Unknown Event", sortType);
+          return;
+      }
+
+      useAsync(async () => {
+        // reset pagination
+        page.value = 1;
+        hasMore.value = true;
+
+        state.sortLoading = true;
+        loading.value = true;
+
+        // fetch new recipes
+        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+
+        state.sortLoading = false;
+        loading.value = false;
+      }, useAsyncKey());
+    };
+
+    function sortRecipesFrontend(sortType: string) {
       state.sortLoading = true;
       const sortTarget = [...props.recipes];
       switch (sortType) {
@@ -209,7 +375,7 @@ export default defineComponent({
       }
       context.emit(SORT_EVENT, sortTarget);
       state.sortLoading = false;
-    }
+    };
 
     return {
       mobileCards,
@@ -217,8 +383,11 @@ export default defineComponent({
       EVENTS,
       viewScale,
       displayTitleIcon,
+      infiniteScroll,
+      loading,
       navigateRandom,
       sortRecipes,
+      sortRecipesFrontend,
     };
   },
 });

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -157,10 +157,10 @@
 
 <script lang="ts">
 import { computed, defineComponent, onMounted, reactive, ref, toRefs, useAsync, useContext, useRouter } from "@nuxtjs/composition-api";
-import { useAsyncKey } from "~/composables/use-utils";
 import { useThrottleFn } from "@vueuse/core";
 import RecipeCard from "./RecipeCard.vue";
 import RecipeCardMobile from "./RecipeCardMobile.vue";
+import { useAsyncKey } from "~/composables/use-utils";
 import { useLazyRecipes, useSorter } from "~/composables/recipes";
 import { Recipe } from "~/types/api-types/recipe";
 
@@ -247,7 +247,7 @@ export default defineComponent({
 
     onMounted(async () => {
       if (props.usePagination) {
-        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        const newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
         context.emit(REPLACE_RECIPES_EVENT, newRecipes);
         ready.value = true;
       }
@@ -262,7 +262,7 @@ export default defineComponent({
         loading.value = true;
         page.value = page.value + 1;
 
-        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        const newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
         if (!newRecipes.length) {
           hasMore.value = false;
         }
@@ -289,43 +289,43 @@ export default defineComponent({
 
       switch (sortType) {
         case EVENTS.az:
-          if (orderBy.value != "name") {
+          if (orderBy.value !== "name") {
             orderBy.value = "name";
             orderDirection.value = "asc";
           }
 
           else {
-            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+            orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
         case EVENTS.rating:
-          if (orderBy.value != "rating") {
+          if (orderBy.value !== "rating") {
             orderBy.value = "rating";
             orderDirection.value = "desc";
           }
 
           else {
-            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+            orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
         case EVENTS.created:
-          if (orderBy.value != "created_at") {
+          if (orderBy.value !== "created_at") {
             orderBy.value = "created_at";
             orderDirection.value = "desc";
           }
 
           else {
-            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+            orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
         case EVENTS.updated:
-          if (orderBy.value != "update_at") {
+          if (orderBy.value !== "update_at") {
             orderBy.value = "update_at";
             orderDirection.value = "desc";
           }
 
           else {
-            orderDirection.value = orderDirection.value == "asc" ? "desc" : "asc";
+            orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
         default:
@@ -342,7 +342,7 @@ export default defineComponent({
         loading.value = true;
 
         // fetch new recipes
-        let newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
+        const newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
         context.emit(REPLACE_RECIPES_EVENT, newRecipes);
 
         state.sortLoading = false;

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -289,6 +289,7 @@ export default defineComponent({
     (without pagination) and does the sorting in the frontend.
 
     TODO: remove sortRecipesFrontend and remove duplicate "sortRecipes" section in the template (above)
+    TODO: use indicator to show asc / desc order
     */
 
     function sortRecipes(sortType: string) {

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -14,17 +14,7 @@
         </v-icon>
         {{ $vuetify.breakpoint.xsOnly ? null : $t("general.random") }}
       </v-btn>
-      <ContextMenu
-        v-if="!$vuetify.breakpoint.xsOnly"
-        :items="[
-          {
-            title: 'Toggle View',
-            icon: $globals.icons.eye,
-            event: 'toggle-dense-view',
-          },
-        ]"
-        @toggle-dense-view="mobileCards = !mobileCards"
-      />
+
       <v-menu v-if="$listeners.sort" offset-y left>
         <template #activator="{ on, attrs }">
           <v-btn text :icon="$vuetify.breakpoint.xsOnly" v-bind="attrs" :loading="sortLoading" v-on="on">
@@ -103,6 +93,17 @@
           </v-list-item>
         </v-list>
       </v-menu>
+      <ContextMenu
+        v-if="!$vuetify.breakpoint.xsOnly"
+        :items="[
+          {
+            title: 'Toggle View',
+            icon: $globals.icons.eye,
+            event: 'toggle-dense-view',
+          },
+        ]"
+        @toggle-dense-view="mobileCards = !mobileCards"
+      />
     </v-app-bar>
     <div v-if="recipes" class="mt-2">
       <v-row v-if="!viewScale">
@@ -156,7 +157,17 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, reactive, ref, toRefs, useAsync, useContext, useRouter } from "@nuxtjs/composition-api";
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  reactive,
+  ref,
+  toRefs,
+  useAsync,
+  useContext,
+  useRouter,
+} from "@nuxtjs/composition-api";
 import { useThrottleFn } from "@vueuse/core";
 import RecipeCard from "./RecipeCard.vue";
 import RecipeCardMobile from "./RecipeCardMobile.vue";
@@ -197,7 +208,7 @@ export default defineComponent({
     usePagination: {
       type: Boolean,
       default: false,
-    }
+    },
   },
   setup(props, context) {
     const mobileCards = ref(false);
@@ -265,9 +276,7 @@ export default defineComponent({
         const newRecipes = await fetchMore(page.value, perPage.value, orderBy.value, orderDirection.value);
         if (!newRecipes.length) {
           hasMore.value = false;
-        }
-
-        else {
+        } else {
           context.emit(APPEND_RECIPES_EVENT, newRecipes);
         }
 
@@ -292,9 +301,7 @@ export default defineComponent({
           if (orderBy.value !== "name") {
             orderBy.value = "name";
             orderDirection.value = "asc";
-          }
-
-          else {
+          } else {
             orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
@@ -302,9 +309,7 @@ export default defineComponent({
           if (orderBy.value !== "rating") {
             orderBy.value = "rating";
             orderDirection.value = "desc";
-          }
-
-          else {
+          } else {
             orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
@@ -312,9 +317,7 @@ export default defineComponent({
           if (orderBy.value !== "created_at") {
             orderBy.value = "created_at";
             orderDirection.value = "desc";
-          }
-
-          else {
+          } else {
             orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
@@ -322,9 +325,7 @@ export default defineComponent({
           if (orderBy.value !== "update_at") {
             orderBy.value = "update_at";
             orderDirection.value = "desc";
-          }
-
-          else {
+          } else {
             orderDirection.value = orderDirection.value === "asc" ? "desc" : "asc";
           }
           break;
@@ -348,7 +349,7 @@ export default defineComponent({
         state.sortLoading = false;
         loading.value = false;
       }, useAsyncKey());
-    };
+    }
 
     function sortRecipesFrontend(sortType: string) {
       state.sortLoading = true;
@@ -375,7 +376,7 @@ export default defineComponent({
       }
       context.emit(SORT_EVENT, sortTarget);
       state.sortLoading = false;
-    };
+    }
 
     return {
       mobileCards,

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -67,6 +67,7 @@ export const useLazyRecipes = function () {
   }
 
   return {
+    recipes,
     fetchMore,
   };
 };

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -63,15 +63,10 @@ export const useLazyRecipes = function () {
 
   async function fetchMore(page: number, perPage: number, orderBy: string | null = null, orderDirection = "desc") {
     const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection });
-    if (data) {
-      data.items.forEach((recipe) => {
-        recipes.value?.push(recipe);
-      });
-    }
+    return data ? data.items : [];
   }
 
   return {
-    recipes,
     fetchMore,
   };
 };

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -4,7 +4,7 @@
       :icon="$globals.icons.primary"
       :title="$t('page.all-recipes')"
       :recipes="recipes"
-      :usePagination="true"
+      :use-pagination="true"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"
       @appendRecipes="appendRecipes"
@@ -28,11 +28,11 @@ export default defineComponent({
       val.forEach((recipe) => {
         recipes.value.push(recipe);
       });
-    };
+    }
 
     function assignSorted(val: Array<Recipe>) {
       recipes.value = val;
-    };
+    }
 
     function removeRecipe(slug: string) {
       for (let i = 0; i < recipes?.value?.length; i++) {
@@ -41,11 +41,11 @@ export default defineComponent({
           break;
         }
       }
-    };
+    }
 
     function replaceRecipes(val: Array<Recipe>) {
       recipes.value = val;
-    };
+    }
 
     return { appendRecipes, assignSorted, recipes, removeRecipe, replaceRecipes };
   },

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -26,12 +26,12 @@ export default defineComponent({
 
     function appendRecipes(val: Array<Recipe>) {
       val.forEach((recipe) => {
-        this.recipes.push(recipe);
+        recipes.value.push(recipe);
       });
     };
 
     function assignSorted(val: Array<Recipe>) {
-      this.recipes = val;
+      recipes.value = val;
     };
 
     function removeRecipe(slug: string) {
@@ -44,7 +44,7 @@ export default defineComponent({
     };
 
     function replaceRecipes(val: Array<Recipe>) {
-      this.recipes = val;
+      recipes.value = val;
     };
 
     return { appendRecipes, assignSorted, recipes, removeRecipe, replaceRecipes };

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -4,48 +4,34 @@
       :icon="$globals.icons.primary"
       :title="$t('page.all-recipes')"
       :recipes="recipes"
+      :usePagination="true"
+      @sortRecipes="assignSorted"
+      @replaceRecipes="replaceRecipes"
+      @appendRecipes="appendRecipes"
       @delete="removeRecipe"
     ></RecipeCardSection>
-    <v-card v-intersect="infiniteScroll"></v-card>
-    <v-fade-transition>
-      <AppLoader v-if="loading" :loading="loading" />
-    </v-fade-transition>
   </v-container>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
-import { useThrottleFn } from "@vueuse/core";
+import { defineComponent } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useLazyRecipes } from "~/composables/recipes";
 
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
-    const page = ref(1);
-    const perPage = ref(30);
-    const orderBy = "name";
-    const orderDirection = "asc";
-
-    const ready = ref(false);
-    const loading = ref(false);
-
     const { recipes, fetchMore } = useLazyRecipes();
 
-    onMounted(async () => {
-      await fetchMore(page.value, perPage.value, orderBy, orderDirection);
-      ready.value = true;
-    });
+    function appendRecipes(val: Array<Recipe>) {
+      val.forEach((recipe) => {
+        this.recipes.push(recipe);
+      });
+    };
 
-    const infiniteScroll = useThrottleFn(() => {
-      if (!ready.value) {
-        return;
-      }
-      loading.value = true;
-      page.value = page.value + 1;
-      fetchMore(page.value, perPage.value, orderBy, orderDirection);
-      loading.value = false;
-    }, 500);
+    function assignSorted(val: Array<Recipe>) {
+      this.recipes = val;
+    };
 
     function removeRecipe(slug: string) {
       for (let i = 0; i < recipes?.value?.length; i++) {
@@ -54,9 +40,13 @@ export default defineComponent({
           break;
         }
       }
-    }
+    };
 
-    return { recipes, infiniteScroll, loading, removeRecipe };
+    function replaceRecipes(val: Array<Recipe>) {
+      this.recipes = val;
+    };
+
+    return { appendRecipes, assignSorted, recipes, removeRecipe, replaceRecipes };
   },
   head() {
     return {

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -17,6 +17,7 @@
 import { defineComponent } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useLazyRecipes } from "~/composables/recipes";
+import { Recipe } from "~/types/api-types/recipe";
 
 export default defineComponent({
   components: { RecipeCardSection },

--- a/frontend/pages/recipes/categories/index.vue
+++ b/frontend/pages/recipes/categories/index.vue
@@ -30,7 +30,7 @@ export default defineComponent({
     };
   },
   head: {
-    title: "Tags",
+    title: "Categories",
   },
 });
 </script>


### PR DESCRIPTION
This refactors a bunch of the frontend to support sorting for all recipes. Specifically, this leverages the new backend pagination API to sort using the backend (as opposed to sorting on the frontend).

I was unable to figure out how to get categories and tags to work properly, we might need to make some backend changes to get all recipes filtered by category/tag. Maybe there's a way to do it already, in which case we can merge the two solutions.

Since I only modified the behavior for all recipes, I introduced a few variables to accommodate the split logic:
1. In `RecipeCardSection.vue` I created a second filter which uses different callbacks. I renamed the old one to `sortRecipesFrontend` to indicate that we'll depreciate this once we merge categories and tags into the new logic.
2. I created a `usePagination` prop which helps preload the first page of data (if pagination is being used).

For the new logic: sorting by a new attribute requires us to clear the existing data and re-populate it with the new first page of data. While scrolling, we should extend this data. I created `replaceRecipes` and `appendRecipes` events/functions to accommodate this. I also added support for reverse sorting if you click the same sort twice (e.g. if you click on alphabetical sort it will sort A-Z, but if you click on it again it will sort Z-A).

I did my best to remove any unnecessary code following the all recipes logic refactoring, but I could've missed some of it. I also tried to place everything in the right file/section, but there might be some re-arranging to do since I'm still fairly new to Vue.

---

Next steps are to get categories and tags to use the same backend pagination/ordering methods. It might be an easy change, it might require some backend changes. Once that is done we can fully deprecate the old frontend sorting and remove the dual sorting functions/duplicate filter section.