### PR TITLE
Create new foods and units from their Data Management pages

### DIFF
--- a/frontend/components/global/CrudTable.vue
+++ b/frontend/components/global/CrudTable.vue
@@ -3,7 +3,7 @@
     <v-card-actions>
       <v-menu v-if="tableConfig.hideColumns" offset-y bottom nudge-bottom="6" :close-on-content-click="false">
         <template #activator="{ on, attrs }">
-          <v-btn color="accent" class="mr-1" dark v-bind="attrs" v-on="on">
+          <v-btn color="accent" class="mr-2" dark v-bind="attrs" v-on="on">
             <v-icon>
               {{ $globals.icons.cog }}
             </v-icon>

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -54,6 +54,30 @@
       </v-card-text>
     </BaseDialog>
 
+    <!-- Create Dialog -->
+    <BaseDialog
+      v-model="createDialog"
+      :icon="$globals.icons.foods"
+      title="Create Food"
+      :submit-text="$tc('general.save')"
+      @submit="createFood"
+    >
+      <v-card-text>
+        <v-form ref="domCreateFoodForm">
+          <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
+          <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
+          <v-autocomplete
+            v-model="createTarget.labelId"
+            clearable
+            :items="allLabels"
+            item-value="id"
+            item-text="name"
+            label="Food Label"
+          >
+          </v-autocomplete>
+        </v-form> </v-card-text
+    ></BaseDialog>
+
     <!-- Edit Dialog -->
     <BaseDialog
       v-model="editDialog"
@@ -100,8 +124,13 @@
       :bulk-actions="[]"
       @delete-one="deleteEventHandler"
       @edit-one="editEventHandler"
+      @create-one="createEventHandler"
     >
       <template #button-row>
+        <BaseButton @click="createDialog = true">
+          <template #icon> {{ $globals.icons.create }} </template>
+          Create
+        </BaseButton>
         <BaseButton @click="mergeDialog = true">
           <template #icon> {{ $globals.icons.foods }} </template>
           Combine
@@ -128,7 +157,7 @@ import { computed } from "vue-demi";
 import type { LocaleObject } from "@nuxtjs/i18n";
 import { validators } from "~/composables/use-validators";
 import { useUserApi } from "~/composables/api";
-import { IngredientFood } from "~/types/api-types/recipe";
+import { CreateIngredientFood, IngredientFood } from "~/types/api-types/recipe";
 import MultiPurposeLabel from "~/components/Domain/ShoppingList/MultiPurposeLabel.vue";
 import { useLocales } from "~/composables/use-locales";
 import { useFoodStore, useLabelStore } from "~/composables/store";
@@ -165,6 +194,25 @@ export default defineComponent({
     ];
 
     const foodStore = useFoodStore();
+
+    // ===============================================================
+    // Food Creator
+
+    const createDialog = ref(false);
+    const createTarget = ref<CreateIngredientFood>({});
+
+    function createEventHandler() {
+      createDialog.value = true;
+    }
+
+    async function createFood() {
+      if (!createTarget.value || !createTarget.value.name) {
+        return;
+      }
+
+      await foodStore.actions.createOne(createTarget.value);
+      createDialog.value = false;
+    }
 
     // ===============================================================
     // Food Editor
@@ -262,6 +310,11 @@ export default defineComponent({
       foods: foodStore.foods,
       allLabels,
       validators,
+      // Create
+      createDialog,
+      createEventHandler,
+      createFood,
+      createTarget,
       // Edit
       editDialog,
       editEventHandler,

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -212,10 +212,12 @@ export default defineComponent({
         return;
       }
 
+      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientUnit type
       await foodStore.actions.createOne(createTarget.value);
       createDialog.value = false;
 
       // reset form
+      // @ts-ignore TS doesn't like this.$refs despite it working just fine
       this.$refs.domNewFoodForm.reset();
       createTarget.value = {
         name: ""

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -212,7 +212,7 @@ export default defineComponent({
         return;
       }
 
-      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientUnit type
+      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientFood type
       await foodStore.actions.createOne(createTarget.value);
       createDialog.value = false;
 

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -64,7 +64,12 @@
     >
       <v-card-text>
         <v-form ref="domNewFoodForm">
-          <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
+          <v-text-field
+            v-model="createTarget.name"
+            autofocus
+            label="Name"
+            :rules="[validators.required]"
+          ></v-text-field>
           <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
           <v-autocomplete
             v-model="createTarget.labelId"
@@ -87,7 +92,7 @@
       @submit="editSaveFood"
     >
       <v-card-text v-if="editTarget">
-        <v-form ref="domCreateFoodForm">
+        <v-form ref="domNewFoodForm">
           <v-text-field v-model="editTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
           <v-text-field v-model="editTarget.description" label="Description"></v-text-field>
           <v-autocomplete
@@ -127,10 +132,7 @@
       @create-one="createEventHandler"
     >
       <template #button-row>
-        <BaseButton @click="createDialog = true">
-          <template #icon> {{ $globals.icons.create }} </template>
-          Create
-        </BaseButton>
+        <BaseButton create @click="createDialog = true" />
         <BaseButton @click="mergeDialog = true">
           <template #icon> {{ $globals.icons.foods }} </template>
           Combine
@@ -161,6 +163,7 @@ import { CreateIngredientFood, IngredientFood } from "~/types/api-types/recipe";
 import MultiPurposeLabel from "~/components/Domain/ShoppingList/MultiPurposeLabel.vue";
 import { useLocales } from "~/composables/use-locales";
 import { useFoodStore, useLabelStore } from "~/composables/store";
+import { VForm } from "~/types/vuetify";
 
 export default defineComponent({
   components: { MultiPurposeLabel },
@@ -198,9 +201,10 @@ export default defineComponent({
     // ===============================================================
     // Food Creator
 
+    const domNewFoodForm = ref<VForm>();
     const createDialog = ref(false);
     const createTarget = ref<CreateIngredientFood>({
-      name: ""
+      name: "",
     });
 
     function createEventHandler() {
@@ -212,15 +216,13 @@ export default defineComponent({
         return;
       }
 
-      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientFood type
+      // @ts-expect-error the createOne function erroneously expects an id because it uses the IngredientFood type
       await foodStore.actions.createOne(createTarget.value);
       createDialog.value = false;
 
-      // reset form
-      // @ts-ignore TS doesn't like this.$refs despite it working just fine
-      this.$refs.domNewFoodForm.reset();
+      domNewFoodForm.value?.reset();
       createTarget.value = {
-        name: ""
+        name: "",
       };
     }
 

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -199,7 +199,9 @@ export default defineComponent({
     // Food Creator
 
     const createDialog = ref(false);
-    const createTarget = ref<CreateIngredientFood>({});
+    const createTarget = ref<CreateIngredientFood>({
+      name: ""
+    });
 
     function createEventHandler() {
       createTarget.value = {};
@@ -216,7 +218,9 @@ export default defineComponent({
 
       // reset form
       this.$refs.domNewFoodForm.reset();
-      createTarget.value = {};
+      createTarget.value = {
+        name: ""
+      };
     }
 
     // ===============================================================

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -63,7 +63,7 @@
       @submit="createFood"
     >
       <v-card-text>
-        <v-form ref="domCreateFoodForm">
+        <v-form ref="domNewFoodForm">
           <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
           <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
           <v-autocomplete
@@ -202,6 +202,7 @@ export default defineComponent({
     const createTarget = ref<CreateIngredientFood>({});
 
     function createEventHandler() {
+      createTarget.value = {};
       createDialog.value = true;
     }
 
@@ -212,6 +213,10 @@ export default defineComponent({
 
       await foodStore.actions.createOne(createTarget.value);
       createDialog.value = false;
+
+      // reset form
+      this.$refs.domNewFoodForm.reset();
+      createTarget.value = {};
     }
 
     // ===============================================================

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -204,7 +204,6 @@ export default defineComponent({
     });
 
     function createEventHandler() {
-      createTarget.value = {};
       createDialog.value = true;
     }
 

--- a/frontend/pages/group/data/recipes.vue
+++ b/frontend/pages/group/data/recipes.vue
@@ -65,7 +65,7 @@
       <v-card-actions class="mt-n5 mb-1">
         <v-menu offset-y bottom nudge-bottom="6" :close-on-content-click="false">
           <template #activator="{ on, attrs }">
-            <v-btn color="accent" class="mr-1" dark v-bind="attrs" v-on="on">
+            <v-btn color="accent" class="mr-2" dark v-bind="attrs" v-on="on">
               <v-icon left>
                 {{ $globals.icons.cog }}
               </v-icon>

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -31,7 +31,7 @@
       @submit="createUnit"
     >
       <v-card-text>
-        <v-form ref="domCreateUnitForm">
+        <v-form ref="domNewUnitForm">
           <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
           <v-text-field v-model="createTarget.abbreviation" label="Abbreviation"></v-text-field>
           <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
@@ -206,7 +206,12 @@ export default defineComponent({
     // Create Units
 
     const createDialog = ref(false);
-    const createTarget = ref<CreateIngredientUnit>({});
+
+    // we explicitly set booleans to false since forms don't POST unchecked boxes
+    const createTarget = ref<CreateIngredientUnit>({
+        fraction: false,
+        useAbbreviation: false
+      });
 
     function createEventHandler() {
       createDialog.value = true;
@@ -219,6 +224,13 @@ export default defineComponent({
 
       await unitActions.createOne(createTarget.value);
       createDialog.value = false;
+
+      // reset form
+      this.$refs.domNewUnitForm.reset();
+      createTarget.value = {
+        fraction: false,
+        useAbbreviation: false
+      };
     }
 
     // ============================================================
@@ -239,6 +251,7 @@ export default defineComponent({
       editDialog.value = false;
     }
 
+    // ============================================================
     // Delete Units
     const deleteDialog = ref(false);
     const deleteTarget = ref<IngredientUnit | null>(null);

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -223,10 +223,12 @@ export default defineComponent({
         return;
       }
 
+      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientUnit type
       await unitActions.createOne(createTarget.value);
       createDialog.value = false;
 
       // reset form
+      // @ts-ignore TS doesn't like this.$refs despite it working just fine
       this.$refs.domNewUnitForm.reset();
       createTarget.value = {
         name: "",

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -209,6 +209,7 @@ export default defineComponent({
 
     // we explicitly set booleans to false since forms don't POST unchecked boxes
     const createTarget = ref<CreateIngredientUnit>({
+        name: "",
         fraction: false,
         useAbbreviation: false
       });
@@ -228,6 +229,7 @@ export default defineComponent({
       // reset form
       this.$refs.domNewUnitForm.reset();
       createTarget.value = {
+        name: "",
         fraction: false,
         useAbbreviation: false
       };

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -22,6 +22,25 @@
       </v-card-text>
     </BaseDialog>
 
+    <!-- Create Dialog -->
+    <BaseDialog
+      v-model="createDialog"
+      :icon="$globals.icons.units"
+      title="Create Unit"
+      :submit-text="$tc('general.save')"
+      @submit="createUnit"
+    >
+      <v-card-text>
+        <v-form ref="domCreateUnitForm">
+          <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
+          <v-text-field v-model="createTarget.abbreviation" label="Abbreviation"></v-text-field>
+          <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
+          <v-checkbox v-model="createTarget.fraction" hide-details label="Display as Fraction"></v-checkbox>
+          <v-checkbox v-model="createTarget.useAbbreviation" hide-details label="Use Abbreviation"></v-checkbox>
+        </v-form>
+      </v-card-text>
+    </BaseDialog>
+
     <!-- Edit Dialog -->
     <BaseDialog
       v-model="editDialog"
@@ -100,8 +119,13 @@
       :bulk-actions="[]"
       @delete-one="deleteEventHandler"
       @edit-one="editEventHandler"
+      @create-one="createEventHandler"
     >
       <template #button-row>
+        <BaseButton @click="createDialog = true">
+          <template #icon> {{ $globals.icons.create }} </template>
+          Create
+        </BaseButton>
         <BaseButton @click="mergeDialog = true">
           <template #icon> {{ $globals.icons.units }} </template>
           Combine
@@ -132,7 +156,7 @@ import { computed, defineComponent, onMounted, ref } from "@nuxtjs/composition-a
 import type { LocaleObject } from "@nuxtjs/i18n";
 import { validators } from "~/composables/use-validators";
 import { useUserApi } from "~/composables/api";
-import { IngredientUnit } from "~/types/api-types/recipe";
+import { CreateIngredientUnit, IngredientUnit } from "~/types/api-types/recipe";
 import { useLocales } from "~/composables/use-locales";
 import { useUnitStore } from "~/composables/store";
 
@@ -178,6 +202,26 @@ export default defineComponent({
 
     const { units, actions: unitActions } = useUnitStore();
 
+    // ============================================================
+    // Create Units
+
+    const createDialog = ref(false);
+    const createTarget = ref<CreateIngredientUnit>({});
+
+    function createEventHandler() {
+      createDialog.value = true;
+    }
+
+    async function createUnit() {
+      if (!createTarget.value || !createTarget.value.name) {
+        return;
+      }
+
+      await unitActions.createOne(createTarget.value);
+      createDialog.value = false;
+    }
+
+    // ============================================================
     // Edit Units
     const editDialog = ref(false);
     const editTarget = ref<IngredientUnit | null>(null);
@@ -263,6 +307,11 @@ export default defineComponent({
       tableHeaders,
       units,
       validators,
+      // Create
+      createDialog,
+      createEventHandler,
+      createUnit,
+      createTarget,
       // Edit
       editDialog,
       editEventHandler,

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -32,7 +32,12 @@
     >
       <v-card-text>
         <v-form ref="domNewUnitForm">
-          <v-text-field v-model="createTarget.name" label="Name" :rules="[validators.required]"></v-text-field>
+          <v-text-field
+            v-model="createTarget.name"
+            autofocus
+            label="Name"
+            :rules="[validators.required]"
+          ></v-text-field>
           <v-text-field v-model="createTarget.abbreviation" label="Abbreviation"></v-text-field>
           <v-text-field v-model="createTarget.description" label="Description"></v-text-field>
           <v-checkbox v-model="createTarget.fraction" hide-details label="Display as Fraction"></v-checkbox>
@@ -122,10 +127,8 @@
       @create-one="createEventHandler"
     >
       <template #button-row>
-        <BaseButton @click="createDialog = true">
-          <template #icon> {{ $globals.icons.create }} </template>
-          Create
-        </BaseButton>
+        <BaseButton create @click="createDialog = true" />
+
         <BaseButton @click="mergeDialog = true">
           <template #icon> {{ $globals.icons.units }} </template>
           Combine
@@ -159,6 +162,7 @@ import { useUserApi } from "~/composables/api";
 import { CreateIngredientUnit, IngredientUnit } from "~/types/api-types/recipe";
 import { useLocales } from "~/composables/use-locales";
 import { useUnitStore } from "~/composables/store";
+import { VForm } from "~/types/vuetify";
 
 export default defineComponent({
   setup() {
@@ -206,13 +210,14 @@ export default defineComponent({
     // Create Units
 
     const createDialog = ref(false);
+    const domNewUnitForm = ref<VForm>();
 
     // we explicitly set booleans to false since forms don't POST unchecked boxes
     const createTarget = ref<CreateIngredientUnit>({
-        name: "",
-        fraction: false,
-        useAbbreviation: false
-      });
+      name: "",
+      fraction: false,
+      useAbbreviation: false,
+    });
 
     function createEventHandler() {
       createDialog.value = true;
@@ -223,17 +228,15 @@ export default defineComponent({
         return;
       }
 
-      // @ts-ignore the createOne function erroneously expects an id because it uses the IngredientUnit type
+      // @ts-expect-error the createOne function erroneously expects an id because it uses the IngredientUnit type
       await unitActions.createOne(createTarget.value);
       createDialog.value = false;
 
-      // reset form
-      // @ts-ignore TS doesn't like this.$refs despite it working just fine
-      this.$refs.domNewUnitForm.reset();
+      domNewUnitForm.value?.reset();
       createTarget.value = {
         name: "",
         fraction: false,
-        useAbbreviation: false
+        useAbbreviation: false,
       };
     }
 


### PR DESCRIPTION
This adds a "Create" dialog to the food and unit data management pages.

One thing I noticed is that if you create a new food/unit, it doesn't appear in the list until you refresh. I'm unsure how to fix that, however this is also true if you delete one (which is an existing functionality) so it's not a new issue. I noticed there's a refresh on the `foodStore` and `unitStore`, and monitoring the network I can see that the new data is fetched, it's just not being re-rendered. Something to look into.