### PR TITLE
Use `flex-basis`, not width to fix min size bug

### DIFF
--- a/frontend/pages/register/register.vue
+++ b/frontend/pages/register/register.vue
@@ -173,7 +173,7 @@
                   @click:append="pwFields.togglePasswordShow"
                 />
                 <div class="d-flex justify-center pb-6 mt-n1">
-                  <div style="width: 500px">
+                  <div style="flex-basis: 500px">
                     <strong> {{ $t("user.password-strength", { strength: pwStrength.strength.value }) }}</strong>
                     <v-progress-linear
                       :value="pwStrength.score.value"


### PR DESCRIPTION
On mobile screens when following a registration invite link, the page
would be too wide to interact with, extending well over the sides of the
phone.

![An image of a mobile size emulated browser, showing overflow](https://user-images.githubusercontent.com/6252212/184050748-bc15a9b9-8b58-4c57-9f00-d54c4bf4dc2a.png)


This is because the minimum size of content is set to `auto` (by
default), and accord to the spec (https://www.w3.org/TR/css-flexbox-1/#specified-size-suggestion)
the minimum size of the element is the mimimum size of it's content. The
password strength element in the panel had a width of 500px, making the
entire component overflow the screen.

Changing the width to `flex-basis` instead, allows for the password
strength element to shrink if it overflows the screen.

![Screenshot from 2022-08-10 21-32-23](https://user-images.githubusercontent.com/6252212/184050787-0d338184-b336-47f1-9fe4-10c82b483578.png)

