### PR TITLE
Add the RecipeCardMenu to the recipe in a mealplan

### DIFF
--- a/frontend/pages/group/mealplan/planner.vue
+++ b/frontend/pages/group/mealplan/planner.vue
@@ -237,7 +237,7 @@
                 </v-chip>
                 <RecipeContextMenu
                   :name="mealplan.recipe.name"
-                  :recipeId="mealplan.recipe.id"
+                  :recipe-id="mealplan.recipe.id"
                   :slug="mealplan.recipe ? mealplan.recipe.slug : ''"
                   :use-items="{
                     delete: false,

--- a/frontend/pages/group/mealplan/planner.vue
+++ b/frontend/pages/group/mealplan/planner.vue
@@ -118,7 +118,8 @@
                     tiny
                     icon-size="25"
                     :slug="mealplan.recipe ? mealplan.recipe.slug : ''"
-                  />
+                  >
+                  </RecipeCardImage>
                   <v-icon v-else>
                     {{ $globals.icons.primary }}
                   </v-icon>
@@ -234,6 +235,20 @@
                   </v-icon>
                   {{ mealplan.entryType }}
                 </v-chip>
+                <RecipeContextMenu
+                  :name="mealplan.recipe.name"
+                  :recipeId="mealplan.recipe.id"
+                  :slug="mealplan.recipe ? mealplan.recipe.slug : ''"
+                  :use-items="{
+                    delete: false,
+                    edit: false,
+                    download: true,
+                    mealplanner: false,
+                    print: true,
+                    share: false,
+                    shoppingList: true,
+                  }"
+                />
               </v-card-actions>
             </template>
           </RecipeCard>
@@ -254,6 +269,7 @@ import { useMealplans, planTypeOptions } from "~/composables/use-group-mealplan"
 import { useRecipes, allRecipes } from "~/composables/recipes";
 import RecipeCardImage from "~/components/Domain/Recipe/RecipeCardImage.vue";
 import RecipeCard from "~/components/Domain/Recipe/RecipeCard.vue";
+import RecipeContextMenu from "~/components/Domain/Recipe/RecipeContextMenu.vue";
 import { PlanEntryType } from "~/types/api-types/meal-plan";
 import { useUserApi } from "~/composables/api";
 
@@ -262,6 +278,7 @@ export default defineComponent({
     draggable,
     RecipeCardImage,
     RecipeCard,
+    RecipeContextMenu,
   },
   setup() {
     const state = reactive({


### PR DESCRIPTION
This PR adds the recipe menu to recipes shown in the mealplanner. I use it as a shortcut to add all recipes in a mealplan to the shopping list.

![image](https://user-images.githubusercontent.com/12159227/184385900-7d890ad3-3408-4d71-bd6f-b588e27759ea.png)
