### PR TITLE
fix: missing instructions header on recipe page

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipeInstructions.vue
@@ -58,9 +58,9 @@
       </v-card>
     </v-dialog>
 
-    <div v-if="showCookMode" class="d-flex justify-space-between justify-start">
+    <div class="d-flex justify-space-between justify-start">
       <h2 class="mb-4 mt-1">{{ $t("recipe.instructions") }}</h2>
-      <BaseButton v-if="!public && !edit" minor cancel color="primary" @click="toggleCookMode()">
+      <BaseButton v-if="!public && !edit && showCookMode" minor cancel color="primary" @click="toggleCookMode()">
         <template #icon>
           {{ $globals.icons.primary }}
         </template>


### PR DESCRIPTION
After reading the blog post today I went to go look at cook mode and found that it was missing from my recipes. I don't have many linked ingredients yet so that made sense, but I also noticed the "instructions" header was missing...

![image](https://user-images.githubusercontent.com/71845777/184542969-b1bdd16b-20c1-4012-8e70-40f4f39d645c.png)

I found the cause here:
https://github.com/hay-kot/mealie/commit/c64da1fdb7c15bc699e1b20915f75587d1330794#diff-8fd994ad2d8706bf296dfaf258bdd95c6eab888841ebf78390a1dc26de6362ba

I just moved the header out of the conditional block:
![image](https://user-images.githubusercontent.com/71845777/184543018-0ce792d4-1b19-43cf-b1fd-2bb2e342164d.png)
