### PR TITLE
feat: Unify Recipe Card Sections

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -169,6 +169,10 @@ export default defineComponent({
       type: String,
       default: null,
     },
+    toolSlug: {
+      type: String,
+      default: null,
+    },
   },
   setup(props, context) {
     const preferences = useUserSortPreferences();
@@ -211,6 +215,7 @@ export default defineComponent({
     const loading = ref(false);
     const category = ref<string>(props.categorySlug);
     const tag = ref<string>(props.tagSlug);
+    const tool = ref<string>(props.toolSlug);
 
     const { fetchMore } = useLazyRecipes();
 
@@ -224,6 +229,7 @@ export default defineComponent({
         preferences.value.orderDirection,
         category.value,
         tag.value,
+        tool.value,
       );
 
       // since we doubled the first call, we also need to advance the page
@@ -249,6 +255,7 @@ export default defineComponent({
           preferences.value.orderDirection,
           category.value,
           tag.value,
+          tool.value,
         );
         if (!newRecipes.length) {
           hasMore.value = false;
@@ -309,6 +316,7 @@ export default defineComponent({
           preferences.value.orderDirection,
           category.value,
           tag.value,
+          tool.value,
         );
         context.emit(REPLACE_RECIPES_EVENT, newRecipes);
 

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -15,49 +15,7 @@
         {{ $vuetify.breakpoint.xsOnly ? null : $t("general.random") }}
       </v-btn>
 
-      <v-menu v-if="$listeners.sort" offset-y left>
-        <template #activator="{ on, attrs }">
-          <v-btn text :icon="$vuetify.breakpoint.xsOnly" v-bind="attrs" :loading="sortLoading" v-on="on">
-            <v-icon :left="!$vuetify.breakpoint.xsOnly">
-              {{ $globals.icons.sort }}
-            </v-icon>
-            {{ $vuetify.breakpoint.xsOnly ? null : $t("general.sort") }}
-          </v-btn>
-        </template>
-        <v-list>
-          <v-list-item @click="sortRecipesFrontend(EVENTS.az)">
-            <v-icon left>
-              {{ $globals.icons.orderAlphabeticalAscending }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.sort-alphabetically") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="sortRecipesFrontend(EVENTS.rating)">
-            <v-icon left>
-              {{ $globals.icons.star }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.rating") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="sortRecipesFrontend(EVENTS.created)">
-            <v-icon left>
-              {{ $globals.icons.newBox }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.created") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="sortRecipesFrontend(EVENTS.updated)">
-            <v-icon left>
-              {{ $globals.icons.update }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.updated") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="sortRecipesFrontend(EVENTS.shuffle)">
-            <v-icon left>
-              {{ $globals.icons.shuffleVariant }}
-            </v-icon>
-            <v-list-item-title>{{ $t("general.shuffle") }}</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-menu>
-      <v-menu v-if="$listeners.sortRecipes" offset-y left>
+      <v-menu offset-y left>
         <template #activator="{ on, attrs }">
           <v-btn text :icon="$vuetify.breakpoint.xsOnly" v-bind="attrs" :loading="sortLoading" v-on="on">
             <v-icon :left="!$vuetify.breakpoint.xsOnly">
@@ -147,12 +105,10 @@
         </v-col>
       </v-row>
     </div>
-    <div v-if="usePagination">
-      <v-card v-intersect="infiniteScroll"></v-card>
-      <v-fade-transition>
-        <AppLoader v-if="loading" :loading="loading" />
-      </v-fade-transition>
-    </div>
+    <v-card v-intersect="infiniteScroll"></v-card>
+    <v-fade-transition>
+      <AppLoader v-if="loading" :loading="loading" />
+    </v-fade-transition>
   </div>
 </template>
 
@@ -172,11 +128,10 @@ import { useThrottleFn } from "@vueuse/core";
 import RecipeCard from "./RecipeCard.vue";
 import RecipeCardMobile from "./RecipeCardMobile.vue";
 import { useAsyncKey } from "~/composables/use-utils";
-import { useLazyRecipes, useSorter } from "~/composables/recipes";
+import { useLazyRecipes } from "~/composables/recipes";
 import { Recipe } from "~/types/api-types/recipe";
 import { useUserSortPreferences } from "~/composables/use-users/preferences";
 
-const SORT_EVENT = "sort";
 const REPLACE_RECIPES_EVENT = "replaceRecipes";
 const APPEND_RECIPES_EVENT = "appendRecipes";
 
@@ -214,15 +169,9 @@ export default defineComponent({
       type: String,
       default: null,
     },
-    usePagination: {
-      type: Boolean,
-      default: false,
-    },
   },
   setup(props, context) {
     const preferences = useUserSortPreferences();
-
-    const utils = useSorter();
 
     const EVENTS = {
       az: "az",
@@ -269,24 +218,22 @@ export default defineComponent({
     const { fetchMore } = useLazyRecipes();
 
     onMounted(async () => {
-      if (props.usePagination) {
-        const newRecipes = await fetchMore(
-          page.value,
+      const newRecipes = await fetchMore(
+        page.value,
 
-          // we double-up the first call to avoid a bug with large screens that render the entire first page without scrolling, preventing additional loading
-          perPage.value*2,
-          preferences.value.orderBy,
-          preferences.value.orderDirection,
-          category.value,
-          tag.value
-        );
+        // we double-up the first call to avoid a bug with large screens that render the entire first page without scrolling, preventing additional loading
+        perPage.value*2,
+        preferences.value.orderBy,
+        preferences.value.orderDirection,
+        category.value,
+        tag.value
+      );
 
-        // since we doubled the first call, we also need to advance the page
-        page.value = page.value + 1;
+      // since we doubled the first call, we also need to advance the page
+      page.value = page.value + 1;
 
-        context.emit(REPLACE_RECIPES_EVENT, newRecipes);
-        ready.value = true;
-      }
+      context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+      ready.value = true;
     });
 
     const infiniteScroll = useThrottleFn(() => {
@@ -316,12 +263,6 @@ export default defineComponent({
       }, useAsyncKey());
     }, 500);
 
-    /**
-     * sortRecipes helps filter using the API. This will eventually replace the sortRecipesFrontend function which pulls all recipes
-     * (without pagination) and does the sorting in the frontend.
-     * TODO: remove sortRecipesFrontend and remove duplicate "sortRecipes" section in the template (above)
-     * @param sortType
-     */
     function sortRecipes(sortType: string) {
       if (state.sortLoading || loading.value) {
         return;
@@ -377,33 +318,6 @@ export default defineComponent({
       }, useAsyncKey());
     }
 
-    function sortRecipesFrontend(sortType: string) {
-      state.sortLoading = true;
-      const sortTarget = [...props.recipes];
-      switch (sortType) {
-        case EVENTS.az:
-          utils.sortAToZ(sortTarget);
-          break;
-        case EVENTS.rating:
-          utils.sortByRating(sortTarget);
-          break;
-        case EVENTS.created:
-          utils.sortByCreated(sortTarget);
-          break;
-        case EVENTS.updated:
-          utils.sortByUpdated(sortTarget);
-          break;
-        case EVENTS.shuffle:
-          utils.shuffle(sortTarget);
-          break;
-        default:
-          console.log("Unknown Event", sortType);
-          return;
-      }
-      context.emit(SORT_EVENT, sortTarget);
-      state.sortLoading = false;
-    }
-
     function toggleMobileCards() {
       preferences.value.useMobileCards = !preferences.value.useMobileCards;
     }
@@ -417,7 +331,6 @@ export default defineComponent({
       navigateRandom,
       preferences,
       sortRecipes,
-      sortRecipesFrontend,
       toggleMobileCards,
       useMobileCards,
     };

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -206,6 +206,14 @@ export default defineComponent({
       type: Array as () => Recipe[],
       default: () => [],
     },
+    categorySlug: {
+      type: String,
+      default: null,
+    },
+    tagSlug: {
+      type: String,
+      default: null,
+    },
     usePagination: {
       type: Boolean,
       default: false,
@@ -252,6 +260,11 @@ export default defineComponent({
     const hasMore = ref(true);
     const ready = ref(false);
     const loading = ref(false);
+    const category = ref<string>(props.categorySlug);
+    const tag = ref<string>(props.tagSlug);
+
+    console.log(props);
+    console.log(category);
 
     const { fetchMore } = useLazyRecipes();
 
@@ -263,7 +276,9 @@ export default defineComponent({
           // we double-up the first call to avoid a bug with large screens that render the entire first page without scrolling, preventing additional loading
           perPage.value*2,
           preferences.value.orderBy,
-          preferences.value.orderDirection
+          preferences.value.orderDirection,
+          category.value,
+          tag.value
         );
 
         // since we doubled the first call, we also need to advance the page
@@ -287,7 +302,9 @@ export default defineComponent({
           page.value,
           perPage.value,
           preferences.value.orderBy,
-          preferences.value.orderDirection
+          preferences.value.orderDirection,
+          category.value,
+          tag.value
         );
         if (!newRecipes.length) {
           hasMore.value = false;

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -212,9 +212,6 @@ export default defineComponent({
     const category = ref<string>(props.categorySlug);
     const tag = ref<string>(props.tagSlug);
 
-    console.log(props);
-    console.log(category);
-
     const { fetchMore } = useLazyRecipes();
 
     onMounted(async () => {

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -226,7 +226,7 @@ export default defineComponent({
         preferences.value.orderBy,
         preferences.value.orderDirection,
         category.value,
-        tag.value
+        tag.value,
       );
 
       // since we doubled the first call, we also need to advance the page
@@ -251,7 +251,7 @@ export default defineComponent({
           preferences.value.orderBy,
           preferences.value.orderDirection,
           category.value,
-          tag.value
+          tag.value,
         );
         if (!newRecipes.length) {
           hasMore.value = false;
@@ -309,7 +309,9 @@ export default defineComponent({
           page.value,
           perPage.value,
           preferences.value.orderBy,
-          preferences.value.orderDirection
+          preferences.value.orderDirection,
+          category.value,
+          tag.value,
         );
         context.emit(REPLACE_RECIPES_EVENT, newRecipes);
 

--- a/frontend/composables/recipes/index.ts
+++ b/frontend/composables/recipes/index.ts
@@ -1,6 +1,6 @@
 export { useFraction } from "./use-fraction";
 export { useRecipe } from "./use-recipe";
-export { useRecipes, recentRecipes, allRecipes, useLazyRecipes, useSorter } from "./use-recipes";
+export { useRecipes, recentRecipes, allRecipes, useLazyRecipes } from "./use-recipes";
 export { parseIngredientText } from "./use-recipe-ingredients";
 export { useRecipeSearch } from "./use-recipe-search";
 export { useTools } from "./use-recipe-tools";

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -6,56 +6,6 @@ import { Recipe } from "~/types/api-types/recipe";
 export const allRecipes = ref<Recipe[]>([]);
 export const recentRecipes = ref<Recipe[]>([]);
 
-const rand = (n: number) => Math.floor(Math.random() * n);
-
-function swap(t: Array<unknown>, i: number, j: number) {
-  const q = t[i];
-  t[i] = t[j];
-  t[j] = q;
-  return t;
-}
-
-export const useSorter = () => {
-  function sortAToZ(list: Array<Recipe>) {
-    list.sort((a, b) => {
-      const textA: string = a.name?.toUpperCase() ?? "";
-      const textB: string = b.name?.toUpperCase() ?? "";
-      return textA < textB ? -1 : textA > textB ? 1 : 0;
-    });
-  }
-  function sortByCreated(list: Array<Recipe>) {
-    list.sort((a, b) => ((a.dateAdded ?? "") > (b.dateAdded ?? "") ? -1 : 1));
-  }
-  function sortByUpdated(list: Array<Recipe>) {
-    list.sort((a, b) => ((a.dateUpdated ?? "") > (b.dateUpdated ?? "") ? -1 : 1));
-  }
-  function sortByRating(list: Array<Recipe>) {
-    list.sort((a, b) => ((a.rating ?? 0) > (b.rating ?? 0) ? -1 : 1));
-  }
-
-  function randomRecipe(list: Array<Recipe>): Recipe {
-    return list[Math.floor(Math.random() * list.length)];
-  }
-
-  function shuffle(list: Array<Recipe>) {
-    let last = list.length;
-    let n;
-    while (last > 0) {
-      n = rand(last);
-      swap(list, n, --last);
-    }
-  }
-
-  return {
-    sortAToZ,
-    sortByCreated,
-    sortByUpdated,
-    sortByRating,
-    randomRecipe,
-    shuffle,
-  };
-};
-
 export const useLazyRecipes = function () {
   const api = useUserApi();
 
@@ -66,9 +16,36 @@ export const useLazyRecipes = function () {
     return data ? data.items : [];
   }
 
+  function appendRecipes(val: Array<Recipe>) {
+    val.forEach((recipe) => {
+      recipes.value.push(recipe);
+    });
+  }
+
+  function assignSorted(val: Array<Recipe>) {
+    recipes.value = val;
+  }
+
+  function removeRecipe(slug: string) {
+    for (let i = 0; i < recipes?.value?.length; i++) {
+      if (recipes?.value[i].slug === slug) {
+        recipes?.value.splice(i, 1);
+        break;
+      }
+    }
+  }
+
+  function replaceRecipes(val: Array<Recipe>) {
+    recipes.value = val;
+  }
+
   return {
     recipes,
     fetchMore,
+    appendRecipes,
+    assignSorted,
+    removeRecipe,
+    replaceRecipes
   };
 };
 

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -61,8 +61,8 @@ export const useLazyRecipes = function () {
 
   const recipes = ref<Recipe[]>([]);
 
-  async function fetchMore(page: number, perPage: number, orderBy: string | null = null, orderDirection = "desc") {
-    const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection });
+  async function fetchMore(page: number, perPage: number, orderBy: string | null = null, orderDirection = "desc", category: string | null = null, tag: string | null = null) {
+    const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection, "categories": category, "tags": tag });
     return data ? data.items : [];
   }
 

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -11,8 +11,8 @@ export const useLazyRecipes = function () {
 
   const recipes = ref<Recipe[]>([]);
 
-  async function fetchMore(page: number, perPage: number, orderBy: string | null = null, orderDirection = "desc", category: string | null = null, tag: string | null = null) {
-    const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection, "categories": category, "tags": tag });
+  async function fetchMore(page: number, perPage: number, orderBy: string | null = null, orderDirection = "desc", category: string | null = null, tag: string | null = null, tool: string | null = null) {
+    const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection, "categories": category, "tags": tag, "tools": tool });
     return data ? data.items : [];
   }
 

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -22,7 +22,7 @@ import { Recipe } from "~/types/api-types/recipe";
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
-    const { recipes, fetchMore } = useLazyRecipes();
+    const { recipes } = useLazyRecipes();
 
     function appendRecipes(val: Array<Recipe>) {
       val.forEach((recipe) => {

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -4,7 +4,6 @@
       :icon="$globals.icons.primary"
       :title="$t('page.all-recipes')"
       :recipes="recipes"
-      :use-pagination="true"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"
       @appendRecipes="appendRecipes"

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -17,36 +17,11 @@
 import { defineComponent } from "@nuxtjs/composition-api";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useLazyRecipes } from "~/composables/recipes";
-import { Recipe } from "~/types/api-types/recipe";
 
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
-    const { recipes } = useLazyRecipes();
-
-    function appendRecipes(val: Array<Recipe>) {
-      val.forEach((recipe) => {
-        recipes.value.push(recipe);
-      });
-    }
-
-    function assignSorted(val: Array<Recipe>) {
-      recipes.value = val;
-    }
-
-    function removeRecipe(slug: string) {
-      for (let i = 0; i < recipes?.value?.length; i++) {
-        if (recipes?.value[i].slug === slug) {
-          recipes?.value.splice(i, 1);
-          break;
-        }
-      }
-    }
-
-    function replaceRecipes(val: Array<Recipe>) {
-      recipes.value = val;
-    }
-
+    const { recipes, appendRecipes, assignSorted, removeRecipe, replaceRecipes } = useLazyRecipes();
     return { appendRecipes, assignSorted, recipes, removeRecipe, replaceRecipes };
   },
   head() {

--- a/frontend/pages/recipes/categories/_slug.vue
+++ b/frontend/pages/recipes/categories/_slug.vue
@@ -6,7 +6,6 @@
       :title="category.name"
       :recipes="recipes"
       :tag-slug="tag.slug"
-      :use-pagination="true"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"
       @appendRecipes="appendRecipes"
@@ -62,12 +61,11 @@ import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from
 import { useLazyRecipes } from "~/composables/recipes";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useUserApi } from "~/composables/api";
-import { Recipe } from "~/types/api-types/recipe";
 
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
-    const { recipes } = useLazyRecipes();
+    const { recipes, appendRecipes, assignSorted, removeRecipe, replaceRecipes } = useLazyRecipes();
 
     const api = useUserApi();
     const route = useRoute();
@@ -106,29 +104,6 @@ export default defineComponent({
       if (data) {
         router.push("/recipes/categories/" + data.slug);
       }
-    }
-
-    function appendRecipes(val: Array<Recipe>) {
-      val.forEach((recipe) => {
-        recipes.value.push(recipe);
-      });
-    }
-
-    function assignSorted(val: Array<Recipe>) {
-      recipes.value = val;
-    }
-
-    function removeRecipe(slug: string) {
-      for (let i = 0; i < recipes?.value?.length; i++) {
-        if (recipes?.value[i].slug === slug) {
-          recipes?.value.splice(i, 1);
-          break;
-        }
-      }
-    }
-
-    function replaceRecipes(val: Array<Recipe>) {
-      recipes.value = val;
     }
 
     return {

--- a/frontend/pages/recipes/categories/_slug.vue
+++ b/frontend/pages/recipes/categories/_slug.vue
@@ -4,8 +4,13 @@
       v-if="category"
       :icon="$globals.icons.tags"
       :title="category.name"
-      :recipes="category.recipes"
-      @sort="assignSorted"
+      :recipes="recipes"
+      :tag-slug="tag.slug"
+      :use-pagination="true"
+      @sortRecipes="assignSorted"
+      @replaceRecipes="replaceRecipes"
+      @appendRecipes="appendRecipes"
+      @delete="removeRecipe"
     >
       <template #title>
         <v-btn icon class="mr-1">
@@ -54,6 +59,7 @@
 
 <script lang="ts">
 import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from "@nuxtjs/composition-api";
+import { useLazyRecipes } from "~/composables/recipes";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useUserApi } from "~/composables/api";
 import { Recipe } from "~/types/api-types/recipe";
@@ -61,6 +67,8 @@ import { Recipe } from "~/types/api-types/recipe";
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
+    const { recipes } = useLazyRecipes();
+
     const api = useUserApi();
     const route = useRoute();
     const router = useRouter();
@@ -100,24 +108,45 @@ export default defineComponent({
       }
     }
 
+    function appendRecipes(val: Array<Recipe>) {
+      val.forEach((recipe) => {
+        recipes.value.push(recipe);
+      });
+    }
+
+    function assignSorted(val: Array<Recipe>) {
+      recipes.value = val;
+    }
+
+    function removeRecipe(slug: string) {
+      for (let i = 0; i < recipes?.value?.length; i++) {
+        if (recipes?.value[i].slug === slug) {
+          recipes?.value.splice(i, 1);
+          break;
+        }
+      }
+    }
+
+    function replaceRecipes(val: Array<Recipe>) {
+      recipes.value = val;
+    }
+
     return {
       category,
       reset,
       ...toRefs(state),
       updateCategory,
+      appendRecipes,
+      assignSorted,
+      recipes,
+      removeRecipe,
+      replaceRecipes,
     };
   },
   head() {
     return {
       title: this.$t("category.categories") as string,
     };
-  },
-  methods: {
-    assignSorted(val: Array<Recipe>) {
-      if (this.category) {
-        this.category.recipes = val;
-      }
-    },
   },
 });
 </script>

--- a/frontend/pages/recipes/categories/_slug.vue
+++ b/frontend/pages/recipes/categories/_slug.vue
@@ -5,7 +5,7 @@
       :icon="$globals.icons.tags"
       :title="category.name"
       :recipes="recipes"
-      :tag-slug="tag.slug"
+      :category-slug="category.slug"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"
       @appendRecipes="appendRecipes"

--- a/frontend/pages/recipes/tags/_slug.vue
+++ b/frontend/pages/recipes/tags/_slug.vue
@@ -6,7 +6,6 @@
       :title="tag.name"
       :recipes="recipes"
       :tag-slug="tag.slug"
-      :use-pagination="true"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"
       @appendRecipes="appendRecipes"

--- a/frontend/pages/recipes/tags/_slug.vue
+++ b/frontend/pages/recipes/tags/_slug.vue
@@ -1,11 +1,16 @@
 <template>
   <v-container>
     <RecipeCardSection
-      v-if="tags"
+      v-if="tag"
       :icon="$globals.icons.tags"
-      :title="tags.name"
-      :recipes="tags.recipes"
-      @sort="assignSorted"
+      :title="tag.name"
+      :recipes="recipes"
+      :tag-slug="tag.slug"
+      :use-pagination="true"
+      @sortRecipes="assignSorted"
+      @replaceRecipes="replaceRecipes"
+      @appendRecipes="appendRecipes"
+      @delete="removeRecipe"
     >
       <template #title>
         <v-btn icon class="mr-1">
@@ -16,7 +21,7 @@
 
         <template v-if="edit">
           <v-text-field
-            v-model="tags.name"
+            v-model="tag.name"
             autofocus
             single-line
             dense
@@ -41,7 +46,7 @@
           <v-tooltip top>
             <template #activator="{ on, attrs }">
               <v-toolbar-title v-bind="attrs" style="cursor: pointer" class="headline" v-on="on" @click="edit = true">
-                {{ tags.name }}
+                {{ tag.name }}
               </v-toolbar-title>
             </template>
             <span> Click to Edit </span>
@@ -54,6 +59,7 @@
 
 <script lang="ts">
 import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from "@nuxtjs/composition-api";
+import { useLazyRecipes } from "~/composables/recipes";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useUserApi } from "~/composables/api";
 import { Recipe } from "~/types/api-types/recipe";
@@ -61,6 +67,8 @@ import { Recipe } from "~/types/api-types/recipe";
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
+    const { recipes } = useLazyRecipes();
+
     const api = useUserApi();
     const route = useRoute();
     const router = useRouter();
@@ -71,7 +79,7 @@ export default defineComponent({
       edit: false,
     });
 
-    const tags = useAsync(async () => {
+    const tag = useAsync(async () => {
       const { data } = await api.tags.bySlug(slug);
       if (data) {
         state.initialValue = data.name;
@@ -82,42 +90,63 @@ export default defineComponent({
     function reset() {
       state.edit = false;
 
-      if (tags.value) {
-        tags.value.name = state.initialValue;
+      if (tag.value) {
+        tag.value.name = state.initialValue;
       }
     }
 
     async function updateTags() {
       state.edit = false;
 
-      if (!tags.value) {
+      if (!tag.value) {
         return;
       }
-      const { data } = await api.tags.updateOne(tags.value.id, tags.value);
+      const { data } = await api.tags.updateOne(tag.value.id, tag.value);
 
       if (data) {
         router.push("/recipes/tags/" + data.slug);
       }
     }
 
+    function appendRecipes(val: Array<Recipe>) {
+      val.forEach((recipe) => {
+        recipes.value.push(recipe);
+      });
+    }
+
+    function assignSorted(val: Array<Recipe>) {
+      recipes.value = val;
+    }
+
+    function removeRecipe(slug: string) {
+      for (let i = 0; i < recipes?.value?.length; i++) {
+        if (recipes?.value[i].slug === slug) {
+          recipes?.value.splice(i, 1);
+          break;
+        }
+      }
+    }
+
+    function replaceRecipes(val: Array<Recipe>) {
+      recipes.value = val;
+    }
+
     return {
-      tags,
+      tag,
       reset,
       ...toRefs(state),
       updateTags,
+      appendRecipes,
+      assignSorted,
+      recipes,
+      removeRecipe,
+      replaceRecipes,
     };
   },
   head() {
     return {
       title: this.$t("tag.tags") as string,
     };
-  },
-  methods: {
-    assignSorted(val: Array<Recipe>) {
-      if (this.tags) {
-        this.tags.recipes = val;
-      }
-    },
   },
 });
 </script>

--- a/frontend/pages/recipes/tags/_slug.vue
+++ b/frontend/pages/recipes/tags/_slug.vue
@@ -62,12 +62,11 @@ import { defineComponent, useAsync, useRoute, reactive, toRefs, useRouter } from
 import { useLazyRecipes } from "~/composables/recipes";
 import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
 import { useUserApi } from "~/composables/api";
-import { Recipe } from "~/types/api-types/recipe";
 
 export default defineComponent({
   components: { RecipeCardSection },
   setup() {
-    const { recipes } = useLazyRecipes();
+    const { recipes, appendRecipes, assignSorted, removeRecipe, replaceRecipes } = useLazyRecipes();
 
     const api = useUserApi();
     const route = useRoute();
@@ -106,29 +105,6 @@ export default defineComponent({
       if (data) {
         router.push("/recipes/tags/" + data.slug);
       }
-    }
-
-    function appendRecipes(val: Array<Recipe>) {
-      val.forEach((recipe) => {
-        recipes.value.push(recipe);
-      });
-    }
-
-    function assignSorted(val: Array<Recipe>) {
-      recipes.value = val;
-    }
-
-    function removeRecipe(slug: string) {
-      for (let i = 0; i < recipes?.value?.length; i++) {
-        if (recipes?.value[i].slug === slug) {
-          recipes?.value.splice(i, 1);
-          break;
-        }
-      }
-    }
-
-    function replaceRecipes(val: Array<Recipe>) {
-      recipes.value = val;
     }
 
     return {

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -136,6 +136,7 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
         load_food=False,
         categories: Optional[list[UUID4 | str]] = None,
         tags: Optional[list[UUID4 | str]] = None,
+        tools: Optional[list[UUID4 | str]] = None,
     ) -> RecipePagination:
         q = self.session.query(self.model)
 
@@ -168,6 +169,14 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
 
                 else:
                     q = q.filter(RecipeModel.tags.any(Tag.slug == tag))
+
+        if tools:
+            for tool in tools:
+                if isinstance(tool, UUID):
+                    q = q.filter(RecipeModel.tools.any(Tool.id == tool))
+
+                else:
+                    q = q.filter(RecipeModel.tools.any(Tool.slug == tool))
 
         q, count, total_pages = self.add_pagination_to_query(q, pagination)
 

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -213,12 +213,14 @@ class RecipeController(BaseRecipeController):
         q: RecipePaginationQuery = Depends(RecipePaginationQuery),
         categories: Optional[list[UUID4 | str]] = Query(None),
         tags: Optional[list[UUID4 | str]] = Query(None),
+        tools: Optional[list[UUID4 | str]] = Query(None),
     ):
         response = self.repo.page_all(
             pagination=q,
             load_food=q.load_food,
             categories=categories,
             tags=tags,
+            tools=tools,
         )
 
         response.set_pagination_guides(router.url_path_for("get_all"), q.dict())


### PR DESCRIPTION
This completes #1497 by unifying the category and tag recipe views. I also almost forgot about the recipe by tool view (which I never mentioned in #1497), but I took care of it here. Consequently, I had to update the backend API to allow filtering by tool and added some tests.

I had trouble with the frontend calling the backend using an array (it kept sticking square brackets in the param key, e.g. `categories[]=my-category`) and I couldn't figure out how to fix it, so I did a cheeky mapping instead:

```js
const { data } = await api.recipes.getAll(page, perPage, { orderBy, orderDirection, "categories": category, "tags": tag, "tools": tool });
```

Not sure if it matters since the frontend always exclusively filters by exactly one category, tag, or tool anyway.