### PR TITLE
Feat/dev container improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,8 +35,13 @@
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
+    "dbaeumer.vscode-eslint",
+    "matangover.mypy",
+    "ms-python.black-formatter",
+    "ms-python.isort",
     "ms-python.python",
-    "ms-python.vscode-pylance"
+    "ms-python.vscode-pylance",
+    "Vue.volar"
   ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,8 +48,9 @@
     3000,
     9000
   ],
+  // Use 'onCreateCommand' to run commands at the end of container creation.
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/mealie/frontend/node_modules && make setup",
+  "onCreateCommand": "sudo chown -R vscode:vscode /workspaces/mealie/frontend/node_modules && make setup",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
   // "features": {


### PR DESCRIPTION
This adds additional formatting/linting extensions to the dev container. The required packages are already in poetry/yarn (isort, mypy, eslint) but every time the container is rebuilt you have to install the extensions manually.

I also moved the "make setup" makefile command to "onCreateCommand". This builds the dependencies out before extensions are installed (if left on "postCreateCommand" the extensions throw initialization errors because Python is missing, and you have to restart the container to fix it). As far as I can tell this doesn't impact anything else.