### PR TITLE
Tweaked print view to layout ingredients more naturally

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -22,7 +22,7 @@
         :key="`ingredient-section-${sectionIndex}`"
         class="print-section"
       >
-        <div class="ingredient-grid">
+        <div class="ingredient-grid" :style="{gridTemplateRows:`repeat(${Math.ceil(ingredientSection.ingredients.length / 2)}, 1fr)`}">
           <template v-for="(ingredient, ingredientIndex) in ingredientSection.ingredients">
             <h4 v-if="ingredient.title" :key="`ingredient-title-${ingredientIndex}`" class="ingredient-title mt-2">
               {{ ingredient.title }}
@@ -245,6 +245,7 @@ p {
 
 .ingredient-grid {
   display: grid;
+  grid-auto-flow: column;
   grid-template-columns: 1fr 1fr;
   grid-gap: 0.5rem;
 }


### PR DESCRIPTION
The previous grid implementation laid out ingredient sections like this:
| | |
| ------------- | ------------- |
| Ingredient 1  | Ingredient 2  |
| Ingredient 3  | Ingredient 4  |
| Ingredient 5  | Ingredient 6  |
| Ingredient 7  | Ingredient 8  |

But it feels far more natural to read it like this:

| | |
| ------------- | ------------- |
| Ingredient 1  | Ingredient 5  |
| Ingredient 2  | Ingredient 6  |
| Ingredient 3  | Ingredient 7  |
| Ingredient 4  | Ingredient 8  |