### PR TITLE
fix(frontend): proper null check for notes

### DIFF
--- a/frontend/pages/group/mealplan/planner.vue
+++ b/frontend/pages/group/mealplan/planner.vue
@@ -218,7 +218,7 @@
           <RecipeCard
             v-for="mealplan in plan.meals"
             :key="mealplan.id"
-            :recipe-id="mealplan.recipe ? mealplan.recipe.id : null"
+            :recipe-id="mealplan.recipe ? mealplan.recipe.id : ''"
             :image-height="125"
             class="mb-2"
             :route="mealplan.recipe ? true : false"
@@ -236,8 +236,8 @@
                   {{ mealplan.entryType }}
                 </v-chip>
                 <RecipeContextMenu
-                  :name="mealplan.recipe.name"
-                  :recipe-id="mealplan.recipe.id"
+                  :name="mealplan.recipe ? mealplan.recipe.name : mealplan.title"
+                  :recipe-id="mealplan.recipe ? mealplan.recipe.id : ''"
                   :slug="mealplan.recipe ? mealplan.recipe.slug : ''"
                   :use-items="{
                     delete: false,


### PR DESCRIPTION
Adds a proper check for the mealplan.recipe property in multiple places to resolve the bug described in #1571. In development the page would fail to render.

Closes #1571 