### PR TITLE
Removed sort menu from pages that don't support it

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -15,7 +15,7 @@
         {{ $vuetify.breakpoint.xsOnly ? null : $t("general.random") }}
       </v-btn>
 
-      <v-menu offset-y left>
+      <v-menu v-if="$listeners.sortRecipes" offset-y left>
         <template #activator="{ on, attrs }">
           <v-btn text :icon="$vuetify.breakpoint.xsOnly" v-bind="attrs" :loading="sortLoading" v-on="on">
             <v-icon :left="!$vuetify.breakpoint.xsOnly">


### PR DESCRIPTION
As flagged in #1605, sorting isn't working right on recent recipes and cookbook recipes. This is because the current implementation of those pages doesn't paginate, which is where our sorting logic is.

This PR does _not_ fix the issue; I just restored the sort listener that [I removed by accident](https://github.com/hay-kot/mealie/pull/1560/files#diff-f2df6268f62d4643e3970f02eb2cf6d7816141a5ccf39fa495a7bc43f95a4afcR18) which will hide the issue by removing the sort menu.

This is a temporary fix until we can implement pagination on those routes (I can work on this separately).