### PR TITLE
WIP: Add generic SSO authentication support

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -67,3 +67,9 @@ Changing the webworker settings may cause unforeseen memory leak issues with Mea
 | LDAP_SERVER_URL    |  None   | LDAP server URL (e.g. ldap://ldap.example.com)                                                                     |
 | LDAP_BIND_TEMPLATE |  None   | Templated DN for users, `{}` will be replaced with the username (e.g. `cn={},dc=example,dc=com`)                   |
 | LDAP_ADMIN_FILTER  |  None   | Optional LDAP filter, which tells Mealie the LDAP user is an admin (e.g. `(memberOf=cn=admins,dc=example,dc=com)`) |
+
+### SSO
+
+| Variables               | Default | Description                                                                                                                                                   |
+| ----------------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SSO_TRUSTED_HEADER_USER |  None   | Authenticate via an external SSO server with this HTTP header being trusted from a reverse proxy. Must be identical to the frontend setting of the same name. |

--- a/docs/docs/documentation/getting-started/installation/frontend-config.md
+++ b/docs/docs/documentation/getting-started/installation/frontend-config.md
@@ -27,3 +27,11 @@ Setting the following environmental variables will change the theme of the front
 | THEME_DARK_INFO       | #1976D2 | Dark Theme Config Variable  |
 | THEME_DARK_WARNING    | #FF6D00 | Dark Theme Config Variable  |
 | THEME_DARK_ERROR      | #EF5350 | Dark Theme Config Variable  |
+
+### SSO
+
+| Variables               | Default | Description                                                                                                                                                  |
+| ----------------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| SSO_TRUSTED_HEADER_USER |  None   | Authenticate via an external SSO server with this HTTP header being trusted from a reverse proxy. Must be identical to the backend setting of the same name. |
+| SSO_LOGIN_URL           |  None   | URL to redirect to when a login is required. Must be an absolute URL.                                                                                        |
+| SSO_LOGOUT_URL          |  None   | URL to redirect to after the frontend logs the user out (logout page of the IdP)                                                                             |

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -110,7 +110,8 @@ export default {
     },
     // Options
     strategies: {
-      local: {
+      maybeSSO: {
+        scheme: './schemes/maybeSSO',
         resetOnError: true,
         token: {
           property: "access_token",
@@ -235,6 +236,9 @@ export default {
   publicRuntimeConfig: {
     GLOBAL_MIDDLEWARE: process.env.GLOBAL_MIDDLEWARE || null,
     SUB_PATH: process.env.SUB_PATH || "",
+    SSO_TRUSTED_HEADER_USER: process.env.SSO_TRUSTED_HEADER_USER || null,
+    SSO_LOGIN_URL: process.env.SSO_LOGIN_URL || null,
+    SSO_LOGOUT_URL: process.env.SSO_LOGOUT_URL || null,
     axios: {
       browserBaseURL: process.env.SUB_PATH || "",
     },

--- a/frontend/schemes/maybeSSO.ts
+++ b/frontend/schemes/maybeSSO.ts
@@ -1,0 +1,21 @@
+import { HTTPResponse } from "@nuxtjs/auth-next";
+import { LocalScheme } from "~auth/runtime"
+
+export default class MaybeSSO extends LocalScheme {
+  async mounted(): Promise<HTTPResponse | void> {
+    // nuxt-auth can't be configured from the environment directly, so we
+    // overwrite redirect.logout here
+    if (this.$auth.ctx.$config.SSO_LOGOUT_URL !== null) {
+      this.$auth.options.redirect.logout = this.$auth.ctx.$config.SSO_LOGOUT_URL;
+    }
+
+    if (!this.$auth.loggedIn && this.$auth.ctx.store.state.ssoUser !== null) {
+      const formData = new FormData();
+      formData.append("username", "sso");
+      formData.append("password", "sso");
+      await this.$auth.loginWith("maybeSSO", { data: formData });
+    }
+
+    return await super.mounted();
+  }
+}

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,1 +1,25 @@
 export const store = {};
+
+export const state = () => ({
+  ssoUser: null
+})
+
+export const mutations = {
+  set_sso_user(state, user) {
+    state.ssoUser = user
+  }
+}
+
+export const actions = {
+  async nuxtServerInit({ commit }, { req, $config }) {
+    let trustedHeader = $config.SSO_TRUSTED_HEADER_USER;
+    if (trustedHeader !== null) {
+      // req.headers has lower-cased keys
+      trustedHeader = trustedHeader.toLowerCase();
+
+      if (req.headers && req.headers[trustedHeader]) {
+        await commit("set_sso_user", req.headers[trustedHeader]);
+      }
+    }
+  }
+}

--- a/frontend/types/ts-shim.d.ts
+++ b/frontend/types/ts-shim.d.ts
@@ -2,3 +2,7 @@ declare module "*.vue" {
   import Vue from "vue";
   export default Vue;
 }
+
+declare module "~auth/runtime" {
+  export { LocalScheme, SchemeCheck } from "@nuxtjs/auth-next"
+}

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -130,6 +130,11 @@ class AppSettings(BaseSettings):
         return self.LDAP_AUTH_ENABLED and not_none
 
     # ===============================================
+    # SSO Configuration
+
+    SSO_TRUSTED_HEADER_USER: NoneStr = None
+
+    # ===============================================
     # Testing Config
 
     TESTING: bool = False

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Form, status
+from fastapi import APIRouter, Depends, Form, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
@@ -49,13 +49,12 @@ class MealieAuthToken(BaseModel):
 
 
 @public_router.post("/token")
-def get_token(data: CustomOAuth2Form = Depends(), session: Session = Depends(generate_session)):
-
+def get_token(request: Request, data: CustomOAuth2Form = Depends(), session: Session = Depends(generate_session)):
     email = data.username
     password = data.password
 
     try:
-        user = authenticate_user(session, email, password)  # type: ignore
+        user = authenticate_user(session, email, password, request)  # type: ignore
     except UserLockedOut as e:
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="User is locked out") from e
 

--- a/template.env
+++ b/template.env
@@ -39,3 +39,8 @@ LDAP_AUTH_ENABLED=False
 LDAP_SERVER_URL=None
 LDAP_BIND_TEMPLATE=None
 LDAP_ADMIN_FILTER=None
+
+# Configuration for authentication via an external SSO service
+#SSO_TRUSTED_HEADER_USER="REMOTE_USER"
+#SSO_LOGIN_URL=""
+#SSO_LOGOUT_URL=""


### PR DESCRIPTION
This adds SSO support using a trusted HTTP header from a reverse proxy.

There are a few rough edges before this can get merged, but given my lack of experience with nuxt, I would appreciate feedback on what I have right now.

## How it works

A new setting is added to both front- and backend for the name of the trusted header.

The backend will unconditionally return a token for the user contained in this header.

The frontend will add the content of this header to the store using SSR (so its available on the client) and the new auth scheme will automatically request a token when this is present. If `/login` is opened and the header is not present, the user will be redirected to the external login page and conversely, they will be redirected to an external logout page after logging out. 

That way, only `/login` and `/api/auth/token` have to be protected by the reverse proxy, everything else including public links will continue to work as always.

I've tested this with Apache ([mod_auth_openidc](https://github.com/zmartzone/mod_auth_openidc)) and [authentik](https://goauthentik.io/) and so far it seems to work great.

## Questions / Checklist

- [x] Is there some way to enable SSR in the devcontainer for easier testing? `vite: { ssr: true }` leads to errors (also without the changes in this PR).
- [ ] Do we want to add `SSO_TRUSTED_HEADER_ADMIN` and `SSO_TRUSTED_HEADER_GROUP` (similar to #1487)? Are others needed?
- [x] `mounted`/`onMounted` are not optimal for doing authentication, for example `/login` renders before the user is redirected to the app after login. Is there another option?
- [ ] Add some tests
- [ ] Write documentation, maybe provide a simple reverse proxy config
