### PR TITLE
fix: properly set "advanced features" during user registration

### DIFF
--- a/frontend/pages/register/register.vue
+++ b/frontend/pages/register/register.vue
@@ -461,12 +461,12 @@ export default defineComponent({
         password: password1.value,
         passwordConfirm: password2.value,
         locale: locale.value,
-        seedData: groupSeed.value,
+        advanced: advancedOptions.value,
       };
       if (state.ctx.type === RegistrationType.CreateGroup) {
         payload.group = groupName.value;
-        payload.advanced = advancedOptions.value;
         payload.private = groupPrivate.value;
+        payload.seedData = groupSeed.value;
       } else {
         payload.groupToken = token.value;
       }


### PR DESCRIPTION
Previously, "advanced features" was per group, not per user. With this change, this is now properly submitted on user registration. The "seed data" setting is also per group.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?


<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
- `register.vue`: The `advanced` option is now also set when joining an existing group. The `seedData` option is only set when creating a new group.

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->
Fixed #1443
## Testing

- Create invite link
- In new browser, load invite link
- Fill out user info, and click checkbox to enable advanced features
- Login with new user
- Navigate to [Name] > Manage User Profile
- See that  "Show Advanced Features" is now enabled


## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
When registering as a user with an invite link, the "Advanced Features" option during registration now properly works.
```
