### PR TITLE
feat: public all recipes page for groups

### DIFF
--- a/frontend/api/public/explore.ts
+++ b/frontend/api/public/explore.ts
@@ -1,14 +1,20 @@
 import { BaseAPI } from "../_base";
-import { Recipe } from "~/types/api-types/recipe";
+import { Recipe, RecipeSummary } from "~/types/api-types/recipe";
+import { PaginationData } from "~/types/api";
 
 const prefix = "/api";
 
 const routes = {
   recipe: (groupId: string, recipeSlug: string) => `${prefix}/explore/recipes/${groupId}/${recipeSlug}`,
+  recipes: (groupId: string) => `${prefix}/explore/recipes/${groupId}`,
 };
 
 export class ExploreApi extends BaseAPI {
   async recipe(groupId: string, recipeSlug: string) {
     return await this.requests.get<Recipe>(routes.recipe(groupId, recipeSlug));
+  }
+
+  async allRecipes(groupId: string) {
+    return await this.requests.get<PaginationData<RecipeSummary>>(routes.recipes(groupId));
   }
 }

--- a/frontend/pages/explore/recipes/_groupId/index.vue
+++ b/frontend/pages/explore/recipes/_groupId/index.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-container>
+    <RecipeCardSection :icon="$globals.icons.primary" :title="$tc('page.all-recipes')" :recipes="recipes || []" />
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent, useAsync, useRoute, useRouter } from "@nuxtjs/composition-api";
+import { usePublicApi } from "~/composables/api/api-client";
+import RecipeCardSection from "~/components/Domain/Recipe/RecipeCardSection.vue";
+
+export default defineComponent({
+  components: { RecipeCardSection },
+  layout: "basic",
+  setup() {
+    const route = useRoute();
+    const router = useRouter();
+    const groupId = route.value.params.groupId;
+    const api = usePublicApi();
+
+    const recipes = useAsync(async () => {
+      const { data, error } = await api.explore.allRecipes(groupId);
+
+      if (error || !data) {
+        console.error("error loading recipes -> ", error);
+        router.push("/");
+        return;
+      }
+
+      return data.items;
+    });
+
+    return {
+      recipes,
+    };
+  },
+});
+</script>
+
+<style scoped></style>

--- a/frontend/pages/recipes/all.vue
+++ b/frontend/pages/recipes/all.vue
@@ -2,7 +2,7 @@
   <v-container>
     <RecipeCardSection
       :icon="$globals.icons.primary"
-      :title="$t('page.all-recipes')"
+      :title="$tc('page.all-recipes')"
       :recipes="recipes"
       @sortRecipes="assignSorted"
       @replaceRecipes="replaceRecipes"

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -135,10 +135,11 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
         pagination: PaginationQuery,
         override=None,
         load_food=False,
-        cookbook: Optional[ReadCookBook] = None,
-        categories: Optional[list[UUID4 | str]] = None,
-        tags: Optional[list[UUID4 | str]] = None,
-        tools: Optional[list[UUID4 | str]] = None,
+        cookbook: ReadCookBook | None = None,
+        categories: list[UUID4 | str] | None = None,
+        tags: list[UUID4 | str] | None = None,
+        tools: list[UUID4 | str] | None = None,
+        public_only: bool = False,
     ) -> RecipePagination:
         q = self.session.query(self.model)
 
@@ -155,6 +156,9 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
 
         fltr = self._filter_builder()
         q = q.filter_by(**fltr)
+
+        if public_only:
+            q = q.join(RecipeSettings).filter(RecipeSettings.public == True)  # noqa: 711
 
         if cookbook:
             cb_filters = self._category_tag_filters(

--- a/mealie/routes/explore/controller_public_recipes.py
+++ b/mealie/routes/explore/controller_public_recipes.py
@@ -1,15 +1,44 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import UUID4
 
 from mealie.routes._base import controller
 from mealie.routes._base.base_controllers import BasePublicController
 from mealie.schema.recipe import Recipe
+from mealie.schema.recipe.recipe import RecipePagination, RecipePaginationQuery, RecipeSummary
 
 router = APIRouter(prefix="/explore", tags=["Explore: Recipes"])
 
 
 @controller(router)
 class PublicRecipesController(BasePublicController):
+    @router.get("/recipes/{group_id}", response_model=RecipePagination)
+    def get_group_recipes(
+        self,
+        group_id: UUID4,
+        request: Request,
+        q: RecipePaginationQuery = Depends(),
+    ) -> list[RecipeSummary]:
+        group = self.repos.groups.get_one(group_id)
+
+        if not group or group.preferences.private_group:
+            raise HTTPException(404, "group not found")
+
+        # merge default pagination with the request's query params
+        query_params = q.dict() | {**request.query_params}
+
+        pagination_response = self.repos.recipes.page_all(
+            pagination=q,
+            load_food=q.load_food,
+            public_only=True,
+        )
+
+        pagination_response.set_pagination_guides(
+            "/api/explore/recipes",  # TODO - this should be set dynamically
+            {k: v for k, v in query_params.items() if v is not None},
+        )
+
+        return pagination_response
+
     @router.get("/recipes/{group_id}/{recipe_slug}", response_model=Recipe)
     def get_recipe(self, group_id: UUID4, recipe_slug: str) -> Recipe:
         group = self.repos.groups.get_one(group_id)

--- a/tests/integration_tests/public_explorer_tests/public_recipe_tests.py
+++ b/tests/integration_tests/public_explorer_tests/public_recipe_tests.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from dataclasses import dataclass
 
 import pytest
@@ -6,11 +7,16 @@ from pydantic import UUID4
 
 from mealie.repos.repository_factory import AllRepositories
 from mealie.schema.recipe.recipe import Recipe
+from tests.utils import random_string
 from tests.utils.fixture_schemas import TestUser
 
 
 class Routes:
     base = "/api/explore/recipes"
+
+    @staticmethod
+    def all_recipes(group_id: UUID4 | str) -> str:
+        return f"{Routes.base}/{group_id}"
 
     @staticmethod
     def recipe(groud_id: str | UUID4, recipe_slug: str | UUID4) -> str:
@@ -34,7 +40,7 @@ class PublicRecipeTestCase:
     ),
     ids=("is public", "group private", "recipe private"),
 )
-def test_public_recipe_success(
+def test_public_recipe_access(
     api_client: TestClient,
     unique_user: TestUser,
     random_recipe: Recipe,
@@ -60,3 +66,75 @@ def test_public_recipe_success(
     as_json = response.json()
     assert as_json["name"] == random_recipe.name
     assert as_json["slug"] == random_recipe.slug
+
+
+@pytest.fixture()
+def test_recipes(
+    unique_user: TestUser, database: AllRepositories
+) -> Generator[tuple[list[Recipe], list[str]], None, None]:
+    created_ids: list[str] = []
+    recipes: list[Recipe] = []
+    for _ in range(10):
+        data = Recipe(
+            name=random_string(10),
+            group_id=unique_user.group_id,
+        )
+
+        recipe = database.recipes.create(data)
+        recipe.settings.public = True
+        result = database.recipes.update(recipe.slug, recipe)
+        created_ids.append(str(result.id))
+        recipes.append(result)
+
+    try:
+        yield recipes, created_ids
+    finally:
+        for recipe in recipes:
+            database.recipes.delete(recipe.slug)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PublicRecipeTestCase(private_group=False, public_recipe=True, status_code=200, error=None),
+        PublicRecipeTestCase(private_group=True, public_recipe=True, status_code=404, error="group not found"),
+        PublicRecipeTestCase(private_group=False, public_recipe=True, status_code=200, error=None),
+    ),
+    ids=("is public", "group private", "public group w/ private recipe"),
+)
+def test_public_recipe_get_all(
+    api_client: TestClient,
+    unique_user: TestUser,
+    database: AllRepositories,
+    test_case: PublicRecipeTestCase,
+    test_recipes: tuple[list[Recipe], list[str]],
+):
+    # Setup
+    recipes, created_ids = test_recipes
+
+    # Set Group `preferences.private_group` attribute
+    group = database.groups.get_one(unique_user.group_id)
+    group.preferences.private_group = test_case.private_group
+    database.group_preferences.update(group.id, group.preferences)
+
+    # Set Recipe `settings.public` attribute
+    for recipe in recipes:
+        recipe.settings.public = test_case.public_recipe
+        database.recipes.update(recipe.slug, recipe)
+
+    # Assert
+    response = api_client.get(Routes.all_recipes(unique_user.group_id))
+    assert response.status_code == test_case.status_code
+
+    if test_case.error:
+        assert response.json()["detail"] == test_case.error
+        return
+
+    body = response.json()
+
+    if test_case.public_recipe:
+        assert len(body["items"]) == 10
+        for recipe_json in body["items"]:
+            assert recipe_json["id"] in created_ids
+    else:
+        assert len(body["items"]) == 0


### PR DESCRIPTION
## Todo's

- [x] API Endpoint for Getting All Recipes from a Group
- [x] Initial UI View w/ API methods
- [ ] useExplorer composable to access state like the active users to conditionally render buttons, set links, and menu options. 
- [ ] Make use of composable to conditionally render only what options _should_ be available to non-authenticated users in the explore view without breaking 

## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR implements work towards completing issue #1326 

## Which issue(s) this PR fixes:

Partial #1326

## Testing

Tests are implemented in the suite for the new endpoint

## Release Notes

```release-note
```