### PR TITLE
Press enter to create a shopping list!

### DIFF
--- a/frontend/components/global/BaseDialog.vue
+++ b/frontend/components/global/BaseDialog.vue
@@ -7,6 +7,10 @@
       :width="width"
       :content-class="top ? 'top-dialog' : undefined"
       :fullscreen="$vuetify.breakpoint.xsOnly"
+      @keydown.enter="
+        $emit('submit');
+        dialog = false;
+      "
     >
       <v-card height="100%">
         <v-app-bar dark dense :color="color" class="">

--- a/frontend/pages/shopping-lists/index.vue
+++ b/frontend/pages/shopping-lists/index.vue
@@ -2,7 +2,7 @@
   <v-container v-if="shoppingLists" class="narrow-container">
     <BaseDialog v-model="createDialog" :title="$tc('shopping-list.create-shopping-list')" @submit="createOne">
       <v-card-text>
-        <v-text-field v-model="createName" autofocus :label="$t('shopping-list.new-list')" @keyup.enter="createOne(); createDialog = false;" > </v-text-field>
+        <v-text-field v-model="createName" autofocus :label="$t('shopping-list.new-list')"> </v-text-field>
       </v-card-text>
     </BaseDialog>
 

--- a/frontend/pages/shopping-lists/index.vue
+++ b/frontend/pages/shopping-lists/index.vue
@@ -2,7 +2,7 @@
   <v-container v-if="shoppingLists" class="narrow-container">
     <BaseDialog v-model="createDialog" :title="$tc('shopping-list.create-shopping-list')" @submit="createOne">
       <v-card-text>
-        <v-text-field v-model="createName" autofocus :label="$t('shopping-list.new-list')"> </v-text-field>
+        <v-text-field v-model="createName" autofocus :label="$t('shopping-list.new-list')" @keyup.enter="createOne(); createDialog = false;" > </v-text-field>
       </v-card-text>
     </BaseDialog>
 


### PR DESCRIPTION
## What type of PR is this?
- feature (kind of)

## What this PR does / why we need it:
This has been bothering me for a while... Pressing enter now creates the shopping list instead of having to click the create button. I hate using my mouse to do anything :)

## Which issue(s) this PR fixes:
No issue is related to this as far as I'm aware.

## Special notes for your reviewer:
This initial implementation is near-sighted. Maybe it makes more sense to add it to the BaseDialog component if such behavior is more generally desired. A decision I leave to the reviewer.

## Testing
No testing added

## Release Notes


```
It is now possible to press enter to create a shopping list instead of having to click the create button.
```
