### PR TITLE
Refactor webhook events

### DIFF
--- a/frontend/components/Domain/Group/GroupWebhookEditor.vue
+++ b/frontend/components/Domain/Group/GroupWebhookEditor.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <v-card-text>
-      <v-switch v-model="webhookCopy.enabled" label="$t('general.enabled')"></v-switch>
-      <v-text-field v-model="webhookCopy.name" label="$t('settings.webhooks.webhook-name')"></v-text-field>
-      <v-text-field v-model="webhookCopy.url" label="$t('settings.webhooks.webhook-url')"></v-text-field>
+      <v-switch v-model="webhookCopy.enabled" :label="$t('general.enabled')"></v-switch>
+      <v-text-field v-model="webhookCopy.name" :label="$t('settings.webhooks.webhook-name')"></v-text-field>
+      <v-text-field v-model="webhookCopy.url" :label="$t('settings.webhooks.webhook-url')"></v-text-field>
       <v-time-picker v-model="scheduledTime" class="elevation-2" ampm-in-title format="ampm"></v-time-picker>
     </v-card-text>
     <v-card-actions class="py-0 justify-end">

--- a/mealie/routes/_base/base_controllers.py
+++ b/mealie/routes/_base/base_controllers.py
@@ -122,7 +122,7 @@ class BaseCrudController(BaseUserController):
     Base class for all CRUD controllers to facilitate common CRUD functions.
     """
 
-    event_bus: EventBusService = Depends(EventBusService)
+    event_bus: EventBusService = Depends(EventBusService.create)
 
     def publish_event(self, event_type: EventTypes, document_data: EventDocumentDataBase, message: str = "") -> None:
         self.event_bus.dispatch(

--- a/mealie/routes/groups/controller_group_notifications.py
+++ b/mealie/routes/groups/controller_group_notifications.py
@@ -35,7 +35,7 @@ router = APIRouter(
 
 @controller(router)
 class GroupEventsNotifierController(BaseUserController):
-    event_bus: EventBusService = Depends(EventBusService)
+    event_bus: EventBusService = Depends(EventBusService.create)
 
     @cached_property
     def repo(self):

--- a/mealie/routes/groups/controller_webhooks.py
+++ b/mealie/routes/groups/controller_webhooks.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import cached_property
 
 from fastapi import APIRouter, Depends
@@ -9,6 +10,7 @@ from mealie.routes._base.mixins import HttpRepo
 from mealie.schema import mapper
 from mealie.schema.group.webhook import CreateWebhook, ReadWebhook, SaveWebhook, WebhookPagination
 from mealie.schema.response.pagination import PaginationQuery
+from mealie.services.scheduler.tasks.post_webhooks import post_group_webhooks
 
 router = APIRouter(prefix="/groups/webhooks", tags=["Groups: Webhooks"])
 
@@ -37,6 +39,14 @@ class ReadWebhookController(BaseUserController):
     def create_one(self, data: CreateWebhook):
         save = mapper.cast(data, SaveWebhook, group_id=self.group.id)
         return self.mixins.create_one(save)
+
+    @router.post("/rerun")
+    def rerun_webhooks(self):
+        """Manually re-fires all previously scheduled webhooks for today"""
+
+        start_time = datetime.min.time()
+        start_dt = datetime.combine(datetime.utcnow().date(), start_time)
+        post_group_webhooks(start_dt=start_dt, group_id=self.group.id)
 
     @router.get("/{item_id}", response_model=ReadWebhook)
     def get_one(self, item_id: UUID4):

--- a/mealie/schema/group/group_events.py
+++ b/mealie/schema/group/group_events.py
@@ -13,6 +13,9 @@ class GroupEventNotifierOptions(MealieModel):
     If you modify this, make sure to update the EventBusService as well.
     """
 
+    test_message: bool = False
+    webhook_task: bool = False
+
     recipe_created: bool = False
     recipe_updated: bool = False
     recipe_deleted: bool = False

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -84,6 +84,6 @@ class EventBusService:
             if subscribers := listener.get_subscribers(event):
                 listener.publish_to_subscribers(event, subscribers)
 
-    @staticmethod
-    def create(bg: BackgroundTasks, session=Depends(generate_session), group_id: UUID4 | None = None):
-        return EventBusService(bg, session, group_id)
+    @classmethod
+    def create(cls, bg: BackgroundTasks, session=Depends(generate_session), group_id: UUID4 | None = None):
+        return cls(bg, session, group_id)

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm.session import Session
 
 from mealie.core.config import get_app_settings
 from mealie.db.db_setup import generate_session
-from mealie.services.event_bus_service.event_bus_listeners import AppriseEventListener, EventListenerBase
+from mealie.services.event_bus_service.event_bus_listeners import (
+    AppriseEventListener,
+    EventListenerBase,
+    WebhookEventListener,
+)
 
 from .event_types import Event, EventBusMessage, EventDocumentDataBase, EventTypes
 
@@ -46,7 +50,10 @@ class EventBusService:
         self.session = session
         self.group_id = group_id
 
-        self.listeners: list[EventListenerBase] = [AppriseEventListener(self.session, self.group_id)]
+        self.listeners: list[EventListenerBase] = [
+            AppriseEventListener(self.session, self.group_id),
+            WebhookEventListener(self.session, self.group_id),
+        ]
 
     def dispatch(
         self,

--- a/mealie/services/event_bus_service/event_types.py
+++ b/mealie/services/event_bus_service/event_types.py
@@ -1,10 +1,13 @@
 import uuid
 from datetime import datetime
 from enum import Enum, auto
+from typing import Any
 
 from pydantic import UUID4
 
 from ...schema._mealie.mealie_model import MealieModel
+
+INTERNAL_INTEGRATION_ID = "mealie_generic_user"
 
 
 class EventTypes(Enum):
@@ -18,7 +21,9 @@ class EventTypes(Enum):
     (like shopping list items), modify the event document type instead (which is not tied to a database entry).
     """
 
+    # used internally and cannot be subscribed to
     test_message = auto()
+    webhook_task = auto()
 
     recipe_created = auto()
     recipe_updated = auto()
@@ -54,6 +59,7 @@ class EventDocumentType(Enum):
 
     category = "category"
     cookbook = "cookbook"
+    mealplan = "mealplan"
     shopping_list = "shopping_list"
     shopping_list_item = "shopping_list_item"
     recipe = "recipe"
@@ -120,6 +126,12 @@ class EventRecipeBulkReportData(EventDocumentDataBase):
 class EventTagData(EventDocumentDataBase):
     document_type = EventDocumentType.tag
     tag_id: UUID4
+
+
+class EventWebhookData(EventDocumentDataBase):
+    webhook_start_dt: datetime
+    webhook_end_dt: datetime
+    webhook_body: Any
 
 
 class EventBusMessage(MealieModel):

--- a/mealie/services/scheduler/tasks/post_webhooks.py
+++ b/mealie/services/scheduler/tasks/post_webhooks.py
@@ -1,54 +1,64 @@
 from datetime import datetime, timezone
+from typing import Optional
 
-import requests
-from fastapi.encoders import jsonable_encoder
 from pydantic import UUID4
-from sqlalchemy.orm import Session
 
 from mealie.db.db_setup import create_session
-from mealie.db.models.group.webhooks import GroupWebhooksModel
 from mealie.repos.all_repositories import get_repositories
+from mealie.services.event_bus_service.event_bus_service import EventBusService
+from mealie.services.event_bus_service.event_types import (
+    INTERNAL_INTEGRATION_ID,
+    EventDocumentType,
+    EventOperation,
+    EventTypes,
+    EventWebhookData,
+)
 
 last_ran = datetime.now(timezone.utc)
 
 
-def get_scheduled_webhooks(session: Session, bottom: datetime, top: datetime) -> list[GroupWebhooksModel]:
+def post_group_webhooks(start_dt: Optional[datetime] = None, group_id: Optional[UUID4] = None) -> None:
+    """Post webhook events to specified group, or all groups"""
+
+    global last_ran
+
+    end_dt = datetime.now(timezone.utc)
+    if start_dt is None:
+        # set the webhook query bounds to start at the last time the service ran
+        start_dt = last_ran
+
+    # update the last ran time so we continue here next time the service runs
+    last_ran = end_dt
+
+    if group_id is None:
+        # publish the webhook event to each group's event bus
+        session = create_session()
+        repos = get_repositories(session)
+        groups = repos.groups.get_all()
+        group_ids = [group.id for group in groups]
+
+    else:
+        group_ids = [group_id]
+
     """
-    get_scheduled_webhooks queries the database for all webhooks scheduled between the bottom and
-    top time ranges. It returns a list of GroupWebhooksModel objects.
+    At this time only mealplan webhooks are supported. To add support for more types,
+    add a dispatch event for that type here (e.g. EventDocumentType.recipe_bulk_report) and
+    handle the webhook data in the webhook event bus listener
     """
 
-    return (
-        session.query(GroupWebhooksModel)
-        .where(
-            GroupWebhooksModel.enabled == True,  # noqa: E712 - required for SQLAlchemy comparison
-            GroupWebhooksModel.scheduled_time > bottom.astimezone(timezone.utc).time(),
-            GroupWebhooksModel.scheduled_time <= top.astimezone(timezone.utc).time(),
-        )
-        .all()
+    event_type = EventTypes.webhook_task
+    event_document_data = EventWebhookData(
+        document_type=EventDocumentType.mealplan,
+        operation=EventOperation.info,
+        webhook_start_dt=start_dt,
+        webhook_end_dt=end_dt,
     )
 
-
-def post_group_webhooks() -> None:
-    global last_ran
-    session = create_session()
-    results = get_scheduled_webhooks(session, last_ran, datetime.now())
-
-    last_ran = datetime.now(timezone.utc)
-
-    repos = get_repositories(session)
-
-    memo = {}
-
-    def get_meals(group_id: UUID4):
-        if group_id not in memo:
-            memo[group_id] = repos.meals.get_all(group_id=group_id)
-        return memo[group_id]
-
-    for result in results:
-        meals = get_meals(result.group_id)
-
-        if not meals:
-            continue
-
-        requests.post(result.url, json=jsonable_encoder(meals))
+    for group_id in group_ids:
+        event_bus = EventBusService(group_id=group_id)
+        event_bus.dispatch(
+            integration_id=INTERNAL_INTEGRATION_ID,
+            group_id=group_id,
+            event_type=event_type,
+            document_data=event_document_data,
+        )

--- a/mealie/services/scheduler/tasks/post_webhooks.py
+++ b/mealie/services/scheduler/tasks/post_webhooks.py
@@ -23,13 +23,11 @@ def post_group_webhooks(start_dt: Optional[datetime] = None, group_id: Optional[
 
     global last_ran
 
-    end_dt = datetime.now(timezone.utc)
-    if start_dt is None:
-        # set the webhook query bounds to start at the last time the service ran
-        start_dt = last_ran
+    # if not specified, start the query at the last time the service ran
+    start_dt = start_dt or last_ran
 
-    # update the last ran time so we continue here next time the service runs
-    last_ran = end_dt
+    # end the query at the current time
+    last_ran = end_dt = datetime.now(timezone.utc)
 
     if group_id is None:
         # publish the webhook event to each group's event bus

--- a/mealie/services/scheduler/tasks/post_webhooks.py
+++ b/mealie/services/scheduler/tasks/post_webhooks.py
@@ -5,6 +5,7 @@ from pydantic import UUID4
 
 from mealie.db.db_setup import create_session
 from mealie.repos.all_repositories import get_repositories
+from mealie.schema.response.pagination import PaginationQuery
 from mealie.services.event_bus_service.event_bus_service import EventBusService
 from mealie.services.event_bus_service.event_types import (
     INTERNAL_INTEGRATION_ID,
@@ -34,8 +35,8 @@ def post_group_webhooks(start_dt: Optional[datetime] = None, group_id: Optional[
         # publish the webhook event to each group's event bus
         session = create_session()
         repos = get_repositories(session)
-        groups = repos.groups.get_all()
-        group_ids = [group.id for group in groups]
+        groups_data = repos.groups.page_all(PaginationQuery(page=1, per_page=-1))
+        group_ids = [group.id for group in groups_data.items]
 
     else:
         group_ids = [group_id]


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

This takes the previous webhook implementation and unifies it with our new event bus API. There are no functional changes, although since we're using our uniform API the webhook content changed to conform to the `Event` schema. It also allows us to easily implement webhooks for other scheduled events.

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

Unsure if there's a particular issue open for this, but I know it's on the release roadmap somewhere (discussed in #1574)

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

There are two changes I made that I'm unsure about; they work fine, but I wonder if there's a better way:

1. I modified the `EventBusService` to be executable outside of the FastAPI context. This is required since the app triggers scheduled events without using FastAPI. To accommodate this, I made the `BackgroundTasks` param optional, and added a "FastAPI-friendly" method that preserves dependency injection. One issue this causes is that since webhooks can't access background tasks, the `publish` method is called directly. If this is an issue, we either need to trigger scheduled events through FastAPI (not sure if this is possible) or use a different service for handling background tasks that isn't dependent on FastAPI.
2. Since our event bus service is tied to a group, and the scheduled service is not, I needed a way to trigger the service for all groups. I _think_ the best way to do this is to query the database for all groups, then instantiate `EventBusService` for each of these groups, then let the service handle the filtering, so this is what I did in the `post_group_webhooks` method. If we don't like this database call, we need to decouple the event bus service from the group id, which I'm not sure we want to do.

Some outstanding things to take care of after this PR is accepted:

1. On the frontend there is a "test webhook" button that does nothing. It didn't do anything before this PR either. We should implement this. I created a super rudimentary test route to re-fire all webhooks, but we need something more granular. I'm happy to tackle that after this is accepted (the implementation depends on this being finalized).
2. Currently _all_ meal plans are sent in this webhook. I _think_ this is how it behaved previously, I'm pretty sure I didn't change the content of the webhook (just the format). We should probably limit this to a reasonable range (otherwise as time goes on the webhook data will continue to grow).

## Testing

https://webhook.site/ is amazing for testing webhooks. I used this a lot when refactoring the Apprise events, too.

<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
changed mealplan webhook format to aid integration triaging
```
