### PR TITLE
Allow to overwrite data dir using environtment variable

### DIFF
--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -18,16 +18,17 @@ ENV = BASE_DIR.joinpath(".env")
 dotenv.load_dotenv(ENV)
 PRODUCTION = os.getenv("PRODUCTION", "True").lower() in ["true", "1"]
 TESTING = os.getenv("TESTING", "False").lower() in ["true", "1"]
+DATA_DIR = os.getenv("DATA_DIR")
 
 
 def determine_data_dir() -> Path:
-    global PRODUCTION, TESTING, BASE_DIR
+    global PRODUCTION, TESTING, BASE_DIR, DATA_DIR
 
     if TESTING:
-        return BASE_DIR.joinpath("tests/.temp")
+        return BASE_DIR.joinpath(DATA_DIR if DATA_DIR else "tests/.temp")
 
     if PRODUCTION:
-        return Path("/app/data")
+        return Path(DATA_DIR if DATA_DIR else "/app/data")
 
     return BASE_DIR.joinpath("dev", "data")
 


### PR DESCRIPTION
Mealie tries to create its data dir in **/app/data**.
This is not the place where you want stuff like this if you dont use docker.

This PR introduces another environment variable called **DATA_DIR** which overwrites this location if set.

It is needed while installing (e.g.)
`
PRODUCTION=1 DATA_DIR=/var/lib/mealie/app/data python mealie/db/init_db.py
`
and when running the application (e.g.)
`
PRODUCTION=1 DATA_DIR=/var/lib/mealie/app/data uvicorn mealie.app:app --host 0.0.0.0 --port 9000
`

