### PR TITLE
Fix min-original version of image not saved when the original image is already a webp 

### DIFF
--- a/mealie/pkgs/img/minify.py
+++ b/mealie/pkgs/img/minify.py
@@ -65,9 +65,6 @@ class PillowMinifier(ABCMinifier):
         Converts an image to the webp format in-place. The original image is not
         removed By default, the quality is set to 100.
         """
-        if image_file.suffix == WEBP:
-            return image_file
-
         img = Image.open(image_file)
 
         dest = dest or image_file.with_suffix(WEBP)


### PR DESCRIPTION

## What type of PR is this?
- bug
## What this PR does / why we need it:
When a webp file uploaded as a recipe image goes through the minifying process, the min-original version of the image is skipped because the extension is already webp.
This behaviour is not wanted.

## Which issue(s) this PR fixes:

Fixes #1713 

## Special notes for your reviewer:

I removed the condition skipping webp images.
Overall, the code of this process looks messy to me, I don't understand why the minify function is so unnecessarily complex.

Additionally, this change will prevent this bug to happen in the future but **will not** fix the damage that is already done. e.g. Missing min-orignal.webp images will still be missing.

## Testing

No further testing written.

## Release Notes

```
Fixed bug where uploading a webp image as a recipe's image will not create the thumbnail sized version. 
```
