### PR TITLE
fix: apply API_PORT in containers

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -36,7 +36,7 @@
 
 	handle @apidocs {
 		uri strip_suffix /
-		reverse_proxy http://mealie-api:9000
+		reverse_proxy {$API_URL}
 	}
 
 	handle {

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -12,7 +12,7 @@ class GunicornConfig:
 
         # Env Variables
         self.host = os.getenv("HOST", "127.0.0.1")
-        self.port = os.getenv("PORT", "9000")
+        self.port = os.getenv("API_PORT", "9000")
         self.log_level: str = os.getenv("LOG_LEVEL", "info")
         self.bind: str = os.getenv("BIND", None)
         self.errorlog: str = os.getenv("ERROR_LOG", "-") or None
@@ -72,4 +72,4 @@ log_data = {
     "port": gunicorn_conf.port,
 }
 
-print("---- Gunicorn Configuration ----", json.dumps(log_data, indent=4))
+print("---- Gunicorn Configuration ----", json.dumps(log_data, indent=4))  # noqa: T001

--- a/mealie/run.sh
+++ b/mealie/run.sh
@@ -43,8 +43,8 @@ init() {
 
 # Migrations
 # TODO
-    # Migrations
-    # Set Port from ENV Variable
+# Migrations
+# Set Port from ENV Variable
 
 if [ "$ARG1" == "reload" ]; then
     echo "Hot Reload!"
@@ -60,7 +60,9 @@ else
 
     init
 
+    GUNICORN_PORT=${API_PORT:-9000}
+
     # Start API
     # uvicorn mealie.app:app --host 0.0.0.0 --port 9000
-    gunicorn mealie.app:app -b 0.0.0.0:9000 -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload
+    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload
 fi


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

Currently the `API_PORT` env variable doesn't do anything. This PR uses it in the Gunicorn Configuration. Additionally, I've added the API_URL env to the caddyfile so the docs are properly routed 

## Which issue(s) this PR fixes:

Closes #1666 

