### PR TITLE
feat: fix recipe rating overwriting

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageHeader.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageHeader.vue
@@ -4,8 +4,8 @@
       <v-card v-if="!landscape" width="50%" flat class="d-flex flex-column justify-center align-center">
         <v-card-text>
           <v-card-title class="headline pa-0 flex-column align-center">
-            {{ recipe.name }}
-            <RecipeRating :key="recipe.slug" :value="recipe.rating" :name="recipe.name" :slug="recipe.slug" />
+            {{ recipe.name }} {{ recipe.rating }}
+            <RecipeRating :key="recipe.slug" v-model="recipe.rating" :name="recipe.name" :slug="recipe.slug" />
           </v-card-title>
           <v-divider class="my-2"></v-divider>
           <SafeMarkdown :source="recipe.description" />

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageScale.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageScale.vue
@@ -19,7 +19,7 @@
     <RecipeRating
       v-if="landscape && $vuetify.breakpoint.smAndUp"
       :key="recipe.slug"
-      :value="recipe.rating"
+      :v-model="recipe.rating"
       :name="recipe.name"
       :slug="recipe.slug"
     />

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageTitleContent.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageTitleContent.vue
@@ -15,7 +15,7 @@
         <RecipeRating
           v-if="$vuetify.breakpoint.smAndDown"
           :key="recipe.slug"
-          :value="recipe.rating"
+          v-model="recipe.rating"
           :name="recipe.name"
           :slug="recipe.slug"
         />

--- a/frontend/components/Domain/Recipe/RecipeRating.vue
+++ b/frontend/components/Domain/Recipe/RecipeRating.vue
@@ -53,13 +53,12 @@ export default defineComponent({
 
     const api = useUserApi();
     function updateRating(val: number) {
-      if (props.emitOnly) {
-        context.emit("input", val);
-        return;
+      if (!props.emitOnly) {
+        api.recipes.patchOne(props.slug, {
+          rating: val,
+        });
       }
-      api.recipes.patchOne(props.slug, {
-        rating: val,
-      });
+      context.emit("input", val);
     }
 
     return { loggedIn, rating, updateRating };


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Previously, the recipe-ratings component would not sync to the v-modeled value when doing it's own updating. This PR fixes that issue and ensures that the value is pushed up to the parent whether in emit only mode or not. 

## Which issue(s) this PR fixes:

Closes #1397

