### PR TITLE
chore: lint-and-fix-vue-demi-imports

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -52,7 +52,10 @@ module.exports = {
         "ts-ignore": "allow-with-description",
       },
     ],
-    "no-restricted-imports": ["error", { paths: ["@vue/reactivity", "@vue/runtime-dom", "@vue/composition-api"] }],
+    "no-restricted-imports": [
+      "error",
+      { paths: ["@vue/reactivity", "@vue/runtime-dom", "@vue/composition-api", "vue-demi"] },
+    ],
 
     // TODO Gradually activate all rules
     "@typescript-eslint/no-unsafe-assignment": "off",

--- a/frontend/components/Domain/Recipe/RecipeOcrEditorPage/RecipeOcrEditorPageParts/RecipeOcrEditorPageCanvas.vue
+++ b/frontend/components/Domain/Recipe/RecipeOcrEditorPage/RecipeOcrEditorPageParts/RecipeOcrEditorPageCanvas.vue
@@ -39,8 +39,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, useContext, ref, toRefs, watch } from "@nuxtjs/composition-api";
-import { onMounted } from "vue-demi";
+import { defineComponent, reactive, useContext, ref, toRefs, watch, onMounted } from "@nuxtjs/composition-api";
 import { NoUndefinedField } from "~/lib/api/types/non-generated";
 import { OcrTsvResponse as NullableOcrTsvResponse } from "~/lib/api/types/ocr";
 import { CanvasModes, SelectedTextSplitModes, ImagePosition, Mouse, CanvasRect, ToolbarIcons } from "~/types/ocr-types";

--- a/frontend/components/Domain/Recipe/RecipeOrganizerSelector.vue
+++ b/frontend/components/Domain/Recipe/RecipeOrganizerSelector.vue
@@ -39,8 +39,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, useContext } from "@nuxtjs/composition-api";
-import { computed, onMounted } from "vue-demi";
+import { defineComponent, ref, useContext, computed, onMounted } from "@nuxtjs/composition-api";
 import RecipeOrganizerDialog from "./RecipeOrganizerDialog.vue";
 import { RecipeCategory, RecipeTag } from "~/lib/api/types/user";
 import { RecipeTool } from "~/lib/api/types/admin";

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -75,9 +75,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useContext, useRouter, computed, ref, useMeta } from "@nuxtjs/composition-api";
+import {
+  defineComponent,
+  useContext,
+  useRouter,
+  computed,
+  ref,
+  useMeta,
+  onMounted,
+  onUnmounted,
+} from "@nuxtjs/composition-api";
 import { invoke, until, useWakeLock } from "@vueuse/core";
-import { onMounted, onUnmounted } from "vue-demi";
 import RecipePageEditorToolbar from "./RecipePageParts/RecipePageEditorToolbar.vue";
 import RecipePageFooter from "./RecipePageParts/RecipePageFooter.vue";
 import RecipePageHeader from "./RecipePageParts/RecipePageHeader.vue";

--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -114,8 +114,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, ref, toRefs, useContext } from "@nuxtjs/composition-api";
-import { onMounted } from "vue-demi";
+import { defineComponent, reactive, ref, toRefs, useContext, onMounted } from "@nuxtjs/composition-api";
 import { useAdminApi } from "~/composables/api";
 import { AllBackups } from "~/lib/api/types/admin";
 

--- a/frontend/pages/admin/maintenance/logs.vue
+++ b/frontend/pages/admin/maintenance/logs.vue
@@ -32,8 +32,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "@nuxtjs/composition-api";
-import { computed, onMounted, reactive } from "vue-demi";
+import { defineComponent, ref, computed, onMounted, reactive } from "@nuxtjs/composition-api";
 import { useAdminApi } from "~/composables/api";
 
 export default defineComponent({

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -154,8 +154,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "@nuxtjs/composition-api";
-import { computed } from "vue-demi";
+import { defineComponent, onMounted, ref, computed } from "@nuxtjs/composition-api";
 import type { LocaleObject } from "@nuxtjs/i18n";
 import { validators } from "~/composables/use-validators";
 import { useUserApi } from "~/composables/api";

--- a/frontend/pages/recipe/create/url.vue
+++ b/frontend/pages/recipe/create/url.vue
@@ -63,9 +63,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs, ref, useRouter, computed, useRoute } from "@nuxtjs/composition-api";
+import {
+  defineComponent,
+  reactive,
+  toRefs,
+  ref,
+  useRouter,
+  computed,
+  useRoute,
+  onMounted,
+} from "@nuxtjs/composition-api";
 import { AxiosResponse } from "axios";
-import { onMounted } from "vue-demi";
 import { useUserApi } from "~/composables/api";
 import { validators } from "~/composables/use-validators";
 import { VForm } from "~/types/vuetify";


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- cleanup


## What this PR does / why we need it:

Some components were incorrectly importing from 'vue-demi' when they needed to import from the nuxt composition API package. This PR introducted a linting rule and fixes the incorrect imports.
