### PR TITLE
fix the text overflow on RecipeCard

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeCard.vue
@@ -19,7 +19,7 @@
           <v-expand-transition v-if="description">
             <div v-if="hover" class="d-flex transition-fast-in-fast-out secondary v-card--reveal" style="height: 100%">
               <v-card-text class="v-card--text-show white--text">
-                {{ description }}
+                {{ description.length < 350 ? description : description.substring(0,350) + "..." }}
               </v-card-text>
             </div>
           </v-expand-transition>

--- a/frontend/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeCard.vue
@@ -19,7 +19,9 @@
           <v-expand-transition v-if="description">
             <div v-if="hover" class="d-flex transition-fast-in-fast-out secondary v-card--reveal" style="height: 100%">
               <v-card-text class="v-card--text-show white--text">
-                {{ description.length < 350 ? description : description.substring(0,350) + "..." }}
+                <div class="descriptionWrapper">
+                  {{ description}}
+                </div>
               </v-card-text>
             </div>
           </v-expand-transition>
@@ -142,5 +144,11 @@ export default defineComponent({
   word-break: normal;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.descriptionWrapper{
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 8;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This PR fixes the recipe description text overflow issue when the text length is longer than 500 characters. If the description text is longer than 350 characters, only the first 350 characters will be shown on a card view.

New Card View with the long description:

![Screen Shot 2022-11-15 at 4 42 24 PM](https://user-images.githubusercontent.com/26856199/201962222-0abec9c1-0735-4d25-a3b9-92076c367b64.png)

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

#1829

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
 the recipe description text overflow issue on a card view has been fixed
```
