### PR TITLE
Shopping List Frontend Throttling

### DIFF
--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -215,6 +215,7 @@ export default defineComponent({
   },
   setup() {
     const { idle } = useIdle(5 * 60 * 1000) // 5 minutes
+    const loading = ref(true);
     const userApi = useUserApi();
 
     const edit = ref(false);
@@ -241,8 +242,8 @@ export default defineComponent({
 
     // constantly polls for changes
     async function pollForChanges() {
-      // pause polling if the user isn't active
-      if (idle.value) {
+      // pause polling if the user isn't active or we're busy
+      if (idle.value || loading.value) {
         return;
       }
 
@@ -269,6 +270,7 @@ export default defineComponent({
     }
 
     // start polling
+    loading.value = false;
     const pollFrequency = 5000;
 
     let attempts = 0;
@@ -338,9 +340,11 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       deleteListItems(checked);
 
       refresh();
+      loading.value = false;
     }
 
     // =====================================
@@ -458,11 +462,14 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       const { data } = await userApi.shopping.lists.addRecipe(shoppingList.value.id, recipeId);
 
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     async function removeRecipeReferenceToList(recipeId: string) {
@@ -470,11 +477,14 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       const { data } = await userApi.shopping.lists.removeRecipe(shoppingList.value.id, recipeId);
 
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     // =====================================
@@ -490,6 +500,7 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       if (item.checked && shoppingList.value.listItems) {
         const lst = shoppingList.value.listItems.filter((itm) => itm.id !== item.id);
         lst.push(item);
@@ -501,6 +512,8 @@ export default defineComponent({
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     async function deleteListItem(item: ShoppingListItemOut) {
@@ -508,11 +521,14 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       const { data } = await userApi.shopping.items.deleteOne(item.id);
 
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     // =====================================
@@ -540,6 +556,7 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       const { data } = await userApi.shopping.items.createOne(createListItemData.value);
 
       if (data) {
@@ -547,6 +564,8 @@ export default defineComponent({
         createEditorOpen.value = false;
         refresh();
       }
+
+      loading.value = false;
     }
 
     function updateIndex(data: ShoppingListItemOut[]) {
@@ -562,11 +581,14 @@ export default defineComponent({
         return;
       }
 
+      loading.value = true;
       const { data } = await userApi.shopping.items.deleteMany(items);
 
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     async function updateListItems() {
@@ -580,11 +602,14 @@ export default defineComponent({
         return itm;
       });
 
+      loading.value = true;
       const { data } = await userApi.shopping.items.updateMany(shoppingList.value.listItems);
 
       if (data) {
         refresh();
       }
+
+      loading.value = false;
     }
 
     return {

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -458,7 +458,7 @@ export default defineComponent({
     });
 
     async function addRecipeReferenceToList(recipeId: string) {
-      if (!shoppingList.value) {
+      if (!shoppingList.value || loading.value) {
         return;
       }
 
@@ -473,7 +473,7 @@ export default defineComponent({
     }
 
     async function removeRecipeReferenceToList(recipeId: string) {
-      if (!shoppingList.value) {
+      if (!shoppingList.value || loading.value) {
         return;
       }
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Mentioned in #1847, the polling/auto-refresh we added to the shopping list frontend makes things look weird for bulk operations (i.e. adding or removing recipes). If only part of a recipe is added by the time a refresh is triggered, it looks wrong to the end user until the next refresh.

This simply adds a `loading` variable that must be `false` when polling occurs (direct refreshes are unaffected). I also noticed if you try to spam adding a recipe (e.g. click "+" 20 times very fast) it causes the API to freak out and only part of the operation is successful, so I throttled that too. We should probably find a way to prevent this on the backend, but at least now you can't do it on the frontend.

## Which issue(s) this PR fixes:

_(REQUIRED)_

None, but mentioned in #1847

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
NONE
```
