### PR TITLE
Tweaked Recipe Sort Behavior

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -243,7 +243,10 @@ export default defineComponent({
         cookbook.value,
         category.value,
         tag.value,
-        tool.value
+        tool.value,
+
+        // filter out recipes that have a null value for the property we're sorting by
+        preferences.value.filterNull && preferences.value.orderBy ? `${preferences.value.orderBy} <> null` : null
       );
 
       // since we doubled the first call, we also need to advance the page
@@ -270,7 +273,10 @@ export default defineComponent({
           cookbook.value,
           category.value,
           tag.value,
-          tool.value
+          tool.value,
+
+          // filter out recipes that have a null value for the property we're sorting by
+          preferences.value.filterNull && preferences.value.orderBy ? `${preferences.value.orderBy} <> null` : null
         );
         if (!newRecipes.length) {
           hasMore.value = false;
@@ -287,10 +293,11 @@ export default defineComponent({
         return;
       }
 
-      function setter(orderBy: string, ascIcon: string, descIcon: string, defaultOrderDirection = "asc") {
+      function setter(orderBy: string, ascIcon: string, descIcon: string, defaultOrderDirection = "asc", filterNull = false) {
         if (preferences.value.orderBy !== orderBy) {
           preferences.value.orderBy = orderBy;
           preferences.value.orderDirection = defaultOrderDirection;
+          preferences.value.filterNull = filterNull;
         } else {
           preferences.value.orderDirection = preferences.value.orderDirection === "asc" ? "desc" : "asc";
         }
@@ -299,19 +306,19 @@ export default defineComponent({
 
       switch (sortType) {
         case EVENTS.az:
-          setter("name", $globals.icons.sortAlphabeticalAscending, $globals.icons.sortAlphabeticalDescending, "asc");
+          setter("name", $globals.icons.sortAlphabeticalAscending, $globals.icons.sortAlphabeticalDescending, "asc", false);
           break;
         case EVENTS.rating:
-          setter("rating", $globals.icons.sortAscending, $globals.icons.sortDescending, "desc");
+          setter("rating", $globals.icons.sortAscending, $globals.icons.sortDescending, "desc", true);
           break;
         case EVENTS.created:
-          setter("created_at", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc");
+          setter("created_at", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc", false);
           break;
         case EVENTS.updated:
-          setter("update_at", $globals.icons.sortClockAscending, $globals.icons.sortClockDescending, "desc");
+          setter("update_at", $globals.icons.sortClockAscending, $globals.icons.sortClockDescending, "desc", false);
           break;
         case EVENTS.lastMade:
-          setter("last_made", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc");
+          setter("last_made", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc", true);
           break;
         default:
           console.log("Unknown Event", sortType);
@@ -335,7 +342,10 @@ export default defineComponent({
           cookbook.value,
           category.value,
           tag.value,
-          tool.value
+          tool.value,
+
+          // filter out recipes that have a null value for the property we're sorting by
+          preferences.value.filterNull && preferences.value.orderBy ? `${preferences.value.orderBy} <> null` : null
         );
         context.emit(REPLACE_RECIPES_EVENT, newRecipes);
 

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -287,10 +287,10 @@ export default defineComponent({
         return;
       }
 
-      function setter(orderBy: string, ascIcon: string, descIcon: string) {
+      function setter(orderBy: string, ascIcon: string, descIcon: string, defaultOrderDirection = "asc") {
         if (preferences.value.orderBy !== orderBy) {
           preferences.value.orderBy = orderBy;
-          preferences.value.orderDirection = "asc";
+          preferences.value.orderDirection = defaultOrderDirection;
         } else {
           preferences.value.orderDirection = preferences.value.orderDirection === "asc" ? "desc" : "asc";
         }
@@ -299,19 +299,19 @@ export default defineComponent({
 
       switch (sortType) {
         case EVENTS.az:
-          setter("name", $globals.icons.sortAlphabeticalAscending, $globals.icons.sortAlphabeticalDescending);
+          setter("name", $globals.icons.sortAlphabeticalAscending, $globals.icons.sortAlphabeticalDescending, "asc");
           break;
         case EVENTS.rating:
-          setter("rating", $globals.icons.sortAscending, $globals.icons.sortDescending);
+          setter("rating", $globals.icons.sortAscending, $globals.icons.sortDescending, "desc");
           break;
         case EVENTS.created:
-          setter("created_at", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending);
+          setter("created_at", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc");
           break;
         case EVENTS.updated:
-          setter("update_at", $globals.icons.sortClockAscending, $globals.icons.sortClockDescending);
+          setter("update_at", $globals.icons.sortClockAscending, $globals.icons.sortClockDescending, "desc");
           break;
         case EVENTS.lastMade:
-          setter("last_made", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending);
+          setter("last_made", $globals.icons.sortCalendarAscending, $globals.icons.sortCalendarDescending, "desc");
           break;
         default:
           console.log("Unknown Event", sortType);

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -19,7 +19,8 @@ export const useLazyRecipes = function () {
     cookbook: string | null = null,
     category: string | null = null,
     tag: string | null = null,
-    tool: string | null = null
+    tool: string | null = null,
+    queryFilter: string | null = null,
   ) {
     const { data } = await api.recipes.getAll(page, perPage, {
       orderBy,
@@ -28,6 +29,7 @@ export const useLazyRecipes = function () {
       categories: category,
       tags: tag,
       tools: tool,
+      queryFilter,
     });
     return data ? data.items : [];
   }

--- a/frontend/composables/use-users/preferences.ts
+++ b/frontend/composables/use-users/preferences.ts
@@ -4,6 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 export interface UserRecipePreferences {
   orderBy: string;
   orderDirection: string;
+  filterNull: boolean;
   sortIcon: string;
   useMobileCards: boolean;
 }
@@ -16,6 +17,7 @@ export function useUserSortPreferences(): Ref<UserRecipePreferences> {
     {
       orderBy: "name",
       orderDirection: "asc",
+      filterNull: false,
       sortIcon: $globals.icons.sortAlphabeticalAscending,
       useMobileCards: false,
     },

--- a/mealie/schema/response/query_filter.py
+++ b/mealie/schema/response/query_filter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime
 import re
-from datetime import datetime
 from enum import Enum
 from typing import Any, TypeVar, cast
 
@@ -93,7 +93,7 @@ class QueryFilter:
                 # in the meantime, this will work for the specific usecase of non-null dates/datetimes
                 if value in ["none", "null"] and component.relational_operator == RelationalOperator.NOTEQ:
                     component.relational_operator = RelationalOperator.GTE
-                    value = datetime(1900, 1, 1)
+                    value = datetime.datetime(datetime.MINYEAR, 1, 1)
 
                 else:
                     try:

--- a/mealie/schema/response/query_filter.py
+++ b/mealie/schema/response/query_filter.py
@@ -88,13 +88,20 @@ class QueryFilter:
             value: Any = component.value
 
             if isinstance(attr.type, (sqltypes.Date, sqltypes.DateTime)):
-                try:
-                    value = date_parser.parse(component.value)
+                # TODO: add support for IS NULL and IS NOT NULL
+                # in the meantime, this will work for the specific usecase of non-null dates/datetimes
+                if value in ["none", "null"] and component.relational_operator == RelationalOperator.NOTEQ:
+                    component.relational_operator = RelationalOperator.GTE
+                    value = date_parser.parse("1900-01-01")
 
-                except ParserError as e:
-                    raise ValueError(
-                        f"invalid query string: unknown date or datetime format '{component.value}'"
-                    ) from e
+                else:
+                    try:
+                        value = date_parser.parse(component.value)
+
+                    except ParserError as e:
+                        raise ValueError(
+                            f"invalid query string: unknown date or datetime format '{component.value}'"
+                        ) from e
 
             if isinstance(attr.type, sqltypes.Boolean):
                 try:

--- a/mealie/schema/response/query_filter.py
+++ b/mealie/schema/response/query_filter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from enum import Enum
 from typing import Any, TypeVar, cast
 
@@ -92,7 +93,7 @@ class QueryFilter:
                 # in the meantime, this will work for the specific usecase of non-null dates/datetimes
                 if value in ["none", "null"] and component.relational_operator == RelationalOperator.NOTEQ:
                     component.relational_operator = RelationalOperator.GTE
-                    value = date_parser.parse("1900-01-01")
+                    value = datetime(1900, 1, 1)
 
                 else:
                     try:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Tweaks some of the behavior for sorting recipes on the frontend. It changes the default sort direction for certain `orderBy` attrs (e.g. `rating` will default to descending, thus showing the highest-rated recipes first).

It also filters out null values for certain sorts (e.g. `lastMade` will only show recipes that actually have a value for `lastMade` and not just stick the nulls at the end).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

I had to implement a slightly-dirty workaround for filtering out null datetimes for the `lastMade` date. I added a note to revisit the filter API to properly implement `IS NULL` and `IS NOT NULL`. In the meantime, this implementation will handle `<> null` as `>= 0001-1-1` strictly when addressing dates/datetimes.

## Testing

_(fill-in or delete this section)_

Manually via the frontend.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
improved recipe sorting to only show relevant recipes when sorting by certain attributes (such as rating)
```
