### PR TITLE
bugfix : fix user_entry validation control

### DIFF
--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,7 +86,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if user_entry is not None and user_entry[0][0] is not None:
+    if user_entry is not None and len(user_entry[0]) != 0 and user_entry[0][0] is not None:
         user_dn, user_attr = user_entry[0]
     else:
         return False

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,7 +86,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if not user_entry is None and not user_entry[0][0] is None:
+    if not user_entry is None and user_entry[0][0] is not None:
         user_dn, user_attr = user_entry[0]
     else:
         return False

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,7 +86,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if user_entry is not None and user_entry[0][0] is not None :
+    if not user_entry is None and not user_entry[0][0] is None :
         user_dn, user_attr = user_entry[0]
     else:
         return False

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,7 +86,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if not user_entry is None and not user_entry[0][0] is None :
+    if not user_entry is None and not user_entry[0][0] is None:
         user_dn, user_attr = user_entry[0]
     else:
         return False

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,7 +86,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if not user_entry is None and user_entry[0][0] is not None:
+    if user_entry is not None and user_entry[0][0] is not None:
         user_dn, user_attr = user_entry[0]
     else:
         return False

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,10 +86,12 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if not user_entry:
-        user_dn, user_attr = user_entry[0]
-    else:
+    if user_entry is None :
         return False
+    elif user_entry[0][0] is None:
+        return False
+    else:
+        user_dn, user_attr = user_entry[0]
 
     if user is None:
         user = db.users.create(

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -86,12 +86,10 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
         f"(&(objectClass=user)(|(cn={username})(sAMAccountName={username})(mail={username})))",
         ["name", "mail"],
     )
-    if user_entry is None :
-        return False
-    elif user_entry[0][0] is None:
-        return False
-    else:
+    if user_entry is not None and user_entry[0][0] is not None :
         user_dn, user_attr = user_entry[0]
+    else:
+        return False
 
     if user is None:
         user = db.users.create(


### PR DESCRIPTION
search_s return list or None (see https://www.python-ldap.org/en/python-ldap-3.4.3/reference/ldap.html?highlight=search_s#ldap.LDAPObject.search_s)

On my case search_s never return None
**User exists**
```
>>> user_entry = conn.search_s(
... "DC=lan,DC=lgy,DC=fr",
... ldap.SCOPE_SUBTREE,
... f"(&(objectClass=user)(|(cn=thomas)(sAMAccountName=thomas)(mail=thomas@lgy.fr)))",
... ["name", "mail"],
... )
>>> user_entry
[('CN=thomas,CN=Users,DC=lan,DC=lgy,DC=fr', {'name': [b'thomas'], 'mail': [b'thomas@lgy.fr']}), (None, ['ldaps://lan.lgy.fr/CN=Configuration,DC=lan,DC=lgy,DC=fr']), (None, ['ldaps://lan.lgy.fr/DC=DomainDnsZones,DC=lan,DC=lgy,DC=fr']), (None, ['ldaps://lan.lgy.fr/DC=ForestDnsZones,DC=lan,DC=lgy,DC=fr'])]
>>> not user_entry
False
```

**User not exists**
```

>>> user_entry2 = conn.search_s(
... "DC=lan,DC=lgy,DC=fr",
... ldap.SCOPE_SUBTREE,
... f"(&(objectClass=user)(|(cn=none)(sAMAccountName=none)(mail=none@lgy.fr)))",
... ["name", "mail"],
... )
>>> user_entry2
[(None, ['ldaps://lan.lgy.fr/CN=Configuration,DC=lan,DC=lgy,DC=fr']), (None, ['ldaps://lan.lgy.fr/DC=DomainDnsZones,DC=lan,DC=lgy,DC=fr']), (None, ['ldaps://lan.lgy.fr/DC=ForestDnsZones,DC=lan,DC=lgy,DC=fr'])]
>>> not user_entry2
False

```

