### PR TITLE
Delay dark mode loading to bypass Vuetify rendering bug

### DIFF
--- a/frontend/plugins/dark-mode.client.ts
+++ b/frontend/plugins/dark-mode.client.ts
@@ -4,7 +4,10 @@ import { useDark } from "@vueuse/core";
 const darkModePlugin: Plugin = ({ $vuetify }, _) => {
   const isDark = useDark();
 
-  $vuetify.theme.dark = isDark.value;
+  // Vuetify metadata is bugged and doesn't render dark mode fully when called immediately
+  // Adding a 0.5 millisecond delay fixes this problem
+  // https://stackoverflow.com/questions/69399797/vuetify-darkmode-colors-wrong-after-page-reload
+  setTimeout( () => { $vuetify.theme.dark = isDark.value; }, 0.5);
 };
 
 export default darkModePlugin;


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Apparently something is up with Vuetify's dark mode metadata that causes it to give up rendering halfway through:
https://stackoverflow.com/questions/69399797/vuetify-darkmode-colors-wrong-after-page-reload

Per the OP on that thread, adding a 0.5 millisecond delay fixes this.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #1802 

## Testing

_(fill-in or delete this section)_

I built a prod instance locally first with no change to confirm the bug is reproduceable locally (it was), then I made the change and confirmed the bug is gone.

(and by _made the change_ I mean _made several changes over the course of an embarrassingly long time before stumbling upon the linked stackoverflow thread_)

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
fixed dark mode not rendering correctly in certain instances
```
