### PR TITLE
Fix for several Shopping List bugs

### DIFF
--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -237,7 +237,12 @@ export default defineComponent({
     }
 
     async function refresh() {
-      shoppingList.value = await fetchShoppingList();
+      const newListValue = await fetchShoppingList();
+
+      // only update the list with the new value if we're not loading, to prevent UI jitter
+      if (!loading.value) {
+        shoppingList.value = newListValue;
+      }
     }
 
     // constantly polls for changes

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -557,6 +557,9 @@ export default defineComponent({
       }
 
       loading.value = true;
+
+      // make sure it's inserted into the end of the list, which may have been updated
+      createListItemData.value.position = shoppingList.value?.listItems?.length || 1;
       const { data } = await userApi.shopping.items.createOne(createListItemData.value);
 
       if (data) {

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -216,6 +216,7 @@ export default defineComponent({
   setup() {
     const { idle } = useIdle(5 * 60 * 1000) // 5 minutes
     const loadingCounter = ref(1);
+    const recipeReferenceLoading = ref(false);
     const userApi = useUserApi();
 
     const edit = ref(false);
@@ -465,12 +466,14 @@ export default defineComponent({
     });
 
     async function addRecipeReferenceToList(recipeId: string) {
-      if (!shoppingList.value || loadingCounter.value) {
+      if (!shoppingList.value || recipeReferenceLoading.value) {
         return;
       }
 
       loadingCounter.value += 1;
+      recipeReferenceLoading.value = true;
       const { data } = await userApi.shopping.lists.addRecipe(shoppingList.value.id, recipeId);
+      recipeReferenceLoading.value = false;
       loadingCounter.value -= 1;
 
       if (data) {
@@ -479,12 +482,14 @@ export default defineComponent({
     }
 
     async function removeRecipeReferenceToList(recipeId: string) {
-      if (!shoppingList.value || loadingCounter.value) {
+      if (!shoppingList.value || recipeReferenceLoading.value) {
         return;
       }
 
       loadingCounter.value += 1;
+      recipeReferenceLoading.value = true;
       const { data } = await userApi.shopping.lists.removeRecipe(shoppingList.value.id, recipeId);
+      recipeReferenceLoading.value = false;
       loadingCounter.value -= 1;
 
       if (data) {

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -18,8 +18,8 @@
               :labels="allLabels || []"
               :units="allUnits || []"
               :foods="allFoods || []"
-              @checked="saveListItem(item)"
-              @save="saveListItem(item)"
+              @checked="saveListItem"
+              @save="saveListItem"
               @delete="deleteListItem(item)"
             />
           </v-lazy>
@@ -43,8 +43,8 @@
               :labels="allLabels || []"
               :units="allUnits || []"
               :foods="allFoods || []"
-              @checked="saveListItem(item)"
-              @save="saveListItem(item)"
+              @checked="saveListItem"
+              @save="saveListItem"
               @delete="deleteListItem(item)"
             />
           </v-lazy>
@@ -134,8 +134,8 @@
                 :labels="allLabels"
                 :units="allUnits || []"
                 :foods="allFoods || []"
-                @checked="saveListItem(item)"
-                @save="saveListItem(item)"
+                @checked="saveListItem"
+                @save="saveListItem"
                 @delete="deleteListItem(item)"
               />
             </div>
@@ -637,6 +637,7 @@ export default defineComponent({
       itemsByLabel,
       listItems,
       listRecipes,
+      loading,
       presentLabels,
       removeRecipeReferenceToList,
       saveListItem,

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -10,7 +10,7 @@
     <!-- Viewer -->
     <section v-if="!edit" class="py-2">
       <div v-if="!byLabel">
-        <draggable :value="shoppingList.listItems" handle=".handle" @input="updateIndex">
+        <draggable :value="shoppingList.listItems" handle=".handle" @start="loading=true" @end="loading=false" @input="updateIndex">
           <v-lazy v-for="(item, index) in listItems.unchecked" :key="item.id">
             <ShoppingListItem
               v-model="listItems.unchecked[index]"

--- a/mealie/services/group_services/shopping_lists.py
+++ b/mealie/services/group_services/shopping_lists.py
@@ -24,6 +24,10 @@ class ShoppingListService:
         can_merge checks if the two items can be merged together.
         """
 
+        # Check if items are both checked or both unchecked
+        if item1.checked != item2.checked:
+            return False
+
         # Check if foods are equal
         foods_is_none = item1.food_id is None and item2.food_id is None
         foods_not_none = not foods_is_none
@@ -34,7 +38,7 @@ class ShoppingListService:
         units_not_none = not units_is_none
         units_equal = item1.unit_id == item2.unit_id
 
-        # Check if Notes are equal
+        # Check if notes are equal
         if foods_is_none and units_is_none:
             return item1.note == item2.note
 
@@ -48,7 +52,7 @@ class ShoppingListService:
 
     def consolidate_list_items(self, item_list: list[ShoppingListItemOut]) -> list[ShoppingListItemOut]:
         """
-        itterates through the shopping list provided and returns
+        iterates through the shopping list provided and returns
         a consolidated list where all items that are matched against multiple values are
         de-duplicated and only the first item is kept where the quantity is updated accordingly.
         """


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This fixes several issues with the shopping list feature. Once #1847 is merged I think I'll take another look at the backend shopping list service because I think there are some additional improvements to be had.

The main issues this PR addresses are around the auto-refresh we implemented fairly recently - it broke... a lot more than I thought it did, as you'll see below. This PR more-or-less restores the shopping list back to how it used to behave for the user, but keeps the auto-refresh intact which required some changes. It also fixes a backend bug where checked items were being merged with unchecked items.

Below are two of the bigger frontend changes:

### Editing Items
The current state of the shopping list makes it virtually impossible to modify individual items on multiple fronts, since a refresh overwrites any changes a user is in the middle of making. Here is an example from the current build:
![2022-12-21_14h22_19](https://user-images.githubusercontent.com/71845777/208996288-0af11e0a-aef4-4b23-b01c-5ceb8503145e.gif)

You can see my changes are just being replaced by the original value. My solution in this PR is to basically copy the item in the component which is edited, and then once the user saves the item the copied item emits up to the main component to replace it.
Not pictured: I'm monitoring the network to make sure we are, in fact, still polling.
![2022-12-21_14h25_51](https://user-images.githubusercontent.com/71845777/208996721-44e2a90d-6c0c-4dcd-820d-0e22ce610067.gif)


### Performing a ton of actions at once
We implemented a `loading` value to make sure a refresh doesn't occur when we're still doing some work (e.g. updating a recipe reference, which takes a while). However, if you do a ton of things at once, whatever finishes first sets the loading value to False. That leads to behavior like this where items pop in and out (note: in the gif the issue takes 4-5 seconds to appear):
![2022-12-21_14h29_30](https://user-images.githubusercontent.com/71845777/208997281-541e64c8-5a41-4131-ad7a-f71253c7e75c.gif)

So I replaced the `loading` bool with a `loadingCounter` int. Every list action that pauses loading increments the counter, then decrements it. Refreshes only occur when the loading counter is zero (thus everything is done loading).
Not pictured: network requests for the updated list stop until all the operations are done (the gif continues until all network requests finished and the first refresh occurs)
![2022-12-21_14h31_43](https://user-images.githubusercontent.com/71845777/208997766-4fa8e899-0d60-47e8-a58e-34411b020f4a.gif)


## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A


## Testing

_(fill-in or delete this section)_

I testing this much more robustly: adding a ton of recipes at once, incrementing them, decrementing them, editing one item, editing several items, etc. Everything seems nice and responsive.

One drawback of this approach is that when you edit an item, it waits for the backend call to show the updated item to the user (you can see this in the second gif where the update is successful, but it takes a sec). I think this is okay, since it gives the user visual feedback that the change did indeed occur and nothing went wrong, but we lose that instant responsiveness. We could probably change this so the update is shown to the user before the backend call, but I'm unsure if we want to. Maybe I'm over thinking it.


## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
increased shopping list responsiveness
fixed an issue where adding a recipe to a shopping list that has checked items will sometimes uncheck them
```
