### PR TITLE
Fix/issue#2003 - Unable to remove all instructions/ingredients from a recipe

### DIFF
--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -146,10 +146,10 @@ class RecipeModel(SqlAlchemyBase, BaseMixins):
     ) -> None:
         self.nutrition = Nutrition(**nutrition) if nutrition else Nutrition()
 
-        if recipe_instructions:
+        if recipe_instructions is not None:
             self.recipe_instructions = [RecipeInstruction(**step, session=session) for step in recipe_instructions]
 
-        if recipe_ingredient:
+        if recipe_ingredient is not None:
             self.recipe_ingredient = [RecipeIngredient(**ingr, session=session) for ingr in recipe_ingredient]
 
         if assets:


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the original issue in #2003 where you could not remove all instructions/ingredients from a recipe and it would always revert to its original state

## Which issue(s) this PR fixes:

Fixes #2003

## Testing

Added and additional test_case to verify intended behaviour

## Release Notes

```release-note
* Fix not being able to delete all instructions/ingredients from a recipe
```
