### PR TITLE
Default recipe for new groups

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -58,6 +58,54 @@
       </v-card>
     </v-dialog>
 
+    <!-- Markdown Guide -->
+    <v-dialog v-model="markdownGuideDialog" width="600">
+      <v-card :ripple="false">
+        <v-app-bar dark color="primary" class="mt-n1 mb-3">
+          <v-icon large left>
+            {{ $globals.icons.information }}
+          </v-icon>
+          <v-toolbar-title class="headline"> {{ $t("new-recipe.formatting-guide") }} </v-toolbar-title>
+          <v-spacer></v-spacer>
+        </v-app-bar>
+
+        <v-card-text class="pt-4">
+          <p>
+            Recipe steps as well as other fields in the recipe page support markdown syntax.
+            Below are some examples of text formatting with markdown.
+          </p>
+
+          <h2>Styling</h2>
+          <ul>
+            <li><i>italic</i> - <code>*text*</code></li>
+            <li><b>bold</b> - <code>**text**</code></li>
+          </ul>
+          <br />
+
+          <h2>New Line</h2>
+          <p>There are a few different ways to insert a new line:</p>
+          <ul>
+            <li>Write two consecutive new line characters</li>
+            <li>Put two spaces at the end of a line</li>
+            <li>Write <code>&lt;br&gt;</code></li>
+          </ul>
+          <br />
+
+          <h2>Links</h2>
+          <p><code>[link text](https://demo.mealie.io)</code></p>
+
+          <h2>Images</h2>
+          <p><code>&lt;img height="100" src="https://url.to/image.png" /&gt;</code></p>
+          <p>Use the <code>height="100"</code> or <code>width="100"</code> attributes to set the size of the image.</p>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <BaseButton cancel @click="markdownGuideDialog = false">Close</BaseButton>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <div class="d-flex justify-space-between justify-start">
       <h2 class="mb-4 mt-1">{{ $t("recipe.instructions") }}</h2>
       <BaseButton v-if="!isEditForm && showCookMode" minor cancel color="primary" @click="toggleCookMode()">
@@ -157,9 +205,8 @@
                       @merge-above="mergeAbove(index - 1, index)"
                       @toggle-section="toggleShowTitle(step.id)"
                       @link-ingredients="openDialog(index, step.text, step.ingredientReferences)"
-                      @preview-step="togglePreviewState(index)"
-                      @delete="value.splice(index, 1)"
-                    />
+                      @info="markdownGuideDialog = true" @preview-step="togglePreviewState(index)"
+                      @delete="value.splice(index, 1)" />
                   </div>
                 </template>
                 <v-fade-transition>
@@ -278,6 +325,7 @@ export default defineComponent({
 
     const state = reactive({
       dialog: false,
+      markdownGuideDialog: false,
       disabledSteps: [] as number[],
       unusedIngredients: [] as RecipeIngredient[],
       usedIngredients: [] as RecipeIngredient[],

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -241,6 +241,7 @@
     "bulk-add": "Bulk Add",
     "error-details": "Only websites containing ld+json or microdata can be imported by Mealie. Most major recipe websites support this data structure. If your site cannot be imported but there is json data in the log, please submit a github issue with the URL and data.",
     "error-title": "Looks Like We Couldn't Find Anything",
+    "formatting-guide": "Formatting Guide",
     "from-url": "Import a Recipe",
     "github-issues": "GitHub Issues",
     "google-ld-json-info": "Google ld+json Info",

--- a/mealie/db/init_db.py
+++ b/mealie/db/init_db.py
@@ -23,8 +23,9 @@ logger = root_logger.get_logger("init_db")
 
 
 def init_db(db: AllRepositories) -> None:
-    default_group_init(db)
-    default_user_init(db)
+    group_id = default_group_init(db).id
+    user_id = default_user_init(db).id
+    GroupService.add_defaults(db, group_id, user_id)
 
 
 def default_group_init(db: AllRepositories):
@@ -32,7 +33,7 @@ def default_group_init(db: AllRepositories):
 
     logger.info("Generating Default Group")
 
-    GroupService.create_group(db, GroupBase(name=settings.DEFAULT_GROUP))
+    return GroupService.create_group(db, GroupBase(name=settings.DEFAULT_GROUP))
 
 
 # Adapted from https://alembic.sqlalchemy.org/en/latest/cookbook.html#test-current-database-revision-is-at-head-s

--- a/mealie/repos/seed/init_users.py
+++ b/mealie/repos/seed/init_users.py
@@ -55,8 +55,10 @@ def default_user_init(db: AllRepositories):
     }
 
     logger.info("Generating Default User")
-    db.users.create(default_user)
+    new_user = db.users.create(default_user)
 
     if not settings.PRODUCTION:
         for user in dev_users():
             db.users.create(user)
+
+    return new_user

--- a/mealie/routes/admin/admin_management_groups.py
+++ b/mealie/routes/admin/admin_management_groups.py
@@ -48,7 +48,10 @@ class AdminUserManagementRoutes(BaseAdminController):
 
     @router.post("", response_model=GroupInDB, status_code=status.HTTP_201_CREATED)
     def create_one(self, data: GroupBase):
-        return GroupService.create_group(self.repos, data)
+        new_group = GroupService.create_group(self.repos, GroupBase(name=data.name))
+        GroupService.add_defaults(self.repos, new_group.id, self.user.id)
+
+        return new_group
 
     @router.get("/{item_id}", response_model=GroupInDB)
     def get_one(self, item_id: UUID4):

--- a/mealie/services/group_services/group_service.py
+++ b/mealie/services/group_services/group_service.py
@@ -4,10 +4,20 @@ from mealie.pkgs.stats import fs_stats
 from mealie.repos.repository_factory import AllRepositories
 from mealie.schema.group.group_preferences import CreateGroupPreferences
 from mealie.schema.group.group_statistics import GroupStatistics, GroupStorage
+from mealie.schema.recipe.recipe import Recipe
+from mealie.schema.recipe.recipe_ingredient import RecipeIngredient
+from mealie.schema.recipe.recipe_step import RecipeStep
 from mealie.schema.user.user import GroupBase
 from mealie.services._base_service import BaseService
 
 ALLOWED_SIZE = 500 * fs_stats.megabyte
+
+STEP_TEXT = """Recipe steps as well as other fields in the recipe page support markdown syntax.
+**Add a link**
+[My Link](https://demo.mealie.io)
+"""
+
+INGREDIENT_NOTE = "1 Cup Flour"
 
 
 class GroupService(BaseService):
@@ -32,6 +42,19 @@ class GroupService(BaseService):
         repos.group_preferences.create(prefs)
 
         return new_group
+
+    @staticmethod
+    def add_defaults(repos: AllRepositories, group_id: UUID4, user_id: UUID4):
+        default_recipe = Recipe(
+            user_id=user_id,
+            group_id=group_id,
+            name="Example Recipe",
+            recipe_ingredient=[
+                RecipeIngredient(note=INGREDIENT_NOTE),
+            ],
+            recipe_instructions=[RecipeStep(text=STEP_TEXT)],
+        )
+        repos.recipes.create(default_recipe)
 
     def calculate_statistics(self, group_id: None | UUID4 = None) -> GroupStatistics:
         """

--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -24,16 +24,6 @@ from mealie.services.recipe.recipe_data_service import RecipeDataService
 
 from .template_service import TemplateService
 
-step_text = """Recipe steps as well as other fields in the recipe page support markdown syntax.
-
-**Add a link**
-
-[My Link](https://demo.mealie.io)
-
-"""
-
-ingredient_note = "1 Cup Flour"
-
 
 class RecipeService(BaseService):
     def __init__(self, repos: AllRepositories, user: PrivateUser, group: GroupInDB):
@@ -98,12 +88,6 @@ class RecipeService(BaseService):
         if additional_attrs.get("tags"):
             for i in range(len(additional_attrs.get("tags", []))):
                 additional_attrs["tags"][i]["group_id"] = user.group_id
-
-        if not additional_attrs.get("recipe_ingredient"):
-            additional_attrs["recipe_ingredient"] = [RecipeIngredient(note=ingredient_note)]
-
-        if not additional_attrs.get("recipe_instructions"):
-            additional_attrs["recipe_instructions"] = [RecipeStep(text=step_text)]
 
         return Recipe(**additional_attrs)
 

--- a/mealie/services/user_services/registration_service.py
+++ b/mealie/services/user_services/registration_service.py
@@ -85,6 +85,7 @@ class RegistrationService:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"message": "Missing group"})
 
         user = self._create_new_user(group, new_group)
+        GroupService.add_defaults(self.repos, group.id, user.id)
 
         if new_group and registration.seed_data:
             seeder_service = SeederService(self.repos, user, group)

--- a/tests/integration_tests/admin_tests/test_admin_group_actions.py
+++ b/tests/integration_tests/admin_tests/test_admin_group_actions.py
@@ -61,6 +61,10 @@ def test_admin_update_group(api_client: TestClient, admin_user: TestUser, unique
 
 
 def test_admin_delete_group(api_client: TestClient, admin_user: TestUser, unique_user: TestUser):
+    # Delete Default Recipe
+    response = api_client.delete(api_routes.recipes_slug("example-recipe"), headers=unique_user.token)
+    assert response.status_code == 200
+
     # Delete User
     response = api_client.delete(api_routes.admin_users_item_id(unique_user.user_id), headers=admin_user.token)
     assert response.status_code == 200

--- a/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
@@ -42,7 +42,8 @@ def test_get_all_only_includes_group_recipes(api_client: TestClient, unique_user
 
     recipes = response.json()["items"]
 
-    assert len(recipes) == 5
+    # The 6th one is the default recipe
+    assert len(recipes) == 6
 
     for recipe in recipes:
         assert recipe["groupId"] == unique_user.group_id


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

I'm not familiar with this code-base, so it might not work out in the end, but I decided I might as well try at least! It seems to work so far, but there are some decisions that would need to be made.

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

I realised two things: someone needs to actually own the recipe, and there might need to be some way to delete a group containing only the default recipe.

On my branch, I made the group creator the owner of the recipe. When a user registers, then that user is going to be the owner of the recipe. However, if an administrator creates a group manually, then the administrator is going to be the owner of the recipe. To me, this makes sense, but I'm not very familiar with the code-base.

When a default recipe is created together with a group, it is not going to be possible to remove the group right away. You'd have to manually remove the default recipe. Maybe that is fine, but slightly annoying? It also becomes an issue in the integration test that removes a group, since that group is going to have the default recipe. I did a bit of a hack and made it delete the recipe by its slug, but there would probably need to be a more reliable way to find example recipes? A field in the database specifically for this would work, but might be overkill? Not sure what else though.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

* [mealie/services/group_services/group_service.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-642bc128e8ca740e54d94e87d4289e10cd99d9928a03feea4b484559044192c4) - Adds a function (`add_defaults`) that adds defaults to a group (right now just the default recipe). It takes a group id and a user id, where the user id is whoever should own the recipe. This function would be called after creating a group and a user.
* [mealie/services/user_services/registration_service.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-007561acf2a1cab65deea21bc69cb12499cb15d610d4cb36ebf4aadf6ac7daea) - Adds a call to `add_defaults` after creating a group and user.
* [mealie/routes/admin/admin_management_groups.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-1aca57d1d526081ea1c352a0b6ad677da7a5071099b287c6da12a292b55b7307) - Adds a call to `add_defaults` right after creating the group, since we already have the user id.
* [mealie/db/init_db.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-241663d8ec2a6b8e490e55530d0c040ef2e612182a75c5ffb2802769aad07b18) - Adds a call to `add_defaults` after creating the initial user and group. Also had to make `default_group_init` return the created group, since the id is needed to create the default recipe.
* [mealie/repos/seed/init_users.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-7b23aff3bb83c82f0c66c750919e7f7208cbffe2eead64c4370abe5a92098b2c) - Return the user from `default_user_init` since the user id is needed when creating the default recipe.
* [tests/integration_tests/admin_tests/test_admin_group_actions.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-c6d724173a763002b4e8d9e1bd7a9c683ce92c0a50f1242d7d7a5df1a1903d31) - *Hack*: Removes the default recipe before removing the group in the integration test, by querying the slug...
* [tests/integration_tests/user_recipe_tests/test_recipe_owner.py](https://github.com/PaddiM8/mealie/commit/c9b4c1f83b90d795725119f7150f647efcff07c6#diff-6ae0dcf7c0581202b7939d98abae985466aec69f3ed21e359beec83819d8e3fb) - Since groups now come with a recipe, this comparison needed to be incremented from 5 to 6.
* [mealie/services/recipe/recipe_service.py](https://github.com/PaddiM8/mealie/commit/0af805c7c2998544e7c4e4737dbbca7d5d9f15ec#diff-b8993bc5f301cf5db867bb139264c1950c83f8add97b78f1d75ce1113191602d) - Removes the default ingredients and steps.

## Which issue(s) this PR fixes:

Solves "Add An example recipe for new groups?" and "Remove defaults from the backend" from #2012.

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

I jumped in to this head-first just to get the ball rolling. There are some things that need to be discussed (hence the draft), and I'm sure I've missed some things since I'm new to mealie.

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Default recipe for new groups
```
