### PR TITLE
Fix devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_CREATE=false
+    POETRY_HOME="/opt/poetry"
 
 # prepend poetry and venv to path
 ENV PATH="$POETRY_HOME/bin:$PATH"


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

New contributors are hindered by the broken devcontainer setup, which may discourage them from ever submitting any code at all.

## Which issue(s) this PR fixes:

Fixes #2026 

## Special notes for your reviewer:

I'm not sure why virtualenv was disabled. Without it, we're attempting to install dependencies into system-level directories as the `vscode` user, which is of course not possible.

## Testing

You can test this by cloning [my fork](https://github.com/wbrawner/mealie) from the `Remote: Clone Repository in Container Volume` action within VS Code
