### PR TITLE
Fix encoding issue when seeding the database with foods, units and labels

### DIFF
--- a/mealie/repos/seed/seeders.py
+++ b/mealie/repos/seed/seeders.py
@@ -17,7 +17,7 @@ class MultiPurposeLabelSeeder(AbstractSeeder):
     def load_data(self, locale: str | None = None) -> Generator[MultiPurposeLabelSave, None, None]:
         file = self.get_file(locale)
 
-        for label in json.loads(file.read_text()):
+        for label in json.loads(file.read_text(encoding="utf-8")):
             yield MultiPurposeLabelSave(
                 name=label["name"],
                 group_id=self.group_id,
@@ -40,7 +40,7 @@ class IngredientUnitsSeeder(AbstractSeeder):
     def load_data(self, locale: str | None = None) -> Generator[SaveIngredientUnit, None, None]:
         file = self.get_file(locale)
 
-        for unit in json.loads(file.read_text()).values():
+        for unit in json.loads(file.read_text(encoding="utf-8")).values():
             yield SaveIngredientUnit(
                 group_id=self.group_id,
                 name=unit["name"],
@@ -65,7 +65,7 @@ class IngredientFoodsSeeder(AbstractSeeder):
     def load_data(self, locale: str | None = None) -> Generator[SaveIngredientFood, None, None]:
         file = self.get_file(locale)
 
-        seed_foods: dict[str, str] = json.loads(file.read_text())
+        seed_foods: dict[str, str] = json.loads(file.read_text(encoding="utf-8"))
         for food in seed_foods.values():
             yield SaveIngredientFood(
                 group_id=self.group_id,


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Seed data is UTF-8 encoded, which is not the default encoding mode when reading a file. This results in encoding errors.
![image](https://user-images.githubusercontent.com/34862846/213668817-7760ba83-1239-4c56-be81-37f028a85ff3.png)


## Which issue(s) this PR fixes:

NONE

## Testing

![image](https://user-images.githubusercontent.com/34862846/213668966-8323da64-5b37-4ec5-a9e3-24f967c68556.png)

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fix encoding issue when seeding the database with foods, units and labels
```
