### PR TITLE
Improve the default search by focussing on title and description

### DIFF
--- a/frontend/composables/recipes/use-recipe-search.ts
+++ b/frontend/composables/recipes/use-recipe-search.ts
@@ -13,7 +13,8 @@ export const useRecipeSearch = (recipes: Ref<Recipe[] | null>) => {
       findAllMatches: true,
       maxPatternLength: 32,
       minMatchCharLength: 2,
-      keys: ["name", "description", "recipeIngredient.note", "recipeIngredient.food.name"],
+      ignoreFieldNorm: true,
+      keys: [{ name: "name", weight: 1.3 }, { name: "description", weight: 1.2 }, "recipeIngredient.note", "recipeIngredient.food.name"],
     },
   });
 

--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -3,43 +3,91 @@
     <v-container fluid class="pa-0">
       <v-row dense>
         <v-col>
-          <v-text-field v-model="searchString" outlined autofocus color="primary accent-3"
-            :placeholder="$t('search.search-placeholder')" :prepend-inner-icon="$globals.icons.search" clearable>
+          <v-text-field
+            v-model="searchString"
+            outlined
+            autofocus
+            color="primary accent-3"
+            :placeholder="$t('search.search-placeholder')"
+            :prepend-inner-icon="$globals.icons.search"
+            clearable
+          >
           </v-text-field>
         </v-col>
         <v-col cols="12" md="2" sm="12">
-          <v-text-field v-model="maxResults" class="mt-0 pt-0" :label="$t('search.max-results')" type="number"
-            outlined />
+          <v-text-field
+            v-model="maxResults"
+            class="mt-0 pt-0"
+            :label="$t('search.max-results')"
+            type="number"
+            outlined
+          />
         </v-col>
       </v-row>
 
       <div>
-        <v-switch v-model="advanced" color="info" class="ma-0 pa-0" label="Advanced" @input="advanced = !advanced"
-          @click="advanced = !advanced" />
+        <v-switch
+          v-model="advanced"
+          color="info"
+          class="ma-0 pa-0"
+          label="Advanced"
+          @input="advanced = !advanced"
+          @click="advanced = !advanced"
+        />
         <v-expand-transition>
           <v-row v-show="advanced" dense class="my-0 dense flex-row align-center justify-space-around">
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <RecipeOrganizerSelector v-model="includeCategories" :input-attrs="{
-                solo: true,
-                hideDetails: true,
-                dense: false,
-              }" :show-add="false" :return-object="false" selector-type="categories" />
+              <RecipeOrganizerSelector
+                v-model="includeCategories"
+                :input-attrs="{
+                  solo: true,
+                  hideDetails: true,
+                  dense: false,
+                }"
+                :show-add="false"
+                :return-object="false"
+                selector-type="categories"
+              />
               <RecipeSearchFilterSelector class="mb-1" @update="updateCatParams" />
             </v-col>
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <RecipeOrganizerSelector v-model="includeTags" :input-attrs="{
-                solo: true,
-                hideDetails: true,
-                dense: false,
-              }" :show-add="false" :return-object="false" selector-type="tags" />
+              <RecipeOrganizerSelector
+                v-model="includeTags"
+                :input-attrs="{
+                  solo: true,
+                  hideDetails: true,
+                  dense: false,
+                }"
+                :show-add="false"
+                :return-object="false"
+                selector-type="tags"
+              />
               <RecipeSearchFilterSelector class="mb-1" @update="updateTagParams" />
             </v-col>
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <v-autocomplete v-model="includeFoods" chips hide-details deletable-chips solo multiple
-                :items="foods || []" item-text="name" :prepend-inner-icon="$globals.icons.foods" label="Foods">
+              <v-autocomplete
+                v-model="includeFoods"
+                chips
+                hide-details
+                deletable-chips
+                solo
+                multiple
+                :items="foods || []"
+                item-text="name"
+                :prepend-inner-icon="$globals.icons.foods"
+                label="Foods"
+              >
                 <template #selection="data">
-                  <v-chip :key="data.index" class="ma-1" :input-value="data.selected" close label color="accent" dark
-                    @click:close="includeFoods.splice(data.index, 1)">
+                  <v-chip
+                    :key="data.index"
+                    class="ma-1"
+                    :input-value="data.selected"
+                    close
+                    label
+                    color="accent"
+                    dark
+                    @click:close="includeFoods.splice(data.index, 1)"
+                  >
                     {{ data.item.name || data.item }}
                   </v-chip>
                 </template>
@@ -51,8 +99,13 @@
       </div>
     </v-container>
     <v-container class="px-0 mt-6">
-      <RecipeCardSection class="mt-n5" :icon="$globals.icons.search" title="Results"
-        :recipes="showRecipes.slice(0, maxResults)" @sort="assignFuzzy" />
+      <RecipeCardSection
+        class="mt-n5"
+        :icon="$globals.icons.search"
+        title="Results"
+        :recipes="showRecipes.slice(0, maxResults)"
+        @sort="assignFuzzy"
+      />
     </v-container>
   </v-container>
 </template>
@@ -253,6 +306,4 @@ export default defineComponent({
 });
 </script>
 
-<style>
-
-</style>
+<style></style>

--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -3,91 +3,43 @@
     <v-container fluid class="pa-0">
       <v-row dense>
         <v-col>
-          <v-text-field
-            v-model="searchString"
-            outlined
-            autofocus
-            color="primary accent-3"
-            :placeholder="$t('search.search-placeholder')"
-            :prepend-inner-icon="$globals.icons.search"
-            clearable
-          >
+          <v-text-field v-model="searchString" outlined autofocus color="primary accent-3"
+            :placeholder="$t('search.search-placeholder')" :prepend-inner-icon="$globals.icons.search" clearable>
           </v-text-field>
         </v-col>
         <v-col cols="12" md="2" sm="12">
-          <v-text-field
-            v-model="maxResults"
-            class="mt-0 pt-0"
-            :label="$t('search.max-results')"
-            type="number"
-            outlined
-          />
+          <v-text-field v-model="maxResults" class="mt-0 pt-0" :label="$t('search.max-results')" type="number"
+            outlined />
         </v-col>
       </v-row>
 
       <div>
-        <v-switch
-          v-model="advanced"
-          color="info"
-          class="ma-0 pa-0"
-          label="Advanced"
-          @input="advanced = !advanced"
-          @click="advanced = !advanced"
-        />
+        <v-switch v-model="advanced" color="info" class="ma-0 pa-0" label="Advanced" @input="advanced = !advanced"
+          @click="advanced = !advanced" />
         <v-expand-transition>
           <v-row v-show="advanced" dense class="my-0 dense flex-row align-center justify-space-around">
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <RecipeOrganizerSelector
-                v-model="includeCategories"
-                :input-attrs="{
-                  solo: true,
-                  hideDetails: true,
-                  dense: false,
-                }"
-                :show-add="false"
-                :return-object="false"
-                selector-type="categories"
-              />
+              <RecipeOrganizerSelector v-model="includeCategories" :input-attrs="{
+                solo: true,
+                hideDetails: true,
+                dense: false,
+              }" :show-add="false" :return-object="false" selector-type="categories" />
               <RecipeSearchFilterSelector class="mb-1" @update="updateCatParams" />
             </v-col>
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <RecipeOrganizerSelector
-                v-model="includeTags"
-                :input-attrs="{
-                  solo: true,
-                  hideDetails: true,
-                  dense: false,
-                }"
-                :show-add="false"
-                :return-object="false"
-                selector-type="tags"
-              />
+              <RecipeOrganizerSelector v-model="includeTags" :input-attrs="{
+                solo: true,
+                hideDetails: true,
+                dense: false,
+              }" :show-add="false" :return-object="false" selector-type="tags" />
               <RecipeSearchFilterSelector class="mb-1" @update="updateTagParams" />
             </v-col>
             <v-col cols="12" class="d-flex flex-wrap flex-md-nowrap justify-center" style="gap: 0.8rem">
-              <v-autocomplete
-                v-model="includeFoods"
-                chips
-                hide-details
-                deletable-chips
-                solo
-                multiple
-                :items="foods || []"
-                item-text="name"
-                :prepend-inner-icon="$globals.icons.foods"
-                label="Foods"
-              >
+              <v-autocomplete v-model="includeFoods" chips hide-details deletable-chips solo multiple
+                :items="foods || []" item-text="name" :prepend-inner-icon="$globals.icons.foods" label="Foods">
                 <template #selection="data">
-                  <v-chip
-                    :key="data.index"
-                    class="ma-1"
-                    :input-value="data.selected"
-                    close
-                    label
-                    color="accent"
-                    dark
-                    @click:close="includeFoods.splice(data.index, 1)"
-                  >
+                  <v-chip :key="data.index" class="ma-1" :input-value="data.selected" close label color="accent" dark
+                    @click:close="includeFoods.splice(data.index, 1)">
                     {{ data.item.name || data.item }}
                   </v-chip>
                 </template>
@@ -99,13 +51,8 @@
       </div>
     </v-container>
     <v-container class="px-0 mt-6">
-      <RecipeCardSection
-        class="mt-n5"
-        :icon="$globals.icons.search"
-        title="Results"
-        :recipes="showRecipes.slice(0, maxResults)"
-        @sort="assignFuzzy"
-      />
+      <RecipeCardSection class="mt-n5" :icon="$globals.icons.search" title="Results"
+        :recipes="showRecipes.slice(0, maxResults)" @sort="assignFuzzy" />
     </v-container>
   </v-container>
 </template>
@@ -186,7 +133,8 @@ export default defineComponent({
         findAllMatches: true,
         maxPatternLength: 32,
         minMatchCharLength: 2,
-        keys: ["name", "description", "recipeIngredient.note", "recipeIngredient.food.name"],
+        ignoreFieldNorm: true,
+        keys: [{ name: "name", weight: 1.3 }, { name: "description", weight: 1.2 }, "recipeIngredient.note", "recipeIngredient.food.name"],
       },
     });
 
@@ -305,4 +253,6 @@ export default defineComponent({
 });
 </script>
 
-<style></style>
+<style>
+
+</style>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?


<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

This changes the functionality of the string search to give priority to the title and description of a recipe, instead of its ingredients.
- It adds `ignoreFieldNorm: true`. This makes it so the length of the searched text does not matter. Before, a match of an ingredient would get a greater score than a match of a (long) title, because the ingredient is a shorter string. With this configuration, the length of the string is ignored.
- It gives a weight of 1.3 to the title and 1.2 to the description. These exact weights have not been tested thoroughly. I kept them small to hopefully avoid sudden weird changes, but still give some improvement of the search.
<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Partial fix for #804

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->
## Special notes for your reviewer
<del>The same search is used in `RecipeOrganizerPage.vue`.
I think this is used for the search on the pages like `/recipes/categories`. In this case, it only does the search on the title of the recipe.
Is this for a reason? Wouldn't it make sense to do the same kind of search (also on the description and ingredients) on those pages?</del>
I moved this consideration to #2060, as that needs more changes and is more of a feature, while this PR is a bug fix.

The config for the search is now in two places (and if RecipeOrganizerPage.vue is changes, three places). It might make sense to extract this code to avoid this duplication, but I feel like that might get in the territory of over-abstraction.

## Testing

I tested this with some recipes by adding a keyword in the description and ingredients. I did not test how the fuzzy search might react to these changes.

Before:
![afbeelding](https://user-images.githubusercontent.com/52831920/213931168-cefc5308-9523-464b-ba0c-b7e42dc51793.png)

After:
![afbeelding](https://user-images.githubusercontent.com/52831920/213931126-2924a6e7-b065-46e2-86df-84a02e5ad600.png)

The same test done in the advanced search (with same before/after)
<!--
  Describe how you tested this change.
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```
Searching recipes by string now returns recipes with the string in the title and description more often
```
