### PR TITLE
Fix/all recipes performance

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -156,6 +156,7 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
 
         if load_food:
             args.append(joinedload(RecipeModel.recipe_ingredient).options(joinedload(RecipeIngredient.food)))
+            args.append(joinedload(RecipeModel.recipe_ingredient).options(joinedload(RecipeIngredient.unit)))
             item_class = RecipeSummaryWithIngredients
         else:
             item_class = RecipeSummary

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -1,5 +1,5 @@
 from random import randint
-from typing import Any, Type
+from typing import Any
 from uuid import UUID
 
 from pydantic import UUID4

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -1,5 +1,5 @@
 from random import randint
-from typing import Any
+from typing import Any, Type
 from uuid import UUID
 
 from pydantic import UUID4
@@ -211,12 +211,13 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
             self.session.rollback()
             raise e
 
-        return PaginationBase[item_class](
+        items = [item_class.from_orm(item) for item in data]
+        return PaginationBase(
             page=pagination.page,
             per_page=pagination.per_page,
             total=count,
             total_pages=total_pages,
-            items=data,
+            items=items,
         )
 
     def get_by_categories(self, categories: list[RecipeCategory]) -> list[RecipeSummary]:

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -25,13 +25,21 @@ from mealie.routes._base.mixins import HttpRepo
 from mealie.routes._base.routers import MealieCrudRoute, UserAPIRouter
 from mealie.schema.cookbook.cookbook import ReadCookBook
 from mealie.schema.recipe import Recipe, RecipeImageTypes, ScrapeRecipe
-from mealie.schema.recipe.recipe import CreateRecipe, CreateRecipeByUrlBulk, RecipePagination, RecipePaginationQuery
+from mealie.schema.recipe.recipe import (
+    CreateRecipe,
+    CreateRecipeByUrlBulk,
+    RecipePagination,
+    RecipePaginationQuery,
+    RecipeSummary,
+    RecipeSummaryWithIngredients,
+)
 from mealie.schema.recipe.recipe_asset import RecipeAsset
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient
 from mealie.schema.recipe.recipe_scraper import ScrapeRecipeTest
 from mealie.schema.recipe.recipe_settings import RecipeSettings
 from mealie.schema.recipe.recipe_step import RecipeStep
 from mealie.schema.recipe.request_helpers import RecipeDuplicate, RecipeZipTokenResponse, UpdateImageResponse
+from mealie.schema.response import PaginationBase
 from mealie.schema.response.responses import ErrorResponse
 from mealie.services import urls
 from mealie.services.event_bus_service.event_types import (
@@ -232,7 +240,7 @@ class RecipeController(BaseRecipeController):
     # ==================================================================================================================
     # CRUD Operations
 
-    @router.get("", response_model=RecipePagination)
+    @router.get("", response_model=PaginationBase[RecipeSummary | RecipeSummaryWithIngredients])
     def get_all(
         self,
         request: Request,

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -91,8 +91,6 @@ class RecipeSummary(MealieModel):
     rating: int | None
     org_url: str | None = Field(None, alias="orgURL")
 
-    recipe_ingredient: list[RecipeIngredient] | None = []
-
     date_added: datetime.date | None
     date_updated: datetime.datetime | None
 
@@ -213,4 +211,5 @@ class Recipe(RecipeSummary):
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient  # noqa: E402
 
 RecipeSummary.update_forward_refs()
+RecipeSummaryWithIngredients.update_forward_refs()
 Recipe.update_forward_refs()

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -103,29 +103,9 @@ class RecipeSummary(MealieModel):
     class Config:
         orm_mode = True
 
-    @validator("tags", always=True, pre=True, allow_reuse=True)
-    def validate_tags(cats: list[Any]):  # type: ignore
-        if isinstance(cats, list) and cats and isinstance(cats[0], str):
-            return [RecipeTag(id=uuid4(), name=c, slug=slugify(c)) for c in cats]
-        return cats
 
-    @validator("recipe_category", always=True, pre=True, allow_reuse=True)
-    def validate_categories(cats: list[Any]):  # type: ignore
-        if isinstance(cats, list) and cats and isinstance(cats[0], str):
-            return [RecipeCategory(id=uuid4(), name=c, slug=slugify(c)) for c in cats]
-        return cats
-
-    @validator("group_id", always=True, pre=True, allow_reuse=True)
-    def validate_group_id(group_id: Any):
-        if isinstance(group_id, int):
-            return uuid4()
-        return group_id
-
-    @validator("user_id", always=True, pre=True, allow_reuse=True)
-    def validate_user_id(user_id: Any):
-        if isinstance(user_id, int):
-            return uuid4()
-        return user_id
+class RecipeSummaryWithIngredients(RecipeSummary):
+    recipe_ingredient: list[RecipeIngredient] | None = []
 
 
 class RecipePaginationQuery(PaginationQuery):
@@ -204,6 +184,30 @@ class Recipe(RecipeSummary):
             return [RecipeIngredient(note=x) for x in recipe_ingredient]
 
         return recipe_ingredient
+
+    @validator("tags", always=True, pre=True, allow_reuse=True)
+    def validate_tags(cats: list[Any]):  # type: ignore
+        if isinstance(cats, list) and cats and isinstance(cats[0], str):
+            return [RecipeTag(id=uuid4(), name=c, slug=slugify(c)) for c in cats]
+        return cats
+
+    @validator("recipe_category", always=True, pre=True, allow_reuse=True)
+    def validate_categories(cats: list[Any]):  # type: ignore
+        if isinstance(cats, list) and cats and isinstance(cats[0], str):
+            return [RecipeCategory(id=uuid4(), name=c, slug=slugify(c)) for c in cats]
+        return cats
+
+    @validator("group_id", always=True, pre=True, allow_reuse=True)
+    def validate_group_id(group_id: Any):
+        if isinstance(group_id, int):
+            return uuid4()
+        return group_id
+
+    @validator("user_id", always=True, pre=True, allow_reuse=True)
+    def validate_user_id(user_id: Any):
+        if isinstance(user_id, int):
+            return uuid4()
+        return user_id
 
 
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient  # noqa: E402


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Calling /api/recipes with `loadFood: false` (or any other endpoint that lists recipes) would lead to an interesting case, where all the recipe ingredients are not eager loaded any more but pydantic would still try to fill the `recipe_ingredient` field of the response model in orm mode, i.e. sqlalchemy will generate a new lazy-loading ingredient query for every single recipe. I assume this issue gets even worse, if you use ingredient foods/units, but I have not tested this any further. 
I created a new response model that explicitly has the ingredients and removed them from the normal recipe summary, so only /api/recipes with loadFood enabled should ever try to load them now and all other endpoints that list recipes should behave the correct way.

Additionally - as discussed on discord - I also moved all validation from RecipeSummary to Recipe, since they are never needed for output validation. They are still needed on Recipe, otherwise all the migration tests will fail (and I assume the migrations wont work anymore)

This hopefully should improve performance for loading recipe pages considerably, especially for slower devices that really seem to have problems here

## Which issue(s) this PR fixes:

No explicit issue exists AFAIK, but it has been raised on discord a few times

## Testing

Ran all automated tests and also tried listing everything on the locally running frontend

## Release Notes

```release-note
* Improved recipe listing performance
```
