### PR TITLE
chore: disable PWA in development

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -81,7 +81,7 @@ export default {
     // https://go.nuxtjs.dev/axios
     "@nuxtjs/axios",
     // https://go.nuxtjs.dev/pwa
-    "@nuxtjs/pwa",
+    ...(process.env.NODE_ENV === "production" ? ["@nuxtjs/pwa"] : []),
     // https://i18n.nuxtjs.org/setup
     "@nuxtjs/i18n",
     // https://auth.nuxtjs.org/guide/setup


### PR DESCRIPTION
This is a terrible work around to avoid forking the nuxt/pwa module because the current version that we're using avoids the PWA white screen issue, however it containers another bug, where in develpment the import cannot be resolved. 

When we eventually move to nuxt 3 this should hopefull no longer be an issue.