### PR TITLE
Fix routes getting listed twice in API documentation

### DIFF
--- a/mealie/app.py
+++ b/mealie/app.py
@@ -78,6 +78,12 @@ def api_routers():
 
 api_routers()
 
+# fix routes that would get their tags duplicated by use of @controller,
+# leading to duplicate definitions in the openapi spec
+for route in app.routes:
+    if isinstance(route, APIRoute):
+        route.tags = list(set(route.tags))
+
 
 @app.on_event("startup")
 async def system_startup():

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -1,6 +1,7 @@
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.routing import APIRoute
 
 from mealie.core.config import get_app_settings
 from mealie.core.root_logger import get_logger


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The openapi spec/swagger doc/redoc would show a lot of routes twice, which was somewhat annoying. 
I am pretty sure the reason for this lies somewhere in `@controller`, but after looking at it for about an hour, I just couldnt figure out where it happens so I decided that it should probably suffice to clean up all tags after all routers are mounted

## Which issue(s) this PR fixes:

## Testing

Ran tests, apart from that it shouldnt really be needed?

## Release Notes

```release-note
* Remove duplicate routes from API documentation
```
