### PR TITLE
Fix duplicate network calls on index page

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -183,6 +183,10 @@ export default defineComponent({
       type: String,
       default: null,
     },
+    skipLoad: {
+      type: Boolean,
+      default: false
+    }
   },
   setup(props, context) {
     const preferences = useUserSortPreferences();
@@ -233,6 +237,9 @@ export default defineComponent({
     const { fetchMore } = useLazyRecipes();
 
     onMounted(async () => {
+      if (props.skipLoad) {
+        return;
+      }
       const newRecipes = await fetchMore(
         page.value,
 

--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -65,7 +65,7 @@ export default defineComponent({
   },
 
   setup(_, context) {
-    const { refreshRecipes } = useRecipes(true, false);
+    const { refreshRecipes } = useRecipes(true, false, true);
 
     const state = reactive({
       loading: false,

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -67,7 +67,7 @@ export const useLazyRecipes = function () {
   };
 };
 
-export const useRecipes = (all = false, fetchRecipes = true) => {
+export const useRecipes = (all = false, fetchRecipes = true, loadFood = false) => {
   const api = useUserApi();
 
   // recipes is non-reactive!!
@@ -88,7 +88,7 @@ export const useRecipes = (all = false, fetchRecipes = true) => {
   })();
 
   async function refreshRecipes() {
-    const { data } = await api.recipes.getAll(page, perPage, { loadFood: true, orderBy: "created_at" });
+    const { data } = await api.recipes.getAll(page, perPage, { loadFood, orderBy: "created_at" });
     if (data) {
       recipes.value = data.items;
     }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -4,6 +4,7 @@
       :icon="$globals.icons.primary"
       :title="$t('general.recent')"
       :recipes="recentRecipes"
+      :skip-load="true"
     ></RecipeCardSection>
   </v-container>
 </template>

--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -134,7 +134,7 @@ export default defineComponent({
     RecipeCardSection,
   },
   setup() {
-    const { assignSorted } = useRecipes(true);
+    const { assignSorted } = useRecipes(true, true, true);
 
     // ================================================================
     // Advanced Toggle


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The index page (Recent Recipes) would always load the recipes itself and then the contained RecipeCardSection would also trigger another recipe load (which just gets ignored). That second one is of course just wasteful, but the hook is needed for all other pages, so I added a prop to just skip it in this particular case

I also modified the initial recipe loads, so that the foods only get loaded on search pages, since they are not needed anywhere else and having them added takes considerably longer

## Which issue(s) this PR fixes:

Issue #2063

## Testing

Ran tests, looked at all the different recipe pages

## Release Notes

```release-note
NONE
```
