### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
 
       # =====================================
       # Web Concurrency
-      WEB_GUNICORN: true
+      WEB_GUNICORN: "true"
       WORKERS_PER_CORE: 0.5
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - 9092:9000
     environment:
       ALLOW_SIGNUP: "false"
+      BASE_URL: "http://localhost:8080" # changeme
 
       DB_ENGINE: sqlite # Optional: 'sqlite', 'postgres'
       # =====================================

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,13 +72,13 @@ services:
 
       # =====================================
       # Email Configuration
-      # SMTP_HOST=
-      # SMTP_PORT=587
-      # SMTP_FROM_NAME=Mealie
-      # SMTP_AUTH_STRATEGY=TLS # Options: 'TLS', 'SSL', 'NONE'
-      # SMTP_FROM_EMAIL=
-      # SMTP_USER=
-      # SMTP_PASSWORD=
+      # SMTP_HOST: "mx.example.com"
+      # SMTP_PORT: 587
+      # SMTP_FROM_NAME: "Mealie"
+      # SMTP_AUTH_STRATEGY: "TLS" # Options: 'TLS', 'SSL', 'NONE'
+      # SMTP_FROM_EMAIL: "mealie@example.com"
+      # SMTP_USER: "mealie"
+      # SMTP_PASSWORD: "SuperSekretPasswerd"
 
   # postgres:
   #   container_name: postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,8 +53,7 @@ services:
       - 9092:9000
     environment:
       ALLOW_SIGNUP: "false"
-      BASE_URL: "http://localhost:8080" # changeme
-
+      
       DB_ENGINE: sqlite # Optional: 'sqlite', 'postgres'
       # =====================================
       # Postgres Config
@@ -73,13 +72,13 @@ services:
 
       # =====================================
       # Email Configuration
-      # SMTP_HOST: "mx.example.com"
-      # SMTP_PORT: 587
-      # SMTP_FROM_NAME: "Mealie"
-      # SMTP_AUTH_STRATEGY: "TLS" # Options: 'TLS', 'SSL', 'NONE'
-      # SMTP_FROM_EMAIL: "mealie@example.com"
-      # SMTP_USER: "mealie"
-      # SMTP_PASSWORD: "SuperSekretPasswerd"
+      # SMTP_HOST=
+      # SMTP_PORT=587
+      # SMTP_FROM_NAME=Mealie
+      # SMTP_AUTH_STRATEGY=TLS # Options: 'TLS', 'SSL', 'NONE'
+      # SMTP_FROM_EMAIL=
+      # SMTP_USER=
+      # SMTP_PASSWORD=
 
   # postgres:
   #   container_name: postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,7 +53,6 @@ services:
       - 9092:9000
     environment:
       ALLOW_SIGNUP: "false"
-      
       DB_ENGINE: sqlite # Optional: 'sqlite', 'postgres'
       # =====================================
       # Postgres Config


### PR DESCRIPTION
ERROR: The Compose file './docker-compose.yml' is invalid because: services.mealie.environment.WEB_GUNICORN contains true, which is an invalid type, it should be a string, number, or a null


## What type of PR is this?

- bug

## What this PR does / why we need it:

ERROR: The Compose file './docker-compose.yml' is invalid because:
services.mealie.environment.WEB_GUNICORN contains true, which is an invalid type, it should be a string, number, or a null

## Which issue(s) this PR fixes:

N/A - Should I open an issue first, or is jumping straight to PR sufficient?

## Special notes for your reviewer:

None, simple fix.

## Testing

```
docker01:~# docker version
Client:
 Version:           20.10.16
 API version:       1.41
 Go version:        go1.18.2
 Git commit:        aa7e414fdcb23a66e8fabbef0a560ef1769eace5
 Built:             Sun May 15 14:51:52 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.16
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.2
  Git commit:       f756502055d2e36a84f2068e6620bea5ecf09058
  Built:            Sun May 15 14:46:21 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.6.6
  GitCommit:        10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1
 runc:
  Version:          1.1.2
  GitCommit:        a916309fff0f838eb94e928713dbc3c0d0ac7aa4
 docker-init:
  Version:          0.19.0
  GitCommit:
```

## Release Notes

N/A