### PR TITLE
Feature: Select Ingredients to add to Shopping List

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -58,7 +58,6 @@
               readonly
               v-on="on"
             ></v-text-field>
-
           </template>
           <v-date-picker v-model="newMealdate" no-title @input="pickerMenu = false"></v-date-picker>
         </v-menu>
@@ -77,13 +76,66 @@
           :key="list.id"
           hover
           class="my-2 left-border"
-          @click="addRecipeToList(list.id)"
+          @click="openShoppingListIngredientDialog(list)"
         >
           <v-card-title class="py-2">
             {{ list.name }}
           </v-card-title>
         </v-card>
       </v-card-text>
+    </BaseDialog>
+    <BaseDialog
+      v-model="shoppingListIngredientDialog"
+      :title="selectedShoppingList ? selectedShoppingList.name : $t('recipe.add-to-list')"
+      :icon="$globals.icons.cartCheck"
+      width="70%"
+      :submit-text="$tc('recipe.add-to-list')"
+      @submit="addRecipeToList()"
+    >
+      <v-card
+        elevation="0"
+        height="fit-content"
+        max-height="60vh"
+        width="100%"
+        class="ingredient-grid"
+        :style="{ gridTemplateRows: `repeat(${Math.ceil(recipeIngredients.length / 2)}, min-content)` }"
+        style="overflow-y: auto"
+      >
+        <v-list-item
+          v-for="(ingredientData, i) in recipeIngredients"
+          :key="'ingredient' + i"
+          dense
+          @click="recipeIngredients[i].checked = !recipeIngredients[i].checked"
+        >
+          <v-checkbox
+            hide-details
+            :input-value="ingredientData.checked"
+            class="pt-0 my-auto py-auto"
+            color="secondary"
+          />
+          <v-list-item-content :key="ingredientData.ingredient.quantity">
+            <SafeMarkdown class="ma-0 pa-0 text-subtitle-1 dense-markdown" :source="ingredientData.display" />
+          </v-list-item-content>
+        </v-list-item>
+      </v-card>
+      <div class="d-flex justify-end mb-4 mt-2">
+        <BaseButtonGroup
+          :buttons="[
+            {
+              icon: $globals.icons.checkboxBlankOutline,
+              text: $tc('shopping-list.uncheck-all-items'),
+              event: 'uncheck',
+            },
+            {
+              icon: $globals.icons.checkboxOutline,
+              text: $tc('shopping-list.check-all-items'),
+              event: 'check',
+            },
+          ]"
+          @uncheck="bulkCheckIngredients(false)"
+          @check="bulkCheckIngredients(true)"
+        />
+      </div>
     </BaseDialog>
     <v-menu
       offset-y
@@ -121,7 +173,8 @@ import RecipeDialogShare from "./RecipeDialogShare.vue";
 import { useUserApi } from "~/composables/api";
 import { alert } from "~/composables/use-toast";
 import { planTypeOptions } from "~/composables/use-group-mealplan";
-import { Recipe } from "~/lib/api/types/recipe";
+import { Recipe, RecipeIngredient } from "~/lib/api/types/recipe";
+import { parseIngredientText } from "~/composables/recipes";
 import { ShoppingListSummary } from "~/lib/api/types/group";
 import { PlanEntryType } from "~/lib/api/types/meal-plan";
 import { useAxiosDownloader } from "~/composables/api/use-axios-download";
@@ -232,6 +285,7 @@ export default defineComponent({
       recipeDeleteDialog: false,
       mealplannerDialog: false,
       shoppingListDialog: false,
+      shoppingListIngredientDialog: false,
       recipeDuplicateDialog: false,
       recipeName: props.name,
       loading: false,
@@ -328,6 +382,9 @@ export default defineComponent({
     // Context Menu Event Handler
 
     const shoppingLists = ref<ShoppingListSummary[]>();
+    const selectedShoppingList = ref<ShoppingListSummary>();
+    const recipe = ref<Recipe>(props.recipe);
+    const recipeIngredients = ref<{ checked: boolean; ingredient: RecipeIngredient; display: string }[]>([]);
 
     async function getShoppingLists() {
       const { data } = await api.shopping.lists.getAll();
@@ -336,11 +393,65 @@ export default defineComponent({
       }
     }
 
-    async function addRecipeToList(listId: string) {
-      const { data } = await api.shopping.lists.addRecipe(listId, props.recipeId, props.recipeScale);
+    async function refreshRecipe() {
+      const { data } = await api.recipes.getOne(props.slug);
+      if (data) {
+        recipe.value = data;
+      }
+    }
+
+    async function openShoppingListIngredientDialog(list: ShoppingListSummary) {
+      selectedShoppingList.value = list;
+      if (!recipe.value) {
+        await refreshRecipe();
+      }
+
+      if (recipe.value?.recipeIngredient) {
+        recipeIngredients.value = recipe.value.recipeIngredient.map((ingredient) => {
+          return {
+            checked: true,
+            ingredient,
+            display: parseIngredientText(ingredient, recipe.value?.settings?.disableAmount || false, props.recipeScale),
+          };
+        });
+      }
+
+      state.shoppingListDialog = false;
+      state.shoppingListIngredientDialog = true;
+    }
+
+    function bulkCheckIngredients(value = true) {
+      recipeIngredients.value.forEach((data) => {
+        data.checked = value;
+      });
+    }
+
+    async function addRecipeToList() {
+      if (!selectedShoppingList.value) {
+        return;
+      }
+
+      const ingredients: RecipeIngredient[] = [];
+      recipeIngredients.value.forEach((data) => {
+        if (data.checked) {
+          ingredients.push(data.ingredient);
+        }
+      });
+
+      if (!ingredients.length) {
+        return;
+      }
+
+      const { data } = await api.shopping.lists.addRecipe(
+        selectedShoppingList.value.id,
+        props.recipeId,
+        props.recipeScale,
+        ingredients
+      );
       if (data) {
         alert.success(i18n.t("recipe.recipe-added-to-list") as string);
         state.shoppingListDialog = false;
+        state.shoppingListIngredientDialog = false;
       }
     }
 
@@ -404,7 +515,9 @@ export default defineComponent({
       },
       shoppingList: () => {
         getShoppingLists();
+
         state.shoppingListDialog = true;
+        state.shoppingListIngredientDialog = false;
       },
       share: () => {
         state.shareDialog = true;
@@ -435,14 +548,27 @@ export default defineComponent({
     return {
       ...toRefs(state),
       shoppingLists,
+      selectedShoppingList,
+      openShoppingListIngredientDialog,
       addRecipeToList,
+      bulkCheckIngredients,
       duplicateRecipe,
       contextMenuEventHandler,
       deleteRecipe,
       addRecipeToPlan,
       icon,
       planTypeOptions,
+      recipeIngredients,
     };
   },
 });
 </script>
+
+<style scoped lang="css">
+.ingredient-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 0.5rem;
+}
+</style>

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -604,6 +604,7 @@
     "delete-checked": "Delete Checked",
     "toggle-label-sort": "Toggle Label Sort",
     "uncheck-all-items": "Uncheck All Items",
+    "check-all-items": "Check All Items",
     "linked-recipes-count": "No Linked Recipes|One Linked Recipe|{count} Linked Recipes",
     "items-checked-count": "No items checked|One item checked|{count} items checked",
     "no-label": "No Label"

--- a/frontend/lib/api/user/group-shopping-lists.ts
+++ b/frontend/lib/api/user/group-shopping-lists.ts
@@ -1,4 +1,5 @@
 import { BaseCRUDAPI } from "../base/base-clients";
+import { RecipeIngredient } from "../types/recipe";
 import { ApiRequestInstance } from "~/lib/api/types/non-generated";
 import {
   ShoppingListCreate,
@@ -25,12 +26,12 @@ export class ShoppingListsApi extends BaseCRUDAPI<ShoppingListCreate, ShoppingLi
   baseRoute = routes.shoppingLists;
   itemRoute = routes.shoppingListsId;
 
-  async addRecipe(itemId: string, recipeId: string, recipeIncrementQuantity = 1) {
-    return await this.requests.post(routes.shoppingListIdAddRecipe(itemId, recipeId), {recipeIncrementQuantity});
+  async addRecipe(itemId: string, recipeId: string, recipeIncrementQuantity = 1, recipeIngredients: RecipeIngredient[] | null = null) {
+    return await this.requests.post(routes.shoppingListIdAddRecipe(itemId, recipeId), { recipeIncrementQuantity, recipeIngredients });
   }
 
   async removeRecipe(itemId: string, recipeId: string, recipeDecrementQuantity = 1) {
-    return await this.requests.post(routes.shoppingListIdRemoveRecipe(itemId, recipeId), {recipeDecrementQuantity});
+    return await this.requests.post(routes.shoppingListIdRemoveRecipe(itemId, recipeId), { recipeDecrementQuantity });
   }
 }
 

--- a/frontend/lib/icons/icons.ts
+++ b/frontend/lib/icons/icons.ts
@@ -133,6 +133,7 @@ import {
   mdiDockRight,
   mdiDockTop,
   mdiDockBottom,
+  mdiCheckboxOutline,
 } from "@mdi/js";
 
 export const icons = {
@@ -167,6 +168,7 @@ export const icons = {
   cartCheck: mdiCartCheck,
   check: mdiCheck,
   checkboxBlankOutline: mdiCheckboxBlankOutline,
+  checkboxOutline: mdiCheckboxOutline,
   checkboxMarkedCircle: mdiCheckboxMarkedCircle,
   chefHat: mdiChefHat,
   clipboardCheck: mdiClipboardCheck,

--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -228,7 +228,7 @@ class ShoppingListController(BaseCrudController):
         self, item_id: UUID4, recipe_id: UUID4, data: ShoppingListAddRecipeParams | None = None
     ):
         shopping_list, items = self.service.add_recipe_ingredients_to_list(
-            item_id, recipe_id, data.recipe_increment_quantity if data else 1
+            item_id, recipe_id, data.recipe_increment_quantity if data else 1, data.recipe_ingredients if data else None
         )
 
         publish_list_item_events(self.publish_event, items)

--- a/mealie/schema/group/group_shopping_list.py
+++ b/mealie/schema/group/group_shopping_list.py
@@ -14,6 +14,7 @@ from mealie.schema.recipe.recipe_ingredient import (
     MAX_INGREDIENT_DENOMINATOR,
     IngredientFood,
     IngredientUnit,
+    RecipeIngredient,
 )
 from mealie.schema.response.pagination import PaginationBase
 
@@ -237,6 +238,8 @@ class ShoppingListOut(ShoppingListUpdate):
 
 class ShoppingListAddRecipeParams(MealieModel):
     recipe_increment_quantity: float = 1
+    recipe_ingredients: list[RecipeIngredient] | None = None
+    """optionally override which ingredients are added from the recipe"""
 
 
 class ShoppingListRemoveRecipeParams(MealieModel):


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Currently, when adding a recipe to your shopping list, you must add _all_ ingredients to your list. I don't know about you, but I keep copious amounts of salt and pepper at home, so I don't need to buy more any time soon.

This PR allows you to filter out ingredients before you add a recipe to your list. It adds a simple backend param to include a list of recipe ingredients to add to your list (the param is optional, and if it's left null, we use the old behavior of adding everything, so existing integrations are unaffected). To do this, a second dialog was added to the recipe -> list flow:
![2023-02-15_21h06_13](https://user-images.githubusercontent.com/71845777/219258038-e5aa1598-52ea-4cb9-9a1b-35184d6c2718.gif)
![image](https://user-images.githubusercontent.com/71845777/219258071-0f2387f2-c42b-469a-989a-963c306ca97c.png)


## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Pytest for the backend

## Release Notes

_(REQUIRED)_

```release-note
added recipe ingredients filter when adding a recipe to a shopping list
```
