### PR TITLE
Fix: added limited context menu for public users

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeActionMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeActionMenu.vue
@@ -22,23 +22,25 @@
     <v-spacer></v-spacer>
     <div v-if="!open" class="custom-btn-group ma-1">
       <RecipeFavoriteBadge v-if="loggedIn" class="mx-1" color="info" button-style :slug="recipe.slug" show-always />
-      <RecipeTimelineBadge button-style :slug="recipe.slug" :recipe-name="recipe.name"  />
-      <v-tooltip v-if="!locked" bottom color="info">
-        <template #activator="{ on, attrs }">
-          <v-btn fab small class="mx-1" color="info" v-bind="attrs" v-on="on" @click="$emit('edit', true)">
-            <v-icon> {{ $globals.icons.edit }} </v-icon>
-          </v-btn>
-        </template>
-        <span>{{ $t("general.edit") }}</span>
-      </v-tooltip>
-      <v-tooltip v-else bottom color="info">
-        <template #activator="{ on, attrs }">
-          <v-btn fab small class="mx-1" color="info" v-bind="attrs" v-on="on">
-            <v-icon> {{ $globals.icons.lock }} </v-icon>
-          </v-btn>
-        </template>
-        <span> {{ $t("recipe.locked-by-owner") }} </span>
-      </v-tooltip>
+      <RecipeTimelineBadge v-if="loggedIn" button-style :slug="recipe.slug" :recipe-name="recipe.name" />
+      <div v-if="loggedIn">
+        <v-tooltip v-if="!locked" bottom color="info">
+          <template #activator="{ on, attrs }">
+            <v-btn fab small class="mx-1" color="info" v-bind="attrs" v-on="on" @click="$emit('edit', true)">
+              <v-icon> {{ $globals.icons.edit }} </v-icon>
+            </v-btn>
+          </template>
+          <span>{{ $t("general.edit") }}</span>
+        </v-tooltip>
+        <v-tooltip v-else bottom color="info">
+          <template #activator="{ on, attrs }">
+            <v-btn fab small class="mx-1" color="info" v-bind="attrs" v-on="on">
+              <v-icon> {{ $globals.icons.lock }} </v-icon>
+            </v-btn>
+          </template>
+          <span> {{ $t("recipe.locked-by-owner") }} </span>
+        </v-tooltip>
+      </div>
 
       <RecipeContextMenu
         show-print
@@ -56,14 +58,13 @@
         :use-items="{
           delete: false,
           edit: false,
-          download: true,
-          duplicate: true,
-          mealplanner: true,
-          shoppingList: true,
+          download: loggedIn,
+          duplicate: loggedIn,
+          mealplanner: loggedIn,
+          shoppingList: loggedIn,
           print: true,
-          printPreferences: true,
-          share: true,
-          publicUrl: recipe.settings ? recipe.settings.public : false,
+          share: loggedIn,
+          publicUrl: recipe.settings && loggedIn ? recipe.settings.public : false,
         }"
         @print="$emit('print')"
       />

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageHeader.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageHeader.vue
@@ -42,7 +42,6 @@
     </div>
     <v-divider></v-divider>
     <RecipeActionMenu
-      v-if="user.id"
       :recipe="recipe"
       :slug="recipe.slug"
       :recipe-scale="recipeScale"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Previously, if you weren't logged-in (public/shared), the action menu (and thus context menu) were hidden. While there aren't many options in there for public users, the option to print is.

This PR enables the action menu for public users, but limits most functionality to only logged-in users.

![image](https://user-images.githubusercontent.com/71845777/219432511-4ab3625a-7bd2-4ea7-9d2d-e767e70a2e21.png)

## Which issue(s) this PR fixes:

_(REQUIRED)_

Resolves #2111

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
restored print button for public users
```
