### PR TITLE
Fix: recipe scraper image cleaning

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -82,9 +82,10 @@ def clean_image(image: str | list | dict | None = None, default="no image") -> s
     image attempts to parse the image field from a recipe and return a string. Currenty
 
     Supported Structures:
-        - `["https://exmaple.com"]` - A list of strings
         - `https://exmaple.com` - A string
-        - `{ "url": "https://exmaple.com"` - A dictionary with a `url` key
+        - `{ "url": "https://exmaple.com" }` - A dictionary with a `url` key
+        - `["https://exmaple.com"]` - A list of strings
+        - `[{ "url": "https://exmaple.com" }]` - A list of dictionaries with a `url` key
 
     Raises:
         TypeError: If the image field is not a supported type a TypeError is raised.
@@ -95,15 +96,20 @@ def clean_image(image: str | list | dict | None = None, default="no image") -> s
     if not image:
         return default
 
-    match image:  # noqa - match statement not supported
+    match image:
         case str(image):
             return image
+        case {"url": str(url)}:
+            return url
         case list(image):
-            return image[0]
-        case {"url": str(image)}:
-            return image
-        case _:
-            raise TypeError(f"Unexpected type for image: {type(image)}, {image}")
+            for image_data in image:
+                match image_data:
+                    case str(image_data):
+                        return image_data
+                    case {"url": str(url)}:
+                        return url
+
+    raise TypeError(f"Unexpected type for image: {type(image)}, {image}")
 
 
 def clean_instructions(steps_object: list | dict | str, default: list | None = None) -> list[dict]:

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -150,7 +150,7 @@ class RecipeScraperPackage(ABCScraperStrategy):
         recipe = Recipe(
             name=try_get_default(scraped_data.title, "name", "No Name Found", cleaner.clean_string),
             slug="",
-            image=try_get_default(None, "image", None),
+            image=try_get_default(None, "image", None, cleaner.clean_image),
             description=try_get_default(None, "description", "", cleaner.clean_string),
             nutrition=try_get_default(None, "nutrition", None, cleaner.clean_nutrition),
             recipe_yield=try_get_default(scraped_data.yields, "recipeYield", "1", cleaner.clean_string),

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
@@ -73,22 +73,27 @@ image_cleaner_test_cases = (
     CleanerCase(
         test_id="empty_string",
         input="",
-        expected="no image",
+        expected=["no image"],
     ),
     CleanerCase(
         test_id="no_change",
         input="https://example.com/image.jpg",
-        expected="https://example.com/image.jpg",
+        expected=["https://example.com/image.jpg"],
     ),
     CleanerCase(
         test_id="dict with url key",
         input={"url": "https://example.com/image.jpg"},
-        expected="https://example.com/image.jpg",
+        expected=["https://example.com/image.jpg"],
     ),
     CleanerCase(
         test_id="list of strings",
         input=["https://example.com/image.jpg"],
-        expected="https://example.com/image.jpg",
+        expected=["https://example.com/image.jpg"],
+    ),
+    CleanerCase(
+        test_id="list of dicts with url key",
+        input=[{"url": "https://example.com/image.jpg"}],
+        expected=["https://example.com/image.jpg"],
     ),
 )
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The recipe scraper wasn't accounting for nested dictionaries of image urls, as mentioned in #2087. I found that the scraper actually wasn't cleaning images at all, so I enabled that.

## Which issue(s) this PR fixes:

_(REQUIRED)_

resolves #2087

## Release Notes

_(REQUIRED)_

```release-note
recipe scraper has a higher chance of finding an image when scraping
```
