### PR TITLE
Fix: Allow Last Made to be Updated on Locked Recipes

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeLastMade.vue
+++ b/frontend/components/Domain/Recipe/RecipeLastMade.vue
@@ -126,8 +126,7 @@ export default defineComponent({
 
       // we also update the recipe's last made value
       if (!props.value || newTimelineEvent.value.timestamp > props.value) {
-        const payload = {lastMade: newTimelineEvent.value.timestamp};
-        actions.push(userApi.recipes.patchOne(props.recipeSlug, payload));
+        actions.push(userApi.recipes.updateLastMade(props.recipeSlug,  newTimelineEvent.value.timestamp));
 
         // update recipe in parent so the user can see it
         // we remove the trailing "Z" since this is how the API returns it

--- a/frontend/lib/api/types/recipe.ts
+++ b/frontend/lib/api/types/recipe.ts
@@ -303,6 +303,9 @@ export interface RecipeCommentUpdate {
 export interface RecipeDuplicate {
   name?: string;
 }
+export interface RecipeLastMade {
+  timestamp: string;
+}
 export interface RecipeShareToken {
   recipeId: string;
   expiresAt?: string;

--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -10,6 +10,7 @@ import {
   ParsedIngredient,
   UpdateImageResponse,
   RecipeZipTokenResponse,
+  RecipeLastMade,
   RecipeTimelineEventIn,
   RecipeTimelineEventOut,
   RecipeTimelineEventUpdate,
@@ -167,7 +168,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
   }
 
   async updateLastMade(recipeSlug: string, timestamp: string) {
-    return await this.requests.patch(routes.recipesSlugLastMade(recipeSlug), { timestamp })
+    return await this.requests.patch<Recipe, RecipeLastMade>(routes.recipesSlugLastMade(recipeSlug), { timestamp })
   }
 
   async createTimelineEvent(recipeSlug: string, payload: RecipeTimelineEventIn) {

--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -48,6 +48,8 @@ const routes = {
   recipesSlugComments: (slug: string) => `${prefix}/recipes/${slug}/comments`,
   recipesSlugCommentsId: (slug: string, id: number) => `${prefix}/recipes/${slug}/comments/${id}`,
 
+  recipesSlugLastMade: (slug: string) => `${prefix}/recipes/${slug}/last-made`,
+
   recipesSlugTimelineEvent: (slug: string) => `${prefix}/recipes/${slug}/timeline/events`,
   recipesSlugTimelineEventId: (slug: string, id: string) => `${prefix}/recipes/${slug}/timeline/events/${id}`,
 };
@@ -162,6 +164,10 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
     formData.append("makefilerecipeimage", String(makeFileRecipeImage));
 
     return await this.requests.post(routes.recipesCreateFromOcr, formData);
+  }
+
+  async updateLastMade(recipeSlug: string, timestamp: string) {
+    return await this.requests.patch(routes.recipesSlugLastMade(recipeSlug), { timestamp })
   }
 
   async createTimelineEvent(recipeSlug: string, payload: RecipeTimelineEventIn) {

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -200,6 +200,10 @@ class Recipe(RecipeSummary):
         return user_id
 
 
+class RecipeLastMade(BaseModel):
+    timestamp: datetime.datetime
+
+
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient  # noqa: E402
 
 RecipeSummary.update_forward_refs()

--- a/mealie/services/backups_v2/alchemy_exporter.py
+++ b/mealie/services/backups_v2/alchemy_exporter.py
@@ -16,7 +16,7 @@ class AlchemyExporter(BaseService):
     engine: base.Engine
     meta: MetaData
 
-    look_for_datetime = {"created_at", "update_at", "date_updated", "timestamp", "expires_at", "locked_at"}
+    look_for_datetime = {"created_at", "update_at", "date_updated", "timestamp", "expires_at", "locked_at", "last_made"}
     look_for_date = {"date_added", "date"}
     look_for_time = {"scheduled_time"}
 

--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -24,6 +24,9 @@ from mealie.services.recipe.recipe_data_service import RecipeDataService
 
 from .template_service import TemplateService
 
+ALLOWED_LOCKED_PROPERTIES = ["last_made"]
+"""If a recipe is locked, but a user request contains only these properties, then the request will be allowed"""
+
 step_text = """Recipe steps as well as other fields in the recipe page support markdown syntax.
 
 **Add a link**
@@ -48,10 +51,10 @@ class RecipeService(BaseService):
             raise exceptions.NoEntryFound("Recipe not found.")
         return recipe
 
-    def can_update(self, recipe: Recipe) -> bool:
+    def can_update(self, recipe: Recipe, bypass_lock: bool = False) -> bool:
         if recipe.settings is None:
             raise exceptions.UnexpectedNone("Recipe Settings is None")
-        return recipe.settings.locked is False or self.user.id == recipe.user_id
+        return bypass_lock or recipe.settings.locked is False or self.user.id == recipe.user_id
 
     def can_lock_unlock(self, recipe: Recipe) -> bool:
         return recipe.user_id == self.user.id
@@ -235,7 +238,7 @@ class RecipeService(BaseService):
 
         return new_recipe
 
-    def _pre_update_check(self, slug: str, new_data: Recipe) -> Recipe:
+    def _pre_update_check(self, slug: str, new_data: Recipe, bypass_lock: bool = False) -> Recipe:
         """
         gets the recipe from the database and performs a check to see if the user can update the recipe.
         If the user can't update the recipe, an exception is raised.
@@ -247,6 +250,8 @@ class RecipeService(BaseService):
 
         Args:
             slug (str): recipe slug
+            new_data (Recipe): the new recipe data
+            bypass_lock (bool): flag to ignore locked state
 
         Raises:
             exceptions.PermissionDenied (403)
@@ -257,7 +262,7 @@ class RecipeService(BaseService):
         if recipe is None or recipe.settings is None:
             raise exceptions.NoEntryFound("Recipe not found.")
 
-        if not self.can_update(recipe):
+        if not self.can_update(recipe, bypass_lock=bypass_lock):
             raise exceptions.PermissionDenied("You do not have permission to edit this recipe.")
 
         setting_lock = new_data.settings is not None and recipe.settings.locked != new_data.settings.locked
@@ -274,13 +279,16 @@ class RecipeService(BaseService):
         return new_data
 
     def patch_one(self, slug: str, patch_data: Recipe) -> Recipe:
-        recipe: Recipe | None = self._pre_update_check(slug, patch_data)
+        patch_data_raw = patch_data.dict(exclude_unset=True)
+        bypass_lock = all([field in ALLOWED_LOCKED_PROPERTIES for field in patch_data_raw])
+
+        recipe: Recipe | None = self._pre_update_check(slug, patch_data, bypass_lock=bypass_lock)
         recipe = self.repos.recipes.by_group(self.group.id).get_one(slug)
 
         if recipe is None:
             raise exceptions.NoEntryFound("Recipe not found.")
 
-        new_data = self.repos.recipes.by_group(self.group.id).patch(recipe.slug, patch_data.dict(exclude_unset=True))
+        new_data = self.repos.recipes.by_group(self.group.id).patch(recipe.slug, patch_data_raw)
 
         self.check_assets(new_data, recipe.slug)
         return new_data

--- a/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_owner.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi.testclient import TestClient
 
 from tests.utils import api_routes
@@ -84,6 +86,38 @@ def test_user_locked_recipe(api_client: TestClient, user_tuple: list[TestUser]) 
     # Try To Update Recipe with User 2
     response = api_client.put(api_routes.recipes + f"/{recipe_name}", json=recipe, headers=usr_2.token)
     assert response.status_code == 403
+
+
+def test_user_bypass_locked_recipe(api_client: TestClient, user_tuple: list[TestUser]) -> None:
+    usr_1, usr_2 = user_tuple
+
+    # Setup Recipe
+    recipe_name = random_string()
+    response = api_client.post(api_routes.recipes, json={"name": recipe_name}, headers=usr_1.token)
+    assert response.status_code == 201
+
+    # Get Recipe
+    response = api_client.get(api_routes.recipes + f"/{recipe_name}", headers=usr_1.token)
+    assert response.status_code == 200
+    recipe = response.json()
+
+    # Lock Recipe
+    recipe["settings"]["locked"] = True
+    response = api_client.put(api_routes.recipes + f"/{recipe_name}", json=recipe, headers=usr_1.token)
+
+    # Try To Patch Recipe with User 2
+    locked_json = {"name": random_string()}
+    response = api_client.patch(api_routes.recipes + f"/{recipe_name}", json=locked_json, headers=usr_2.token)
+    assert response.status_code == 403
+
+    # "lastMade" is an unlocked field, but "name" isn't
+    locked_json = {"name": random_string(), "lastMade": datetime.now().isoformat()}
+    response = api_client.patch(api_routes.recipes + f"/{recipe_name}", json=locked_json, headers=usr_2.token)
+    assert response.status_code == 403
+
+    unlocked_json = {"lastMade": datetime.now().isoformat()}
+    response = api_client.patch(api_routes.recipes + f"/{recipe_name}", json=unlocked_json, headers=usr_2.token)
+    assert response.status_code == 200
 
 
 def test_other_user_cant_lock_recipe(api_client: TestClient, user_tuple: list[TestUser]) -> None:

--- a/tests/utils/api_routes/__init__.py
+++ b/tests/utils/api_routes/__init__.py
@@ -376,6 +376,11 @@ def recipes_slug_image(slug):
     return f"{prefix}/recipes/{slug}/image"
 
 
+def recipes_slug_last_made(slug):
+    """`/api/recipes/{slug}/last-made`"""
+    return f"{prefix}/recipes/{slug}/last-made"
+
+
 def recipes_slug_timeline_events(slug):
     """`/api/recipes/{slug}/timeline/events`"""
     return f"{prefix}/recipes/{slug}/timeline/events"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This allows certain fields to bypass the locked state of a recipe in a patch request. All fields in the patch request _must_ be explicitly allowed (e.g. a request with `name` and `last_made` will fail with a 403 error). At the moment this only applies to `last_made`.

## Which issue(s) this PR fixes:

_(REQUIRED)_

resolves #2089

## Testing

_(fill-in or delete this section)_

pytest

## Release Notes

_(REQUIRED)_

```release-note
fixed bug with locked recipes that prevented users from using the "I Made This" button
```
