### PR TITLE
Fix: check temp dir before attempting to delete

### DIFF
--- a/mealie/routes/admin/admin_maintenance.py
+++ b/mealie/routes/admin/admin_maintenance.py
@@ -111,7 +111,9 @@ class AdminMaintenanceController(BaseAdminController):
     @router.post("/clean/temp", response_model=SuccessResponse)
     def clean_temp(self):
         try:
-            shutil.rmtree(self.folders.TEMP_DIR)
+            if self.folders.TEMP_DIR.exists():
+                shutil.rmtree(self.folders.TEMP_DIR)
+
             self.folders.TEMP_DIR.mkdir(parents=True, exist_ok=True)
         except Exception as e:
             raise HTTPException(status_code=500, detail=ErrorResponse.respond("Failed to clean temp")) from e


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Previously when cleaning the temp directory, we would just try to delete the directory outright. Most of the time this is fine, but especially with new instances the directory may or may not exist yet. This just adds a check.

## Which issue(s) this PR fixes:

_(REQUIRED)_

resolves #2031

## Release Notes

_(REQUIRED)_

```release-note
fixed rare server error when cleaning temporary files
```
