### PR TITLE
Fix: Remove Trailing Slash from BASE_URL

### DIFF
--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -1,7 +1,7 @@
 import secrets
 from pathlib import Path
 
-from pydantic import BaseSettings, NoneStr
+from pydantic import BaseSettings, NoneStr, validator
 
 from .db_providers import AbstractDBProvider, db_provider_factory
 
@@ -25,12 +25,17 @@ def determine_secrets(data_dir: Path, production: bool) -> str:
 class AppSettings(BaseSettings):
     PRODUCTION: bool
     BASE_URL: str = "http://localhost:8080"
+    """trailing slashes are trimmed (ex. `http://localhost:8080/` becomes ``http://localhost:8080`)"""
+
     IS_DEMO: bool = False
     API_PORT: int = 9000
     API_DOCS: bool = True
-    TOKEN_TIME: int = 48  # Time in Hours
+    TOKEN_TIME: int = 48
+    """time in hours"""
+
     SECRET: str
-    LOG_LEVEL: str = "INFO"  # Corresponds to standard Python log levels.
+    LOG_LEVEL: str = "INFO"
+    """corresponds to standard Python log levels"""
 
     GIT_COMMIT_HASH: str = "unknown"
 
@@ -40,7 +45,15 @@ class AppSettings(BaseSettings):
     # Security Configuration
 
     SECURITY_MAX_LOGIN_ATTEMPTS: int = 5
-    SECURITY_USER_LOCKOUT_TIME: int = 24  # Time in Hours
+    SECURITY_USER_LOCKOUT_TIME: int = 24
+    "time in hours"
+
+    @validator("BASE_URL")
+    def remove_trailing_slash(cls, v: str) -> str:
+        if v and v[-1] == "/":
+            return v[:-1]
+
+        return v
 
     @property
     def DOCS_URL(self) -> str | None:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Throughout the application, the `BASE_URL` is assumed to not have a trailing slash. Since it relies on user input, it's possible for it to have a trailing slash, which breaks certain processes (e.g. the password reset URL constructer).

This adds a simple Pydantic validator to remove trailing slashes.

## Which issue(s) this PR fixes:

_(REQUIRED)_

resolves #2030

## Special notes for your reviewer:

_(fill-in or delete this section)_

While I was in there I moved some of the old-style Python field comments to docstring format so linters can pick them up.

## Testing

_(fill-in or delete this section)_

I set the `BASE_URL` manually to have a trailing slash, and to be empty, then manually verified it validated as expected.

## Release Notes

_(REQUIRED)_

```release-note
made the BASE_URL environment variable a little more forgiving
```
