### PR TITLE
Feature: Shopping List Item Pagination Route

### DIFF
--- a/mealie/routes/groups/controller_shopping_lists.py
+++ b/mealie/routes/groups/controller_shopping_lists.py
@@ -12,6 +12,7 @@ from mealie.schema.group.group_shopping_list import (
     ShoppingListCreate,
     ShoppingListItemCreate,
     ShoppingListItemOut,
+    ShoppingListItemPagination,
     ShoppingListItemsCollectionOut,
     ShoppingListItemUpdate,
     ShoppingListItemUpdateBulk,
@@ -100,6 +101,12 @@ class ShoppingListItemController(BaseCrudController):
             self.repo,
             self.logger,
         )
+
+    @item_router.get("", response_model=ShoppingListItemPagination)
+    def get_all(self, q: PaginationQuery = Depends()):
+        response = self.repo.page_all(pagination=q, override=ShoppingListItemOut)
+        response.set_pagination_guides(router.url_path_for("get_all"), q.dict())
+        return response
 
     @item_router.post("/create-bulk", response_model=ShoppingListItemsCollectionOut, status_code=201)
     def create_many(self, data: list[ShoppingListItemCreate]):

--- a/mealie/schema/group/group_shopping_list.py
+++ b/mealie/schema/group/group_shopping_list.py
@@ -177,6 +177,10 @@ class ShoppingListItemsCollectionOut(MealieModel):
     deleted_items: list[ShoppingListItemOut] = []
 
 
+class ShoppingListItemPagination(PaginationBase):
+    items: list[ShoppingListItemOut]
+
+
 class ShoppingListCreate(MealieModel):
     name: str | None = None
     extras: dict | None = {}

--- a/tests/integration_tests/user_group_tests/test_group_shopping_list_items.py
+++ b/tests/integration_tests/user_group_tests/test_group_shopping_list_items.py
@@ -101,6 +101,17 @@ def test_shopping_list_items_get_one(
         assert response.status_code == 200
 
 
+def test_shopping_list_items_get_all(
+    api_client: TestClient,
+    unique_user: TestUser,
+    list_with_items: ShoppingListOut,
+) -> None:
+    params = {"page": 1, "perPage": -1, "queryFilter": f"shopping_list_id={list_with_items.id}"}
+    response = api_client.get(api_routes.groups_shopping_items, params=params, headers=unique_user.token)
+    pagination_json = utils.assert_derserialize(response, 200)
+    assert len(pagination_json["items"]) == len(list_with_items.list_items)
+
+
 def test_shopping_list_items_get_one_404(api_client: TestClient, unique_user: TestUser) -> None:
     response = api_client.get(api_routes.groups_shopping_items_item_id(uuid4()), headers=unique_user.token)
     assert response.status_code == 404


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Adds a pagination route for shopping list items. This is particularly useful to query for only unchecked items, i.e. `checked=false` (which is generally what you want in an external app).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Pytest

## Release Notes

_(REQUIRED)_

```release-note
added API route for querying shopping list items
```
