### PR TITLE
Fix: last made query value

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -316,7 +316,7 @@ export default defineComponent({
       {
         icon: $globals.icons.chefHat,
         name: i18n.tc("general.last-made"),
-        value: "time",
+        value: "last_made",
       },
       {
         icon: $globals.icons.star,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Changes the last made query param from "time" to "last_made".

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #2152

## Release Notes

```release-note
NONE
```
