### PR TITLE
Fix: Remove dead search link

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -180,6 +180,6 @@ export default defineComponent({
 
 <style>
 .scroll {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 </style>

--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -31,7 +31,7 @@
           <div class="mr-auto">
             {{ $t("search.results") }}
           </div>
-          <router-link to="/search?advanced=true"> {{ $t("search.advanced-search") }} </router-link>
+          <router-link to="/"> {{ $t("search.advanced-search") }} </router-link>
         </v-card-actions>
 
         <RecipeCardMobile

--- a/frontend/layouts/error.vue
+++ b/frontend/layouts/error.vue
@@ -51,7 +51,6 @@ export default defineComponent({
     const buttons = [
       { icon: $globals.icons.home, to: "/", text: i18n.t("general.home") },
       { icon: $globals.icons.primary, to: "/recipes/all", text: i18n.t("page.all-recipes") },
-      { icon: $globals.icons.search, to: "/search", text: i18n.t("search.search") },
     ];
 
     return {


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This removes references to the old search page (`/search`). The "advanced search" link now goes to the homepage, and the 404 button was removed (since "home" is already on there).

I also tweaked the CSS on the search bar to remove the scrollbar if there aren't enough results to warrant scrolling

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
NONE
```
