### PR TITLE
fix performance issues on /api/foods

### DIFF
--- a/mealie/repos/repository_foods.py
+++ b/mealie/repos/repository_foods.py
@@ -1,5 +1,7 @@
 from pydantic import UUID4
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.interfaces import LoaderOption
 
 from mealie.db.models.recipe.ingredient import IngredientFoodModel
 from mealie.schema.recipe.recipe_ingredient import IngredientFood
@@ -29,3 +31,9 @@ class RepositoryFood(RepositoryGeneric[IngredientFood, IngredientFoodModel]):
 
     def by_group(self, group_id: UUID4) -> "RepositoryFood":
         return super().by_group(group_id)
+
+    def query_options(self) -> list[LoaderOption]:
+        return [
+            joinedload(IngredientFoodModel.extras),
+            joinedload(IngredientFoodModel.label),
+        ]

--- a/mealie/repos/repository_foods.py
+++ b/mealie/repos/repository_foods.py
@@ -32,7 +32,7 @@ class RepositoryFood(RepositoryGeneric[IngredientFood, IngredientFoodModel]):
     def by_group(self, group_id: UUID4) -> "RepositoryFood":
         return super().by_group(group_id)
 
-    def query_options(self) -> list[LoaderOption]:
+    def paging_query_options(self) -> list[LoaderOption]:
         return [
             joinedload(IngredientFoodModel.extras),
             joinedload(IngredientFoodModel.label),

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -7,6 +7,7 @@ from typing import Any, Generic, TypeVar
 from fastapi import HTTPException
 from pydantic import UUID4, BaseModel
 from sqlalchemy import Select, delete, func, select
+from sqlalchemy.orm.interfaces import LoaderOption
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import sqltypes
 
@@ -284,6 +285,10 @@ class RepositoryGeneric(Generic[Schema, Model]):
             q = self._query().filter(attribute_name == attr_match)
             return [eff_schema.from_orm(x) for x in self.session.execute(q).scalars().all()]
 
+    def query_options(self) -> list[LoaderOption]:
+        # Override this in subclasses to specify joinedloads or similar for page_all
+        return []
+
     def page_all(self, pagination: PaginationQuery, override=None) -> PaginationBase[Schema]:
         """
         pagination is a method to interact with the filtered database table and return a paginated result
@@ -303,7 +308,7 @@ class RepositoryGeneric(Generic[Schema, Model]):
         q, count, total_pages = self.add_pagination_to_query(q, pagination)
 
         try:
-            data = self.session.execute(q).scalars().all()
+            data = self.session.execute(q).unique().scalars().all()
         except Exception as e:
             self._log_exception(e)
             self.session.rollback()

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -285,7 +285,7 @@ class RepositoryGeneric(Generic[Schema, Model]):
             q = self._query().filter(attribute_name == attr_match)
             return [eff_schema.from_orm(x) for x in self.session.execute(q).scalars().all()]
 
-    def query_options(self) -> list[LoaderOption]:
+    def paging_query_options(self) -> list[LoaderOption]:
         # Override this in subclasses to specify joinedloads or similar for page_all
         return []
 
@@ -301,7 +301,7 @@ class RepositoryGeneric(Generic[Schema, Model]):
         """
         eff_schema = override or self.schema
 
-        q = self._query()
+        q = self._query().options(*self.paging_query_options())
 
         fltr = self._filter_builder()
         q = q.filter_by(**fltr)

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -313,7 +313,6 @@ class RepositoryGeneric(Generic[Schema, Model]):
             self._log_exception(e)
             self.session.rollback()
             raise e
-
         return PaginationBase(
             page=pagination.page,
             per_page=pagination.per_page,

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -39,12 +39,12 @@ class IngredientFood(CreateIngredientFood):
     class Config:
         class _FoodGetter(GetterDict):
             def get(self, key: Any, default: Any = None) -> Any:
-                # element attributes
+                # Transform extras into key-value dict
                 if key == "extras":
                     value = super().get(key, default)
                     return {x.key_name: x.value for x in value}
 
-                # element children
+                # Keep all other fields as they are
                 else:
                     return super().get(key, default)
 

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import datetime
 import enum
+from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import UUID4, Field, validator
 from pydantic.utils import GetterDict
 
-from mealie.db.models.recipe.ingredient import IngredientFoodModel
 from mealie.schema._mealie import MealieModel
 from mealie.schema._mealie.types import NoneFloat
 from mealie.schema.response.pagination import PaginationBase
@@ -37,14 +37,19 @@ class IngredientFood(CreateIngredientFood):
     update_at: datetime.datetime | None
 
     class Config:
-        orm_mode = True
+        class _FoodGetter(GetterDict):
+            def get(self, key: Any, default: Any = None) -> Any:
+                # element attributes
+                if key == "extras":
+                    value = super().get(key, default)
+                    return {x.key_name: x.value for x in value}
 
-        @classmethod
-        def getter_dict(cls, name_orm: IngredientFoodModel):
-            return {
-                **GetterDict(name_orm),
-                "extras": {x.key_name: x.value for x in name_orm.extras},
-            }
+                # element children
+                else:
+                    return super().get(key, default)
+
+        orm_mode = True
+        getter_dict = _FoodGetter
 
 
 class IngredientFoodPagination(PaginationBase):


### PR DESCRIPTION

# What type of PR is this?

- bug

## What this PR does / why we need it:

As mentioned in discord, the /api/foods endpoint can be pretty slow if you have a larger number of foods and especially if you use the extras feature for foods. I identified two causes for this:

1) Any repository that just uses RepositoryGeneric's page_all functionality without modifications can not make use of eager-loading and if there are relations used in the response (i.e. label and extras in this case), they will all be lazy-loaded for any given entry
2) IngredientFood's getter_dict override was kinda terrible, because the line `**GetterDict(name_orm)` would cause pydantic to try and resolve ALL model relationships, even if they are not used in the response, causing even more lazy-loading

To improve on this, I added a query_options function to RepositoryGeneric, so every sub-repository can specify its own loading options, if needed. Additionally I rewrote the getter_dict override so it just does the thing it is supposed to do and not cause any more unnecessary loading

## Which issue(s) this PR fixes:

No issue filed

## Testing

Ran all the tests and tried everything manually

## Release Notes

```release-note
* Improve performance for loading foods on search page
```
