### PR TITLE
Fix: Last Made Date Does Funky Stuff

### DIFF
--- a/mealie/services/scheduler/tasks/create_timeline_events.py
+++ b/mealie/services/scheduler/tasks/create_timeline_events.py
@@ -5,7 +5,7 @@ from pydantic import UUID4
 from mealie.db.db_setup import session_context
 from mealie.repos.all_repositories import get_repositories
 from mealie.schema.meal_plan.new_meal import PlanEntryType
-from mealie.schema.recipe.recipe import Recipe, RecipeSummary
+from mealie.schema.recipe.recipe import RecipeSummary
 from mealie.schema.recipe.recipe_timeline_events import (
     RecipeTimelineEventCreate,
     TimelineEventType,

--- a/mealie/services/scheduler/tasks/create_timeline_events.py
+++ b/mealie/services/scheduler/tasks/create_timeline_events.py
@@ -26,12 +26,6 @@ def create_mealplan_timeline_events(group_id: UUID4 | None = None):
 
     with session_context() as session:
         repos = get_repositories(session)
-        event_bus_service = EventBusService(session=session, group_id=group_id)
-
-        timeline_events_to_create: list[RecipeTimelineEventCreate] = []
-        recipes_to_update: dict[UUID4, RecipeSummary] = {}
-        recipe_id_to_slug_map: dict[UUID4, str] = {}
-
         if group_id is None:
             # if not specified, we check all groups
             groups_data = repos.groups.page_all(PaginationQuery(page=1, per_page=-1))
@@ -41,6 +35,12 @@ def create_mealplan_timeline_events(group_id: UUID4 | None = None):
             group_ids = [group_id]
 
         for group_id in group_ids:
+            event_bus_service = EventBusService(session=session, group_id=group_id)
+
+            timeline_events_to_create: list[RecipeTimelineEventCreate] = []
+            recipes_to_update: dict[UUID4, RecipeSummary] = {}
+            recipe_id_to_slug_map: dict[UUID4, str] = {}
+
             mealplans = repos.meals.get_today(group_id)
             for mealplan in mealplans:
                 if not (mealplan.recipe and mealplan.user_id):
@@ -92,29 +92,28 @@ def create_mealplan_timeline_events(group_id: UUID4 | None = None):
 
                 recipe_id_to_slug_map[mealplan.recipe_id] = mealplan.recipe.slug
 
-        if not timeline_events_to_create:
-            return
+            if not timeline_events_to_create:
+                return
 
-        # TODO: use bulk operations
-        for event in timeline_events_to_create:
-            new_event = repos.recipe_timeline_events.create(event)
-            event_bus_service.dispatch(
-                integration_id=DEFAULT_INTEGRATION_ID,
-                group_id=group_id,  # type: ignore
-                event_type=EventTypes.recipe_updated,
-                document_data=EventRecipeTimelineEventData(
-                    operation=EventOperation.create,
-                    recipe_slug=recipe_id_to_slug_map[new_event.recipe_id],
-                    recipe_timeline_event_id=new_event.id,
-                ),
-            )
+            # TODO: use bulk operations
+            for event in timeline_events_to_create:
+                new_event = repos.recipe_timeline_events.create(event)
+                event_bus_service.dispatch(
+                    integration_id=DEFAULT_INTEGRATION_ID,
+                    group_id=group_id,
+                    event_type=EventTypes.recipe_updated,
+                    document_data=EventRecipeTimelineEventData(
+                        operation=EventOperation.create,
+                        recipe_slug=recipe_id_to_slug_map[new_event.recipe_id],
+                        recipe_timeline_event_id=new_event.id,
+                    ),
+                )
 
-        for recipe in recipes_to_update.values():
-            recipe.last_made = event_time
-            repos.recipes.update(recipe.slug, recipe.cast(Recipe))
-            event_bus_service.dispatch(
-                integration_id=DEFAULT_INTEGRATION_ID,
-                group_id=group_id,  # type: ignore
-                event_type=EventTypes.recipe_updated,
-                document_data=EventRecipeData(operation=EventOperation.update, recipe_slug=recipe.slug),
-            )
+            for recipe in recipes_to_update.values():
+                repos.recipes.patch(recipe.slug, {"last_made": event_time})
+                event_bus_service.dispatch(
+                    integration_id=DEFAULT_INTEGRATION_ID,
+                    group_id=group_id,
+                    event_type=EventTypes.recipe_updated,
+                    document_data=EventRecipeData(operation=EventOperation.update, recipe_slug=recipe.slug),
+                )


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Fixes a nasty bug that erases some recipe data when a mealplan triggers an update to the `last_made` property.

## Which issue(s) this PR fixes:

_(REQUIRED)_

None in GitHub, surprisingly, but raised several times in Discord.

## Special notes for your reviewer:

_(fill-in or delete this section)_

I was going to use the new service method for timeline events, but because we don't have a user I can't construct the recipe service. I _could_ fetch the user by id, but figured it was way over-complicating it to save 1-2 lines of code reuse.

If you could, give it a look over and make sure I didn't miss anything. In addition to the main issue, I fixed an indentation issue which probably created problems for instances with multiple groups.

## Testing

_(fill-in or delete this section)_

I manually added a few recipes to my mealplan, ran the task, then observed that the timeline event was added, the last made date was updated, and all data was intact (namely the instructions and ingredients). I also added some additional checks to one of our tests.

## Release Notes

_(REQUIRED)_

```release-note
fixed a bug where some recipe data got deleted after being added to a mealplan
```
