### PR TITLE
Feature: add password reset token endpoint to the admin panel

### DIFF
--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -689,6 +689,7 @@
     "error-cannot-delete-super-user": "Error! Cannot Delete Super User",
     "existing-password-does-not-match": "Existing password does not match",
     "full-name": "Full Name",
+    "generate-password-reset-link": "Generate Password Reset Link",
     "invite-only": "Invite Only",
     "link-id": "Link ID",
     "link-name": "Link Name",

--- a/frontend/lib/api/admin/admin-users.ts
+++ b/frontend/lib/api/admin/admin-users.ts
@@ -1,5 +1,5 @@
 import { BaseCRUDAPI } from "../base/base-clients";
-import { UnlockResults, UserIn, UserOut } from "~/lib/api/types/user";
+import { ForgotPassword, PasswordResetToken, UnlockResults, UserIn, UserOut } from "~/lib/api/types/user";
 
 const prefix = "/api";
 
@@ -7,6 +7,7 @@ const routes = {
   adminUsers: `${prefix}/admin/users`,
   adminUsersId: (tag: string) => `${prefix}/admin/users/${tag}`,
   adminResetLockedUsers: (force: boolean) => `${prefix}/admin/users/unlock?force=${force ? "true" : "false"}`,
+  adminPasswordResetToken: `${prefix}/admin/users/password-reset-token`,
 };
 
 export class AdminUsersApi extends BaseCRUDAPI<UserIn, UserOut, UserOut> {
@@ -15,5 +16,9 @@ export class AdminUsersApi extends BaseCRUDAPI<UserIn, UserOut, UserOut> {
 
   async unlockAllUsers(force = false) {
     return await this.requests.post<UnlockResults>(routes.adminResetLockedUsers(force), {});
+  }
+
+  async generatePasswordResetToken(payload: ForgotPassword) {
+    return await this.requests.post<PasswordResetToken>(routes.adminPasswordResetToken, payload);
   }
 }

--- a/frontend/lib/api/types/user.ts
+++ b/frontend/lib/api/types/user.ts
@@ -233,3 +233,6 @@ export interface UserIn {
 export interface ValidateResetToken {
   token: string;
 }
+export interface PasswordResetToken {
+  token: string;
+}

--- a/frontend/pages/admin/manage/users/_id.vue
+++ b/frontend/pages/admin/manage/users/_id.vue
@@ -27,6 +27,13 @@
             label="User Group"
             :rules="[validators.required]"
           ></v-select>
+          <div class="d-flex py-2 pr-2">
+            <BaseButton type="button" :loading="generatingToken" create @click.prevent="handlePasswordReset">
+              Generate Password Reset Link
+            </BaseButton>
+            <AppButtonCopy v-if="resetUrl" :copy-text="resetUrl"></AppButtonCopy>
+          </div>
+
           <AutoForm v-model="user" :items="userForm" update-mode />
         </v-card-text>
       </v-card>
@@ -67,6 +74,9 @@ export default defineComponent({
 
     const userError = ref(false);
 
+    const resetUrl = ref<string | null>(null);
+    const generatingToken = ref(false);
+
     onMounted(async () => {
       const { data, error } = await adminApi.users.getOne(userId);
 
@@ -90,6 +100,20 @@ export default defineComponent({
       }
     }
 
+    async function handlePasswordReset() {
+      if (user.value === null) return;
+      generatingToken.value = true;
+
+      const { response, data } = await adminApi.users.generatePasswordResetToken({ email: user.value.email });
+
+      if (response?.status === 201 && data) {
+        const token: string = data.token;
+        resetUrl.value = `${window.location.origin}/reset-password?token=${token}`;
+      }
+
+      generatingToken.value = false;
+    }
+
     return {
       user,
       userError,
@@ -98,6 +122,9 @@ export default defineComponent({
       handleSubmit,
       groups,
       validators,
+      handlePasswordReset,
+      resetUrl,
+      generatingToken,
     };
   },
 });

--- a/frontend/pages/admin/manage/users/_id.vue
+++ b/frontend/pages/admin/manage/users/_id.vue
@@ -29,7 +29,7 @@
           ></v-select>
           <div class="d-flex py-2 pr-2">
             <BaseButton type="button" :loading="generatingToken" create @click.prevent="handlePasswordReset">
-              Generate Password Reset Link
+              {{ $t("user.generate-password-reset-link") }}
             </BaseButton>
             <AppButtonCopy v-if="resetUrl" :copy-text="resetUrl"></AppButtonCopy>
           </div>

--- a/mealie/routes/admin/admin_management_users.py
+++ b/mealie/routes/admin/admin_management_users.py
@@ -11,8 +11,8 @@ from mealie.schema.response.responses import ErrorResponse
 from mealie.schema.user.auth import UnlockResults
 from mealie.schema.user.user import UserIn, UserOut, UserPagination
 from mealie.schema.user.user_passwords import ForgotPassword, PasswordResetToken
-from mealie.services.user_services.user_service import UserService
 from mealie.services.user_services.password_reset_service import PasswordResetService
+from mealie.services.user_services.user_service import UserService
 
 router = APIRouter(prefix="/users", tags=["Admin: Users"])
 
@@ -73,4 +73,6 @@ class AdminUserManagementRoutes(BaseAdminController):
         """Generates a reset token and returns it. This is an authenticated endpoint"""
         f_service = PasswordResetService(self.session)
         token_entry = f_service.generate_reset_token(email.email)
+        if not token_entry:
+            raise HTTPException(status_code=500, detail=ErrorResponse.respond("error while generating reset token"))
         return PasswordResetToken(token=token_entry.token)

--- a/mealie/routes/admin/admin_management_users.py
+++ b/mealie/routes/admin/admin_management_users.py
@@ -10,7 +10,9 @@ from mealie.schema.response.pagination import PaginationQuery
 from mealie.schema.response.responses import ErrorResponse
 from mealie.schema.user.auth import UnlockResults
 from mealie.schema.user.user import UserIn, UserOut, UserPagination
+from mealie.schema.user.user_passwords import ForgotPassword, PasswordResetToken
 from mealie.services.user_services.user_service import UserService
+from mealie.services.user_services.password_reset_service import PasswordResetService
 
 router = APIRouter(prefix="/users", tags=["Admin: Users"])
 
@@ -65,3 +67,10 @@ class AdminUserManagementRoutes(BaseAdminController):
     @router.delete("/{item_id}", response_model=UserOut)
     def delete_one(self, item_id: UUID4):
         return self.mixins.delete_one(item_id)
+
+    @router.post("/password-reset-token", response_model=PasswordResetToken, status_code=201)
+    def generate_token(self, email: ForgotPassword):
+        """Generates a reset token and returns it. This is an authenticated endpoint"""
+        f_service = PasswordResetService(self.session)
+        token_entry = f_service.generate_reset_token(email.email)
+        return PasswordResetToken(token=token_entry.token)

--- a/mealie/schema/user/user_passwords.py
+++ b/mealie/schema/user/user_passwords.py
@@ -9,6 +9,10 @@ class ForgotPassword(MealieModel):
     email: str
 
 
+class PasswordResetToken(MealieModel):
+    token: str
+
+
 class ValidateResetToken(MealieModel):
     token: str
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR adds a password reset link in the admin panel for each user. This link will allow the administrator to generate a password reset link for a user so as not to require the use of SMTP as discussed [here](https://github.com/hay-kot/mealie/pull/2143#issuecomment-1442254353)

## Which issue(s) this PR fixes:

None

## Testing

Tested visually that the button shows up and works.
Manually tested that the endpoint could only be called with an admin JWT.

## Release Notes

```release-note
admins can now generate password reset links without setting up SMTP
```

## Screenshots
![image](https://user-images.githubusercontent.com/35710697/221208385-9b13aeb8-ef9d-47f6-b631-b8388c3a5b11.png)

After url generation, the copy button shows up
![image](https://user-images.githubusercontent.com/35710697/221208453-60d4c553-f4d9-439e-b01e-62aa47f1cb4d.png)
