### PR TITLE
Fix/2169 webhooks

### DIFF
--- a/frontend/components/Domain/Group/GroupWebhookEditor.vue
+++ b/frontend/components/Domain/Group/GroupWebhookEditor.vue
@@ -18,6 +18,8 @@
             icon: $globals.icons.testTube,
             text: $tc('general.test'),
             event: 'test',
+            // TODO: There is no functionality hooked up to this. Enable it when there is
+            disabled: true,
           },
           {
             icon: $globals.icons.save,

--- a/frontend/components/global/BaseButtonGroup.vue
+++ b/frontend/components/global/BaseButtonGroup.vue
@@ -25,7 +25,7 @@
         content-class="text-caption"
       >
         <template #activator="{ on, attrs }">
-          <v-btn tile :large="large" icon v-bind="attrs" @click="$emit(btn.event)" v-on="on">
+          <v-btn tile :large="large" icon v-bind="attrs" @click="$emit(btn.event)" v-on="on" :disabled="btn.disabled">
             <v-icon> {{ btn.icon }} </v-icon>
           </v-btn>
         </template>
@@ -43,6 +43,7 @@ export interface ButtonOption {
   text: string;
   event: string;
   children?: ButtonOption[];
+  disabled?: boolean;
 }
 
 export default defineComponent({

--- a/frontend/lib/api/admin/admin-tasks.ts
+++ b/frontend/lib/api/admin/admin-tasks.ts
@@ -1,5 +1,6 @@
 import { BaseAPI } from "../base/base-clients";
 import { ServerTask } from "~/lib/api/types/server";
+import { PaginationData } from "~/lib/api/types/non-generated";
 
 const prefix = "/api";
 
@@ -13,6 +14,6 @@ export class AdminTaskAPI extends BaseAPI {
   }
 
   async getAll() {
-    return await this.requests.get<ServerTask[]>(routes.base);
+    return await this.requests.get<PaginationData<ServerTask>>(routes.base);
   }
 }

--- a/frontend/pages/admin/background-tasks.vue
+++ b/frontend/pages/admin/background-tasks.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       const { data } = await api.serverTasks.getAll();
 
       if (data) {
-        tasks.value = data;
+        tasks.value = data.items;
       }
       loading.value = false;
     }

--- a/mealie/routes/groups/controller_group_notifications.py
+++ b/mealie/routes/groups/controller_group_notifications.py
@@ -100,5 +100,5 @@ class GroupEventsNotifierController(BaseUserController):
             document_data=EventDocumentDataBase(document_type=EventDocumentType.generic, operation=EventOperation.info),
         )
 
-        test_listener = AppriseEventListener(self.event_bus.session, self.group_id)
+        test_listener = AppriseEventListener(self.group_id)
         test_listener.publish_to_subscribers(test_event, [item.apprise_url])

--- a/mealie/services/event_bus_service/event_bus_service.py
+++ b/mealie/services/event_bus_service/event_bus_service.py
@@ -50,8 +50,8 @@ class EventBusService:
         self.group_id = group_id
 
         self.listeners: list[EventListenerBase] = [
-            AppriseEventListener(self.session, self.group_id),
-            WebhookEventListener(self.session, self.group_id),
+            AppriseEventListener(self.group_id),
+            WebhookEventListener(self.group_id),
         ]
 
     def dispatch(

--- a/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
+++ b/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
@@ -51,7 +51,7 @@ def test_get_scheduled_webhooks_filter_query(database: AllRepositories, unique_u
         if new_item.enabled:
             expected.append(new_item)
 
-    event_bus_listener = WebhookEventListener(database.session, unique_user.group_id)  # type: ignore
+    event_bus_listener = WebhookEventListener(unique_user.group_id)  # type: ignore
     results = event_bus_listener.get_scheduled_webhooks(start, datetime.now() + timedelta(minutes=5))
 
     assert len(results) == len(expected)


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The webhooks didnt work at all and this fixes that
So, this was a nightmare to debug and I still dont quite fully understand the EventBusService with its 5 or so levels of indirection, so I am not fully certain if this solution is very sound, but I do at least know that before it was completely indeterminable if an EventBusListener had a session available or not and this should at least improve that.
While digging for this issue I found 2 other bugs that are very small and had no own issues so I rolled them up here as well:

* The test button in the webhook editor just doesnt do anything. It is not hooked up to any function and as far as I see there is also no api to just trigger a single webhook for testing purposes. I just disabled it for now so it at least wont confuse other people and will add a seperate issue
* The background tasks page in the admin section was just completely broken, because the api paginates results and the frontend doesnt expect it. I guess noone ever uses this and I am not quite sure what this is for either, but I fixed it regardless

## Which issue(s) this PR fixes:

* Fixes #2169 

## Testing

I write the same thing here every single time, you know the drill by now :)

## Release Notes

```release-note
* Fixes webhooks not firing
* Fixes "Background Tasks" page
* Disable webhook test button
```
