### PR TITLE
Fix font loading in css

### DIFF
--- a/frontend/assets/css/fonts.css
+++ b/frontend/assets/css/fonts.css
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-cyrillic-ext1.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-cyrillic-ext1.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -13,7 +13,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-cyrillic2.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-cyrillic2.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -22,7 +22,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-greek-ext3.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-greek-ext3.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -31,7 +31,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-greek4.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-greek4.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -40,7 +40,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-vietnamese5.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-vietnamese5.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -49,7 +49,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-latin-ext6.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-latin-ext6.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -58,7 +58,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-100-latin7.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-100-latin7.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -67,7 +67,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-cyrillic-ext8.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-cyrillic-ext8.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -76,7 +76,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-cyrillic9.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-cyrillic9.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -85,7 +85,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-greek-ext10.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-greek-ext10.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -94,7 +94,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-greek11.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-greek11.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -103,7 +103,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-vietnamese12.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-vietnamese12.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -112,7 +112,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-latin-ext13.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-latin-ext13.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -121,7 +121,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-300-latin14.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-300-latin14.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -130,7 +130,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-cyrillic-ext15.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-cyrillic-ext15.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -139,7 +139,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-cyrillic16.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-cyrillic16.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -148,7 +148,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-greek-ext17.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-greek-ext17.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -157,7 +157,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-greek18.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-greek18.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -166,7 +166,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-vietnamese19.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-vietnamese19.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -175,7 +175,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-latin-ext20.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-latin-ext20.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -184,7 +184,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-400-latin21.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-400-latin21.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -193,7 +193,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-cyrillic-ext22.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-cyrillic-ext22.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -202,7 +202,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-cyrillic23.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-cyrillic23.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -211,7 +211,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-greek-ext24.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-greek-ext24.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -220,7 +220,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-greek25.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-greek25.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -229,7 +229,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-vietnamese26.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-vietnamese26.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -238,7 +238,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-latin-ext27.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-latin-ext27.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -247,7 +247,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-500-latin28.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-500-latin28.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -256,7 +256,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-cyrillic-ext29.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-cyrillic-ext29.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -265,7 +265,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-cyrillic30.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-cyrillic30.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -274,7 +274,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-greek-ext31.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-greek-ext31.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -283,7 +283,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-greek32.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-greek32.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -292,7 +292,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-vietnamese33.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-vietnamese33.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -301,7 +301,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-latin-ext34.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-latin-ext34.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -310,7 +310,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-700-latin35.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-700-latin35.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
@@ -319,7 +319,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-cyrillic-ext36.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-cyrillic-ext36.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -328,7 +328,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-cyrillic37.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-cyrillic37.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -337,7 +337,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-greek-ext38.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-greek-ext38.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -346,7 +346,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-greek39.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-greek39.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -355,7 +355,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-vietnamese40.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-vietnamese40.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -364,7 +364,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-latin-ext41.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-latin-ext41.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -373,6 +373,6 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('/assets/fonts/Roboto-900-latin42.woff2') format('woff2');
+  src: url('~assets/fonts/Roboto-900-latin42.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The frontend actually didnt load fonts correctly at any point except in development mode. Turns out nuxt does not serve the assets directory directly and you have to use "~assets" instead of "/assets" in your css for it to work

## Which issue(s) this PR fixes:

* fixes #2065

## Testing

Built a local docker image and ran app in container to check if fonts load

## Release Notes

```release-note
* Fixes frontend not loading correct fonts
```
