### PR TITLE
chore: auto-set-version-on-ci

### DIFF
--- a/.github/workflows/partial-builder.yml
+++ b/.github/workflows/partial-builder.yml
@@ -71,6 +71,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Override __init__.py
+        run: |
+          echo "__version__ = \"${{ inputs.tag }}\"" > ./mealie/__init__.py
+
       - name: Build Backend Image
         run: |
           docker build --push --no-cache \
@@ -103,6 +107,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Override __init__.py
+        run: |
+          echo "__version__ = \"${{ inputs.tag }}\"" > ./mealie/__init__.py
 
       - name: Build Omni-Image
         run: |

--- a/frontend/pages/admin/site-settings.vue
+++ b/frontend/pages/admin/site-settings.vue
@@ -151,7 +151,7 @@
                   </a>
                 </v-list-item-subtitle>
               </template>
-              <template v-if="property.slot === 'build'">
+              <template v-else-if="property.slot === 'build'">
                 <v-list-item-subtitle>
                   <a target="_blank" :href="`https://github.com/hay-kot/mealie/commit/${property.value}`">
                     {{ property.value }}

--- a/frontend/pages/admin/site-settings.vue
+++ b/frontend/pages/admin/site-settings.vue
@@ -151,6 +151,13 @@
                   </a>
                 </v-list-item-subtitle>
               </template>
+              <template v-if="property.slot === 'build'">
+                <v-list-item-subtitle>
+                  <a target="_blank" :href="`https://github.com/hay-kot/mealie/commit/${property.value}`">
+                    {{ property.value }}
+                  </a>
+                </v-list-item-subtitle>
+              </template>
               <template v-else>
                 <v-list-item-subtitle>
                   {{ property.value }}
@@ -369,6 +376,7 @@ export default defineComponent({
               value: data.version,
             },
             {
+              slot: "build",
               name: "Build",
               icon: $globals.icons.information,
               value: data.buildId,

--- a/mealie/__init__.py
+++ b/mealie/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.0.0beta-5"
+__version__ = "develop"


### PR DESCRIPTION
- Default __version__ is now `develop`
- __version__ is overidden during CI to be the tag of the build with nightly being set to `nightly`
- Build link in settings is now clickable