### PR TITLE
Fix: Shopping List Mobile Usability

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -38,7 +38,7 @@
               </v-list-item>
             </v-list>
           </v-menu>
-          <v-btn small class="ml-2 handle" icon @click="toggleEdit(true)">
+          <v-btn small class="ml-2" icon @click="toggleEdit(true)">
             <v-icon>
               {{ $globals.icons.edit }}
             </v-icon>

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -10,7 +10,7 @@
     <!-- Viewer -->
     <section v-if="!edit" class="py-2">
       <div v-if="!preferences.viewByLabel">
-        <draggable :value="listItems.unchecked" handle=".handle" @start="loadingCounter += 1" @end="loadingCounter -= 1" @input="updateIndexUnchecked">
+        <draggable :value="listItems.unchecked" handle=".handle" delay="250" :delay-on-touch-only="true"  @start="loadingCounter += 1" @end="loadingCounter -= 1" @input="updateIndexUnchecked">
           <v-lazy v-for="(item, index) in listItems.unchecked" :key="item.id" class="my-2">
             <ShoppingListItem
               v-model="listItems.unchecked[index]"
@@ -38,7 +38,7 @@
             </span>
             {{ key }}
           </div>
-          <draggable :value="value" handle=".handle" @start="loadingCounter += 1" @end="loadingCounter -= 1" @input="updateIndexUncheckedByLabel(key, $event)">
+          <draggable :value="value" handle=".handle" delay="250" :delay-on-touch-only="true" @start="loadingCounter += 1" @end="loadingCounter -= 1" @input="updateIndexUncheckedByLabel(key, $event)">
             <v-lazy v-for="(item, index) in value" :key="item.id" class="ml-2 my-2">
               <ShoppingListItem
                 v-model="value[index]"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Makes two small-ish changes to shopping lists related to re-ordering items:
1. removed the draggable handle from the edit button (this is a bug)
2. added a delay when dragging from a touch screen (to make scrolling easier)

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

You may see `:delay-on-touch-only="true"` and wonder "but why not use the v-bind `delay-on-touch-only`?"
It's a bug that doesn't seem to have any activity: https://github.com/SortableJS/Vue.Draggable/issues/1015
¯\\\_(ツ)_/¯

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
made it easier for mobile users to scroll dense shopping lists
```
