### PR TITLE
Fix: update_at sort

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -301,7 +301,7 @@ export default defineComponent({
       {
         icon: $globals.icons.update,
         name: i18n.tc("general.updated"),
-        value: "updated_at",
+        value: "update_at",
       },
     ];
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The new frontend search/sort uses `updated_at` whereas the backend wants `update_at`

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Release Notes

```release-note
fixed "last updated" sort
```
