### PR TITLE
feat: Reduced Ingredients to One Column on Mobile When Adding Recipe to Shopping List

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -97,8 +97,8 @@
         height="fit-content"
         max-height="60vh"
         width="100%"
-        class="ingredient-grid"
-        :style="{ gridTemplateRows: `repeat(${Math.ceil(recipeIngredients.length / 2)}, min-content)` }"
+        :class="$vuetify.breakpoint.smAndDown ? '' : 'ingredient-grid'"
+        :style="$vuetify.breakpoint.smAndDown ? '' : { gridTemplateRows: `repeat(${Math.ceil(recipeIngredients.length / 2)}, min-content)` }"
         style="overflow-y: auto"
       >
         <v-list-item


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Currently when adding a recipe to your shopping list on desktop it looks like this:
![image](https://user-images.githubusercontent.com/71845777/225138291-a537680f-0bb9-4e5b-b615-5970f8c622fd.png)

Which is great, but on mobile it looks awful:
![image](https://user-images.githubusercontent.com/71845777/225138345-f129a1d6-b161-455f-9bd3-e305e5e15f2e.png)

Now on mobile (breakpoint <= small) it condenses to one column:
![image](https://user-images.githubusercontent.com/71845777/225138442-b0228784-46e8-48be-8728-692402847677.png)

## Which issue(s) this PR fixes:

_(REQUIRED)_

Raised in Discord

## Release Notes

_(REQUIRED)_

```release-note
improved mobile interface for adding a recipe to a shopping list
```
