### PR TITLE
Feat: Limited Max Length for Print Preview Dialog

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeDialogPrintPreferences.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogPrintPreferences.vue
@@ -4,6 +4,7 @@
     :icon="$globals.icons.printerSettings"
     :title="$tc('general.print-preferences')"
     width="70%"
+    max-width="816px"
   >
     <div class="pa-6">
       <v-container class="print-config mb-3 pa-0">

--- a/frontend/components/global/BaseDialog.vue
+++ b/frontend/components/global/BaseDialog.vue
@@ -5,6 +5,7 @@
       v-model="dialog"
       absolute
       :width="width"
+      :max-width="maxWidth"
       :content-class="top ? 'top-dialog' : undefined"
       :fullscreen="$vuetify.breakpoint.xsOnly"
       @keydown.enter="
@@ -95,6 +96,10 @@ export default defineComponent({
     width: {
       type: [Number, String],
       default: "500",
+    },
+    maxWidth: {
+      type: [Number, String],
+      default: null,
     },
     loading: {
       type: Boolean,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

The current print preview dialog can be arbitrarily large, which in _most_ cases isn't accurate. Most people are printing on standard printer paper, and most screens are bigger than that (we're actually limiting it to 70% of the screen width, but 70% of a standard screen is still too big). This is especially strange looking because images are sized based on available width.

For instance, check out this preview on my 27 inch monitor:
![image](https://user-images.githubusercontent.com/71845777/225155654-7b56a0a6-749a-447e-b35a-6b893bf054cd.png)

Versus what it actually prints to (notice how much smaller the image looks):
![image](https://user-images.githubusercontent.com/71845777/225155725-e72edec7-5c7d-4b40-a2fc-6f3f214c2db6.png)

---

This PR limits the dialog to _roughly_ printer paper size (can't be exact due to differing standards; it's also still wrong for all _other_ printer sizes, but 8.5 x 11 and A4 are the two most common by far)

Preview:
![image](https://user-images.githubusercontent.com/71845777/225155975-ff430b82-7304-451d-8f5e-9ba6ae41d25e.png)

Actual:
![image](https://user-images.githubusercontent.com/71845777/225156031-73612241-e9d5-4a46-b76b-7b9d51c681b2.png)


## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Release Notes

_(REQUIRED)_

```release-note
limited print preview width to more closely represent what the printed recipe will look like
```
