### PR TITLE
[Fix] Filter out the LDAP entries which do not have a DN

### DIFF
--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -59,9 +59,9 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
     if settings.LDAP_TLS_INSECURE:
         ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
-    ldap.set_option(ldap.OPT_REFERRALS, 0)
     ldap.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
     conn = ldap.initialize(settings.LDAP_SERVER_URL)
+    conn.set_option(ldap.OPT_REFERRALS, 0)
 
     if settings.LDAP_TLS_CACERTFILE:
         conn.set_option(ldap.OPT_X_TLS_CACERTFILE, settings.LDAP_TLS_CACERTFILE)
@@ -119,7 +119,7 @@ def user_from_ldap(db: AllRepositories, username: str, password: str) -> Private
 
     # Check the credentials of the user
     try:
-        logger.debug(f"[LDAP] Attempting to bind to {user_dn} with the provided password")
+        logger.debug(f"[LDAP] Attempting to bind to '{user_dn}' with the provided password")
         conn.simple_bind_s(user_dn, password)
     except (ldap.INVALID_CREDENTIALS, ldap.NO_SUCH_OBJECT):
         conn.unbind_s()


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- fix

## What this PR does / why we need it:


- Filter the entries returned from the LDAP search to those which have a non-null DN. This addresses the issues faced with Active Directory returning forest results
- Sets `OPT_REFERRALS` on the connection object instead of the global object as per [this post](https://stackoverflow.com/questions/140439/authenticating-against-active-directory-using-python-ldap)
- Add some debug logging to help with, well, debugging


## Which issue(s) this PR fixes:

fixes #2279

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
NONE
```
