### PR TITLE
fix: Shopping List Label Dropdown Doesn't Save Correctly

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -138,6 +138,10 @@ export default defineComponent({
     });
     const edit = ref(false);
     function toggleEdit(val = !edit.value) {
+      if (edit.value === val) {
+        return;
+      }
+
       if (val) {
         // update local copy of item with the current value
         localListItem.value = props.value;

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -590,7 +590,15 @@ export default defineComponent({
         item.updateAt = item.updateAt.substring(0, item.updateAt.length-1);
       }
 
-      // if an item was checked/unchecked, make sure it changes sections immediately
+      // make updates reflect immediately
+      if (shoppingList.value.listItems) {
+        shoppingList.value.listItems.forEach((oldListItem: ShoppingListItemOut, idx: number) => {
+          if (oldListItem.id === item.id && shoppingList.value?.listItems) {
+            shoppingList.value.listItems[idx] = item;
+          }
+        });
+      }
+
       updateItemsByLabel();
 
       loadingCounter.value += 1;

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -32,7 +32,7 @@
         <div v-for="(value, key, idx) in itemsByLabel" :key="key" class="mb-6">
           <div @click="toggleShowChecked()">
             <span v-if="idx || key !== $tc('shopping-list.no-label')">
-              <v-icon :color="value[0].label.color">
+              <v-icon :color="getLabelColor(value[0])">
                 {{ $globals.icons.tags }}
               </v-icon>
             </span>
@@ -206,14 +206,13 @@
 <script lang="ts">
 import draggable from "vuedraggable";
 
-import { defineComponent, useAsync, useRoute, computed, ref, watch, onUnmounted, useContext } from "@nuxtjs/composition-api";
+import { defineComponent, useRoute, computed, ref, onUnmounted, useContext } from "@nuxtjs/composition-api";
 import { useIdle, useToggle } from "@vueuse/core";
 import { useCopyList } from "~/composables/use-copy";
 import { useUserApi } from "~/composables/api";
-import { useAsyncKey } from "~/composables/use-utils";
 import MultiPurposeLabelSection from "~/components/Domain/ShoppingList/MultiPurposeLabelSection.vue"
 import ShoppingListItem from "~/components/Domain/ShoppingList/ShoppingListItem.vue";
-import { ShoppingListItemCreate, ShoppingListItemOut, ShoppingListMultiPurposeLabelOut } from "~/lib/api/types/group";
+import { ShoppingListItemCreate, ShoppingListItemOut, ShoppingListMultiPurposeLabelOut, ShoppingListOut } from "~/lib/api/types/group";
 import RecipeList from "~/components/Domain/Recipe/RecipeList.vue";
 import ShoppingListItemEditor from "~/components/Domain/ShoppingList/ShoppingListItemEditor.vue";
 import { useFoodStore, useLabelStore, useUnitStore } from "~/composables/store";
@@ -253,10 +252,7 @@ export default defineComponent({
     // ===============================================================
     // Shopping List Actions
 
-    const shoppingList = useAsync(async () => {
-      return await fetchShoppingList();
-    }, useAsyncKey());
-
+    const shoppingList = ref<ShoppingListOut | null>(null);
     async function fetchShoppingList() {
       const { data } = await userApi.shopping.lists.getOne(id);
       return data;
@@ -270,6 +266,7 @@ export default defineComponent({
       // only update the list with the new value if we're not loading, to prevent UI jitter
       if (!loadingCounter.value) {
         shoppingList.value = newListValue;
+        updateItemsByLabel();
       }
     }
 
@@ -305,6 +302,7 @@ export default defineComponent({
     // start polling
     loadingCounter.value -= 1;
     const pollFrequency = 5000;
+    pollForChanges();  // populate initial list
 
     let attempts = 0;
     const maxAttempts = 3;
@@ -421,6 +419,10 @@ export default defineComponent({
     const { units: allUnits } = useUnitStore();
     const { foods: allFoods } = useFoodStore();
 
+    function getLabelColor(item: ShoppingListItemOut | null) {
+      return item?.label?.color;
+    }
+
     function sortByLabels() {
       preferences.value.viewByLabel = !preferences.value.viewByLabel;
     }
@@ -514,10 +516,6 @@ export default defineComponent({
       itemsByLabel.value = itemsSorted;
     }
 
-    watch(shoppingList, () => {
-      updateItemsByLabel();
-    }, {deep: true});
-
     async function refreshLabels() {
       const { data } = await userApi.multiPurposeLabels.getAll();
 
@@ -587,10 +585,13 @@ export default defineComponent({
         // make sure the item is at the end of the list with the other checked items
         item.position = shoppingList.value.listItems.length;
 
-        // set a temporary updatedAt timestamp so it appears at the top of the checked items in the UI
+        // set a temporary updatedAt timestamp prior to refresh so it appears at the top of the checked items
         item.updateAt = new Date().toISOString();
         item.updateAt = item.updateAt.substring(0, item.updateAt.length-1);
       }
+
+      // if an item was checked/unchecked, make sure it changes sections immediately
+      updateItemsByLabel();
 
       loadingCounter.value += 1;
       const { data } = await userApi.shopping.items.updateOne(item.id, item);
@@ -598,7 +599,7 @@ export default defineComponent({
 
       if (data) {
         refresh();
-        }
+      }
     }
 
     async function deleteListItem(item: ShoppingListItemOut) {
@@ -728,6 +729,7 @@ export default defineComponent({
       deleteChecked,
       deleteListItem,
       edit,
+      getLabelColor,
       itemsByLabel,
       listItems,
       listRecipes,

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -443,6 +443,7 @@ export default defineComponent({
 
       // setting this doesn't have any effect on the data since it's refreshed automatically, but it makes the ux feel smoother
       shoppingList.value.labelSettings = labelSettings;
+      updateItemsByLabel();
 
       loadingCounter.value += 1;
       const { data } = await userApi.shopping.lists.updateLabelSettings(shoppingList.value.id, labelSettings);


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The bug raised in https://github.com/hay-kot/mealie/issues/1236 resurfaced at some point, but inconsistently; when in view-by-label mode, and an item's label is changed, prior to hitting save, the editor would close by itself and not actually update the item on the backend. But only sometimes.

![2023-04-25_10h39_03](https://user-images.githubusercontent.com/71845777/234330087-129dd822-ee4c-49d3-b9e3-9b5ae275c800.gif)
_notice that the first item updates as expected to the soup label, but the oil label closes the editor immediately, then, after a few seconds, the label is reverted_

This fixes that issue by explicitly only running the "update items by label" method when it needs to (i.e. when an item is created or updated).
![2023-04-25_10h42_42](https://user-images.githubusercontent.com/71845777/234330919-16c9c0f7-6184-4705-ba4c-bde79359f809.gif)
_note that these are two different databases, and I didn't add colors to the labels in this one, but they still work_

As a bonus, changing an item's label is more responsive (it's visually updated immediately, without needing to wait for the backend). You can see this in the gif above.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A - raised in https://github.com/hay-kot/mealie/issues/1236 but that issue was closed since it seemed to be fixed.

## Special notes for your reviewer:

_(fill-in or delete this section)_

To be honest I don't know exactly how this broke; it doesn't even seem to break all the time, and it's tough to get it to consistently break (prior to the fix). It's definitely related to the `watch` on shopping list changes (which is now removed), and it _seems_ to be related to polling/refreshing the data, but it doesn't always happen (I tried staring at the network traffic and timing actions during refreshes).

But regardless, I can't get it to break anymore after this fix ¯\\\_(ツ)_/¯

## Testing

_(fill-in or delete this section)_

I tried my best to reproduce the bug after the fix and couldn't.

## Release Notes

_(REQUIRED)_

```release-note
fixed weird behavior when trying to update a shopping list item's label
```
