### PR TITLE
Random sort option for front page

### DIFF
--- a/frontend/composables/recipes/use-recipe-search.ts
+++ b/frontend/composables/recipes/use-recipe-search.ts
@@ -31,7 +31,7 @@ export function useRecipeSearch(api: UserApi): UseRecipeSearchReturn {
       orderBy: "name",
       orderDirection: "asc",
       perPage: 20,
-      timestamp: Date.now(),
+      _searchSeed: Date.now().toString(),
     });
 
     if (error) {

--- a/frontend/composables/recipes/use-recipe-search.ts
+++ b/frontend/composables/recipes/use-recipe-search.ts
@@ -31,6 +31,7 @@ export function useRecipeSearch(api: UserApi): UseRecipeSearchReturn {
       orderBy: "name",
       orderDirection: "asc",
       perPage: 20,
+      timestamp: Date.now(),
     });
 
     if (error) {

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -23,6 +23,8 @@ export const useLazyRecipes = function () {
     const { data } = await api.recipes.getAll(page, perPage, {
       orderBy,
       orderDirection,
+      paginationSeed: query?._searchSeed, // propagate searchSeed to stabilize random order pagination
+      searchSeed: query?._searchSeed, // unused, but pass it along for completeness of data
       search: query?.search,
       cookbook: query?.cookbook,
       categories: query?.categories,
@@ -33,7 +35,6 @@ export const useLazyRecipes = function () {
       requireAllTools: query?.requireAllTools,
       foods: query?.foods,
       requireAllFoods: query?.requireAllFoods,
-      timestamp: query?.timestamp,
       queryFilter,
     });
     return data ? data.items : [];

--- a/frontend/composables/recipes/use-recipes.ts
+++ b/frontend/composables/recipes/use-recipes.ts
@@ -1,8 +1,8 @@
 import { useAsync, ref } from "@nuxtjs/composition-api";
 import { useAsyncKey } from "../use-utils";
 import { useUserApi } from "~/composables/api";
-import {Recipe} from "~/lib/api/types/recipe";
-import {RecipeSearchQuery} from "~/lib/api/user/recipes/recipe";
+import { Recipe } from "~/lib/api/types/recipe";
+import { RecipeSearchQuery } from "~/lib/api/user/recipes/recipe";
 
 export const allRecipes = ref<Recipe[]>([]);
 export const recentRecipes = ref<Recipe[]>([]);
@@ -33,6 +33,7 @@ export const useLazyRecipes = function () {
       requireAllTools: query?.requireAllTools,
       foods: query?.foods,
       requireAllFoods: query?.requireAllFoods,
+      timestamp: query?.timestamp,
       queryFilter,
     });
     return data ? data.items : [];

--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -78,6 +78,8 @@ export type RecipeSearchQuery = {
   page?: number;
   perPage?: number;
   orderBy?: string;
+
+  timestamp: number; // obligatory for now
 };
 
 export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {

--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -79,7 +79,7 @@ export type RecipeSearchQuery = {
   perPage?: number;
   orderBy?: string;
 
-  timestamp: number; // obligatory for now
+  _searchSeed?: string;
 };
 
 export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -212,7 +212,6 @@ export default defineComponent({
           foods: toIDArray(selectedFoods.value),
           tags: toIDArray(selectedTags.value),
           tools: toIDArray(selectedTools.value),
-          timestamp: Date.now().toString(), // shows up in address bar, for debugging
           // Only add the query param if it's or not default
           ...{
             auto: state.value.auto ? undefined : "false",

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -303,6 +303,11 @@ export default defineComponent({
         name: i18n.tc("general.updated"),
         value: "update_at",
       },
+      {
+        icon: $globals.icons.diceMultiple,
+        name: i18n.tc("general.random"),
+        value: "random",
+      },
     ];
 
     onMounted(() => {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -212,7 +212,7 @@ export default defineComponent({
           foods: toIDArray(selectedFoods.value),
           tags: toIDArray(selectedTags.value),
           tools: toIDArray(selectedTools.value),
-
+          timestamp: Date.now().toString(), // shows up in address bar, for debugging
           // Only add the query param if it's or not default
           ...{
             auto: state.value.auto ? undefined : "false",
@@ -239,6 +239,7 @@ export default defineComponent({
         requireAllFoods: state.value.requireAllFoods,
         orderBy: state.value.orderBy,
         orderDirection: state.value.orderDirection,
+        timestamp: Date.now(), // never arrives at backend!
       };
     }
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -238,7 +238,7 @@ export default defineComponent({
         requireAllFoods: state.value.requireAllFoods,
         orderBy: state.value.orderBy,
         orderDirection: state.value.orderDirection,
-        timestamp: Date.now(), // never arrives at backend!
+        _searchSeed: Date.now().toString()
       };
     }
 

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import random
 from collections.abc import Iterable
-from datetime import datetime
 from math import ceil
 from typing import Any, Generic, TypeVar
 
@@ -386,9 +385,6 @@ class RepositoryGeneric(Generic[Schema, Model]):
                 temp_query = query.with_only_columns(self.model.id)
                 allids = self.session.execute(temp_query).scalars().all()  # fast because id is indexed
                 order = list(range(len(allids)))
-                if not pagination.timestamp:
-                    pagination.timestamp = datetime.now().timestamp()
-
                 random.seed(pagination.timestamp)
                 random.shuffle(order)
                 random_dict = dict(zip(allids, order, strict=True))

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import random
 from collections.abc import Iterable
 from math import ceil
-import random
 from typing import Any, Generic, TypeVar
 
 from fastapi import HTTPException
 from pydantic import UUID4, BaseModel
-from sqlalchemy import case, Select, delete, func, select
+from sqlalchemy import Select, case, delete, func, select
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import sqltypes
 
@@ -385,10 +385,10 @@ class RepositoryGeneric(Generic[Schema, Model]):
                 temp_query = query.with_only_columns(self.model.id)
                 allids = self.session.execute(temp_query).scalars().all()  # fast because id is indexed
                 order = list(range(len(allids)))
-                self.logger.warning(f"seed {int(pagination.timestamp)}")
-                random.seed(int(pagination.timestamp))
+                self.logger.warning(f"seed {pagination.timestamp}")
+                random.seed(pagination.timestamp)
                 random.shuffle(order)
-                random_dict = dict(zip(allids, order))
+                random_dict = dict(zip(allids, order, strict=True))
                 case_stmt = case(random_dict, value=self.model.id)
                 query = query.order_by(case_stmt)
 

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import random
 from collections.abc import Iterable
 from math import ceil
@@ -385,6 +386,9 @@ class RepositoryGeneric(Generic[Schema, Model]):
                 temp_query = query.with_only_columns(self.model.id)
                 allids = self.session.execute(temp_query).scalars().all()  # fast because id is indexed
                 order = list(range(len(allids)))
+                if not pagination.timestamp:
+                    pagination.timestamp = datetime.now().timestamp()
+
                 random.seed(pagination.timestamp)
                 random.shuffle(order)
                 random_dict = dict(zip(allids, order, strict=True))

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -385,7 +385,6 @@ class RepositoryGeneric(Generic[Schema, Model]):
                 temp_query = query.with_only_columns(self.model.id)
                 allids = self.session.execute(temp_query).scalars().all()  # fast because id is indexed
                 order = list(range(len(allids)))
-                self.logger.warning(f"seed {pagination.timestamp}")
                 random.seed(pagination.timestamp)
                 random.shuffle(order)
                 random_dict = dict(zip(allids, order, strict=True))

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -385,7 +385,7 @@ class RepositoryGeneric(Generic[Schema, Model]):
                 temp_query = query.with_only_columns(self.model.id)
                 allids = self.session.execute(temp_query).scalars().all()  # fast because id is indexed
                 order = list(range(len(allids)))
-                random.seed(pagination.timestamp)
+                random.seed(pagination.pagination_seed)
                 random.shuffle(order)
                 random_dict = dict(zip(allids, order, strict=True))
                 case_stmt = case(random_dict, value=self.model.id)

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
 import random
 from collections.abc import Iterable
+from datetime import datetime
 from math import ceil
 from typing import Any, Generic, TypeVar
 

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -378,4 +378,8 @@ class RepositoryGeneric(Generic[Schema, Model]):
 
                 query = query.order_by(order_attr)
 
+            elif pagination.order_by == "random":
+                order_attr = func.random()
+                query = query.order_by(order_attr)
+
         return query.limit(pagination.per_page).offset((pagination.page - 1) * pagination.per_page), count, total_pages

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,4 +1,3 @@
-import logging
 from functools import cached_property
 from shutil import copyfileobj
 from zipfile import ZipFile
@@ -253,10 +252,7 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
-        log = logging.getLogger("recipe_crud_routes")
         q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
-        log.warning(f"search {search_query.timestamp}")
-        log.warning(f"pagination {q.timestamp}")
         pagination_response = self.repo.page_all(
             pagination=q,
             cookbook=cookbook_data,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from functools import cached_property
 from shutil import copyfileobj
 from zipfile import ZipFile
@@ -253,10 +252,12 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
-        if q.order_by == "random":
-            if not search_query.timestamp:
-                search_query.timestamp = datetime.now().timestamp()
-            q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
+        if (
+            q.order_by == "random" and not q.pagination_seed
+        ):  # this should be already taken care of upstream, but just in case
+            q.pagination_seed = (
+                search_query._search_seed
+            )  # propagate time of search -> stable randomization across pages
 
         pagination_response = self.repo.page_all(
             pagination=q,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -22,6 +22,7 @@ from mealie.repos.repository_recipes import RepositoryRecipes
 from mealie.routes._base import BaseCrudController, controller
 from mealie.routes._base.mixins import HttpRepo
 from mealie.routes._base.routers import MealieCrudRoute, UserAPIRouter
+from mealie.schema.make_dependable import make_dependable
 from mealie.schema.cookbook.cookbook import ReadCookBook
 from mealie.schema.recipe import Recipe, RecipeImageTypes, ScrapeRecipe
 from mealie.schema.recipe.recipe import CreateRecipe, CreateRecipeByUrlBulk, RecipeLastMade, RecipeSummary
@@ -237,8 +238,8 @@ class RecipeController(BaseRecipeController):
     def get_all(
         self,
         request: Request,
-        q: PaginationQuery = Depends(),
-        search_query: RecipeSearchQuery = Depends(),
+        q: PaginationQuery = Depends(make_dependable(PaginationQuery)),
+        search_query: RecipeSearchQuery = Depends(make_dependable(RecipeSearchQuery)),
         categories: list[UUID4 | str] | None = Query(None),
         tags: list[UUID4 | str] | None = Query(None),
         tools: list[UUID4 | str] | None = Query(None),

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,6 +1,5 @@
-from datetime import datetime
-from functools import cached_property
 import logging
+from functools import cached_property
 from shutil import copyfileobj
 from zipfile import ZipFile
 

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import cached_property
 from shutil import copyfileobj
 from zipfile import ZipFile
@@ -252,7 +253,10 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
+        if not search_query.timestamp:
+            search_query.timestamp = datetime.now().timestamp()
         q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
+
         pagination_response = self.repo.page_all(
             pagination=q,
             cookbook=cookbook_data,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from functools import cached_property
+import logging
 from shutil import copyfileobj
 from zipfile import ZipFile
 
@@ -252,6 +254,10 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
+        log = logging.getLogger("recipe_crud_routes")
+        q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
+        log.warning(f"search {search_query.timestamp}")
+        log.warning(f"pagination {q.timestamp}")
         pagination_response = self.repo.page_all(
             pagination=q,
             cookbook=cookbook_data,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -253,9 +253,10 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
-        if not search_query.timestamp:
-            search_query.timestamp = datetime.now().timestamp()
-        q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
+        if q.order_by == "random":
+            if not search_query.timestamp:
+                search_query.timestamp = datetime.now().timestamp()
+            q.timestamp = search_query.timestamp  # propagate time of search to enable stable randomization across pages
 
         pagination_response = self.repo.page_all(
             pagination=q,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -22,8 +22,8 @@ from mealie.repos.repository_recipes import RepositoryRecipes
 from mealie.routes._base import BaseCrudController, controller
 from mealie.routes._base.mixins import HttpRepo
 from mealie.routes._base.routers import MealieCrudRoute, UserAPIRouter
-from mealie.schema.make_dependable import make_dependable
 from mealie.schema.cookbook.cookbook import ReadCookBook
+from mealie.schema.make_dependable import make_dependable
 from mealie.schema.recipe import Recipe, RecipeImageTypes, ScrapeRecipe
 from mealie.schema.recipe.recipe import CreateRecipe, CreateRecipeByUrlBulk, RecipeLastMade, RecipeSummary
 from mealie.schema.recipe.recipe_asset import RecipeAsset

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -252,13 +252,6 @@ class RecipeController(BaseRecipeController):
             if search_query.cookbook is None:
                 raise HTTPException(status_code=404, detail="cookbook not found")
 
-        if (
-            q.order_by == "random" and not q.pagination_seed
-        ):  # this should be already taken care of upstream, but just in case
-            q.pagination_seed = (
-                search_query._search_seed
-            )  # propagate time of search -> stable randomization across pages
-
         pagination_response = self.repo.page_all(
             pagination=q,
             cookbook=cookbook_data,

--- a/mealie/schema/make_dependable.py
+++ b/mealie/schema/make_dependable.py
@@ -1,0 +1,34 @@
+from inspect import signature
+
+from fastapi.exceptions import HTTPException, ValidationError
+
+
+def make_dependable(cls):
+    """
+    Pydantic BaseModels are very powerful because we get lots of validations and type checking right out of the box.
+    FastAPI can accept a BaseModel as a route Dependency and it will automatically handle things like documentation
+    and error handling. However, if we define custom validators then the errors they raise are not handled, leading
+    to HTTP 500's being returned.
+
+    To better understand this issue, you can visit https://github.com/tiangolo/fastapi/issues/1474 for context.
+
+    A workaround proposed there adds a classmethod which attempts to init the BaseModel and handles formatting of
+    any raised ValidationErrors, custom or otherwise. However, this means essentially duplicating the class's
+    signature. This function automates the creation of a workaround method with a matching signature so that you
+    can avoid code duplication.
+
+    usage:
+    async def fetch(thing_request: ThingRequest = Depends(make_dependable(ThingRequest))):
+    """
+
+    def init_cls_and_handle_errors(*args, **kwargs):
+        try:
+            signature(init_cls_and_handle_errors).bind(*args, **kwargs)
+            return cls(*args, **kwargs)
+        except ValidationError as e:
+            for error in e.errors():
+                error["loc"] = ["query"] + list(error["loc"])
+            raise HTTPException(422, detail=e.errors()) from None
+
+    init_cls_and_handle_errors.__signature__ = signature(cls)
+    return init_cls_and_handle_errors

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import enum
+from datetime import datetime
 from typing import Any, Generic, TypeVar
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -24,7 +24,7 @@ class RecipeSearchQuery(MealieModel):
     require_all_tools: bool = False
     require_all_foods: bool = False
     search: str | None
-    timestamp: float = datetime.now().timestamp()  # never set by frontend. currently set for debug
+    timestamp: float
 
 
 class PaginationQuery(MealieModel):
@@ -33,7 +33,7 @@ class PaginationQuery(MealieModel):
     order_by: str = "created_at"
     order_direction: OrderDirection = OrderDirection.desc
     query_filter: str | None = None
-    timestamp: float = datetime.now().timestamp()  # never set by frontend. currently set for debug
+    timestamp: float  # never set by frontend. currently set for debug
 
 
 class PaginationBase(GenericModel, Generic[DataT]):

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -1,5 +1,4 @@
 import enum
-from datetime import datetime
 from typing import Any, Generic, TypeVar
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
@@ -24,7 +23,7 @@ class RecipeSearchQuery(MealieModel):
     require_all_tools: bool = False
     require_all_foods: bool = False
     search: str | None
-    timestamp: float
+    timestamp: float | None
 
 
 class PaginationQuery(MealieModel):
@@ -33,7 +32,7 @@ class PaginationQuery(MealieModel):
     order_by: str = "created_at"
     order_direction: OrderDirection = OrderDirection.desc
     query_filter: str | None = None
-    timestamp: float  # never set by frontend. currently set for debug
+    timestamp: float | None
 
 
 class PaginationBase(GenericModel, Generic[DataT]):

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import enum
 from typing import Any, Generic, TypeVar
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
@@ -23,6 +24,7 @@ class RecipeSearchQuery(MealieModel):
     require_all_tools: bool = False
     require_all_foods: bool = False
     search: str | None
+    timestamp: float = datetime.now().timestamp()  # never set by frontend. currently set for debug
 
 
 class PaginationQuery(MealieModel):
@@ -31,6 +33,7 @@ class PaginationQuery(MealieModel):
     order_by: str = "created_at"
     order_direction: OrderDirection = OrderDirection.desc
     query_filter: str | None = None
+    timestamp: float = datetime.now().timestamp()  # never set by frontend. currently set for debug
 
 
 class PaginationBase(GenericModel, Generic[DataT]):

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -37,7 +37,7 @@ class PaginationQuery(MealieModel):
     @validator("pagination_seed", always=True, pre=True)
     def validate_randseed(cls, pagination_seed, values):
         if values.get("order_by") == "random" and not pagination_seed:
-            raise ValueError("pagination_seed required for when orderBy is random")
+            raise ValueError("paginationSeed is required when orderBy is random")
         return pagination_seed
 
 

--- a/mealie/schema/response/pagination.py
+++ b/mealie/schema/response/pagination.py
@@ -3,7 +3,7 @@ from typing import Any, Generic, TypeVar
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from humps import camelize
-from pydantic import UUID4, BaseModel
+from pydantic import UUID4, BaseModel, validator
 from pydantic.generics import GenericModel
 
 from mealie.schema._mealie import MealieModel
@@ -23,7 +23,7 @@ class RecipeSearchQuery(MealieModel):
     require_all_tools: bool = False
     require_all_foods: bool = False
     search: str | None
-    timestamp: float | None
+    _search_seed: str | None = None
 
 
 class PaginationQuery(MealieModel):
@@ -32,7 +32,13 @@ class PaginationQuery(MealieModel):
     order_by: str = "created_at"
     order_direction: OrderDirection = OrderDirection.desc
     query_filter: str | None = None
-    timestamp: float | None
+    pagination_seed: str | None = None
+
+    @validator("pagination_seed", always=True, pre=True)
+    def validate_randseed(cls, pagination_seed, values):
+        if values.get("order_by") == "random" and not pagination_seed:
+            raise ValueError("pagination_seed required for when orderBy is random")
+        return pagination_seed
 
 
 class PaginationBase(GenericModel, Generic[DataT]):

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -424,3 +424,28 @@ def test_get_recipe_by_slug_or_id(api_client: TestClient, unique_user: utils.Tes
         recipe_data = response.json()
         assert recipe_data["slug"] == slug
         assert recipe_data["id"] == recipe_id
+
+
+def test_get_random_order(api_client: TestClient, unique_user: utils.TestUser):
+    # Create more recipes for stable random ordering
+    slugs = [random_string(10) for _ in range(7)]
+    for slug in slugs:
+        response = api_client.post(api_routes.recipes, json={"name": slug}, headers=unique_user.token)
+        assert response.status_code == 201
+        assert json.loads(response.text) == slug
+
+    goodparams = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
+    response = api_client.get(api_routes.recipes, params=goodparams, headers=unique_user.token)
+    assert response.status_code == 200
+
+    seed1_params = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
+    seed2_params = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "gfedcba"}
+    data1 = api_client.get(api_routes.recipes, params=seed1_params, headers=unique_user.token).json()
+    data2 = api_client.get(api_routes.recipes, params=seed2_params, headers=unique_user.token).json()
+    data1_new = api_client.get(api_routes.recipes, params=seed1_params, headers=unique_user.token).json()
+    assert data1["items"][0]["slug"] != data2["items"][0]["slug"]  # new seed -> new order
+    assert data1["items"][0]["slug"] == data1_new["items"][0]["slug"]  # same seed -> same order
+
+    badparams = {"page": 1, "perPage": -1, "orderBy": "random"}
+    response = api_client.get(api_routes.recipes, params=badparams, headers=unique_user.token)
+    assert response.status_code == 422

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -434,18 +434,18 @@ def test_get_random_order(api_client: TestClient, unique_user: utils.TestUser):
         assert response.status_code == 201
         assert json.loads(response.text) == slug
 
-    goodparams = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
+    goodparams: dict[str, int | str] = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
     response = api_client.get(api_routes.recipes, params=goodparams, headers=unique_user.token)
     assert response.status_code == 200
 
-    seed1_params = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
-    seed2_params = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "gfedcba"}
+    seed1_params: dict[str, int | str] = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "abcdefg"}
+    seed2_params: dict[str, int | str] = {"page": 1, "perPage": -1, "orderBy": "random", "paginationSeed": "gfedcba"}
     data1 = api_client.get(api_routes.recipes, params=seed1_params, headers=unique_user.token).json()
     data2 = api_client.get(api_routes.recipes, params=seed2_params, headers=unique_user.token).json()
     data1_new = api_client.get(api_routes.recipes, params=seed1_params, headers=unique_user.token).json()
     assert data1["items"][0]["slug"] != data2["items"][0]["slug"]  # new seed -> new order
     assert data1["items"][0]["slug"] == data1_new["items"][0]["slug"]  # same seed -> same order
 
-    badparams = {"page": 1, "perPage": -1, "orderBy": "random"}
+    badparams: dict[str, int | str] = {"page": 1, "perPage": -1, "orderBy": "random"}
     response = api_client.get(api_routes.recipes, params=badparams, headers=unique_user.token)
     assert response.status_code == 422

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -200,6 +200,13 @@ def test_recipe_repo_pagination_by_categories(database: AllRepositories, unique_
         for category in created_categories:
             assert category.id in category_ids
 
+    # Test random ordering with category filter
+    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    random_ordered = []
+    for i in range(5):
+        random_ordered.append(database.recipes.page_all(pagination_query, categories=[category_slug]).items)
+    assert not all(i == random_ordered[0] for i in random_ordered)
+
 
 def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: TestUser):
     slug1, slug2 = (random_string(10) for _ in range(2))
@@ -278,6 +285,13 @@ def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: 
         tag_ids = [tag.id for tag in recipe_summary.tags]
         for tag in created_tags:
             assert tag.id in tag_ids
+
+    # Test random ordering with tag filter
+    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    random_ordered = []
+    for i in range(5):
+        random_ordered.append(database.recipes.page_all(pagination_query, tags=[tag_slug]).items)
+    assert not all(i == random_ordered[0] for i in random_ordered)
 
 
 def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user: TestUser):
@@ -359,6 +373,13 @@ def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user:
         tool_ids = [tool.id for tool in recipe_summary.tools]
         for tool in created_tools:
             assert tool.id in tool_ids
+
+    # Test random ordering with tools filter
+    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    random_ordered = []
+    for i in range(5):
+        random_ordered.append(database.recipes.page_all(pagination_query, tools=[tool_id]).items)
+    assert not all(i == random_ordered[0] for i in random_ordered)
 
 
 def test_recipe_repo_pagination_by_foods(database: AllRepositories, unique_user: TestUser):
@@ -506,3 +527,10 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
     print([r.name for r in normalized_result])
     assert len(normalized_result) == 1
     assert normalized_result[0].name == "Rátàtôuile"
+
+    # Test random ordering with search
+    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    random_ordered = []
+    for i in range(5):
+        random_ordered.append(database.recipes.page_all(pagination_query, search="soup").items)
+    assert not all(i == random_ordered[0] for i in random_ordered)

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -291,6 +291,7 @@ def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: 
     random_ordered = []
     for i in range(5):
         random_ordered.append(database.recipes.page_all(pagination_query, tags=[tag_slug]).items)
+    assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
 
 
@@ -379,6 +380,7 @@ def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user:
     random_ordered = []
     for i in range(5):
         random_ordered.append(database.recipes.page_all(pagination_query, tools=[tool_id]).items)
+    assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
 
 

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -202,10 +202,16 @@ def test_recipe_repo_pagination_by_categories(database: AllRepositories, unique_
             assert category.id in category_ids
 
     # Test random ordering with category filter
-    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    pagination_query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="random",
+        pagination_seed=datetime.now().timestamp(),
+        order_direction=OrderDirection.asc,
+    )
     random_ordered = []
     for i in range(5):
-        pagination_query.timestamp = datetime.now().timestamp()
+        pagination_query.pagination_seed = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, categories=[category_slug]).items)
     assert not all(i == random_ordered[0] for i in random_ordered)
 
@@ -289,10 +295,16 @@ def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: 
             assert tag.id in tag_ids
 
     # Test random ordering with tag filter
-    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    pagination_query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="random",
+        pagination_seed=datetime.now().timestamp(),
+        order_direction=OrderDirection.asc,
+    )
     random_ordered = []
     for i in range(5):
-        pagination_query.timestamp = datetime.now().timestamp()
+        pagination_query.pagination_seed = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, tags=[tag_slug]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -382,7 +394,7 @@ def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user:
     pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
     random_ordered = []
     for i in range(5):
-        pagination_query.timestamp = datetime.now().timestamp()
+        pagination_query.pagination_seed = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, tools=[tool_id]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -457,10 +469,16 @@ def test_recipe_repo_pagination_by_foods(database: AllRepositories, unique_user:
 
     assert len(recipes_with_either_food) == 20
 
-    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    pagination_query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="random",
+        pagination_seed=datetime.now().timestamp(),
+        order_direction=OrderDirection.asc,
+    )
     random_ordered = []
     for i in range(5):
-        pagination_query.timestamp = datetime.now().timestamp()
+        pagination_query.pagination_seed = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, foods=[food_id]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -574,9 +592,15 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
     assert normalized_result[0].name == "Rátàtôuile"
 
     # Test random ordering with search
-    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    pagination_query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="random",
+        pagination_seed=datetime.now().timestamp(),
+        order_direction=OrderDirection.asc,
+    )
     random_ordered = []
     for i in range(5):
-        pagination_query.timestamp = datetime.now().timestamp()
+        pagination_query.pagination_seed = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, search="soup").items)
     assert not all(i == random_ordered[0] for i in random_ordered)

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -504,6 +504,37 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
             group_id=unique_user.group_id,
             name="Rátàtôuile",
         ),
+        # Add a bunch of recipes for stable randomization
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
+        Recipe(
+            user_id=unique_user.user_id,
+            group_id=unique_user.group_id,
+            name=f"{random_string(10)} soup",
+        ),
     ]
 
     for recipe in recipes:

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -610,7 +610,7 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
         fuzzy_result = database.recipes.page_all(pagination_query, search="Steinbuck").items
         assert len(fuzzy_result) == 1
         assert fuzzy_result[0].name == "Steinbock Sloop"
-    
+
     # Test random ordering with search
     pagination_query = PaginationQuery(
         page=1,

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import cast
 
 from mealie.repos.repository_factory import AllRepositories
@@ -204,6 +205,7 @@ def test_recipe_repo_pagination_by_categories(database: AllRepositories, unique_
     pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
     random_ordered = []
     for i in range(5):
+        pagination_query.timestamp = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, categories=[category_slug]).items)
     assert not all(i == random_ordered[0] for i in random_ordered)
 
@@ -290,6 +292,7 @@ def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: 
     pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
     random_ordered = []
     for i in range(5):
+        pagination_query.timestamp = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, tags=[tag_slug]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -379,6 +382,7 @@ def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user:
     pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
     random_ordered = []
     for i in range(5):
+        pagination_query.timestamp = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, tools=[tool_id]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -452,6 +456,14 @@ def test_recipe_repo_pagination_by_foods(database: AllRepositories, unique_user:
     ).items
 
     assert len(recipes_with_either_food) == 20
+
+    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    random_ordered = []
+    for i in range(5):
+        pagination_query.timestamp = datetime.now().timestamp()
+        random_ordered.append(database.recipes.page_all(pagination_query, foods=[food_id]).items)
+    assert len(random_ordered[0]) == 15
+    assert not all(i == random_ordered[0] for i in random_ordered)
 
 
 def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
@@ -534,5 +546,6 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
     pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
     random_ordered = []
     for i in range(5):
+        pagination_query.timestamp = datetime.now().timestamp()
         random_ordered.append(database.recipes.page_all(pagination_query, search="soup").items)
     assert not all(i == random_ordered[0] for i in random_ordered)

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -206,12 +206,12 @@ def test_recipe_repo_pagination_by_categories(database: AllRepositories, unique_
         page=1,
         per_page=-1,
         order_by="random",
-        pagination_seed=datetime.now().timestamp(),
+        pagination_seed=str(datetime.now()),
         order_direction=OrderDirection.asc,
     )
     random_ordered = []
     for i in range(5):
-        pagination_query.pagination_seed = datetime.now().timestamp()
+        pagination_query.pagination_seed = str(datetime.now())
         random_ordered.append(database.recipes.page_all(pagination_query, categories=[category_slug]).items)
     assert not all(i == random_ordered[0] for i in random_ordered)
 
@@ -299,12 +299,12 @@ def test_recipe_repo_pagination_by_tags(database: AllRepositories, unique_user: 
         page=1,
         per_page=-1,
         order_by="random",
-        pagination_seed=datetime.now().timestamp(),
+        pagination_seed=str(datetime.now()),
         order_direction=OrderDirection.asc,
     )
     random_ordered = []
     for i in range(5):
-        pagination_query.pagination_seed = datetime.now().timestamp()
+        pagination_query.pagination_seed = str(datetime.now())
         random_ordered.append(database.recipes.page_all(pagination_query, tags=[tag_slug]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -391,10 +391,16 @@ def test_recipe_repo_pagination_by_tools(database: AllRepositories, unique_user:
             assert tool.id in tool_ids
 
     # Test random ordering with tools filter
-    pagination_query = PaginationQuery(page=1, per_page=-1, order_by="random", order_direction=OrderDirection.asc)
+    pagination_query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="random",
+        pagination_seed=str(datetime.now()),
+        order_direction=OrderDirection.asc,
+    )
     random_ordered = []
     for i in range(5):
-        pagination_query.pagination_seed = datetime.now().timestamp()
+        pagination_query.pagination_seed = str(datetime.now())
         random_ordered.append(database.recipes.page_all(pagination_query, tools=[tool_id]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -473,12 +479,12 @@ def test_recipe_repo_pagination_by_foods(database: AllRepositories, unique_user:
         page=1,
         per_page=-1,
         order_by="random",
-        pagination_seed=datetime.now().timestamp(),
+        pagination_seed=str(datetime.now()),
         order_direction=OrderDirection.asc,
     )
     random_ordered = []
     for i in range(5):
-        pagination_query.pagination_seed = datetime.now().timestamp()
+        pagination_query.pagination_seed = str(datetime.now())
         random_ordered.append(database.recipes.page_all(pagination_query, foods=[food_id]).items)
     assert len(random_ordered[0]) == 15
     assert not all(i == random_ordered[0] for i in random_ordered)
@@ -596,11 +602,11 @@ def test_recipe_repo_search(database: AllRepositories, unique_user: TestUser):
         page=1,
         per_page=-1,
         order_by="random",
-        pagination_seed=datetime.now().timestamp(),
+        pagination_seed=str(datetime.now()),
         order_direction=OrderDirection.asc,
     )
     random_ordered = []
     for i in range(5):
-        pagination_query.pagination_seed = datetime.now().timestamp()
+        pagination_query.pagination_seed = str(datetime.now())
         random_ordered.append(database.recipes.page_all(pagination_query, search="soup").items)
     assert not all(i == random_ordered[0] for i in random_ordered)


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:
Often, recipe managers (and paper-and-ink cookbooks) are used as inspiration for what to cook. The various sort options on the landing page (nightly) are still relatively static, and offer views that do not change much over time. This is good when (for example) going back to something that one is about to make and has recently viewed. But not as useful when planning new things to make from a recipe collection. The current "Random" button is a step towards inspiration, but is awkward when scanning through multiple recipes looking for something to make.

This PR adds a new sorting option called "Random". Choosing this option pages (infinite scroll) through the database just like all the other sort options, but recipes are randomly ordered. Choosing Ascending/Descending order has little meaning here, but choosing these different orders re-randomizes the page. Navigating away from Random order (e.g. to Alphabetical) and then back also re-randomizes the page. Category/tag/search/etc filtering work as normal in Random view. The ordering is just random.

<img width="1312" alt="randomsort" src="https://user-images.githubusercontent.com/1985651/234390956-9543ca0a-53fa-40d7-83e9-0bafb47d6b53.png">


Implementing this involves just two tiny changes: a hook for the random sort type in repository_generic, and adding the random sort order to the index.vue.

## Which issue(s) this PR fixes:

Addresses #2307 

## Testing

All automated tests pass. I did extensive interactive testing via the frontend and really enjoyed scrolling through various random recipe sets.

## Release Notes

```Add Random sorting for landing page @jecorn
```
