### PR TITLE
Add failed login & IP to log

### DIFF
--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, Form, status
+from fastapi import APIRouter, Depends, Form, Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from sqlalchemy.orm.session import Session
 
-from mealie.core import security
+from mealie.core import root_logger, security
 from mealie.core.dependencies import get_current_user
 from mealie.core.security import authenticate_user
 from mealie.core.security.security import UserLockedOut
@@ -16,6 +16,7 @@ from mealie.schema.user import PrivateUser
 
 public_router = APIRouter(tags=["Users: Authentication"])
 user_router = UserAPIRouter(tags=["Users: Authentication"])
+logger = root_logger.get_logger("auth")
 
 
 class CustomOAuth2Form(OAuth2PasswordRequestForm):
@@ -48,16 +49,18 @@ class MealieAuthToken(BaseModel):
 
 
 @public_router.post("/token")
-def get_token(data: CustomOAuth2Form = Depends(), session: Session = Depends(generate_session)):
+def get_token(request: Request, data: CustomOAuth2Form = Depends(), session: Session = Depends(generate_session)):
     email = data.username
     password = data.password
 
     try:
         user = authenticate_user(session, email, password)  # type: ignore
     except UserLockedOut as e:
+        logger.error(f"User is locked out: {request.client.host}")
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="User is locked out") from e
 
     if not user:
+        logger.error(f"Incorrect username or password: {request.client.host}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
         )

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -56,11 +56,11 @@ def get_token(request: Request, data: CustomOAuth2Form = Depends(), session: Ses
     try:
         user = authenticate_user(session, email, password)  # type: ignore
     except UserLockedOut as e:
-        logger.error(f"User is locked out: {request.client.host}")
+        logger.error(f"User is locked out from {request.client.host}")
         raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="User is locked out") from e
 
     if not user:
-        logger.error(f"Incorrect username or password: {request.client.host}")
+        logger.error(f"Incorrect username or password from {request.client.host}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
         )


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Intrusion prevention software such as [fail2ban](https://www.fail2ban.org/wiki/index.php/Main_Page) scans log files based on user-provided regex and starts refusing connections from IP addresses that are failing too often. This protects against brute-force attacks. If you're running a reverse proxy or otherwise exposing a service to the big bad internet, brute force protection such as fail2ban is very highly recommended.

## Which issue(s) this PR fixes:

Fixes #2346 
Fixes #740 
(I was also considering putting mealie behind a reverse proxy, in which case I would also really want this feature)

## Special notes for your reviewer:

None

## Testing

I checked that the IP address of the client failing login was correctly detected from two different clients on my local network. However, I don't have a reverse proxy set up, so it's not possible for me to make sure that public IP addresses are correctly reported. However, this should work just fine with public IPs **so long as the user's reverse proxy is correctly configured to pass along client IPs and not the reverse proxy's IP**. I believe this is default of most reverse proxy, and is anyway out of our control (user land config).

All automated tests pass.

## Release Notes

```Add login failures to mealie.log, for use by intrusion prevention (e.g. fail2ban) @jecorn
```
