### PR TITLE
fix: Last Made not updating and timeline events not posting

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageTitleContent.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageTitleContent.vue
@@ -8,7 +8,7 @@
       <div v-if="user.id" class="pb-2 d-flex justify-center flex-wrap">
         <RecipeLastMade
           v-model="recipe.lastMade"
-          :recipe-slug="recipe.slug"
+          :recipe="recipe"
           class="d-flex justify-center flex-wrap"
           :class="true ? undefined : 'force-bottom'"
         />


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

When a recipe is in landscape view, the "I Made This" component isn't given the recipe, so it can't update it. This fixes the old prop reference.

All my recipes default to portrait so I never noticed, but I just made one of my old favorites imported from 0.5.6 that was still in landscape mode.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

I did a find all to see if there were any other instances of the same issue, but couldn't find any. Seems to just be this one.

## Testing

_(fill-in or delete this section)_

I added/edited/deleted some timeline events and it worked as expected.

## Release Notes

_(REQUIRED)_

```release-note
fixed a bug where the "I Made This" button doesn't update anything in some instances
```
