### PR TITLE
fix: navigating back after importing a recipe by file reimports

### DIFF
--- a/frontend/pages/recipe/create/url.vue
+++ b/frontend/pages/recipe/create/url.vue
@@ -69,8 +69,7 @@ import {
   ref,
   useRouter,
   computed,
-  useRoute,
-  onMounted,
+  useRoute
 } from "@nuxtjs/composition-api";
 import { AxiosResponse } from "axios";
 import { useUserApi } from "~/composables/api";
@@ -125,16 +124,6 @@ export default defineComponent({
       set(v: boolean) {
         router.replace({ query: { ...route.value.query, edit: v ? "1" : "0" } });
       },
-    });
-
-    onMounted(() => {
-      if (!recipeUrl.value) {
-        return;
-      }
-
-      if (recipeUrl.value.includes("https")) {
-        createByUrl(recipeUrl.value, importKeywordsAsTags.value, stayInEditMode.value);
-      }
     });
 
     const domUrlForm = ref<VForm | null>(null);


### PR DESCRIPTION

## What type of PR is this?
- bug

## What this PR does / why we need it:

Removes automatic import when navigating back to the previous page after importing a recipe by url
## Which issue(s) this PR fixes:

Fixes #2267 


## Testing
- Open the application and navigate to /recipe/create/url
- import a recipe by url
- press the back button
- the recipe should not be imported again 

then do the same with stay in edit mode enabled

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Fixed a bug where recipes were imported again when pressing the back button.
```
