### PR TITLE
Fix: Query Filter Date Comparisons Are Off By One Date

### DIFF
--- a/mealie/schema/response/query_filter.py
+++ b/mealie/schema/response/query_filter.py
@@ -177,7 +177,8 @@ class QueryFilterComponent:
 
             if isinstance(model_attr_type, sqltypes.Date | sqltypes.DateTime):
                 try:
-                    sanitized_values[i] = date_parser.parse(v)
+                    dt = date_parser.parse(v)
+                    sanitized_values[i] = dt.date() if isinstance(model_attr_type, sqltypes.Date) else dt
                 except ParserError as e:
                     raise ValueError(f"invalid query string: unknown date or datetime format '{v}'") from e
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The switch from building raw SQL queries to using the ORM in #2366 introduced an... interesting bug with dates. I'm not sure _exactly_ where the issue lies (is it sqlalchemy? is it sqlite? is it SQL?), but the gist lies in this logic:

`date >= 2023-05-11 00:00:00`
This evaluates to `False` for dates that are set to 2023-05-11

`date >= 2023-05-11`
This evaluates to `True` for dates that are set to 2023-05-11

So the obvious solution is just to validate that _date_ fields receive _dates_ and not _datetimes_ (which, to be fair, makes perfect sense).

## Which issue(s) this PR fixes:

_(REQUIRED)_

fixes #2388

## Special notes for your reviewer:

_(fill-in or delete this section)_

I'm not exactly sure why this breaks, because when we built SQL queries directly (before we started using the ORM to query) we still passed datetimes for date fields, but it worked for some reason? I don't know ¯\\\_(ツ)_/¯

Works now though!

## Testing

_(fill-in or delete this section)_

pytest ❤️

## Release Notes

_(REQUIRED)_
```release-note
fixed an issue where today's meal plans would not show up on the meal planner
```
