### PR TITLE
IP logging fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ ENV PYTHONUNBUFFERED=1 \
 # prepend poetry and venv to path
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 # RUN poetry config virtualenvs.create false
 
 RUN apt-get update \

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -71,6 +71,7 @@ ENV GIT_COMMIT_HASH=$COMMIT
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     gosu \
+    iproute2 \
     tesseract-ocr-all \
     libldap-2.4-2 \
     && apt-get autoremove \

--- a/docker/api.entry.sh
+++ b/docker/api.entry.sh
@@ -51,7 +51,7 @@ GUNICORN_PORT=${API_PORT:-9000}
 
 # Start API
 hostip=`/sbin/ip route|awk '/default/ { print $3 }'`
-if [ "$WEB_GUNICORN" == 'true' ]; then
+if [ "$WEB_GUNICORN" = 'true' ]; then
     echo "Starting Gunicorn"
     gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded-allow-ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload
 else

--- a/docker/api.entry.sh
+++ b/docker/api.entry.sh
@@ -50,10 +50,10 @@ init
 GUNICORN_PORT=${API_PORT:-9000}
 
 # Start API
-
+hostip=`/sbin/ip route|awk '/default/ { print $3 }'`
 if [ "$WEB_GUNICORN" == 'true' ]; then
     echo "Starting Gunicorn"
-    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload
+    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded-allow-ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload
 else
-    uvicorn mealie.app:app --host 0.0.0.0 --port $GUNICORN_PORT
+    uvicorn mealie.app:app --host 0.0.0.0 --forwarded-allow-ips=$hostip --port $GUNICORN_PORT
 fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,11 +64,10 @@ services:
 
       # =====================================
       # Web Concurrency
-      WEB_GUNICORN: "true"
+      WEB_GUNICORN: "false"
       WORKERS_PER_CORE: 0.5
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
-
       # =====================================
       # Email Configuration
       # SMTP_HOST=
@@ -79,13 +78,13 @@ services:
       # SMTP_USER=
       # SMTP_PASSWORD=
 
-  # postgres:
-  #   container_name: postgres
-  #   image: postgres
-  #   restart: always
-  #   environment:
-  #     POSTGRES_PASSWORD: mealie
-  #     POSTGRES_USER: mealie
+      # postgres:
+      #   container_name: postgres
+      #   image: postgres
+      #   restart: always
+      #   environment:
+      #     POSTGRES_PASSWORD: mealie
+      #     POSTGRES_USER: mealie
 
 volumes:
   mealie-data:

--- a/docker/omni.Dockerfile
+++ b/docker/omni.Dockerfile
@@ -94,6 +94,7 @@ ENV GIT_COMMIT_HASH=$COMMIT
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     gosu \
+    iproute2 \
     tesseract-ocr-all \
     curl \
     gnupg \

--- a/docker/omni.docker-compose.yml
+++ b/docker/omni.docker-compose.yml
@@ -26,11 +26,10 @@ services:
 
       # =====================================
       # Web Concurrency
-      WEB_GUNICORN: true
+      WEB_GUNICORN: "false"
       WORKERS_PER_CORE: 0.5
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
-
       # =====================================
       # Email Configuration
       # SMTP_HOST=

--- a/docker/omni.entry.sh
+++ b/docker/omni.entry.sh
@@ -47,11 +47,12 @@ GUNICORN_PORT=${API_PORT:-9000}
 
 # Start API
 
+hostip = `/sbin/ip route|awk '/default/ { print $3 }'`
 if [ "$WEB_GUNICORN" == 'true' ]; then
     echo "Starting Gunicorn"
-    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload &
+    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded_allow_ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload &
 else
-    uvicorn mealie.app:app --host 0.0.0.0 --port $GUNICORN_PORT &
+    uvicorn mealie.app:app --host 0.0.0.0 --forwarded_allow_ips=$hostip --port $GUNICORN_PORT &
 fi
 
 # ------------------------------

--- a/docker/omni.entry.sh
+++ b/docker/omni.entry.sh
@@ -50,9 +50,9 @@ GUNICORN_PORT=${API_PORT:-9000}
 hostip = `/sbin/ip route|awk '/default/ { print $3 }'`
 if [ "$WEB_GUNICORN" == 'true' ]; then
     echo "Starting Gunicorn"
-    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded_allow_ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload &
+    gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded-allow-ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload &
 else
-    uvicorn mealie.app:app --host 0.0.0.0 --forwarded_allow_ips=$hostip --port $GUNICORN_PORT &
+    uvicorn mealie.app:app --host 0.0.0.0 --forwarded-allow-ips=$hostip --port $GUNICORN_PORT &
 fi
 
 # ------------------------------

--- a/docker/omni.entry.sh
+++ b/docker/omni.entry.sh
@@ -46,9 +46,8 @@ init
 GUNICORN_PORT=${API_PORT:-9000}
 
 # Start API
-
-hostip = `/sbin/ip route|awk '/default/ { print $3 }'`
-if [ "$WEB_GUNICORN" == 'true' ]; then
+hostip=`/sbin/ip route|awk '/default/ { print $3 }'`
+if [ "$WEB_GUNICORN" = 'true' ]; then
     echo "Starting Gunicorn"
     gunicorn mealie.app:app -b 0.0.0.0:$GUNICORN_PORT --forwarded-allow-ips=$hostip -k uvicorn.workers.UvicornWorker -c /app/gunicorn_conf.py --preload &
 else

--- a/docs/docs/documentation/getting-started/faq.md
+++ b/docs/docs/documentation/getting-started/faq.md
@@ -132,6 +132,15 @@ stateDiagram-v2
   p3 --> n1: No
 ```
 
+## Can I use fail2ban with mealie?
+Yes, mealie is configured to properly forward external IP addresses into the `mealie.log` logfile. Note that, due to restrictions in docker, IP address forwarding only works on linux.
+
+Your fail2ban usage should look like the following:
+```
+Use      datepattern : %d-%b-%y %H:%M:%S : Day-MON-Year2 24hour:Minute:Second
+Use   failregex line : ^ERROR:\s+Incorrect username or password from <HOST>
+```
+
 ## Why An API?
 An API allows integration into applications like [Home Assistant](https://www.home-assistant.io/) that can act as notification engines to provide custom notifications based of Meal Plan data to remind you to defrost the chicken, marinade the steak, or start the CrockPot. Additionally, you can access nearly any backend service via the API giving you total control to extend the application. To explore the API spin up your server and navigate to http://yourserver.com/docs for interactive API documentation.
 

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -295,10 +295,12 @@ export default {
       },
       changeOrigin: true,
       target: process.env.API_URL || "http://localhost:9000",
+      xfwd: true,
     },
     "/api": {
       changeOrigin: true,
       target: process.env.API_URL || "http://localhost:9000",
+      xfwd: true,
     },
   },
 

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -54,6 +54,8 @@ def get_token(request: Request, data: CustomOAuth2Form = Depends(), session: Ses
     password = data.password
     if "x-forwarded-for" in request.headers:
         ip = request.headers["x-forwarded-for"]
+        if "," in ip:  # if there are multiple IPs, the first one is canonically the true client
+            ip = str(ip.split(",")[0])
     else:
         ip = request.client.host
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

IP addresses were logged in mealie.log, but the front and backend weren't correctly set up to get the real IP address through the docker gateway.

## Which issue(s) this PR fixes:

Fixes #2407
Fixes a poetry breaking 404 error in the dev container that was already fixed in the production containers https://github.com/python-poetry/poetry/issues/6676
Fixes a bash bug in the docker entry scripts that prevented gunicorn from ever running, sets WEB_UNICORN in the front/backend and omni docker-compose files to false (per docs).


## Special notes for your reviewer:

`auth.py` checks for the existence of an x-forwarded-for header because caddy and gunicorn/uvicorn handle IP address forwarding differently. gunicorn/uvicorn reset the apparent client IP based on what they find in a trusted x-forwarding-for header and then don't seem to pass along x-forwarded-for. Caddy passes along x-forwarded-for without resetting the client IP. Also, it seemed safer to take a trusted x-forwarded-for header if it exists and fall back to the apparent IP if not.

gunicorn/uvucorn are now set up to only trust IP forwarding headers from the gateway in the default route. Which is the docker host if inside a container. This setting could be opened up more if it ends up being too restrictive. But the option allows only individual IPs or completely open.

The x-forwarded-for header needs to be set by the outer-most proxy. **Both** Caddy and nuxt are set up to proxy, with Caddy outward-facing for the split front/backend image and nuxt outward-facing for the omni image (no Caddy in omni). So x-forward headers need to be set by both Caddy and nuxt, then auth.py takes the canonically true client per the x-forward-for standard.

All of the above only works on linux, since Mac/Windows docker don't correctly pass real IPs (see message thread on Discord)

## Testing

Passes all automated tests.
I built production docker images (both separated front/backend and omni) then manually tested finding the correct IP both through frontend authentication and backend authentication when coming in to these containers from a different IP. 

## Release Notes

```
Correctly forward external IP into docker container for logging
Respect gunicorn vs unicorn setting in docker compose files
```
