### PR TITLE
(docs): re-add and fix the bookmarklet instructions to docs

### DIFF
--- a/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
+++ b/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
@@ -1,0 +1,18 @@
+<!-- prettier-ignore -->
+!!! info
+    This guide was submitted by a community member. Find something wrong? Submit a PR to get it fixed!
+
+You can use bookmarklets to generate a bookmark that will take your current location, and open a new tab that will try to import that URL into Mealie.
+
+You can use a [bookmarklet generator site](https://caiorss.github.io/bookmarklet-maker/) and the code below to generate a bookmark for your site. Just change the `http://localhost:8080` to your sites web address and follow the instructions.
+
+<!-- prettier-ignore -->
+!!! note
+    There is no trailing `/` at the end of the url!
+
+```js
+var url = document.URL;
+var mealie = "http://localhost:8080";
+var dest = mealie + "/recipe/create/url?recipe_import_url=" + url;
+window.open(dest, "_blank");
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - Reverse Proxy (SWAG): "documentation/community-guide/swag.md"
           - Home Assistant: "documentation/community-guide/home-assistant.md"
           - Bulk Url Import: "documentation/community-guide/bulk-url-import.md"
+          - Import Bookmarklet: "documentation/community-guide/import-recipe-bookmarklet.md"
 
   - API Reference: "api/redoc.md"
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- documentation

## What this PR does / why we need it:

Adds back in the information about creating a bookmarklet and fixes the URL to reflect changes made in v1.x

## Which issue(s) this PR fixes:

fixes #2266

## Testing

Tested out the bookmarklet manually

## Release Notes

```release-note
added community guide on importing via bookmarklets
```
