### PR TITLE
Fix omni docker image

### DIFF
--- a/docker/omni.Dockerfile
+++ b/docker/omni.Dockerfile
@@ -102,13 +102,16 @@ RUN apt-get update \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -y curl \
-    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs \
-    && curl -L https://www.npmjs.com/install.sh | sh
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y nodejs
 
 # Add Yarn
-RUN npm install -g yarn
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install yarn
+
+# Clean apt
+RUN apt-get autoremove && rm -rf /var/lib/apt/lists/*
 
 # copying poetry and venv into image
 COPY --from=builder-base $POETRY_HOME $POETRY_HOME


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the nightly build for omni docker... for some reason it was working the other day when I opened #2429, but today it wasn't...
Anyways, seems like installing npm was the issue, and since we use yarn anyways, I thought it was better to just install it directly as shown in the output from installing node.

## Which issue(s) this PR fixes:

N/A

## Release Notes

```release-note
NONE
```
