### PR TITLE
Fix: Missing Paprika and Nextcloud Migration Data

### DIFF
--- a/mealie/services/migrations/nextcloud.py
+++ b/mealie/services/migrations/nextcloud.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import zipfile
 from dataclasses import dataclass
@@ -43,7 +44,10 @@ class NextcloudMigrator(BaseMigrator):
 
         self.key_aliases = [
             MigrationAlias(key="tags", alias="keywords", func=split_by_comma),
-            MigrationAlias(key="org_url", alias="url", func=None),
+            MigrationAlias(key="orgURL", alias="url", func=None),
+            MigrationAlias(key="totalTime", alias="totalTime", func=parse_time),
+            MigrationAlias(key="prepTime", alias="prepTime", func=parse_time),
+            MigrationAlias(key="performTime", alias="cookTime", func=parse_time),
         ]
 
     def _migrate(self) -> None:
@@ -69,3 +73,27 @@ class NextcloudMigrator(BaseMigrator):
                     nc_dir = nextcloud_dirs[slug]
                     if nc_dir.image:
                         import_image(nc_dir.image, recipe_id)
+
+
+def parse_time(time: str) -> str:
+    """Parses a Nextcloud time string in the format 'PT{hours}H{minutes}M{seconds}S'"""
+
+    # TODO: make singular and plural translatable
+    hours = {"singular": "hour", "plural": "hours", "exp": r"\d+(?=H)"}
+    minutes = {"singular": "minute", "plural": "minutes", "exp": r"\d+(?=M)"}
+    seconds = {"singular": "second", "plural": "seconds", "exp": r"\d+(?=S)"}
+
+    try:
+        return_strings: list[str] = []
+        for time_part in [hours, minutes, seconds]:
+            val_search = re.search(time_part["exp"], time)
+            if not val_search:
+                continue
+            val = val_search.group()
+            if val == "0":
+                continue
+            return_strings.append(f'{val} {time_part["singular"] if val == "1" else time_part["plural"]}')
+
+        return " ".join(return_strings)
+    except Exception:
+        return ""

--- a/mealie/services/migrations/nextcloud.py
+++ b/mealie/services/migrations/nextcloud.py
@@ -83,17 +83,14 @@ def parse_time(time: str) -> str:
     minutes = {"singular": "minute", "plural": "minutes", "exp": r"\d+(?=M)"}
     seconds = {"singular": "second", "plural": "seconds", "exp": r"\d+(?=S)"}
 
-    try:
-        return_strings: list[str] = []
-        for time_part in [hours, minutes, seconds]:
-            val_search = re.search(time_part["exp"], time)
-            if not val_search:
-                continue
-            val = val_search.group()
-            if val == "0":
-                continue
-            return_strings.append(f'{val} {time_part["singular"] if val == "1" else time_part["plural"]}')
+    return_strings: list[str] = []
+    for time_part in [hours, minutes, seconds]:
+        val_search = re.search(time_part["exp"], time)
+        if not val_search:
+            continue
+        val = val_search.group()
+        if val == "0":
+            continue
+        return_strings.append(f'{val} {time_part["singular"] if val == "1" else time_part["plural"]}')
 
-        return " ".join(return_strings)
-    except Exception:
-        return ""
+    return " ".join(return_strings) if return_strings else time

--- a/mealie/services/migrations/paprika.py
+++ b/mealie/services/migrations/paprika.py
@@ -39,7 +39,7 @@ class PaprikaMigrator(BaseMigrator):
 
         self.key_aliases = [
             MigrationAlias(key="recipeIngredient", alias="ingredients", func=lambda x: x.split("\n")),
-            MigrationAlias(key="orgUrl", alias="source_url", func=None),
+            MigrationAlias(key="orgURL", alias="source_url", func=None),
             MigrationAlias(key="performTime", alias="cook_time", func=None),
             MigrationAlias(key="recipeYield", alias="servings", func=None),
             MigrationAlias(key="image", alias="image_url", func=None),

--- a/mealie/services/migrations/paprika.py
+++ b/mealie/services/migrations/paprika.py
@@ -44,6 +44,9 @@ class PaprikaMigrator(BaseMigrator):
             MigrationAlias(key="prepTime", alias="prep_time", func=None),
             MigrationAlias(key="performTime", alias="cook_time", func=None),
             MigrationAlias(key="recipeYield", alias="servings", func=None),
+            MigrationAlias(
+                key="tags", alias="categories", func=None
+            ),  # Paprika doesn't support tags, and instead puts tags in categories
             MigrationAlias(key="image", alias="image_url", func=None),
             MigrationAlias(key="dateAdded", alias="created", func=lambda x: x[: x.find(" ")]),
             MigrationAlias(

--- a/mealie/services/migrations/paprika.py
+++ b/mealie/services/migrations/paprika.py
@@ -40,6 +40,8 @@ class PaprikaMigrator(BaseMigrator):
         self.key_aliases = [
             MigrationAlias(key="recipeIngredient", alias="ingredients", func=lambda x: x.split("\n")),
             MigrationAlias(key="orgURL", alias="source_url", func=None),
+            MigrationAlias(key="totalTime", alias="total_time", func=None),
+            MigrationAlias(key="prepTime", alias="prep_time", func=None),
             MigrationAlias(key="performTime", alias="cook_time", func=None),
             MigrationAlias(key="recipeYield", alias="servings", func=None),
             MigrationAlias(key="image", alias="image_url", func=None),


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug
- feature

## What this PR does / why we need it:

_(REQUIRED)_

Makes some modifications to the Paprika and Nextcloud migrations to fix some data issues and add a few missing ones.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #2427

## Special notes for your reviewer:

_(fill-in or delete this section)_

Per the discussion on #2427 I mapped Paprika categories to tags, since it seems it's mostly used for that purpose (similar to [CopyMeThat](https://github.com/hay-kot/mealie/pull/2212)). On that discussion we also floated the possibility of importing Tandoor exports directly, but if I work on that it'll be a separate PR.

## Testing

_(fill-in or delete this section)_

Manual testing of a bunch of exports provided in #2427.

## Release Notes

_(REQUIRED)_

```release-note
improved migrations from Paprika and Nextcloud
```
