### PR TITLE
Prevent All Changes To Default User In Demo Mode

### DIFF
--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -113,6 +113,10 @@ class UserOut(UserBase):
 
         getter_dict = UserGetterDict
 
+    @property
+    def is_default_user(self) -> bool:
+        return self.email == settings.DEFAULT_EMAIL.strip().lower()
+
     @classmethod
     def loader_options(cls) -> list[LoaderOption]:
         return [joinedload(User.group), joinedload(User.favorite_recipes), joinedload(User.tokens)]


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

If the `IS_DEMO` env var is set, all changes to the default user don't go through. The user service still returns the "updated" user, they just aren't actually updated.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Probably 50% of discord messages.

## Testing

_(fill-in or delete this section)_

Tested manually using `export IS_DEMO=true && make backend`

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
