### PR TITLE
Chore: Rename Omni Build Action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "🚀  A New build of mealie:api-nightly and mealie:frontend-nightly is available"
+          args: "🚀  New builds of mealie:api-nightly, mealie:frontend-nightly, and mealie:omni-nightly are available"
 
   deploy-demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/partial-builder.yml
+++ b/.github/workflows/partial-builder.yml
@@ -84,7 +84,7 @@ jobs:
 
   build-omni:
     runs-on: ubuntu-latest
-    name: Build Backend
+    name: Build Omni
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

I noticed Omni wasn't mentioned in Discord:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/031696cc-ded7-4929-bf2f-0911945c3f4a)

And wondered if it was a separate workflow that failed. Then I noticed this in GitHub actions:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/3b9bdcf5-6a71-4720-9938-e703965cc0d4)

It's building fine, it's just a typo. I also added Omni to the Discord notification for clarification.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
