### PR TITLE
Fix: Tandoor doesn't import all images

### DIFF
--- a/mealie/services/migrations/tandoor.py
+++ b/mealie/services/migrations/tandoor.py
@@ -123,8 +123,8 @@ class TandoorMigrator(BaseMigrator):
                     recipe_source_dir = Path(recipe_dir)
                     try:
                         recipe_json_path = next(recipe_source_dir.glob("*.json"))
-                    except StopIteration:
-                        raise Exception("recipe.json not found")
+                    except StopIteration as e:
+                        raise Exception("recipe.json not found") from e
 
                     with open(recipe_json_path) as f:
                         recipes_as_dicts.append(self._process_recipe_document(recipe_source_dir, json.load(f)))

--- a/mealie/services/migrations/tandoor.py
+++ b/mealie/services/migrations/tandoor.py
@@ -97,7 +97,11 @@ class TandoorMigrator(BaseMigrator):
         if serving_size and serving_text:
             recipe_data["recipeYield"] = f"{serving_size} {serving_text}"
 
-        recipe_data["image"] = str(source_dir.joinpath("image.jpeg"))
+        try:
+            recipe_image_path = next(source_dir.glob("image.*"))
+            recipe_data["image"] = str(recipe_image_path)
+        except StopIteration:
+            pass
         return recipe_data
 
     def _migrate(self) -> None:
@@ -117,7 +121,11 @@ class TandoorMigrator(BaseMigrator):
                         recipe_zip.extractall(recipe_dir)
 
                     recipe_source_dir = Path(recipe_dir)
-                    recipe_json_path = recipe_source_dir.joinpath("recipe.json")
+                    try:
+                        recipe_json_path = next(recipe_source_dir.glob("*.json"))
+                    except StopIteration:
+                        raise Exception("recipe.json not found")
+
                     with open(recipe_json_path) as f:
                         recipes_as_dicts.append(self._process_recipe_document(recipe_source_dir, json.load(f)))
 

--- a/mealie/services/migrations/utils/migration_helpers.py
+++ b/mealie/services/migrations/utils/migration_helpers.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import yaml
+from PIL import UnidentifiedImageError
 from pydantic import UUID4
 
 from mealie.services.recipe.recipe_data_service import RecipeDataService
@@ -94,4 +95,8 @@ def import_image(src: str | Path, recipe_id: UUID4):
         return
 
     data_service = RecipeDataService(recipe_id=recipe_id)
-    data_service.write_image(src, src.suffix)
+
+    try:
+        data_service.write_image(src, src.suffix)
+    except UnidentifiedImageError:
+        return


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

When migrating from Tandoor, I assumed in https://github.com/mealie-recipes/mealie/pull/2438 that all image files had the `jpeg` extension. Turns out that was a bad assumption.

This PR uses a glob to look for images properly (I also changed the recipe json file logic just in case that's not consistent, but it probably is).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2486

## Testing

_(fill-in or delete this section)_

I tested using the data in https://github.com/mealie-recipes/mealie/issues/2486 and it works now.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
fixed Tandoor migrations not importing all images correctly
```
