### PR TITLE
fix(deps): update dependency recipe-scrapers to v14.42.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2098,13 +2098,13 @@ tests = ["html5lib", "pytest", "pytest-cov"]
 
 [[package]]
 name = "recipe-scrapers"
-version = "14.36.0"
+version = "14.42.0"
 description = "Python package, scraping recipes from all over the internet"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "recipe_scrapers-14.36.0-py3-none-any.whl", hash = "sha256:2ab9a085e914905e8d78d5f494f34ec42d8a0b6fc70b10905dcffa8f2af1a1fc"},
-    {file = "recipe_scrapers-14.36.0.tar.gz", hash = "sha256:8153f4fd56d62cb7c3205ee2ff8558aa49c9a1686a49000a75b45a743bbb7f33"},
+    {file = "recipe_scrapers-14.42.0-py3-none-any.whl", hash = "sha256:02704e423fcb0219a62ae2e3500eede5050d7a7ceada0e41b96df107bb93a523"},
+    {file = "recipe_scrapers-14.42.0.tar.gz", hash = "sha256:8e82dec359460d3ce3b721d86064f81b3cddbc2af90530384b42b5a85263f4e7"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

Dependency update

<!--
  Delete any of the following that do not apply:
 -->

- deps

## What this PR does / why we need it:

Updates the recipe-scrapers dependency to a newer version which adds support for Ingredient Groups

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

None

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Updated the recipe scraper library to a newer version which adds support for Ingredient Groups
```
Changelong since v14.36.0:

https://github.com/hhursev/recipe-scrapers/releases

```
[14.42.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.42.0) [Latest](https://github.com/hhursev/recipe-scrapers/releases/latest)

https://github.com/hhursev/recipe-scrapers/pull/781, added in 14.41.0, are now available for:

    HalfBakedHarvest (https://github.com/hhursev/recipe-scrapers/pull/803)
    NYTimes (https://github.com/hhursev/recipe-scrapers/pull/803)
    Tesco (https://github.com/hhursev/recipe-scrapers/pull/805)

In addition, we have a few more domain-tailored scrapers:

    saltpepperskillet.com (https://github.com/hhursev/recipe-scrapers/pull/801)
    wellplated.com (https://github.com/hhursev/recipe-scrapers/pull/794)
    insanelygoodrecipes.com (https://github.com/hhursev/recipe-scrapers/pull/800)
    staysnatched.com (https://github.com/hhursev/recipe-scrapers/pull/802)
    foodfidelity.com (https://github.com/hhursev/recipe-scrapers/pull/804)
    persnicketyplates.com (https://github.com/hhursev/recipe-scrapers/pull/806)


[14.41.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.41.0)

    Adds support for https://github.com/hhursev/recipe-scrapers/issues/301 to the library (https://github.com/hhursev/recipe-scrapers/pull/781)
    Multiple schema-based scrapers added
        Vegetarbloggen (https://github.com/hhursev/recipe-scrapers/issues/790)
        The Recipe Critic (https://github.com/hhursev/recipe-scrapers/pull/789)
        Kochbucher (https://github.com/hhursev/recipe-scrapers/pull/792)
        Ministry of Curry (https://github.com/hhursev/recipe-scrapers/pull/795)
        Izzycooking (https://github.com/hhursev/recipe-scrapers/pull/796)
        Blue Jean Chef (https://github.com/hhursev/recipe-scrapers/pull/797)
        Madsvin (https://github.com/hhursev/recipe-scrapers/issues/780)
        The Modern Proper (https://github.com/hhursev/recipe-scrapers/pull/793)
        The Kitchen Community (https://github.com/hhursev/recipe-scrapers/pull/798)

[14.40.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.40.0)

    Add support for chefsavvy.com (https://github.com/hhursev/recipe-scrapers/pull/785)
    Add support for ricetta.it (https://github.com/hhursev/recipe-scrapers/pull/786)

[14.39.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.39.0)

    Adds support for TheExpertGuides.com (https://github.com/hhursev/recipe-scrapers/pull/783)

[14.38.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.38.0)

    Adds support for [http://nibbledish.com](http://nibbledish.com/soon-dubu-chigae/)
    hellofresh update. Previous workaround for recipes yielding 1 portion not needed now
    Fix lxml problems with unittests in MacOS

[14.37.0](https://github.com/hhursev/recipe-scrapers/releases/tag/14.37.0)

    Add support for [https://reciperunner.com/](https://www.reciperunner.com/)
```