### PR TITLE
Fix: Missing RecipeList Import

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -110,7 +110,7 @@ interface actions {
 }
 
 export default defineComponent({
-  components: { ShoppingListItemEditor, MultiPurposeLabel, RecipeIngredientListItem },
+  components: { ShoppingListItemEditor, MultiPurposeLabel, RecipeList, RecipeIngredientListItem },
   props: {
     value: {
       type: Object as () => ShoppingListItemOut,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

I can't figure out where, but one of the merges broke the new shopping list item recipe ref component due to dropping the `RecipeList` dependency. This fixes it

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
