### PR TITLE
Fix: Change Logic for disableAmount in Shopping List Items

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -13,7 +13,7 @@
         >
           <template #label>
             <div :class="listItem.checked ? 'strike-through' : ''">
-              <RecipeIngredientListItem :ingredient="listItem" :disable-amount="!(listItem.quantity && (listItem.isFood || listItem.quantity !== 1))" />
+              <RecipeIngredientListItem :ingredient="listItem" :disable-amount="!(listItem.isFood || listItem.quantity !== 1)" />
             </div>
           </template>
         </v-checkbox>


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

With the new changes in https://github.com/mealie-recipes/mealie/pull/2502, if a shopping list item is added to your shopping list and contains a food with zero quantity, `disableAmount` is flagged and the item comes across blank:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/991bb647-4b75-46cc-96b1-5e74d5aae53b)
![image](https://github.com/mealie-recipes/mealie/assets/71845777/d9402d73-745a-4402-bdf2-4a3ed448f54b)

This PR updates the logic for this edgecase:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/17ba3299-90e3-4744-aa5c-df2ea3b2abb3)

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

I tested these scenarios (just to be thorough) and they behave as expected:
- item with food, note, and 0 qty
- item with food, note, and 1 qty
- item with food, note, and 2 qty
- item with food, no note, and 0 qty
- item with food, no note, and 1 qty
- item with food, no note, and 2 qty
- item with no food, note, and 0 qty
- item with no food, note, and 1 qty
- item with no food, note, and 2 qty



## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
fixed shopping list item display issue when a food with no quantity is added
```
