### PR TITLE
fix: ingredient item should be single-line

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeIngredientListItem.vue
+++ b/frontend/components/Domain/Recipe/RecipeIngredientListItem.vue
@@ -37,7 +37,7 @@ export default defineComponent({
   },
 });
 </script>
-<style>
+<style lang="scss">
 .ingredient-item {
   .d-inline {
     & > p {


### PR DESCRIPTION

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

The component introduced in #2502 uses nested css, but did not have `lang="scss"` enabled. Because of this the styling did not apply. This is an issue on non-chromium browsers. I guess Chromium has some sort of support for nested CSS, whereas other browsers don't.


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

None

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Testing

Tested on chromium and firefox.

## Release Notes


```release-note
Fixes ingredient items not being styled on non-chromium browsers.
```
