### PR TITLE
fix: Removed HTML Tags When Copying Recipe Ingredients

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeIngredients.vue
+++ b/frontend/components/Domain/Recipe/RecipeIngredients.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     const ingredientCopyText = computed(() => {
       return props.value
         .map((ingredient) => {
-          return `${parseIngredientText(ingredient, props.disableAmount, props.scale)}`;
+          return `${parseIngredientText(ingredient, props.disableAmount, props.scale, false)}`;
         })
         .join("\n");
     });

--- a/frontend/composables/recipes/use-recipe-ingredients.test.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.test.ts
@@ -31,7 +31,16 @@ describe(parseIngredientText.name, () => {
   test("ingredient text with fraction", () => {
     const ingredient = createRecipeIngredient({ quantity: 1.5, unit: { fraction: true, id: "1", name: "cup" } });
 
-    expect(parseIngredientText(ingredient, false)).contain("1 <sup>1</sup>").and.to.contain("<sub>2</sub>");
+    expect(parseIngredientText(ingredient, false, 1, true)).contain("1 <sup>1</sup>").and.to.contain("<sub>2</sub>");
+  });
+
+  test("ingredient text with fraction no formatting", () => {
+    const ingredient = createRecipeIngredient({ quantity: 1.5, unit: { fraction: true, id: "1", name: "cup" } });
+    const result = parseIngredientText(ingredient, false, 1, false);
+
+    expect(result).not.contain("<");
+    expect(result).not.contain(">");
+    expect(result).contain("1 1/2");
   });
 
   test("sanitizes html", () => {

--- a/frontend/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.ts
@@ -10,7 +10,7 @@ function sanitizeIngredientHTML(rawHtml: string) {
   });
 }
 
-export function useParsedIngredientText(ingredient: RecipeIngredient, disableAmount: boolean, scale = 1) {
+export function useParsedIngredientText(ingredient: RecipeIngredient, disableAmount: boolean, scale = 1, includeFormating = true) {
   if (disableAmount) {
     return {
       name: ingredient.note ? sanitizeIngredientHTML(ingredient.note) : undefined,
@@ -35,7 +35,9 @@ export function useParsedIngredientText(ingredient: RecipeIngredient, disableAmo
       }
 
       if (fraction[1] > 0) {
-        returnQty += ` <sup>${fraction[1]}</sup>&frasl;<sub>${fraction[2]}</sub>`;
+        returnQty += includeFormating ?
+          ` <sup>${fraction[1]}</sup>&frasl;<sub>${fraction[2]}</sub>` :
+          ` ${fraction[1]}/${fraction[2]}`;
       }
     } else {
       returnQty = (quantity * scale).toString();
@@ -54,8 +56,8 @@ export function useParsedIngredientText(ingredient: RecipeIngredient, disableAmo
   };
 }
 
-export function parseIngredientText(ingredient: RecipeIngredient, disableAmount: boolean, scale = 1): string {
-  const { quantity, unit, name, note } = useParsedIngredientText(ingredient, disableAmount, scale);
+export function parseIngredientText(ingredient: RecipeIngredient, disableAmount: boolean, scale = 1, includeFormating = true): string {
+  const { quantity, unit, name, note } = useParsedIngredientText(ingredient, disableAmount, scale, includeFormating);
 
   const text = `${quantity || ""} ${unit || ""} ${name || ""} ${note || ""}`.replace(/ {2,}/g, " ").trim();
   return sanitizeIngredientHTML(text);


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

When copying recipe ingredients, it includes HTML tags, which is almost never desired (usually you're copying to a text document or similar):
```
1 tsp Italian seasoning
<sup>1</sup>⁄<sub>4</sub> tsp red pepper flakes crushed
salt to taste
14 <sup>1</sup>⁄<sub>2</sub> oz chicken broth
14 <sup>1</sup>⁄<sub>2</sub> oz chopped tomatoes
8 oz tomato sauce
<sup>1</sup>⁄<sub>2</sub> cup ditalini pasta uncooked (any small pasta works, such as spinach pasta)
```

This PR adds the `includeFormating` param to `useParsedIngredientText` so we can switch to plain text:
```
1 tsp Italian seasoning
1/4 tsp red pepper flakes crushed
salt to taste
14 1/2 oz chicken broth
14 1/2 oz chopped tomatoes
8 oz tomato sauce
1/2 cup ditalini pasta uncooked (any small pasta works, such as spinach pasta)
```


## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2531

## Testing

_(fill-in or delete this section)_

Added a test for this.

## Release Notes

_(REQUIRED)_

```release-note
removed HTML tags when copying recipe ingredients from the recipe page
```
