### PR TITLE
use score_cutoff for fuzzy string matching

### DIFF
--- a/mealie/services/parser_services/ingredient_parser.py
+++ b/mealie/services/parser_services/ingredient_parser.py
@@ -96,15 +96,13 @@ class ABCIngredientParser(ABC):
             return store_map[match_value]
 
         # fuzzy match against food store
-        fuzz_result = process.extractOne(match_value, store_map.keys(), scorer=fuzz.ratio)
+        fuzz_result = process.extractOne(
+            match_value, store_map.keys(), scorer=fuzz.ratio, score_cutoff=fuzzy_match_threshold
+        )
         if fuzz_result is None:
             return None
 
-        choice, score, _ = fuzz_result
-        if score < fuzzy_match_threshold:
-            return None
-        else:
-            return store_map[choice]
+        return store_map[fuzz_result[0]]
 
     def find_food_match(self, food: IngredientFood | CreateIngredientFood) -> IngredientFood | None:
         if isinstance(food, IngredientFood):


### PR DESCRIPTION
## What this PR does / why we need it:

Use `score_cutoff` parameter instead of manually performing the check afterwards. This requires less code and is potentially faster. The library is able to perform some optimizations based on the `score_cutoff` / currently best score.

## Special notes for your reviewer:

It's cool to see my library being of use to mealie. I am personally using mealie for quite a while already :)
