### PR TITLE
fix: CSS rendering bug, again

### DIFF
--- a/frontend/plugins/dark-mode.client.ts
+++ b/frontend/plugins/dark-mode.client.ts
@@ -8,7 +8,6 @@ const darkModePlugin: Plugin = ({ $vuetify }, _) => {
   // Adding a 100 millisecond delay fixes this problem
   // https://stackoverflow.com/questions/69399797/vuetify-darkmode-colors-wrong-after-page-reload
   setTimeout(() => { $vuetify.theme.dark = isDark.value; }, 100);
-  console.log("timeout set!");
 };
 
 export default darkModePlugin;

--- a/frontend/plugins/dark-mode.client.ts
+++ b/frontend/plugins/dark-mode.client.ts
@@ -5,9 +5,10 @@ const darkModePlugin: Plugin = ({ $vuetify }, _) => {
   const isDark = useDark();
 
   // Vuetify metadata is bugged and doesn't render dark mode fully when called immediately
-  // Adding a 0.5 millisecond delay fixes this problem
+  // Adding a 100 millisecond delay fixes this problem
   // https://stackoverflow.com/questions/69399797/vuetify-darkmode-colors-wrong-after-page-reload
-  setTimeout( () => { $vuetify.theme.dark = isDark.value; }, 0.5);
+  setTimeout(() => { $vuetify.theme.dark = isDark.value; }, 100);
+  console.log("timeout set!");
 };
 
 export default darkModePlugin;


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

I don't know what the bug is. I don't know why this fix used to work but doesn't work anymore. I don't know why making the timeout longer makes it work again. But it works fine now I guess ¯\\\_(ツ)_\/¯

Before:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/43189a00-213a-4b17-9aa7-e3f85dd1e69a)

After:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/5ac967fd-1871-481b-9625-9435ce1f5f31)

Before:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/db73f698-02ef-4164-8265-72d0cc6f57c4)

After:
![image](https://github.com/mealie-recipes/mealie/assets/71845777/3bbb066f-2e55-4784-8c5c-88b93d93e0f1)

etc.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

Hopefully this actually works. I tried both 1ms and 10ms and they didn't work. 100ms seems to work

¯\\\_(ツ)\_\/¯ ¯\\\_(ツ)\_\/¯ ¯\\\_(ツ)\_\/¯ ¯\\\_(ツ)\_\/¯ ¯\\\_(ツ)\_\/¯


## Testing

Deployed prod locally and messed with the timeout until it worked again.

## Release Notes

_(REQUIRED)_

```release-note
NONE
```
