### PR TITLE
build: optimize apt-get cleanup during image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
     # LDAP Dependencies
     libsasl2-dev libldap2-dev libssl-dev \
     gnupg gnupg2 gnupg1 \
+    && rm -rf /var/lib/apt/lists/* \
     && pip install -U --no-cache-dir pip
 
 # install poetry - respects $POETRY_VERSION & $POETRY_HOME
@@ -92,19 +93,18 @@ RUN apt-get update \
     curl \
     gnupg \
     libldap-common \
-    && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add Yarn
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update && apt-get install yarn
-
-# Clean apt
-RUN apt-get autoremove && rm -rf /var/lib/apt/lists/*
+    && apt-get update \
+    && apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 # copying poetry and venv into image
 COPY --from=builder-base $POETRY_HOME $POETRY_HOME


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- feature

## What this PR does / why we need it:

This PR optimizes the Dockerfile steps that install packages via apt-get by modifying and adding apt-get cleanup steps:

* follow Docker best practices for apt-get cleanup: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
* remove an obsolete and non-functional `RUN`  that did not reduce the image size (the "cleaned up" data was persisted in previous image layers)
* remove `apt autoremove` as no packages are uninstalled

## Which issue(s) this PR fixes:

None

## Testing

You can build a new image with and without the PR changes and compare their size.
For the latest commit, the optimized production image was 18M smaller.

## Release Notes

```
build: optimize apt-get cleanup during image build
```
