### PR TITLE
fix: Make sure recipe state is updated correctly

### DIFF
--- a/frontend/composables/recipe-page/shared-state.ts
+++ b/frontend/composables/recipe-page/shared-state.ts
@@ -51,13 +51,20 @@ interface PageState {
   toggleCookMode: () => void;
 }
 
-const memo: Record<string, PageState> = {};
+type PageRefs = ReturnType<typeof pageRefs>;
 
-function pageStateConstructor(slug: string): PageState {
-  const slugRef = ref(slug);
-  const pageModeRef = ref(PageMode.VIEW);
-  const editModeRef = ref(EditorMode.FORM);
+const memo: Record<string, PageRefs> = {};
 
+function pageRefs(slug: string) {
+  return {
+    slugRef: ref(slug),
+    pageModeRef: ref(PageMode.VIEW),
+    editModeRef: ref(EditorMode.FORM),
+    imageKey: ref(1),
+  };
+}
+
+function pageState({ slugRef, pageModeRef, editModeRef, imageKey }: PageRefs): PageState {
   const toggleEditMode = () => {
     if (editModeRef.value === EditorMode.FORM) {
       editModeRef.value = EditorMode.JSON;
@@ -92,7 +99,7 @@ function pageStateConstructor(slug: string): PageState {
     slug: slugRef,
     pageMode: computed(() => pageModeRef.value),
     editMode: computed(() => editModeRef.value),
-    imageKey: ref(1),
+    imageKey,
 
     toggleEditMode,
     setMode,
@@ -120,10 +127,10 @@ function pageStateConstructor(slug: string): PageState {
  */
 export function usePageState(slug: string): PageState {
   if (!memo[slug]) {
-    memo[slug] = pageStateConstructor(slug);
+    memo[slug] = pageRefs(slug);
   }
 
-  return memo[slug];
+  return pageState(memo[slug]);
 }
 
 export function clearPageState(slug: string) {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

Any computed state in the recipe page view will not update when the ref does update. 

This PR does the following to fix this:
Instead of saving all values (including the computed refs) in the memo cache, only save Refs.
Then return a new object with new computed values, based on the saved Refs, each time `usePageState` is called.

## Which issue(s) this PR fixes:

Fixes #2273

## Release Notes

```release-note
Fix changes in the recipe page not being made when a recipe is reopened
```
