### PR TITLE
fix: removed unused node in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,19 +89,9 @@ RUN apt-get update \
     gosu \
     iproute2 \
     tesseract-ocr-all \
-    curl \
-    gnupg \
     libldap-common \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs
-
-# Add Yarn
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
-    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update && apt-get install yarn
 
 # Clean apt
 RUN apt-get autoremove && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

Node (and yarn) is not needed in the production image. Remove them and save ~100mb of image size.

## Release Notes

```release-note
Remove Node from the production docker image.
```
