### PR TITLE
add tag to postgres image

### DIFF
--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -43,7 +43,7 @@ services:
     restart: always
   postgres:
     container_name: postgres
-    image: postgres
+    image: postgres:15
     restart: always
     volumes:
       - ./mealie-pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

The docs have a Postgres docker-compose example that lacks a specific tag, and so pulls latest. This can have unintended consequences, for example when Postgres:latest increments a version with breaking changes. This happened to me once in the past (never again!) and happened to someone on Discord pretty recently. This PR just updates the docker-compose example in the docs to tag the postgres image to postgres:15. I've been using postgres:15 in production for several months and can vouch that it works well with mealie.

## Which issue(s) this PR fixes:

Discord help requests caused by postgres suddenly updating and causing compatibility problems.

## Special notes for your reviewer:

Honk honk.

## Testing

I've been running postgres:15 in my mealie daily driver for months.

## Release Notes

```Update postgres docker-compose example to specify a fixed postgres tag.
```
