### PR TITLE
fix: Create Recipe with Enter Key

### DIFF
--- a/frontend/pages/recipe/create/new.vue
+++ b/frontend/pages/recipe/create/new.vue
@@ -3,7 +3,7 @@
     <v-card-title class="headline"> {{ $t('recipe.create-recipe') }} </v-card-title>
     <v-card-text>
       {{ $t('recipe.create-a-recipe-by-providing-the-name-all-recipes-must-have-unique-names') }}
-      <v-form ref="domCreateByName">
+      <v-form ref="domCreateByName" @submit.prevent>
         <v-text-field
           v-model="newRecipeName"
           :label="$t('recipe.recipe-name')"
@@ -17,6 +17,7 @@
           :rules="[validators.required]"
           :hint="$t('recipe.new-recipe-names-must-be-unique')"
           persistent-hint
+          v-on:keyup.enter="createByName(newRecipeName)"
         ></v-text-field>
       </v-form>
     </v-card-text>


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Previously, when creating a recipe manually and hitting enter, the v-form executes the default submit behavior (which posts to the current page, which does nothing). This PR disables the default behavior and adds a custom "press enter" behavior (since there's only one field anyway).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2561

## Testing

_(fill-in or delete this section)_

Manually

## Release Notes

_(REQUIRED)_

```release-note
fixed issue with enter key when creating a recipe manually
```
