### PR TITLE
feat: disable admin option when using LDAP auth

### DIFF
--- a/frontend/components/global/AutoForm.vue
+++ b/frontend/components/global/AutoForm.vue
@@ -18,7 +18,7 @@
           :label="inputField.label"
           :name="inputField.varName"
           :hint="inputField.hint || ''"
-          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
+          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (disabledFields && disabledFields.includes(inputField.varName))"
           @change="emitBlur"
         />
 
@@ -26,8 +26,8 @@
         <v-text-field
           v-else-if="inputField.type === fieldTypes.TEXT || inputField.type === fieldTypes.PASSWORD"
           v-model="value[inputField.varName]"
-          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
-          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
+          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (readonlyFields && readonlyFields.includes(inputField.varName))"
+          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (disabledFields && disabledFields.includes(inputField.varName))"
           filled
           :type="inputField.type === fieldTypes.PASSWORD ? 'password' : 'text'"
           rounded
@@ -46,8 +46,8 @@
         <v-textarea
           v-else-if="inputField.type === fieldTypes.TEXT_AREA"
           v-model="value[inputField.varName]"
-          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
-          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
+          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (readonlyFields && readonlyFields.includes(inputField.varName))"
+          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (disabledFields && disabledFields.includes(inputField.varName))"
           filled
           rounded
           class="rounded-lg"
@@ -66,8 +66,8 @@
         <v-select
           v-else-if="inputField.type === fieldTypes.SELECT"
           v-model="value[inputField.varName]"
-          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
-          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate)"
+          :readonly="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (readonlyFields && readonlyFields.includes(inputField.varName))"
+          :disabled="(inputField.disableUpdate && updateMode) || (!updateMode && inputField.disableCreate) || (disabledFields && disabledFields.includes(inputField.varName))"
           filled
           rounded
           class="rounded-lg"
@@ -182,6 +182,14 @@ export default defineComponent({
     dark: {
       default: false,
       type: Boolean,
+    },
+    disabledFields: {
+      default: null,
+      type: Array as () => string[],
+    },
+    readonlyFields: {
+      default: null,
+      type: Array as () => string[],
     },
   },
   setup(props, context) {

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -858,7 +858,7 @@
     "user-details": "User Details",
     "user-name": "User Name",
     "authentication-method": "Authentication Method",
-    "authentication-method-hint": "This specifies how a user will authenticate with Mealie. If you're not sure, choose 'Mealie",
+    "authentication-method-hint": "This specifies how a user will authenticate with Mealie. If you're not sure, choose 'Mealie'",
     "permissions": "Permissions",
     "administrator": "Administrator",
     "user-can-invite-other-to-group": "User can invite other to group",

--- a/frontend/pages/admin/manage/users/_id.vue
+++ b/frontend/pages/admin/manage/users/_id.vue
@@ -34,7 +34,7 @@
             <AppButtonCopy v-if="resetUrl" :copy-text="resetUrl"></AppButtonCopy>
           </div>
 
-          <AutoForm v-model="user" :items="userForm" update-mode />
+          <AutoForm v-model="user" :items="userForm" update-mode :disabled-fields="disabledFields" />
         </v-card-text>
       </v-card>
       <div class="d-flex pa-2">
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useRoute, onMounted, ref } from "@nuxtjs/composition-api";
+import { computed, defineComponent, useRoute, onMounted, ref } from "@nuxtjs/composition-api";
 import { useAdminApi } from "~/composables/api";
 import { useGroups } from "~/composables/use-groups";
 import { alert } from "~/composables/use-toast";
@@ -71,6 +71,9 @@ export default defineComponent({
     const adminApi = useAdminApi();
 
     const user = ref<UserOut | null>(null);
+    const disabledFields = computed(() => {
+      return user.value?.authMethod === "LDAP" ? ["admin"] : [];
+    })
 
     const userError = ref(false);
 
@@ -116,6 +119,7 @@ export default defineComponent({
 
     return {
       user,
+      disabledFields,
       userError,
       userForm,
       refNewUserForm,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

When editing an LDAP user, it looks like you can edit the user's administrator privileges. This doesn't actually work (since admin permissions are defined by LDAP, not Mealie) so it can cause confusion. This PR conditionally disables that field.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2554

## Testing

_(fill-in or delete this section)_

Manually

## Release Notes

_(REQUIRED)_

```release-note
disable admin permission field when editing a user integrated with LDAP
```
