### PR TITLE
fix: Recipe Card Section Infinite Loop

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -249,12 +249,13 @@ export default defineComponent({
       }
     });
 
-    let lastQuery: RecipeSearchQuery | undefined = undefined;
+    let lastQuery: string | undefined = undefined;
     watch(
       () => props.query,
       async (newValue: RecipeSearchQuery | undefined) => {
-        if (newValue && (!ready.value || JSON.stringify(lastQuery) !== JSON.stringify(newValue))) {
-          lastQuery = newValue;
+        const newValueString = JSON.stringify(newValue)
+        if (newValue && (!ready.value || lastQuery !== newValueString)) {
+          lastQuery = newValueString;
           await initRecipes();
           ready.value = true;
         }

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -249,7 +249,7 @@ export default defineComponent({
       }
     });
 
-    let lastQuery: string | undefined = undefined;
+    let lastQuery: string | undefined;
     watch(
       () => props.query,
       async (newValue: RecipeSearchQuery | undefined) => {

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -244,31 +244,35 @@ export default defineComponent({
 
     onMounted(async () => {
       if (props.query) {
-        const newRecipes = await fetchRecipes(2);
-
-        // since we doubled the first call, we also need to advance the page
-        page.value = page.value + 1;
-
-        context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+        await initRecipes();
         ready.value = true;
       }
     });
 
+    let lastQuery: RecipeSearchQuery | undefined = undefined;
     watch(
       () => props.query,
       async (newValue: RecipeSearchQuery | undefined) => {
-        if (newValue) {
-          page.value = 1;
-          const newRecipes = await fetchRecipes(2);
-
-          // since we doubled the first call, we also need to advance the page
-          page.value = page.value + 1;
-
-          context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+        if (newValue && (!ready.value || JSON.stringify(lastQuery) !== JSON.stringify(newValue))) {
+          lastQuery = newValue;
+          await initRecipes();
           ready.value = true;
         }
       }
     );
+
+    async function initRecipes() {
+      page.value = 1;
+      const newRecipes = await fetchRecipes(2);
+      if (!newRecipes.length) {
+        hasMore.value = false;
+      }
+
+      // since we doubled the first call, we also need to advance the page
+      page.value = page.value + 1;
+
+      context.emit(REPLACE_RECIPES_EVENT, newRecipes);
+    }
 
     const infiniteScroll = useThrottleFn(() => {
       useAsync(async () => {


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This refactors a bit of the `RecipeCardSection` component to avoid an infinite loop. I found the root cause to be the query prop constantly refreshing (and thus triggering the vue watcher); I couldn't quite nail down exactly why this happens, _but_ I added a safeguard to force it to only happen once.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2195
Checks off one RC-1 blocker: https://github.com/mealie-recipes/mealie/issues/2478

## Special notes for your reviewer:

_(fill-in or delete this section)_

The _real_ fix would be to figure out why the query prop is getting set to a new instance constantly and prevent it from happening, but I don't have much of a clue where to look.

## Testing

_(fill-in or delete this section)_

I deleted all recipes and visited the main page with/without filters and the cookbook page. I then added >100 recipes and made sure the scrolling still worked correctly. I'm not 100% sure of all the places this bug cropped up, so it's worth looking it over just in case there's some other edge case I'm missing.

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
fixed infinite request loop when a query filter returns zero results
```
