### PR TITLE
fix: Broken Mealplanner Link

### DIFF
--- a/docs/docs/documentation/getting-started/features.md
+++ b/docs/docs/documentation/getting-started/features.md
@@ -69,7 +69,7 @@ Mealie uses a calendar like view to help you plan your meals. It shows you the p
 !!! tip
     You can also add a "Note" type entry to your meal-plan when you want to include something that might not have a specific recipes. This is great for leftovers, or for ordering out.
 
-[Mealplanner Demo](https://demo.mealie.io/group/mealplan/planner){ .md-button .md-button--primary }
+[Mealplanner Demo](https://demo.mealie.io/group/mealplan/planner/view){ .md-button .md-button--primary }
 
 ### Planner Rules
 

--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -175,7 +175,7 @@
         {
           icon: $globals.icons.calendarMultiselect,
           title: i18n.tc("meal-plan.meal-planner"),
-          to: "/group/mealplan/planner",
+          to: "/group/mealplan/planner/view",
           restricted: true,
         },
         {


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Fixes a reference to the old meal planner URL (and another one in the docs). The router is supposed to do this automatically but it doesn't sometimes (???)

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2588

## Testing

_(fill-in or delete this section)_

*click* *click* *click* *click* *click* *click* *click* *click* *click* *click* 

## Release Notes

_(REQUIRED)_

```release-note
fixed bug where clicking on the meal planner sometimes brought you to a blank page
```
