### PR TITLE
first shot at Remote-User support

### DIFF
--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -99,7 +99,6 @@ def authenticate_user(session, email: str, password: str) -> PrivateUser | bool:
             user_service.lock_user(user)
 
         return False
-
     user.login_attemps = 0
     return db.users.update(user.id, user)
 

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -47,6 +47,7 @@ class AppSettings(BaseSettings):
     # ===============================================
     # Security Configuration
 
+	SECURITY_REMOTE_USER_ENABLE: bool = false
     SECURITY_MAX_LOGIN_ATTEMPTS: int = 5
     SECURITY_USER_LOCKOUT_TIME: int = 24
     "time in hours"

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -47,7 +47,7 @@ class AppSettings(BaseSettings):
     # ===============================================
     # Security Configuration
 
-	SECURITY_REMOTE_USER_ENABLE: bool = false
+    SECURITY_REMOTE_USER_ENABLE: bool = false
     SECURITY_MAX_LOGIN_ATTEMPTS: int = 5
     SECURITY_USER_LOCKOUT_TIME: int = 24
     "time in hours"


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?
- feature

## What this PR does / why we need it:
Currently, LDAP or internal authentication is supported. Most people will be using Mealie behind a reverse proxy and already have some form of (single sign-on) authentication in place. While OIDC is a very clean solution, for many setups, the use of the Remote-User header is sufficient. This is a first try of implementing this.

I don't have a running development environment, but this is rather the try to get things started instead of just coming empty handed with only a feature request. I will need some help with the implementation.

## Which issue(s) this PR fixes:

Addresses #2596 

## Special notes for your reviewer:

This is just a first shot, I will need some help with the implementation.

## Testing

No tests at all. This is just a first shot, I will need some help with the implementation.

## Release Notes

```release-note
Support for HTTP header authentication with Remote-User header.
```
