### PR TITLE
docs add banner for recipinned

### DIFF
--- a/docs/docs/assets/stylesheets/custom.css
+++ b/docs/docs/assets/stylesheets/custom.css
@@ -55,3 +55,20 @@ th {
 .md-button {
   padding: 0.2rem 0.75rem !important;
 }
+
+.announce-left {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.announce-left > a {
+  color: #e0e0e0;
+  font-weight: bold;
+}
+
+.announce-left > a:hover {
+  color: var(--md-primary-fg-color);
+  text-decoration: underline;
+}

--- a/docs/docs/overrides/main.html
+++ b/docs/docs/overrides/main.html
@@ -1,8 +1,8 @@
-{% extends "base.html" %} {% block analytics %}
-<script
-  async
-  defer
-  data-domain="hay-kot.github.io/mealie"
-  src="https://plausible.io/js/plausible.js"
-></script>
+{% extends "base.html" %}
+{% block announce %}
+  <div class="announce-left">
+    <a href="https://recipinned.com">
+      Looking for a hosted solution? Explore Recipinned from the creator of Mealie
+    </a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
I'd like to include a banner that links to my new paid project landing page. It's non-invasive IMO and disappears on scroll. 

## What type of PR is this?

- docs

## What this PR does / why we need it:

Plugging Recipinned landing page in the docs

![CleanShot 2023-10-17 at 11 54 54@2x](https://github.com/mealie-recipes/mealie/assets/64056131/3129b9ca-6c43-4320-b5d2-dad213fffaf1)
