### PR TITLE
Remove link to deleted docs file

### DIFF
--- a/docs/docs/documentation/getting-started/installation/installation-checklist.md
+++ b/docs/docs/documentation/getting-started/installation/installation-checklist.md
@@ -8,7 +8,6 @@ To install Mealie on your server there are a few steps for proper configuration.
 
     - [SQLite docker-compose](./sqlite.md)
     - [Postgres docker-compose](./postgres.md)
-    - [Single container docker-compose](./single-container.md)
 
 ## Pre-work
 


### PR DESCRIPTION
The single-container.md file was deleted in 2ad6af2cce53432d0592b4c80c4eb5469c6b982f

## What type of PR is this?
- bug
- documentation

## What this PR does / why we need it:
The single-container.md file was deleted in 2ad6af2cce53432d0592b4c80c4eb5469c6b982f but is still linked to in the docs.

## Which issue(s) this PR fixes:
Couldn't find an existing issue for this.
