### PR TITLE
docs: Add DEFAULT_PASSWORD to backend configuration docs

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -16,7 +16,7 @@
 | API_PORT         |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker** |
 | API_DOCS         |         True          | Turns on/off access to the API documentation locally.                               |
 | TZ               |          UTC          | Must be set to get correct date/time on the server                                  |
-| ALLOW_SIGNUP     |         true          | Allow user sign-up without token (should match frontend env)                        |
+| ALLOW_SIGNUP     |         true          | Allow user sign-up without token                                                    |
 
 ### Security
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -4,18 +4,19 @@
 
 ### General
 
-| Variables     |        Default        | Description                                                                         |
-| ------------- | :-------------------: | ----------------------------------------------------------------------------------- |
-| PUID          |          911          | UserID permissions between host OS and container                                    |
-| PGID          |          911          | GroupID permissions between host OS and container                                   |
-| DEFAULT_GROUP |         Home          | The default group for users                                                         |
-| DEFAULT_EMAIL |  changeme@example.com   | The default username for the superuser                                              |
-| BASE_URL      | http://localhost:8080 | Used for Notifications                                                              |
-| TOKEN_TIME    |          48           | The time in hours that a login/auth token is valid                                  |
-| API_PORT      |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker** |
-| API_DOCS      |         True          | Turns on/off access to the API documentation locally.                               |
-| TZ            |          UTC          | Must be set to get correct date/time on the server                                  |
-| ALLOW_SIGNUP  |         true          | Allow user sign-up without token (should match frontend env)                        |
+| Variables        |        Default        | Description                                                                         |
+| ---------------- | :-------------------: | ----------------------------------------------------------------------------------- |
+| PUID             |          911          | UserID permissions between host OS and container                                    |
+| PGID             |          911          | GroupID permissions between host OS and container                                   |
+| DEFAULT_GROUP    |         Home          | The default group for users                                                         |
+| DEFAULT_EMAIL    | changeme@example.com  | The default username for the superuser                                              |
+| DEFAULT_PASSWORD |       MyPassword      | The default password for the superuser                                              |
+| BASE_URL         | http://localhost:8080 | Used for Notifications                                                              |
+| TOKEN_TIME       |          48           | The time in hours that a login/auth token is valid                                  |
+| API_PORT         |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker** |
+| API_DOCS         |         True          | Turns on/off access to the API documentation locally.                               |
+| TZ               |          UTC          | Must be set to get correct date/time on the server                                  |
+| ALLOW_SIGNUP     |         true          | Allow user sign-up without token (should match frontend env)                        |
 
 ### Security
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- documentation

## What this PR does / why we need it:

The documentation does not yet mention the DEFAULT_PASSWORD env variable in the backend configuration. This adds this to the documentation. 

While i was in there I also deleted a note that mentionend frontend env variables, as backend / frontend are no longer split.

## Which issue(s) this PR fixes:

None
