### PR TITLE
Fix recipe ratings not showing on Meal planner

### DIFF
--- a/frontend/pages/group/mealplan/planner/view.vue
+++ b/frontend/pages/group/mealplan/planner/view.vue
@@ -32,6 +32,7 @@
           :slug="mealplan.recipe ? mealplan.recipe.slug : mealplan.title"
           :description="mealplan.recipe ? mealplan.recipe.description : mealplan.text"
           :name="mealplan.recipe ? mealplan.recipe.name : mealplan.title"
+          :rating="mealplan.recipe ? mealplan.recipe.rating : 0"
         />
       </div>
     </v-col>


### PR DESCRIPTION
This change adds the recipe ratings to the meal planner vue. Addresses issue: https://github.com/mealie-recipes/mealie/issues/2256


## What type of PR is this?

- bug


## What this PR does / why we need it:

This PR addresses a bug on the meal planner. 

## Which issue(s) this PR fixes:

Fixes #2256

## Testing

Rated a recipe and then added it to the Meal Planner. Before the change the recipes would always have 0 stars in the meal planner, and after this change the rating reflects in the meal planner. 