### PR TITLE
Fix broken link to ingredient parser

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
@@ -34,7 +34,7 @@
               class="mb-1"
               :disabled="recipe.settings.disableAmount || hasFoodOrUnit"
               color="accent"
-              :to="`/g/${groupSlug}/${recipe.slug}/ingredient-parser`"
+              :to="`/g/${groupSlug}/r/${recipe.slug}/ingredient-parser`"
               v-bind="attrs"
             >
               <template #icon>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The "PARSE" button that appears after enabling ingredient amounts currently 404s. This PR fixes the link.
