### PR TITLE
feat: Add sort by total time to sort menu

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeExplorerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage.vue
@@ -323,6 +323,11 @@ export default defineComponent({
         name: i18n.tc("general.random"),
         value: "random",
       },
+      {
+        icon: $globals.icons.timer,
+        name: i18n.tc("recipe.total-time"),
+        value: "total_time",
+      },
     ];
 
     onMounted(() => {


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

* Allows sorting of recipes by `Total Time`

<img width="250" alt="Screenshot 2023-11-07 at 8 18 53 PM" src="https://github.com/mealie-recipes/mealie/assets/3268576/eed16678-aae4-47e3-b1eb-91ce3a2de438">


## Which issue(s) this PR fixes:

N/A

## Testing

1. Added various recipes with different Total Time values, including some without any value
2. Went to explore page and change the sort option