### PR TITLE
fix: Can't Delete All Notes

### DIFF
--- a/mealie/db/models/_model_base.py
+++ b/mealie/db/models/_model_base.py
@@ -20,5 +20,11 @@ class BaseMixins:
     `self.update` method which directly passing arguments to the `__init__`
     """
 
-    def update(self, *args, **kwarg):
-        self.__init__(*args, **kwarg)
+    def update(self, *args, **kwargs):
+        self.__init__(*args, **kwargs)
+
+        # sqlalchemy doesn't like this method to remove all instances of a 1:many relationship,
+        # so we explicitly check for that here
+        for k, v in kwargs.items():
+            if hasattr(self, k) and v == []:
+                setattr(self, k, v)


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

If you add notes to a recipe, save, then remove all of them, save, the notes aren't deleted. I'm not sure why, but I traced it back to our update function - when you pass an empty list of notes to the SQLAlchemy object, it just.... ignores it?

To fix this, I added an explicit check:
```python
def update(self, *args, **kwargs):
    self.__init__(*args, **kwargs)  # this used to be the only line

    for k, v in kwargs.items():
        if hasattr(self, k) and v == []:
            setattr(self, k, v)

```

What's weird is that it works for other relationships (categories, tools, etc).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2756

## Testing

_(fill-in or delete this section)_

Tested through the frontend manually, and added a new backend test.
