### PR TITLE
Link to GitHub registry instead of DockerHub in the docs

### DIFF
--- a/docs/docs/documentation/getting-started/installation/installation-checklist.md
+++ b/docs/docs/documentation/getting-started/installation/installation-checklist.md
@@ -17,7 +17,7 @@ To deploy mealie on your local network it is highly recommended to use docker to
 
 [Get Docker Compose](https://docs.docker.com/compose/install/)
 
-[Mealie on Dockerhub](https://hub.docker.com/r/hkotel/mealie)
+[Mealie on GitHub registry](https://github.com/mealie-recipes/mealie/pkgs/container/mealie)
 
 - linux/amd64
 - linux/arm64


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

When going to https://hub.docker.com/r/hkotel/mealie, we see this message:

> These images are no longer regularly updated. Please see the Github registry for the most up to date images.
>
> We plan to re-publish new images to docker-hub some time after a stable release is released.

I believe pointing users directly to the GitHub registry should be better.