### PR TITLE
remove dockerhub mention from installation checklist

### DIFF
--- a/docs/docs/documentation/getting-started/installation/installation-checklist.md
+++ b/docs/docs/documentation/getting-started/installation/installation-checklist.md
@@ -11,7 +11,7 @@ To install Mealie on your server there are a few steps for proper configuration.
 
 ## Pre-work
 
-To deploy mealie on your local network it is highly recommended to use docker to deploy the image straight from dockerhub. Using the docker-compose templates provided, you should be able to get a stack up and running easily by changing a few default values and deploying. You can deploy with either SQLite (default) or Postgres. SQLite is sufficient for most use cases. Additionally, with Mealie's automated backup and restore functionality, you can easily move between SQLite and Postgres as you wish.
+To deploy mealie on your local network it is highly recommended to use docker to deploy the image straight from the GitHub registry. Using the docker-compose templates provided, you should be able to get a stack up and running easily by changing a few default values and deploying. You can deploy with either SQLite (default) or Postgres. SQLite is sufficient for most use cases. Additionally, with Mealie's automated backup and restore functionality, you can easily move between SQLite and Postgres as you wish.
 
 [Get Docker](https://docs.docker.com/get-docker/)
 


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- documentation

## What this PR does / why we need it:

removes the one additional dockerhub mention from the docs

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

could not find any more dockerhub links / mentions in the docs aside from the note that states that we do not publish to dockerhub

