### PR TITLE
Use github.com/mealie-recipes/mealie instead of older github.com/hay-kot/mealie

### DIFF
--- a/docs/docs/documentation/community-guide/ios.md
+++ b/docs/docs/documentation/community-guide/ios.md
@@ -5,8 +5,8 @@
 
 ![Image from apple site](https://help.apple.com/assets/5E8CEA35094622DF10489984/5E8CEA42094622DF1048998D/en_US/ed1f9c157cdefc13e0161e0f70015455.png)
 
-User [brasilikum](https://github.com/brasilikum) opened an issue on the main repo about how they had created an [iOS shortcut](https://github.com/hay-kot/mealie/issues/103) for interested users.
-This original method broke after the transition to version 1.X and an issue was raised on [Github](https://github.com/hay-kot/mealie/issues/2092) GitHub user [Zippyy](https://github.com/zippyy) has helped to create a working shortcut for version 1.X.
+User [brasilikum](https://github.com/brasilikum) opened an issue on the main repo about how they had created an [iOS shortcut](https://github.com/mealie-recipes/mealie/issues/103) for interested users.
+This original method broke after the transition to version 1.X and an issue was raised on [Github](https://github.com/mealie-recipes/mealie/issues/2092) GitHub user [Zippyy](https://github.com/zippyy) has helped to create a working shortcut for version 1.X.
 
 This is a useful utility for iOS users who browse for recipes in their web browser from their devices.
 

--- a/docs/docs/documentation/getting-started/introduction.md
+++ b/docs/docs/documentation/getting-started/introduction.md
@@ -4,7 +4,7 @@
 
     This documentation is for the Mealie v1 Beta release and is not final. As such, it may contain incomplete or incorrect information. You should understand that installing Mealie v1 Beta is a work in progress and while we've committed to maintaining the database schema and provided migrations, we are still in the process of adding new features, and robust testing to ensure the application works as expected.
 
-    You should likely find bugs, errors, and unfinished pages within the application. To find the current status of the release you can checkout the [project on github](https://github.com/hay-kot/mealie/projects/7) or reach out on discord.
+    You should likely find bugs, errors, and unfinished pages within the application. To find the current status of the release you can checkout the [project on github](https://github.com/mealie-recipes/mealie/projects/7) or reach out on discord.
 
 Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family. Easily add recipes into your database by providing the url and Mealie will automatically import the relevant data or add a family recipe with the UI editor. Mealie also provides an API for interactions from 3rd party applications.
 

--- a/docs/docs/documentation/getting-started/migrating-to-mealie-v1.md
+++ b/docs/docs/documentation/getting-started/migrating-to-mealie-v1.md
@@ -54,4 +54,4 @@ In most cases, it's faster to manually migrate the recipes that didn't take inst
 
 v1 Comes with a whole host of new features and improvements. Checkout the changelog to get a sense for what's new.
 
-- [Github releases changelog](https://github.com/hay-kot/mealie/releases)
+- [Github releases changelog](https://github.com/mealie-recipes/mealie/releases)

--- a/docs/docs/documentation/getting-started/usage/backups-and-restoring.md
+++ b/docs/docs/documentation/getting-started/usage/backups-and-restoring.md
@@ -34,4 +34,4 @@ ALTER USER mealie WITH SUPERUSER;
 ALTER USER mealie WITH NOSUPERUSER;
 ```
 
-For more information see [GitHub Issue #1500](https://github.com/hay-kot/mealie/issues/1500)
+For more information see [GitHub Issue #1500](https://github.com/mealie-recipes/mealie/issues/1500)


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- documentation

## What this PR does / why we need it:

I found a few instances of the older repository (https://github.com/hay-kot/mealie) for Mealie in the documentation. I replaced them with https://github.com/mealie-recipes/mealie.

## Special notes for your reviewer:

This could perhaps be done in other parts of the repositories, but I went with only the user documentation for now. The changes were done with the following command at the root of the repository:

```bash
sed -i -e 's|github\.com/hay-kot/mealie|github.com/mealie-recipes/mealie|g' docs/docs/documentation/**/*.md
```