### PR TITLE
cleanup: Update makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,7 +122,7 @@ frontend-lint: ## 🧺 Run yarn lint
 # -----------------------------------------------------------------------------
 # Docker makefile
 
-docker: ## 🐳 Build and Start Docker Production Stack
+prod: ## 🐳 Build and Start Docker Production Stack
 	cd docker && docker compose -f docker-compose.yml -p mealie up --build
 
 generate:

--- a/makefile
+++ b/makefile
@@ -122,8 +122,8 @@ frontend-lint: ## 🧺 Run yarn lint
 # -----------------------------------------------------------------------------
 # Docker makefile
 
-docker/prod: ## 🐳 Build and Start Docker Production Stack
-	cd docker && docker-compose -f docker-compose.yml -p mealie up --build
+docker: ## 🐳 Build and Start Docker Production Stack
+	cd docker && docker compose -f docker-compose.yml -p mealie up --build
 
 generate:
 	poetry run python dev/code-generation/main.py


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

- Change the makefile so that the command to build the docker file is listed when executing `make`
- changes to `docker compose` because `docker-compose` has been deprecated


## Testing

Build and run a mealie image on my ubuntu server