### PR TITLE
cleanup: remove group storage capacity from profile page

### DIFF
--- a/frontend/pages/user/profile/index.vue
+++ b/frontend/pages/user/profile/index.vue
@@ -55,7 +55,7 @@
         <p>{{ $t('profile.account-summary-description') }}</p>
       </div>
       <v-row tag="section">
-        <v-col cols="12" sm="12" md="6">
+        <v-col cols="12" sm="12" md="12">
           <v-card outlined>
             <v-card-title class="headline pb-0"> {{ $t('profile.group-statistics') }} </v-card-title>
             <v-card-text class="py-0">
@@ -72,22 +72,6 @@
                 <template #title> {{ getStatsTitle(key) }}</template>
                 <template #value> {{ value }}</template>
               </StatsCards>
-            </v-card-text>
-          </v-card>
-        </v-col>
-        <v-col cols="12" sm="12" md="6" class="d-flex align-strart">
-          <v-card outlined>
-            <v-card-title class="headline pb-0"> {{ $t('profile.storage-capacity') }} </v-card-title>
-            <v-card-text class="py-0">
-              {{ $t('profile.storage-capacity-description') }}
-              <strong> {{ $t('general.this-feature-is-currently-inactive') }}</strong>
-            </v-card-text>
-            <v-card-text>
-              <v-progress-linear :value="storageUsedPercentage" color="accent" class="rounded" height="30">
-                <template #default>
-                  <strong> {{ storageText }} </strong>
-                </template>
-              </v-progress-linear>
             </v-card-text>
           </v-card>
         </v-col>
@@ -344,33 +328,8 @@ export default defineComponent({
       return statsTo.value[key] ?? "unknown";
     }
 
-    const storage = useAsync(async () => {
-      const { data } = await api.groups.storage();
-
-      if (data) {
-        return data;
-      }
-    }, useAsyncKey());
-
-    const storageUsedPercentage = computed(() => {
-      if (!storage.value) {
-        return 0;
-      }
-
-      return (storage.value?.usedStorageBytes / storage.value?.totalStorageBytes) * 100 ?? 0;
-    });
-
-    const storageText = computed(() => {
-      if (!storage.value) {
-        return "Loading...";
-      }
-      return `${storage.value.usedStorageStr} / ${storage.value.totalStorageStr}`;
-    });
-
     return {
       groupSlug,
-      storageText,
-      storageUsedPercentage,
       getStatsTitle,
       getStatsIcon,
       getStatsTo,


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

This PR removes the field that displays the used group storage from the `/user/profile/` page.

This field does not have much purpose, as the limit set is arbitrary and not enforced which is confusing to users and also not necessairy as mealie can handle larger than 500mb recipe librarys quite well. 

Instead of the storage capacity field i stretched the field for group statistics along the whole width. 

#### Screenshots:
|  | Image | 
|--------|-------|
| Before | ![image](https://github.com/mealie-recipes/mealie/assets/24235032/1be85978-cf49-4661-b0c9-5f0e6fafbd44) | 
| After | ![image](https://github.com/mealie-recipes/mealie/assets/24235032/03fad95f-2ffe-43ce-b8b6-80eccb3e5f66) |
 

## Which issue(s) this PR fixes:

This does not fix any issues in particular, but the removal was discussed in discord multiple times. 

## Special notes for your reviewer:

I left the backend functionality in the code for now, as i think it might be interesting to some admins to know how much space a particular group uses. 
Aditionally we could reuse that functionality on the `/admin/manage/groups` page.

I am not really satisfied with the new look, we might think of something else to put there or justify the block in the middle / the icons to the left.

## Testing

manual testing
