### PR TITLE
fix: Incorrect Cursor On Recipe Page Components

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -330,9 +330,6 @@ export default defineComponent({
 .list-group {
   min-height: 38px;
 }
-.list-group-item {
-  cursor: move;
-}
 .list-group-item i {
   cursor: pointer;
 }

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -117,7 +117,7 @@
               @click="toggleDisabled(index)"
             >
               <v-card-title :class="{ 'pb-0': !isChecked(index) }">
-                <span class="handle">
+                <span :class="isEditForm ? 'handle' : ''">
                   <v-icon v-if="isEditForm" size="26" class="pb-1">{{ $globals.icons.arrowUpDown }}</v-icon>
                   {{ $t("recipe.step-index", { step: index + 1 }) }}
                 </span>
@@ -670,9 +670,6 @@ export default defineComponent({
 }
 .list-group {
   min-height: 38px;
-}
-.list-group-item {
-  cursor: move;
 }
 .list-group-item i {
   cursor: pointer;


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The "move" cursor was being applied erroneously on a few recipe components (as detailed in https://github.com/mealie-recipes/mealie/issues/2262). The recipe ingredients were also using the "drag" cursor, even when they weren't draggable (i.e. not in edit mode).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2262

## Testing

_(fill-in or delete this section)_

Manually
