### PR TITLE
fix: Prevent Duplicate Recipes When Hitting Back Button

### DIFF
--- a/frontend/pages/g/_groupSlug/r/create/url.vue
+++ b/frontend/pages/g/_groupSlug/r/create/url.vue
@@ -103,7 +103,11 @@ export default defineComponent({
       if (refreshTags) {
         tags.actions.refresh();
       }
-      router.push(`/g/${groupSlug.value}/r/${response.data}?edit=${edit.toString()}`);
+
+      // we clear the query params first so if the user hits back, they don't re-import the recipe
+      router.replace({ query: {} }).then(
+        () => router.push(`/g/${groupSlug.value}/r/${response.data}?edit=${edit.toString()}`)
+      );
     }
 
     const recipeUrl = computed({


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

As detailed in https://github.com/mealie-recipes/mealie/issues/2267 - if a recipe is created via URL, then the user hits the back button, Mealie scrapes the URL again (and creates a duplicate recipe). This clears the query param from the browser history to prevent this.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2267

## Testing

_(fill-in or delete this section)_

Manually
