### PR TITLE
fix: Better Scraper Image Processing

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -89,10 +89,10 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
     image attempts to parse the image field from a recipe and return a string. Currenty
 
     Supported Structures:
-        - `https://exmaple.com` - A string
-        - `{ "url": "https://exmaple.com" }` - A dictionary with a `url` key
-        - `["https://exmaple.com"]` - A list of strings
-        - `[{ "url": "https://exmaple.com" }]` - A list of dictionaries with a `url` key
+        - `https://example.com` - A string
+        - `{ "url": "https://example.com" }` - A dictionary with a `url` key
+        - `["https://example.com"]` - A list of strings
+        - `[{ "url": "https://example.com" }]` - A list of dictionaries with a `url` key
 
     Raises:
         TypeError: If the image field is not a supported type a TypeError is raised.
@@ -108,12 +108,12 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
             return [image]
         case [str(_), *_]:
             return [x for x in image if x]  # Only return non-null strings in list
-        case [{"@id": str(_)}, *_]:
-            return [x["@id"] for x in image]
         case [{"url": str(_)}, *_]:
             return [x["url"] for x in image]
         case {"url": str(image)}:
             return [image]
+        case [{"@id": str(_)}, *_]:
+            return [x["@id"] for x in image]
         case _:
             logger.exception(f"Unexpected type for image: {type(image)}, {image}")
             return [default]

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -108,6 +108,8 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
             return [image]
         case [str(_), *_]:
             return [x for x in image if x]  # Only return non-null strings in list
+        case [{"@id": str(_)}, *_]:
+            return [x["@id"] for x in image]
         case [{"url": str(_)}, *_]:
             return [x["url"] for x in image]
         case {"url": str(image)}:

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -115,7 +115,8 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
         case {"url": str(image)}:
             return [image]
         case _:
-            raise TypeError(f"Unexpected type for image: {type(image)}, {image}")
+            logger.exception(f"Unexpected type for image: {type(image)}, {image}")
+            return [default]
 
 
 def clean_instructions(steps_object: list | dict | str, default: list | None = None) -> list[dict]:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug
## What this PR does / why we need it:

_(REQUIRED)_

When the scraper encounters an image tag format it doesn't recognize, it throws an error. This PR makes it log the error but continue to parse without an image.

I also added an additional pattern to account for https://www.maangchi.com (even though it looks like they're using the schema wrong).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2358

## Testing

_(fill-in or delete this section)_

Importing https://www.maangchi.com/recipe/kkanpunggi
