### PR TITLE
fix: Use Scraped URL instead of Open Graph URL when importing a recipe via URL

### DIFF
--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -208,10 +208,6 @@ class RecipeScraperPackage(ABCScraperStrategy):
 
 
 class RecipeScraperOpenGraph(ABCScraperStrategy):
-    """
-    Abstract class for all recipe parsers.
-    """
-
     async def get_html(self, url: str) -> str:
         return await safe_scrape_html(url)
 
@@ -241,7 +237,7 @@ class RecipeScraperOpenGraph(ABCScraperStrategy):
             "recipeIngredient": ["Could not detect ingredients"],
             "recipeInstructions": [{"text": "Could not detect instructions"}],
             "slug": slugify(og_field(properties, "og:title")),
-            "orgURL": og_field(properties, "og:url"),
+            "orgURL": self.url,
             "categories": [],
             "tags": og_fields(properties, "og:article:tag"),
             "dateAdded": None,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently, when scraping a site using the Open Graph scraper, we use the `og:url` tag as the recipe's original URL. This is fine if the site provides it, but it doesn't always (and it could also just be wrong) so instead we use the user-provided URL (which is always correct).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2403