### PR TITLE
Use */mealie-recipes/mealie in all Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">
-  <a href="https://github.com/hay-kot/mealie">
+  <a href="https://github.com/mealie-recipes/mealie">
 <svg style="width:100px;height:100px" viewBox="0 0 24 24">
     <path fill="currentColor" d="M8.1,13.34L3.91,9.16C2.35,7.59 2.35,5.06 3.91,3.5L10.93,10.5L8.1,13.34M13.41,13L20.29,19.88L18.88,21.29L12,14.41L5.12,21.29L3.71,19.88L13.36,10.22L13.16,10C12.38,9.23 12.38,7.97 13.16,7.19L17.5,2.82L18.43,3.74L15.19,7L16.15,7.94L19.39,4.69L20.31,5.61L17.06,8.85L18,9.81L21.26,6.56L22.18,7.5L17.81,11.84C17.03,12.62 15.77,12.62 15,11.84L14.78,11.64L13.41,13Z" />
 </svg>
@@ -21,12 +21,12 @@
     A Place for All Your Recipes
     <br />
     <a href="https://nightly.mealie.io"><strong>Explore the docs »</strong></a>
-  <a href="https://github.com/hay-kot/mealie">
+  <a href="https://github.com/mealie-recipes/mealie">
   </a>
     <br />
     <a href="https://demo.mealie.io/">View Demo</a>
     ·
-    <a href="https://github.com/hay-kot/mealie/issues">Report Bug</a>
+    <a href="https://github.com/mealie-recipes/mealie/issues">Report Bug</a>
     ·
     <a href="https://github.com/mealie-recipes/mealie/pkgs/container/mealie">GitHub Container Registry</a>
 </p>
@@ -76,17 +76,17 @@ Thanks to Linode for providing Hosting for the Demo, Beta, and Documentation sit
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/hay-kot/mealie.svg?style=flat-square
+[contributors-shield]: https://img.shields.io/github/contributors/mealie-recipes/mealie.svg?style=flat-square
 [docker-pull]: https://img.shields.io/docker/pulls/hkotel/mealie
-[contributors-url]: https://github.com/hay-kot/mealie/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/hay-kot/mealie.svg?style=flat-square
-[forks-url]: https://github.com/hay-kot/mealie/network/members
-[stars-shield]: https://img.shields.io/github/stars/hay-kot/mealie.svg?style=flat-square
-[stars-url]: https://github.com/hay-kot/mealie/stargazers
-[issues-shield]: https://img.shields.io/github/issues/hay-kot/mealie.svg?style=flat-square
-[issues-url]: https://github.com/hay-kot/mealie/issues
-[license-shield]: https://img.shields.io/github/license/hay-kot/mealie.svg?style=flat-square
-[license-url]: https://github.com/hay-kot/mealie/blob/mealie-next/LICENSE
+[contributors-url]: https://github.com/mealie-recipes/mealie/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/mealie-recipes/mealie.svg?style=flat-square
+[forks-url]: https://github.com/mealie-recipes/mealie/network/members
+[stars-shield]: https://img.shields.io/github/stars/mealie-recipes/mealie.svg?style=flat-square
+[stars-url]: https://github.com/mealie-recipes/mealie/stargazers
+[issues-shield]: https://img.shields.io/github/issues/mealie-recipes/mealie.svg?style=flat-square
+[issues-url]: https://github.com/mealie-recipes/mealie/issues
+[license-shield]: https://img.shields.io/github/license/mealie-recipes/mealie.svg?style=flat-square
+[license-url]: https://github.com/mealie-recipes/mealie/blob/mealie-next/LICENSE
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=flat-square&logo=linkedin&colorB=555
 [linkedin-url]: https://linkedin.com/in/hay-kot
 [product-screenshot]: docs/docs/assets/img/home_screenshot.png

--- a/docs/docs/changelog/v0.1.0.md
+++ b/docs/docs/changelog/v0.1.0.md
@@ -62,7 +62,7 @@ A quality update with major props to [zackbcom](https://github.com/zackbcom) for
 
 ### Recipes
   - Added user feedback on bad URL
-  - Better backend data validation for updating recipes, avoid small syntax errors corrupting database entry. [Closes #8](https://github.com/hay-kot/mealie/issues/8)
+  - Better backend data validation for updating recipes, avoid small syntax errors corrupting database entry. [Closes #8](https://github.com/mealie-recipes/mealie/issues/8)
   - Fixed spacing Closes while editing new recipes in JSON
 
 ## v0.0.0 - Initial Pre-release

--- a/docs/docs/changelog/v0.4.2.md
+++ b/docs/docs/changelog/v0.4.2.md
@@ -5,7 +5,7 @@
 **Database Version: v0.4.0**
 
 !!! error "Breaking Changes"
-    1. With a recent refactor some users been experiencing issues with an environmental variable not being set correct. If you are experiencing issues, please provide your comments [Here](https://github.com/hay-kot/mealie/issues/281).
+    1. With a recent refactor some users been experiencing issues with an environmental variable not being set correct. If you are experiencing issues, please provide your comments [Here](https://github.com/mealie-recipes/mealie/issues/281).
 
     2. If you are a developer, you may experience issues with development as a new environmental variable has been introduced. Setting `PRODUCTION=false` will allow you to develop as normal.
 
@@ -31,4 +31,4 @@
 - Unify Logger across the backend
 - mealie.log and last_recipe.json are now downloadable from the frontend from the /admin/about
 - New download schema where you request a token and then use that token to hit a single endpoint to download a file. This is a notable change if you are using the API to download backups. 
-- Recipe images can now be added directly from a URL - [See #117 for details](https://github.com/hay-kot/mealie/issues/117)
+- Recipe images can now be added directly from a URL - [See #117 for details](https://github.com/mealie-recipes/mealie/issues/117)

--- a/docs/docs/changelog/v0.5.2.md
+++ b/docs/docs/changelog/v0.5.2.md
@@ -8,7 +8,7 @@
 - Fixed #617 - Section behavior when adding a step
 - Fixed #615 - Recipe Settings are not available when creating new recipe
 - Fixed #625 - API of today's image returns strange characters
-- Fixed [#590](https://github.com/hay-kot/mealie/issues/590) - Duplicate Events when using Gunicorn Workers
+- Fixed [#590](https://github.com/mealie-recipes/mealie/issues/590) - Duplicate Events when using Gunicorn Workers
 
 ## Features and Improvements
 

--- a/docs/docs/changelog/v1.0.0.md
+++ b/docs/docs/changelog/v1.0.0.md
@@ -6,14 +6,14 @@
     - FastAPI to 0.78.0
 
 - Recipe Ingredient Editor
-    - [#1140](https://github.com/hay-kot/mealie/issues/1140) - Error in processing the quantity of ingredients #1140 - UI Now prevents entering not-allowed characters in quantity field
+    - [#1140](https://github.com/mealie-recipes/mealie/issues/1140) - Error in processing the quantity of ingredients #1140 - UI Now prevents entering not-allowed characters in quantity field
     - UI now allows no value to be set in addition to a zero (0) value.
-    - [#1237](https://github.com/hay-kot/mealie/issues/1237) - UI: Saving a 0 quantity ingredient displays 0 until the page is refreshed #1237 - UI Now properly reacts to changes in the quantity field.
+    - [#1237](https://github.com/mealie-recipes/mealie/issues/1237) - UI: Saving a 0 quantity ingredient displays 0 until the page is refreshed #1237 - UI Now properly reacts to changes in the quantity field.
 
-- Fix Mealie v0.5.x migration issue [#1183](https://github.com/hay-kot/mealie/issues/1183)
+- Fix Mealie v0.5.x migration issue [#1183](https://github.com/mealie-recipes/mealie/issues/1183)
 - Consolidated Frontend Types thanks to [@PFischbeck](https://github.com/Fischbeck)
 - Added support for SSL/No Auth Email [@nkringle](https://github.com/nkringle)
-- [Implement several notifications for server actions ](https://github.com/hay-kot/mealie/pull/1234)[@miroito](https://github.com/Miroito)
+- [Implement several notifications for server actions ](https://github.com/mealie-recipes/mealie/pull/1234)[@miroito](https://github.com/Miroito)
 - Fix display issue for shared recipe rendering on server [@PFischbeck](https://github.com/Fischbeck)
 
 ## v1.0.0b - 2022-05-09
@@ -36,7 +36,7 @@
 
 - Mealie now stores the original text from parsed ingredients, with the ability to peak at the original text from a recipe. [@miroito](https://github.com/Miroito)
 - Added some management / utility functions for administrators to manage data and cleanup artifacts from the file system.
-- Fix clear url action in recipe creation [#1101](https://github.com/hay-kot/mealie/pull/1101) [@miroito](https://github.com/Miroito)
+- Fix clear url action in recipe creation [#1101](https://github.com/mealie-recipes/mealie/pull/1101) [@miroito](https://github.com/Miroito)
 - Add group statistics calculations and data storage measurements
     - No hard limits are currently imposed on groups - though this may be implemented in the future.
 

--- a/docs/docs/changelog/v1.0.0beta-2.md
+++ b/docs/docs/changelog/v1.0.0beta-2.md
@@ -1,29 +1,29 @@
 ### Bug Fixes
 
-- Bump isomorphic-dompurify from 0.18.0 to 0.19.0 in /frontend ([#1257](https://github.com/hay-kot/mealie/issues/1257))
-- Bump @nuxtjs/auth-next in /frontend ([#1265](https://github.com/hay-kot/mealie/issues/1265))
-- Bad dev dependency ([#1281](https://github.com/hay-kot/mealie/issues/1281))
-- Add touch support for mealplanner delete ([#1298](https://github.com/hay-kot/mealie/issues/1298))
+- Bump isomorphic-dompurify from 0.18.0 to 0.19.0 in /frontend ([#1257](https://github.com/mealie-recipes/mealie/issues/1257))
+- Bump @nuxtjs/auth-next in /frontend ([#1265](https://github.com/mealie-recipes/mealie/issues/1265))
+- Bad dev dependency ([#1281](https://github.com/mealie-recipes/mealie/issues/1281))
+- Add touch support for mealplanner delete ([#1298](https://github.com/mealie-recipes/mealie/issues/1298))
 
 ### Documentation
 
-- Add references for VSCode dev containers ([#1299](https://github.com/hay-kot/mealie/issues/1299))
-- Docker-compose.dev.yml is currently not functional ([#1300](https://github.com/hay-kot/mealie/issues/1300))
+- Add references for VSCode dev containers ([#1299](https://github.com/mealie-recipes/mealie/issues/1299))
+- Docker-compose.dev.yml is currently not functional ([#1300](https://github.com/mealie-recipes/mealie/issues/1300))
 
 ### Features
 
-- Add reports to bulk recipe import (url) ([#1294](https://github.com/hay-kot/mealie/issues/1294))
-- Rewrite print implementation to support new ing ([#1305](https://github.com/hay-kot/mealie/issues/1305))
+- Add reports to bulk recipe import (url) ([#1294](https://github.com/mealie-recipes/mealie/issues/1294))
+- Rewrite print implementation to support new ing ([#1305](https://github.com/mealie-recipes/mealie/issues/1305))
 
 ### Miscellaneous Tasks
 
-- Github stalebot changes ([#1271](https://github.com/hay-kot/mealie/issues/1271))
-- Bump eslint-plugin-nuxt in /frontend ([#1258](https://github.com/hay-kot/mealie/issues/1258))
-- Bump @vue/runtime-dom in /frontend ([#1259](https://github.com/hay-kot/mealie/issues/1259))
-- Bump nuxt-vite from 0.1.3 to 0.3.5 in /frontend ([#1260](https://github.com/hay-kot/mealie/issues/1260))
-- Bump vue2-script-setup-transform in /frontend ([#1263](https://github.com/hay-kot/mealie/issues/1263))
-- Update dev dependencies ([#1282](https://github.com/hay-kot/mealie/issues/1282))
+- Github stalebot changes ([#1271](https://github.com/mealie-recipes/mealie/issues/1271))
+- Bump eslint-plugin-nuxt in /frontend ([#1258](https://github.com/mealie-recipes/mealie/issues/1258))
+- Bump @vue/runtime-dom in /frontend ([#1259](https://github.com/mealie-recipes/mealie/issues/1259))
+- Bump nuxt-vite from 0.1.3 to 0.3.5 in /frontend ([#1260](https://github.com/mealie-recipes/mealie/issues/1260))
+- Bump vue2-script-setup-transform in /frontend ([#1263](https://github.com/mealie-recipes/mealie/issues/1263))
+- Update dev dependencies ([#1282](https://github.com/mealie-recipes/mealie/issues/1282))
 
 ### Refactor
 
-- Split up recipe create page ([#1283](https://github.com/hay-kot/mealie/issues/1283))
+- Split up recipe create page ([#1283](https://github.com/mealie-recipes/mealie/issues/1283))

--- a/docs/docs/changelog/v1.0.0beta-3.md
+++ b/docs/docs/changelog/v1.0.0beta-3.md
@@ -1,36 +1,36 @@
 ### Bug Fixes
 
-- Update issue links in v1.0.0beta-2 changelog ([#1312](https://github.com/hay-kot/mealie/issues/1312))
-- Bad import path ([#1313](https://github.com/hay-kot/mealie/issues/1313))
-- Printer page refs ([#1314](https://github.com/hay-kot/mealie/issues/1314))
+- Update issue links in v1.0.0beta-2 changelog ([#1312](https://github.com/mealie-recipes/mealie/issues/1312))
+- Bad import path ([#1313](https://github.com/mealie-recipes/mealie/issues/1313))
+- Printer page refs ([#1314](https://github.com/mealie-recipes/mealie/issues/1314))
 - Consolidate stores to fix mismatched state
-- Bump @vue/composition-api from 1.6.1 to 1.6.2 in /frontend ([#1275](https://github.com/hay-kot/mealie/issues/1275))
-- Shopping list label editor  ([#1333](https://github.com/hay-kot/mealie/issues/1333))
+- Bump @vue/composition-api from 1.6.1 to 1.6.2 in /frontend ([#1275](https://github.com/mealie-recipes/mealie/issues/1275))
+- Shopping list label editor  ([#1333](https://github.com/mealie-recipes/mealie/issues/1333))
 
 ### Features
 
 - Default unit fractions to True
-- Add unit abbreviation support ([#1332](https://github.com/hay-kot/mealie/issues/1332))
-- Attached images by drag and drop for recipe steps ([#1341](https://github.com/hay-kot/mealie/issues/1341))
+- Add unit abbreviation support ([#1332](https://github.com/mealie-recipes/mealie/issues/1332))
+- Attached images by drag and drop for recipe steps ([#1341](https://github.com/mealie-recipes/mealie/issues/1341))
 
 ### Docs
 
-- Render homepage social media link images at 32x32 size ([#1310](https://github.com/hay-kot/mealie/issues/1310))
+- Render homepage social media link images at 32x32 size ([#1310](https://github.com/mealie-recipes/mealie/issues/1310))
 
 ### Miscellaneous Tasks
 
 - Init git-cliff config
-- Bump @types/sortablejs in /frontend ([#1287](https://github.com/hay-kot/mealie/issues/1287))
-- Bump @babel/eslint-parser in /frontend ([#1290](https://github.com/hay-kot/mealie/issues/1290))
+- Bump @types/sortablejs in /frontend ([#1287](https://github.com/mealie-recipes/mealie/issues/1287))
+- Bump @babel/eslint-parser in /frontend ([#1290](https://github.com/mealie-recipes/mealie/issues/1290))
 
 ### Refactor
 
-- Unify recipe-organizer components ([#1340](https://github.com/hay-kot/mealie/issues/1340))
+- Unify recipe-organizer components ([#1340](https://github.com/mealie-recipes/mealie/issues/1340))
 
 ### Security
 
-- Delay server response whenever username is non existing ([#1338](https://github.com/hay-kot/mealie/issues/1338))
+- Delay server response whenever username is non existing ([#1338](https://github.com/mealie-recipes/mealie/issues/1338))
 
 ### Wip
 
-- Pagination-repository ([#1316](https://github.com/hay-kot/mealie/issues/1316))
+- Pagination-repository ([#1316](https://github.com/mealie-recipes/mealie/issues/1316))

--- a/docs/docs/changelog/v1.0.0beta-4.md
+++ b/docs/docs/changelog/v1.0.0beta-4.md
@@ -63,57 +63,57 @@ If either of the above actions prevent the user from uploading images, the appli
 
 ### Bug Fixes
 
-- For erroneously-translated datetime config ([#1362](https://github.com/hay-kot/mealie/issues/1362))
-- Fixed text color on RecipeCard in RecipePrintView and implemented ingredient sections ([#1351](https://github.com/hay-kot/mealie/issues/1351))
-- Ingredient sections lost after parsing ([#1368](https://github.com/hay-kot/mealie/issues/1368))
-- Increased float rounding precision for CRF parser ([#1369](https://github.com/hay-kot/mealie/issues/1369))
-- Infinite scroll bug on all recipes page ([#1393](https://github.com/hay-kot/mealie/issues/1393))
-- Fast fail of bulk importer ([#1394](https://github.com/hay-kot/mealie/issues/1394))
-- Bump @mdi/js from 5.9.55 to 6.7.96 in /frontend ([#1279](https://github.com/hay-kot/mealie/issues/1279))
-- Bump @nuxtjs/i18n from 7.0.3 to 7.2.2 in /frontend ([#1288](https://github.com/hay-kot/mealie/issues/1288))
-- Bump date-fns from 2.23.0 to 2.28.0 in /frontend ([#1293](https://github.com/hay-kot/mealie/issues/1293))
-- Bump fuse.js from 6.5.3 to 6.6.2 in /frontend ([#1325](https://github.com/hay-kot/mealie/issues/1325))
-- Bump core-js from 3.17.2 to 3.23.1 in /frontend ([#1383](https://github.com/hay-kot/mealie/issues/1383))
-- All-recipes page now sorts alphabetically ([#1405](https://github.com/hay-kot/mealie/issues/1405))
-- Sort recent recipes by created_at instead of date_added ([#1417](https://github.com/hay-kot/mealie/issues/1417))
-- Only show scaler when ingredients amounts enabled ([#1426](https://github.com/hay-kot/mealie/issues/1426))
-- Add missing types for API token deletion ([#1428](https://github.com/hay-kot/mealie/issues/1428))
-- Entry nutrition checker ([#1448](https://github.com/hay-kot/mealie/issues/1448))
-- Use == operator instead of is_ for sql queries ([#1453](https://github.com/hay-kot/mealie/issues/1453))
-- Use `mtime` instead of `ctime` for backup dates  ([#1461](https://github.com/hay-kot/mealie/issues/1461))
-- Mealplan pagination ([#1464](https://github.com/hay-kot/mealie/issues/1464))
-- Properly use pagination for group event notifies ([#1512](https://github.com/hay-kot/mealie/pull/1512))
+- For erroneously-translated datetime config ([#1362](https://github.com/mealie-recipes/mealie/issues/1362))
+- Fixed text color on RecipeCard in RecipePrintView and implemented ingredient sections ([#1351](https://github.com/mealie-recipes/mealie/issues/1351))
+- Ingredient sections lost after parsing ([#1368](https://github.com/mealie-recipes/mealie/issues/1368))
+- Increased float rounding precision for CRF parser ([#1369](https://github.com/mealie-recipes/mealie/issues/1369))
+- Infinite scroll bug on all recipes page ([#1393](https://github.com/mealie-recipes/mealie/issues/1393))
+- Fast fail of bulk importer ([#1394](https://github.com/mealie-recipes/mealie/issues/1394))
+- Bump @mdi/js from 5.9.55 to 6.7.96 in /frontend ([#1279](https://github.com/mealie-recipes/mealie/issues/1279))
+- Bump @nuxtjs/i18n from 7.0.3 to 7.2.2 in /frontend ([#1288](https://github.com/mealie-recipes/mealie/issues/1288))
+- Bump date-fns from 2.23.0 to 2.28.0 in /frontend ([#1293](https://github.com/mealie-recipes/mealie/issues/1293))
+- Bump fuse.js from 6.5.3 to 6.6.2 in /frontend ([#1325](https://github.com/mealie-recipes/mealie/issues/1325))
+- Bump core-js from 3.17.2 to 3.23.1 in /frontend ([#1383](https://github.com/mealie-recipes/mealie/issues/1383))
+- All-recipes page now sorts alphabetically ([#1405](https://github.com/mealie-recipes/mealie/issues/1405))
+- Sort recent recipes by created_at instead of date_added ([#1417](https://github.com/mealie-recipes/mealie/issues/1417))
+- Only show scaler when ingredients amounts enabled ([#1426](https://github.com/mealie-recipes/mealie/issues/1426))
+- Add missing types for API token deletion ([#1428](https://github.com/mealie-recipes/mealie/issues/1428))
+- Entry nutrition checker ([#1448](https://github.com/mealie-recipes/mealie/issues/1448))
+- Use == operator instead of is_ for sql queries ([#1453](https://github.com/mealie-recipes/mealie/issues/1453))
+- Use `mtime` instead of `ctime` for backup dates  ([#1461](https://github.com/mealie-recipes/mealie/issues/1461))
+- Mealplan pagination ([#1464](https://github.com/mealie-recipes/mealie/issues/1464))
+- Properly use pagination for group event notifies ([#1512](https://github.com/mealie-recipes/mealie/pull/1512))
 
 ### Documentation
 
-- Add go bulk import example ([#1388](https://github.com/hay-kot/mealie/issues/1388))
+- Add go bulk import example ([#1388](https://github.com/mealie-recipes/mealie/issues/1388))
 - Fix old link
-- Pagination and filtering, and fixed a few broken links ([#1488](https://github.com/hay-kot/mealie/issues/1488))
+- Pagination and filtering, and fixed a few broken links ([#1488](https://github.com/mealie-recipes/mealie/issues/1488))
 
 ### Features
 
-- Toggle display of ingredient references in recipe instructions ([#1268](https://github.com/hay-kot/mealie/issues/1268))
-- Add custom scaling option ([#1345](https://github.com/hay-kot/mealie/issues/1345))
-- Implemented "order by" API parameters for recipe, food, and unit queries ([#1356](https://github.com/hay-kot/mealie/issues/1356))
-- Implement user favorites page ([#1376](https://github.com/hay-kot/mealie/issues/1376))
-- Extend Apprise JSON notification functionality with programmatic data ([#1355](https://github.com/hay-kot/mealie/issues/1355))
-- Mealplan-webhooks ([#1403](https://github.com/hay-kot/mealie/issues/1403))
-- Added "last-modified" header to supported record types ([#1379](https://github.com/hay-kot/mealie/issues/1379))
-- Re-write get all routes to use pagination ([#1424](https://github.com/hay-kot/mealie/issues/1424))
-- Advanced filtering API ([#1468](https://github.com/hay-kot/mealie/issues/1468))
-- Restore frontend sorting for all recipes ([#1497](https://github.com/hay-kot/mealie/issues/1497))
-- Implemented local storage for sorting and dynamic sort icons on the new recipe sort card ([1506](https://github.com/hay-kot/mealie/pull/1506))
-- create new foods and units from their Data Management pages ([#1511](https://github.com/hay-kot/mealie/pull/1511))
+- Toggle display of ingredient references in recipe instructions ([#1268](https://github.com/mealie-recipes/mealie/issues/1268))
+- Add custom scaling option ([#1345](https://github.com/mealie-recipes/mealie/issues/1345))
+- Implemented "order by" API parameters for recipe, food, and unit queries ([#1356](https://github.com/mealie-recipes/mealie/issues/1356))
+- Implement user favorites page ([#1376](https://github.com/mealie-recipes/mealie/issues/1376))
+- Extend Apprise JSON notification functionality with programmatic data ([#1355](https://github.com/mealie-recipes/mealie/issues/1355))
+- Mealplan-webhooks ([#1403](https://github.com/mealie-recipes/mealie/issues/1403))
+- Added "last-modified" header to supported record types ([#1379](https://github.com/mealie-recipes/mealie/issues/1379))
+- Re-write get all routes to use pagination ([#1424](https://github.com/mealie-recipes/mealie/issues/1424))
+- Advanced filtering API ([#1468](https://github.com/mealie-recipes/mealie/issues/1468))
+- Restore frontend sorting for all recipes ([#1497](https://github.com/mealie-recipes/mealie/issues/1497))
+- Implemented local storage for sorting and dynamic sort icons on the new recipe sort card ([1506](https://github.com/mealie-recipes/mealie/pull/1506))
+- create new foods and units from their Data Management pages ([#1511](https://github.com/mealie-recipes/mealie/pull/1511))
 
 ### Miscellaneous Tasks
 
-- Bump dev deps ([#1418](https://github.com/hay-kot/mealie/issues/1418))
-- Bump @vue/runtime-dom in /frontend ([#1423](https://github.com/hay-kot/mealie/issues/1423))
-- Backend page_all route cleanup ([#1483](https://github.com/hay-kot/mealie/issues/1483))
+- Bump dev deps ([#1418](https://github.com/mealie-recipes/mealie/issues/1418))
+- Bump @vue/runtime-dom in /frontend ([#1423](https://github.com/mealie-recipes/mealie/issues/1423))
+- Backend page_all route cleanup ([#1483](https://github.com/mealie-recipes/mealie/issues/1483))
 
 ### Refactor
 
-- Remove depreciated repo call ([#1370](https://github.com/hay-kot/mealie/issues/1370))
+- Remove depreciated repo call ([#1370](https://github.com/mealie-recipes/mealie/issues/1370))
 
 ### Hotfix
 
@@ -121,6 +121,6 @@ If either of the above actions prevent the user from uploading images, the appli
 
 ### UI
 
-- Improve parser ui text display ([#1437](https://github.com/hay-kot/mealie/issues/1437))
+- Improve parser ui text display ([#1437](https://github.com/mealie-recipes/mealie/issues/1437))
 
 <!-- generated by git-cliff -->

--- a/docs/docs/contributors/developers-guide/code-contributions.md
+++ b/docs/docs/contributors/developers-guide/code-contributions.md
@@ -20,8 +20,8 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 ## Any contributions you make will be under the AGPL Software License
 In short, when you submit code changes, your submissions are understood to be under the same [AGPL License](https://choosealicense.com/licenses/agpl-3.0/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/hay-kot/mealie/issues)
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/hay-kot/mealie/issues/new); it's that easy!
+## Report bugs using Github's [issues](https://github.com/mealie-recipes/mealie/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/mealie-recipes/mealie/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
 **Great Bug Reports** tend to have:

--- a/docs/docs/contributors/developers-guide/starting-dev-server.md
+++ b/docs/docs/contributors/developers-guide/starting-dev-server.md
@@ -124,9 +124,9 @@ docker-prod          🐳 Build and Start Docker Production Stack
 ```
 ## Internationalization
 ### Frontend
-We use vue-i18n package for internationalization. Translations are stored in json format located in [frontend/lang/messages](https://github.com/hay-kot/mealie/tree/mealie-next/frontend/lang/messages).
+We use vue-i18n package for internationalization. Translations are stored in json format located in [frontend/lang/messages](https://github.com/mealie-recipes/mealie/tree/mealie-next/frontend/lang/messages).
 ### Backend
-Translations are stored in json format located in [mealie/lang/messages](https://github.com/hay-kot/mealie/tree/mealie-next/mealie/lang/messages).
+Translations are stored in json format located in [mealie/lang/messages](https://github.com/mealie-recipes/mealie/tree/mealie-next/mealie/lang/messages).
 
 ### Quick frontend localization with VS Code
 [i18n Ally for VScode](https://marketplace.visualstudio.com/items?itemName=lokalise.i18n-ally) is helpful for generating new strings to translate using Code Actions. It also has a nice feature, which shows translations in-place when editing code.

--- a/docs/docs/contributors/guides/ingredient-parser.md
+++ b/docs/docs/contributors/guides/ingredient-parser.md
@@ -15,6 +15,6 @@ Alternatively, you can register a new parser by fulfilling the `ABCIngredientPar
 
 
 ## Links
-- [Pretrained Model](https://github.com/hay-kot/mealie-nlp-model)
+- [Pretrained Model](https://github.com/mealie-recipes/mealie-nlp-model)
 - [CRF++ (Forked)](https://github.com/hay-kot/crfpp)
 


### PR DESCRIPTION
## What type of PR is this?

- cleanup
- documentation

## What this PR does / why we need it:

I found a few instances of the older repository (https://github.com/hay-kot/mealie) for Mealie in the repository. I replaced them with https://github.com/mealie-recipes/mealie. More files still have a reference to the older, but I didn't want to create a huge PR. 

## Special notes for your reviewer:

The changes were done with the following command at the root of the repository:

```bash
sed -i -e 's|/hay-kot/mealie|/mealie-recipes/mealie|g' **/*.md
```