### PR TITLE
add libldap-2.5 to runtime dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,6 +89,7 @@ RUN apt-get update \
     gosu \
     iproute2 \
     libldap-common \
+    libldap-2.5 \
     && rm -rf /var/lib/apt/lists/*
 
 # copying poetry and venv into image


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes ldap (again). Apparently python-ldap needs `libldap-2.5` now, so this PR adds that to the production image.

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->
Fixes #2847

## Testing
Built and manually tested the docker image locally
