### PR TITLE
chore: bump recipe-scrapers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2204,13 +2204,13 @@ tests = ["html5lib", "pytest", "pytest-cov"]
 
 [[package]]
 name = "recipe-scrapers"
-version = "14.52.0"
+version = "14.53.0"
 description = "Python package, scraping recipes from all over the internet"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "recipe_scrapers-14.52.0-py3-none-any.whl", hash = "sha256:3514048808c7b7de467bfa56bea3921ecff637441cde9085186345e3ce7cabdc"},
-    {file = "recipe_scrapers-14.52.0.tar.gz", hash = "sha256:3d1d2cf7ad8c5fd73b5a0e921b3505daeddb42da705ef5c68523a465ccd8cd8f"},
+    {file = "recipe_scrapers-14.53.0-py3-none-any.whl", hash = "sha256:330353dc824f9d77a089e4830722fef940a04259a1a59a6578a162378ed6bc72"},
+    {file = "recipe_scrapers-14.53.0.tar.gz", hash = "sha256:916e1182fb497b89df8ac29cb816a9566aafc6d2bba73f60462aef42fc1bba22"},
 ]
 
 [package.dependencies]
@@ -3034,4 +3034,4 @@ pgsql = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "984d725b667165ebbf82eeea32a38e4f4891192fc8c6be60864d25d5b36e7970"
+content-hash = "d7537958ae2ddbf8e2b350cb7b1189492a62b02becfe087efbc37a3b0115ff13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ python-jose = "^3.3.0"
 python-ldap = "^3.3.1"
 python-multipart = "^0.0.6"
 python-slugify = "^8.0.0"
-recipe-scrapers = "^14.52.0"
+recipe-scrapers = "^14.53.0"
 requests = "^2.31.0"
 tzdata = "^2022.7"
 uvicorn = { extras = ["standard"], version = "^0.21.0" }


### PR DESCRIPTION
## What type of PR is this?

- dependency bump

## What this PR does / why we need it:

The new version adds support for a exotic recipe schema structure used by for example dietdoctor. 

## Which issue(s) this PR fixes:

fixes #2837 

## Testing

manual testing with previously not working recipes and ran the test suite. 