### PR TITLE
feat: Add a Create Bookmarklet feature

### DIFF
--- a/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
+++ b/docs/docs/documentation/community-guide/import-recipe-bookmarklet.md
@@ -2,20 +2,13 @@
 !!! info
     This guide was submitted by a community member. Find something wrong? Submit a PR to get it fixed!
 
-You can use bookmarklets to generate a bookmark that will take your current location, and open a new tab that will try to import that URL into Mealie.
+You can use bookmarklets to generate a desktop browser bookmark that takes your current tab's URL and sends it to Mealie as a new recipe.
 
-You can use a [bookmarklet generator site](https://caiorss.github.io/bookmarklet-maker/) and the code below to generate a bookmark for your site. Just change the `http://localhost:8080` to your sites web address and follow the instructions.
+To create the bookmarklet configured for your installation and group:
 
-```js
-var url = document.URL;
-var mealie = "http://localhost:8080";
-var group_slug = "home" // Change this to your group slug. You can obtain this from your URL after logging-in to Mealie
-var use_keywords= "&use_keywords=1" // Optional - use keywords from recipe - update to "" if you don't want that
-var edity = "&edit=1" // Optional - keep in edit mode - update to "" if you don't want that
-
-if (mealie.slice(-1) === "/") {
-    mealie = mealie.slice(0, -1)
-}
-var dest = mealie + "/g/" + group_slug + "/r/create/url?recipe_import_url=" + url + use_keywords + edity;
-window.open(dest, "_blank");
-```
+0. Log into your Mealie instance
+1. Click the Create button on the side nav and choose Import
+2. On the right side of the page, switch "Import with URL" to "Create Bookmarklet"
+3. Choose your options
+4. Select and copy all the javascript text to your clipboard
+5. Create a new Bookmark in your browser, and paste the javascript into the URL/Address of the bookmark

--- a/docs/docs/documentation/getting-started/features.md
+++ b/docs/docs/documentation/getting-started/features.md
@@ -6,7 +6,13 @@
 
 ### Creating Recipes
 
-Mealie offers two main ways to create recipes. You can use the integrated recipe-scraper to create recipes from hundreds of websites, or you can create recipes manually using the recipe editor.
+Mealie offers a few ways to bring your recipes in, including:
+
+ - [Pasting the URL](https://demo.mealie.io/g/home/r/create/url) into Mealie
+ - Use a [Bookmarklet](../../community-guide/import-recipe-bookmarklet) to send recipes to Mealie from a desktop web browser
+ - Installable PWA implements the Share_Target API for mobile devices ([limited device and app support](https://caniuse.com/?search=share_target))
+ - [iOS Shortcuts](../../community-guide/ios/)
+ - Creating recipes manually using the recipe editor
 
 [Creation Demo](https://demo.mealie.io/g/home/r/create/url){ .md-button .md-button--primary .align-right }
 

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -209,9 +209,19 @@ export default defineComponent({
     });
 
     async function lockScreen() {
-      if (wakeIsSupported) {
-        console.log("Wake Lock Requested");
-        await request("screen");
+      // https://developer.mozilla.org/en-US/docs/Web/API/WakeLock/request
+      // Even if wakeIsSupported, it can still be blocked with a NotAllowedError
+      // if the browser doesn't feel the user intended this behavior (like if on page
+      // load we try to automatically activate the wake lock).
+      // If the browser blocks it, the user can still enable by explicitly clicking on
+      // the Keep Screen Awake switch
+      try {
+        if (wakeIsSupported) {
+          console.log("Wake Lock Requested");
+          await request("screen");
+        }
+      } catch (e) {
+        console.error("Couldn't activate wake lock: ", e);
       }
     }
 

--- a/frontend/lang/messages/en-GB.json
+++ b/frontend/lang/messages/en-GB.json
@@ -555,7 +555,8 @@
     "unit": "Unit",
     "upload-image": "Upload image",
     "screen-awake": "Keep Screen Awake",
-    "remove-image": "Remove image"
+    "remove-image": "Remove image",
+    "create-bookmarklet": "Create Bookmarklet"
   },
   "search": {
     "advanced-search": "Advanced Search",

--- a/frontend/lang/messages/en-GB.json
+++ b/frontend/lang/messages/en-GB.json
@@ -555,8 +555,7 @@
     "unit": "Unit",
     "upload-image": "Upload image",
     "screen-awake": "Keep Screen Awake",
-    "remove-image": "Remove image",
-    "create-bookmarklet": "Create Bookmarklet"
+    "remove-image": "Remove image"
   },
   "search": {
     "advanced-search": "Advanced Search",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -559,7 +559,7 @@
     "create-bookmarklet": "Create Bookmarklet",
     "create-bookmarklet-description": "Create a bookmarklet that allows you to add recipes from your web browser's bookmark bar.",
     "create-bookmarklet-result": "Bookmarklet",
-    "create-bookmarklet-hint": "Copy the javascript code above and then rightclick on your bookmark bar to Create a New Bookmark, using the code as the Address of the bookmark."
+    "create-bookmarklet-hint": "Copy the javascript code above and then right-click on your bookmark bar to Create a New Bookmark, using the code as the Address of the bookmark."
   },
   "search": {
     "advanced-search": "Advanced Search",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -557,7 +557,9 @@
     "screen-awake": "Keep Screen Awake",
     "remove-image": "Remove image",
     "create-bookmarklet": "Create Bookmarklet",
-    "create-bookmarklet-description": "Create a bookmarklet that allows you to add recipies "
+    "create-bookmarklet-description": "Create a bookmarklet that allows you to add recipes from your web browser's bookmark bar.",
+    "create-bookmarklet-result": "Bookmarklet",
+    "create-bookmarklet-hint": "Copy the javascript code above and then rightclick on your bookmark bar to Create a New Bookmark, using the code as the Address of the bookmark."
   },
   "search": {
     "advanced-search": "Advanced Search",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -555,7 +555,9 @@
     "unit": "Unit",
     "upload-image": "Upload image",
     "screen-awake": "Keep Screen Awake",
-    "remove-image": "Remove image"
+    "remove-image": "Remove image",
+    "create-bookmarklet": "Create Bookmarklet",
+    "create-bookmarklet-description": "Create a bookmarklet that allows you to add recipies "
   },
   "search": {
     "advanced-search": "Advanced Search",

--- a/frontend/pages/g/_groupSlug/r/create.vue
+++ b/frontend/pages/g/_groupSlug/r/create.vue
@@ -50,7 +50,7 @@ export default defineComponent({
       {
         icon: $globals.icons.tags,
         text: i18n.tc("recipe.create-bookmarklet"),
-        value: "new",
+        value: "bookmarklet",
       },
       {
         icon: $globals.icons.zip,

--- a/frontend/pages/g/_groupSlug/r/create.vue
+++ b/frontend/pages/g/_groupSlug/r/create.vue
@@ -48,6 +48,11 @@ export default defineComponent({
         value: "new",
       },
       {
+        icon: $globals.icons.tags,
+        text: i18n.tc("recipe.create-bookmarklet"),
+        value: "new",
+      },
+      {
         icon: $globals.icons.zip,
         text: i18n.tc("recipe.import-with-zip"),
         value: "zip",

--- a/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
+++ b/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
@@ -21,7 +21,6 @@
             :readonly="true"
             @click="copyBookmarklet"
           ></v-textarea>
-
         </div>
       </v-form>
     </div>
@@ -97,7 +96,7 @@
 
         // window.history.replaceState is appended to fix Vivaldi bug
         // https://forum.vivaldi.net/topic/31409/bookmarklets-replaces-the-url-in-the-address-bar/25?lang=en-US&page=2
-        return encodeURIComponent(`javascript:(function(){var dest="${url}/g/${groupSlug.value}/r/create/url?use_keywords=${importKeywordsAsTagAsNumber.value}&edit=${stayInEditModeAsNumber.value}&recipe_import_url="+encodeURIComponent(document.URL);window.open(dest,"_blank");window.history.replaceState({},"",location.href);})();`);
+        return "javascript:" + encodeURIComponent(`(function(){var dest="${url}/g/${groupSlug.value}/r/create/url?use_keywords=${importKeywordsAsTagAsNumber.value}&edit=${stayInEditModeAsNumber.value}&recipe_import_url="+encodeURIComponent(document.URL);window.open(dest,"_blank");window.history.replaceState({},"",location.href);})()`) + ";"
       }
       });
 

--- a/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
+++ b/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
@@ -1,0 +1,121 @@
+<template>
+    <div>
+      <v-form ref="domUrlForm" @submit.prevent="createBookmarklet(importKeywordsAsTags, stayInEditMode)">
+        <div>
+          <v-card-title class="headline"> {{ $t('recipe.create-bookmarklet') }} </v-card-title>
+          <v-card-text>
+            {{ $t('recipe.create-bookmarklet-description') }}
+            <v-checkbox v-model="importKeywordsAsTags" hide-details :label="$t('recipe.import-original-keywords-as-tags')" />
+            <v-checkbox v-model="stayInEditMode" hide-details :label="$t('recipe.stay-in-edit-mode')" />
+          </v-card-text>
+          <v-card-actions class="justify-center">
+            <div style="width: 250px">
+              <BaseButton rounded block type="submit" :loading="loading" />
+            </div>
+          </v-card-actions>
+        </div>
+      </v-form>
+      <v-expand-transition>
+        <v-alert v-show="error" color="error" class="mt-6 white--text">
+          <v-card-title class="ma-0 pa-0">
+            <v-icon left color="white" x-large> {{ $globals.icons.robot }} </v-icon>
+            {{ $t("new-recipe.error-title") }}
+          </v-card-title>
+          <v-divider class="my-3 mx-2"></v-divider>
+
+          <p>
+            {{ $t("new-recipe.error-details") }}
+          </p>
+
+        </v-alert>
+      </v-expand-transition>
+    </div>
+  </template>
+
+  <script lang="ts">
+  import {
+    defineComponent,
+    reactive,
+    toRefs,
+    ref,
+    useRouter,
+    computed,
+    useContext,
+    useRoute
+  } from "@nuxtjs/composition-api";
+  import { AxiosResponse } from "axios";
+  import { useUserApi } from "~/composables/api";
+  import { useTagStore } from "~/composables/store/use-tag-store";
+  import { validators } from "~/composables/use-validators";
+  import { VForm } from "~/types/vuetify";
+
+  export default defineComponent({
+    setup() {
+      const state = reactive({
+        error: false,
+        loading: false,
+      });
+
+      const { $auth } = useContext();
+      const api = useUserApi();
+      const route = useRoute();
+      const groupSlug = computed(() => route.value.params.groupSlug || $auth.user?.groupSlug || "");
+
+      const router = useRouter();
+      const tags = useTagStore();
+
+      function handleResponse(response: AxiosResponse<string> | null, edit = false, refreshTags = false) {
+        if (response?.status !== 201) {
+          state.error = true;
+          state.loading = false;
+          return;
+        }
+        if (refreshTags) {
+          tags.actions.refresh();
+        }
+
+      }
+
+      const importKeywordsAsTags = computed({
+        get() {
+          return route.value.query.use_keywords === "1";
+        },
+        set(v: boolean) {
+          router.replace({ query: { ...route.value.query, use_keywords: v ? "1" : "0" } });
+        },
+      });
+
+      const stayInEditMode = computed({
+        get() {
+          return route.value.query.edit === "1";
+        },
+        set(v: boolean) {
+          router.replace({ query: { ...route.value.query, edit: v ? "1" : "0" } });
+        },
+      });
+
+      const domUrlForm = ref<VForm | null>(null);
+
+      async function createBookmarklet(importKeywordsAsTags: boolean, stayInEditMode: boolean) {
+        state.loading = true;
+        const { response } = await api.recipes.createOneByUrl("https://mattmcnamara.com", importKeywordsAsTags);
+        handleResponse(response, stayInEditMode, importKeywordsAsTags);
+      }
+
+      return {
+        importKeywordsAsTags,
+        stayInEditMode,
+        domUrlForm,
+        createBookmarklet,
+        ...toRefs(state),
+        validators,
+      };
+    },
+  });
+  </script>1
+
+  <style>
+  .force-white > a {
+    color: white !important;
+  }
+  </style>

--- a/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
+++ b/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
@@ -51,23 +51,8 @@
 
       const router = useRouter();
 
-      const importKeywordsAsTags = computed({
-        get() {
-          return route.value.query.use_keywords === "1";
-        },
-        set(v: boolean) {
-          router.replace({ query: { ...route.value.query, use_keywords: v ? "1" : "0" } });
-        },
-      });
-
-      const stayInEditMode = computed({
-        get() {
-          return route.value.query.edit === "1";
-        },
-        set(v: boolean) {
-          router.replace({ query: { ...route.value.query, edit: v ? "1" : "0" } });
-        },
-      });
+      const importKeywordsAsTags = ref<boolean>(false);
+      const stayInEditMode = ref<boolean>(false);
 
       const baseUrl = computed(() => detectServerBaseUrl(req));
       const groupSlug = computed(() => route.value.params.groupSlug || $auth.user?.groupSlug || "");

--- a/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
+++ b/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
@@ -40,7 +40,6 @@
   } from "@nuxtjs/composition-api";
   import { detectServerBaseUrl } from "~/composables/use-utils";
   import { VForm } from "~/types/vuetify";
-  import { alert } from "~/composables/use-toast";
   import { useCopy } from "~/composables/use-copy";
 
   export default defineComponent({
@@ -78,21 +77,24 @@
 
       const bookmarkletResult = computed({
         get() {
-          const route = useRoute();
+        const route = useRoute();
 
-          let url = document.URL;
-          let slashCount = 0;
-          let position = -1;
+        let url = document.URL;
+        let slashCount = 0;
+        let position = -1;
 
-          // The third slash is after the port portion of the URL
-          while(slashCount < 3) {
-            position = url.indexOf("/", position + 1);
-            if (position === -1) {
-              break;
-            }
-            slashCount++;
+        // The third slash is after the port portion of the URL
+        while(slashCount < 3) {
+          position = url.indexOf("/", position + 1);
+          if (position === -1) {
+            break;
           }
+          slashCount++;
+        }
+
+        // Now that we found the third slash, remove it and everything after
         url = url.substring(0, position);
+
         // window.history.replaceState is appended to fix Vivaldi bug
         // https://forum.vivaldi.net/topic/31409/bookmarklets-replaces-the-url-in-the-address-bar/25?lang=en-US&page=2
         return encodeURIComponent(`javascript:(function(){var dest="${url}/g/${groupSlug.value}/r/create/url?use_keywords=${importKeywordsAsTagAsNumber.value}&edit=${stayInEditModeAsNumber.value}&recipe_import_url="+encodeURIComponent(document.URL);window.open(dest,"_blank");window.history.replaceState({},"",location.href);})();`);

--- a/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
+++ b/frontend/pages/g/_groupSlug/r/create/bookmarklet.vue
@@ -59,30 +59,13 @@
       const importKeywordsAsTagAsNumber = computed(() => Number(importKeywordsAsTags.value));
       const stayInEditModeAsNumber = computed(() => Number(stayInEditMode.value));
 
-      const bookmarkletResult = computed({
-        get() {
-        const route = useRoute();
-
-        let url = document.URL;
-        let slashCount = 0;
-        let position = -1;
-
-        // The third slash is after the port portion of the URL
-        while(slashCount < 3) {
-          position = url.indexOf("/", position + 1);
-          if (position === -1) {
-            break;
-          }
-          slashCount++;
-        }
-
-        // Now that we found the third slash, remove it and everything after
-        url = url.substring(0, position);
+      const bookmarkletResult: ComputedRef<string> = computed(() => {
+        // get the origin of the current page
+        const url = new URL(document.URL).origin;
 
         // window.history.replaceState is appended to fix Vivaldi bug
         // https://forum.vivaldi.net/topic/31409/bookmarklets-replaces-the-url-in-the-address-bar/25?lang=en-US&page=2
-        return "javascript:" + encodeURIComponent(`(function(){var dest="${url}/g/${groupSlug.value}/r/create/url?use_keywords=${importKeywordsAsTagAsNumber.value}&edit=${stayInEditModeAsNumber.value}&recipe_import_url="+encodeURIComponent(document.URL);window.open(dest,"_blank");window.history.replaceState({},"",location.href);})()`) + ";"
-      }
+        return "javascript:" + encodeURIComponent(`(function(){var dest="${url}/g/${groupSlug.value}/r/create/url?use_keywords=${Number(importKeywordsAsTags.value)}&edit=${Number(stayInEditMode.value)}&recipe_import_url="+encodeURIComponent(document.URL);window.open(dest,"_blank");window.history.replaceState({},"",location.href);})()`) + ";"
       });
 
       const copyBookmarklet = () => {


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Today, users who want to have a bookmarklet to ingest recipes from a desktop browser need to web search to find the [documentation](https://nightly.mealie.io/documentation/community-guide/import-recipe-bookmarklet/) to manually create a bookmarklet, which requires more technical skill than my mom can handle.  (Sorry mom.)

Ideally, users should be able to:

- Self-discover inapp about the bookmarklet feature
- Have URL parameters like protocol, domain, and port pre-populated
- Use familiar UI options to configure how the bookmarklet can work for them
- Be provided instructions on how to install the bookmarklet

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

This PR implements the following changes

- [x] Within `r/create.vue`, add a new menu option for the subpage switch to a new local `bookmarklet` route
- [x] Implements `r/create/bookmarklet.vue` using the UI from `r/create/url.vue` and the logic from the existing documentation's [Import Bookmarklet](https://nightly.mealie.io/documentation/community-guide/import-recipe-bookmarklet/) page.  This allows users to decide if they want to automatically import keywords as tags or to stay in edit mode.
  - [x] Import `~/composables/use-copy` to enable an `@click` listener on the `v-textarea#bookmarkletResult` JS code that, when able, puts the bookmarklet code into the user's clipboard.  `use-copy` imports `use-toast`, so users will see an appropriate success or failure toast depending on whether writing to the clipboard succeeded.
- [x] Updates `messages/en-US.json` with 4 new strings
- [x] Updates the documentation website with new documentation for this feature

During testing on Safari, after using the bookmarklet to import a recipe, I would see the RecipePage and as soon as it finished loading the page would switch to a 404 with an uncaught error exception (NotAllowedError).  I traced this to the Safari Wake Lock API's security policy.  I believe Safari was being more restrictive and not allowing a newly opened tab to establish the lock w/o user interaction.  Therefore I also made this change:
- [x] Add a try/catch to `RecipePage.vue` around `@vueuse/core.useWakeLock.request()` within our implementation of `lockScreen()`.

## Which issue(s) this PR fixes:

I didn't create an issue.

## Special notes for your reviewer:

No special notes.

## Testing

Tested on:
- [x] Mac Chrome (120.0.6099.199)
- [x] Mac Safari (17.2.1)
- [x] Mac Vivaldi (6.5.3206.50)
- [x] Mac Firefox (121.0)

For each browser above, the following tests are performed:
- [x] Confirm navigation works:
  - [x] Able to directly navigate to the page
  - [x] Able to toggle between ./url and ./bookmarklet
  - [x] URL parameters are updated on check/uncheck for both options
  - [x] URL parameters are respected in setting the checkboxes on page draw
- [x] Rendering and layout: 
  - [x] Widescreen on load
  - [x] Narrow on load
  - [x] Resize between
- [x] Bookmarklet generation:
  - [x] Correctly sets the JS with the protocol, domain, subdomain, port, and groupSlug
  - [x] Live respects the checkboxes
  - [x] Copy works
- [x] Bookmarklet works:
  - [x] Opens in a new tab
  - [x] Existing tab's URL is unchanged
  - [x] Mealie gets a properly encoded URL with protocol, domain, path, and URL parameters
  - [x] Mealie correctly follows the settings defined during bookmarklet generation (auto keywords/auto edit)
