### PR TITLE
fix: Updated Image References To Use Newer Commit And Fixed Email Banner

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -16,7 +16,7 @@ export default {
         hid: "og:image",
         property: "og:image",
         content:
-          "https://raw.githubusercontent.com/hay-kot/mealie/dev/frontend/public/img/icons/android-chrome-512x512.png",
+          "https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/icons/android-chrome-512x512.png",
       },
       { charset: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },

--- a/mealie/routes/spa/__init__.py
+++ b/mealie/routes/spa/__init__.py
@@ -84,9 +84,7 @@ def content_with_meta(group_slug: str, recipe: Recipe) -> str:
             f"{__app_settings.BASE_URL}/api/media/recipes/{recipe.id}/images/original.webp?version={recipe.image}"
         )
     else:
-        image_url = (
-            "https://raw.githubusercontent.com/hay-kot/mealie/dev/frontend/public/img/icons/android-chrome-512x512.png"
-        )
+        image_url = "https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/icons/android-chrome-512x512.png"
 
     ingredients: list[str] = []
     if recipe.settings.disable_amount:  # type: ignore

--- a/mealie/services/email/templates/default.html
+++ b/mealie/services/email/templates/default.html
@@ -212,7 +212,7 @@
                                 <td style="width: 550px">
                                   <img
                                     height="auto"
-                                    src="https://api-test.emailbuilder.top/saemailbuilder/dc23dc82-ffd7-4f4c-b563-94f23db4c2c3/images/256d8bd6-ffde-4bf2-b577-dd8306dae877/file.png"
+                                    src="https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/mealie-email-banner.png"
                                     style="
                                       border: 0;
                                       display: block;

--- a/mealie/services/event_bus_service/publisher.py
+++ b/mealie/services/event_bus_service/publisher.py
@@ -16,7 +16,7 @@ class ApprisePublisher:
     def __init__(self, hard_fail=False) -> None:
         asset = apprise.AppriseAsset(
             async_mode=True,
-            image_url_mask="https://raw.githubusercontent.com/hay-kot/mealie/dev/frontend/public/img/icons/android-chrome-maskable-512x512.png",
+            image_url_mask="https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/icons/android-chrome-maskable-512x512.png",
         )
         self.apprise = apprise.Apprise(asset=asset)
         self.hard_fail = hard_fail

--- a/tests/data/html/mealie-recipe.html
+++ b/tests/data/html/mealie-recipe.html
@@ -5,7 +5,7 @@
       <meta data-n-head="1" data-hid="og:title" property="og:title" content="Mealie">
       <meta data-n-head="1" data-hid="og:site_name" property="og:site_name" content="Mealie">
       <meta data-n-head="1" data-hid="og:description" property="og:description" content="Mealie is a recipe management app for your kitchen.">
-      <meta data-n-head="1" data-hid="og:image" property="og:image" content="https://raw.githubusercontent.com/hay-kot/mealie/dev/frontend/public/img/icons/android-chrome-512x512.png">
+      <meta data-n-head="1" data-hid="og:image" property="og:image" content="https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/icons/android-chrome-512x512.png">
       <meta data-n-head="1" charset="utf-8">
       <meta data-n-head="1" name="viewport" content="width=device-width,initial-scale=1">
       <meta data-n-head="1" data-hid="description" name="description" content="Mealie is a recipe management app for your kitchen.">


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

The Mealie icon referenced the old `dev` branch. I updated the references to use the current latest `mealie-next` branch (it references the commit hash, not the raw branch). Referencing the dev branch made me nervous.

Additionally, I replaced the broken email banner reference with the new one added in https://github.com/mealie-recipes/mealie/pull/2901.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2480