### PR TITLE
Add LOG_DIR env var to set log file directory

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -15,6 +15,7 @@
 | API_DOCS      |         True          | Turns on/off access to the API documentation locally.                               |
 | TZ            |          UTC          | Must be set to get correct date/time on the server                                  |
 | ALLOW_SIGNUP  |         true          | Allow user sign-up without token                                                    |
+| LOG_DIR       |       /app/data       | Directory to place log files in                                                     |
 
 ### Security
 

--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -16,6 +16,7 @@ dotenv.load_dotenv(ENV)
 PRODUCTION = os.getenv("PRODUCTION", "True").lower() in ["true", "1"]
 TESTING = os.getenv("TESTING", "False").lower() in ["true", "1"]
 DATA_DIR = os.getenv("DATA_DIR")
+LOG_DIR = os.getenv("LOG_DIR")
 
 
 def determine_data_dir() -> Path:
@@ -28,6 +29,19 @@ def determine_data_dir() -> Path:
         return Path(DATA_DIR if DATA_DIR else "/app/data")
 
     return BASE_DIR.joinpath("dev", "data")
+
+
+def determine_log_dir() -> Path:
+    global PRODUCTION, TESTING, BASE_DIR, LOG_DIR
+
+    if LOG_DIR:
+        if TESTING:
+            return BASE_DIR.joinpath(LOG_DIR)
+
+        if PRODUCTION:
+            return Path(LOG_DIR)
+
+    return determine_data_dir()
 
 
 @lru_cache

--- a/mealie/core/root_logger.py
+++ b/mealie/core/root_logger.py
@@ -3,13 +3,13 @@ import sys
 from dataclasses import dataclass
 from functools import lru_cache
 
-from mealie.core.config import determine_data_dir
+from mealie.core.config import determine_log_dir
 
-DATA_DIR = determine_data_dir()
+LOG_DIR = determine_log_dir()
 
 from .config import get_app_settings  # noqa E402
 
-LOGGER_FILE = DATA_DIR.joinpath("mealie.log")
+LOGGER_FILE = LOG_DIR.joinpath("mealie.log")
 DATE_FORMAT = "%d-%b-%y %H:%M:%S"
 LOGGER_FORMAT = "%(levelname)s: %(asctime)s \t%(message)s"
 
@@ -40,6 +40,7 @@ def get_logger_config():
             level=log_level,
         )
 
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
     output_file_handler = logging.FileHandler(LOGGER_FILE)
     handler_format = logging.Formatter(LOGGER_FORMAT, datefmt=DATE_FORMAT)
     output_file_handler.setFormatter(handler_format)


### PR DESCRIPTION
If LOG_DIR is not set, the data directory is used to match the previous behavior.

I would add tests, but I am unsure what the best way of testing this feature is.

## What type of PR is this?

- documentation
- feature

## What this PR does / why we need it:

In the old implementation, the mealie log file always was placed in the /app/data folder, preventing it from being separated from non-log application data. i.e. if a user wants to place it under /var/log

- Added `LOG_DIR` handling mirroring the existing `DATA_DIR` support, including adding `determine_log_dir` function
  - Fall back to `determine_data_dir` if `LOG_DIR` is not set
- Used `determine_log_dir` to set the root logger file path
- Added `mkdir` call to ensure `LOG_DIR` exists

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/discussions/2954 (discussion)
