### PR TITLE
Fix: Remove outdated code factor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Issues][issues-shield]][issues-url]
 [![AGPL License][license-shield]][license-url]
 [![Docker Pulls][docker-pull]][docker-pull]
-[![CodeFactor](https://www.codefactor.io/repository/github/mealie-recipes/mealie/badge)](https://www.codefactor.io/repository/github/mealie-recipes/mealie)
 
 <!-- PROJECT LOGO -->
 <br />


### PR DESCRIPTION
On phone, it doesn't give me the PR template. Hopefully this is straight forward enough that you'll forgive me! 