### PR TITLE
fix: frontend backup success check

### DIFF
--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -147,7 +147,7 @@ export default defineComponent({
     async function createBackup() {
       const { data } = await adminApi.backups.create();
 
-      if (!data?.error) {
+      if (data?.error === false) {
         refreshBackups();
         alert.success(i18n.tc("settings.backup.backup-created"));
       } else {


### PR DESCRIPTION
## What type of PR is this?

- bug


## What this PR does / why we need it:

The backup page does display a success statement even when no backup was created.
The if statement checking the returned data also was true when the returned object was null and thus a success alert was displayed. 

Before the fix you could:
- navigate to the Bakcup page
- kill the backend
- create an backup
- recieve an success alert

## Which issue(s) this PR fixes:

fixes #2970 

## Special notes for your reviewer:

None

## Testing

Manual testing
