### PR TITLE
fix: Add Date field to email header

### DIFF
--- a/mealie/services/email/email_senders.py
+++ b/mealie/services/email/email_senders.py
@@ -3,6 +3,7 @@ import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from email import message
+from email.utils import formatdate
 
 from mealie.services._base_service import BaseService
 
@@ -36,6 +37,7 @@ class Message:
         msg["Subject"] = self.subject
         msg["From"] = f"{self.mail_from_name} <{self.mail_from_address}>"
         msg["To"] = to
+        msg["Date"] = formatdate(localtime=True)
         msg.add_alternative(self.html, subtype="html")
 
         if smtp.ssl:


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This adds the Date field to the email header. The reason we did not catch this before is that most SMTP Servers do add the Date field by themselves if it is missing. 
This also fixes an issue in where the SMTP server might add a false date based on the timezone of the smtp server instead on the time zone of the sender. 

## Which issue(s) this PR fixes:

fixes #3028 

## Testing

Build a prod image and tested the email functionality. Everything still works as expected. 