### PR TITLE
fix: Update Group Slug When Updating Group

### DIFF
--- a/frontend/pages/admin/manage/groups/_id.vue
+++ b/frontend/pages/admin/manage/groups/_id.vue
@@ -79,6 +79,8 @@ export default defineComponent({
           window.location.reload();
         }
         group.value = data;
+      } else {
+        alert.error(i18n.tc("settings.settings-update-failed"));
       }
     }
 

--- a/frontend/pages/admin/manage/groups/_id.vue
+++ b/frontend/pages/admin/manage/groups/_id.vue
@@ -74,6 +74,10 @@ export default defineComponent({
 
       const { response, data } = await adminApi.groups.updateOne(group.value.id, group.value);
       if (response?.status === 200 && data) {
+        if (group.value.slug !== data.slug) {
+          // the slug updated, which invalidates the nav URLs
+          window.location.reload();
+        }
         group.value = data;
       }
     }

--- a/mealie/repos/repository_group.py
+++ b/mealie/repos/repository_group.py
@@ -14,7 +14,7 @@ from mealie.db.models.recipe.tag import Tag
 from mealie.db.models.recipe.tool import Tool
 from mealie.db.models.users.users import User
 from mealie.schema.group.group_statistics import GroupStatistics
-from mealie.schema.user.user import GroupBase, GroupInDB
+from mealie.schema.user.user import GroupBase, GroupInDB, UpdateGroup
 
 from ..db.models._model_base import SqlAlchemyBase
 from .repository_generic import RepositoryGeneric
@@ -44,6 +44,18 @@ class RepositoryGroup(RepositoryGeneric[GroupInDB, Group]):
     def create_many(self, data: Iterable[GroupInDB | dict]) -> list[GroupInDB]:
         # since create uses special logic for resolving slugs, we don't want to use the standard create_many method
         return [self.create(new_group) for new_group in data]
+
+    def update(self, match_value: str | int | UUID4, new_data: UpdateGroup | dict) -> GroupInDB:
+        if isinstance(new_data, GroupBase):
+            new_data.slug = slugify(new_data.name)
+        else:
+            new_data["slug"] = slugify(new_data["name"])
+
+        return super().update(match_value, new_data)
+
+    def update_many(self, data: Iterable[UpdateGroup | dict]) -> list[GroupInDB]:
+        # since update uses special logic for resolving slugs, we don't want to use the standard update_many method
+        return [self.update(group["id"] if isinstance(group, dict) else group.id, group) for group in data]
 
     def get_by_name(self, name: str) -> GroupInDB | None:
         dbgroup = self.session.execute(select(self.model).filter_by(name=name)).scalars().one_or_none()

--- a/tests/unit_tests/repository_tests/test_group_repository.py
+++ b/tests/unit_tests/repository_tests/test_group_repository.py
@@ -1,8 +1,10 @@
+from slugify import slugify
+
 from mealie.repos.repository_factory import AllRepositories
 from tests.utils.factories import random_int, random_string
 
 
-def test_group_resolve_similar_names(database: AllRepositories):
+def test_create_group_resolve_similar_names(database: AllRepositories):
     base_group_name = random_string()
     groups = database.groups.create_many({"name": base_group_name} for _ in range(random_int(3, 10)))
 
@@ -22,3 +24,12 @@ def test_group_get_by_slug_or_id(database: AllRepositories):
     for group in groups:
         assert database.groups.get_by_slug_or_id(group.id) == group
         assert database.groups.get_by_slug_or_id(group.slug) == group
+
+
+def test_update_group_updates_slug(database: AllRepositories):
+    group = database.groups.create({"name": random_string()})
+    assert group.slug == slugify(group.name)
+
+    new_name = random_string()
+    group = database.groups.update(group.id, {"name": new_name})
+    assert group.slug == slugify(new_name)


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

When you update the group name (e.g. through the UI) the slug isn't recalculated. Since the slug is used in the URL, this leads to weird-looking behavior (even though functionally everything still works fine).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2868

## Special notes for your reviewer:

If your slug ends up being the same as an existing slug, we don't try to resolve the conflict, it just fails (as opposed to during create, where we add a counter to the name/slug). I think this is fine, since it's not preventing anything critical, it's just indicating that you should pick a different name (whereas during create time you can run into this a multitude of ways, including setup and migration, so resolution is important).

## Testing

_(fill-in or delete this section)_

Pytest for backend, manually for frontend