### PR TITLE
Rectify email message ID, change multipart order

### DIFF
--- a/mealie/services/email/email_senders.py
+++ b/mealie/services/email/email_senders.py
@@ -41,15 +41,15 @@ class Message:
         msg["From"] = f"{self.mail_from_name} <{self.mail_from_address}>"
         msg["To"] = to
         msg["Date"] = formatdate(localtime=True)
-        msg.add_alternative(self.html, subtype="html")
         msg.add_alternative(html2text(self.html), subtype="plain")
+        msg.add_alternative(self.html, subtype="html")
 
         try:
-            message_id = f"{uuid4()}@{self.mail_from_address.split('@')[1]}"
+            message_id = f"<{uuid4()}@{self.mail_from_address.split('@')[1]}>"
         except IndexError:
             # this should never happen with a valid email address,
             # but we let the SMTP server handle it instead of raising it here
-            message_id = f"{uuid4()}@{self.mail_from_address}"
+            message_id = f"<{uuid4()}@{self.mail_from_address}>"
 
         msg["Message-ID"] = message_id
         msg["MIME-Version"] = "1.0"


### PR DESCRIPTION
## What type of PR is this?

- improvement

## What this PR does / why we need it:

Small changes to the email sender updates done in https://github.com/mealie-recipes/mealie/pull/3031

- message ID was missing brackets (< >)
- the plain text part was added after the html part. The last part of a multipart message is considered best and is preferred, so if the mail client follows RFC 2046 (Gmail for example), it shows the text message instead of the HTML message.

## Which issue(s) this PR fixes:

No new issue was raised for this.

Fixes https://github.com/mealie-recipes/mealie/pull/3031

## Special notes for your reviewer:

My first pull request ever, so please be gentle if I made a mistake in the flow somewhere :)

## Testing

Sent a test mail after the change, my spam filter no longer complains about the message ID and Gmail shows the html message instead of plain text.