### PR TITLE
dev: add docker-in-docker to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,9 +49,6 @@
   "onCreateCommand": "sudo chown -R vscode:vscode /workspaces/mealie/frontend/node_modules && task setup",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
-  // "features": {
-  //   "git": "latest"
-  // }
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,8 +53,7 @@
   //   "git": "latest"
   // }
   "features": {
-    "docker-in-docker": {
-      "version": "latest",
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,4 +52,10 @@
   // "features": {
   //   "git": "latest"
   // }
+  "features": {
+    "docker-in-docker": {
+      "version": "latest",
+      "dockerDashComposeVersion": "v2"
+    }
+  }
 }


### PR DESCRIPTION
## What type of PR is this?

- dev
- feature

## What this PR does / why we need it:

This PR adds the ability to run docker commands from within the dev container console. 
This is needed to run `task docker:prod` to create  a production image and `task dev:services` to run a postgres db and mailpit

Uses the feature described here: https://github.com/devcontainers/features/tree/main/src/docker-in-docker

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

Rebuild of the dev container needed. 
[Docker-outside-of-Docker](https://github.com/devcontainers/features/blob/main/src/docker-outside-of-docker/README.md) would be also be an option which runs the container directly on the host. 


## Testing

build a local prod image and started the services.
Only tested on a Windows (win 11) machine. 