### PR TITLE
fix: Taskfile Email Config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,8 +14,8 @@ env:
   SMTP_HOST: localhost
   SMTP_PORT: 1025
   SMTP_FROM_NAME: MealieDev
-  SMTP_AUTH_STRATEGY: NONE
   SMTP_FROM_EMAIL: mealie@example.com
+  SMTP_AUTH_STRATEGY: NONE
   LANG: en-US
 
 # loads .env file if it exists

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ env:
   SMTP_PORT: 1025
   SMTP_FROM_NAME: MealieDev
   SMTP_AUTH_STRATEGY: NONE
+  SMTP_FROM_EMAIL: mealie@example.com
   LANG: en-US
 
 # loads .env file if it exists


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Mealie needs a SMTP_FROM_EMAIL to be able to send emails. This adds mealie@example.com as sender adress for testing purposes together with mailpit. 

## Which issue(s) this PR fixes:

None

## Testing

Tested sending an example email from the admin dashboard. 
