### PR TITLE
fix: Pydantic Serialization Issues

### DIFF
--- a/mealie/schema/group/group_shopping_list.py
+++ b/mealie/schema/group/group_shopping_list.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import UUID4, ConfigDict, field_validator
+from pydantic import UUID4, ConfigDict, field_validator, model_validator
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.interfaces import LoaderOption
 
@@ -100,13 +100,14 @@ class ShoppingListItemOut(ShoppingListItemBase):
     created_at: datetime | None = None
     update_at: datetime | None = None
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
+    @model_validator(mode="after")
+    def post_validate(self):
         # if we're missing a label, but the food has a label, use that as the label
         if (not self.label) and (self.food and self.food.label):
             self.label = self.food.label
             self.label_id = self.label.id
+
+        return self
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 from typing import ClassVar
 from uuid import UUID, uuid4
 
-from pydantic import UUID4, ConfigDict, Field, field_validator
+from pydantic import UUID4, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.interfaces import LoaderOption
 
@@ -134,9 +134,8 @@ class RecipeIngredientBase(MealieModel):
     Automatically calculated after the object is created, unless overwritten
     """
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-
+    @model_validator(mode="after")
+    def post_validate(self):
         # calculate missing is_food and disable_amount values
         # we can't do this in a validator since they depend on each other
         if self.is_food is None and self.disable_amount is not None:
@@ -150,6 +149,8 @@ class RecipeIngredientBase(MealieModel):
         # format the display property
         if not self.display:
             self.display = self._format_display()
+
+        return self
 
     @field_validator("unit", mode="before")
     @classmethod

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -31,6 +31,7 @@ def display_fraction(fraction: Fraction):
 
 
 class UnitFoodBase(MealieModel):
+    id: UUID4 | None = None
     name: str
     plural_name: str | None = None
     description: str = ""
@@ -265,9 +266,6 @@ class RecipeIngredient(RecipeIngredientBase):
     title: str | None = None
     original_text: str | None = None
     disable_amount: bool = True
-
-    unit: IngredientUnit | None = None
-    food: IngredientFood | None = None
 
     # Ref is used as a way to distinguish between an individual ingredient on the frontend
     # It is required for the reorder and section titles to function properly because of how

--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -266,6 +266,9 @@ class RecipeIngredient(RecipeIngredientBase):
     original_text: str | None = None
     disable_amount: bool = True
 
+    unit: IngredientUnit | None = None
+    food: IngredientFood | None = None
+
     # Ref is used as a way to distinguish between an individual ingredient on the frontend
     # It is required for the reorder and section titles to function properly because of how
     # Vue handles reactivity. ref may serve another purpose in the future.


### PR DESCRIPTION
Well, it couldn't be _that_ easy to upgrade, could it?

## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

In certain instances, Pydantic will bypass its `__init__` (mostly related to ORM). In a few instances we were overriding Pydantic's `__init__` to do some post-init validation. Thankfully, Pydantic V2 supports this out of the box with its `model_validator` when set to `mode="after"`.

I also noticed when adding recipes to the shopping list we were losing units for some reason. I'm not _quite_ sure what happened, but somewhere we were relying on Pydantic choosing the correct sub-model (`IngredientUnit` vs `CreateIngredientUnit`), and now it isn't anymore. So I fixed that by adding the id as an optional field so it always gets serialized when present.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

🙃

## Testing

_(fill-in or delete this section)_

Manually
