### PR TITLE
fix: Pydantic Validation For Empty ID String

### DIFF
--- a/mealie/schema/recipe/recipe_ingredient.py
+++ b/mealie/schema/recipe/recipe_ingredient.py
@@ -37,6 +37,15 @@ class UnitFoodBase(MealieModel):
     description: str = ""
     extras: dict | None = {}
 
+    @field_validator("id", mode="before")
+    def convert_empty_id_to_none(cls, v):
+        # sometimes the frontend will give us an empty string instead of null, so we convert it to None,
+        # otherwise Pydantic will try to convert it to a UUID and fail
+        if not v:
+            v = None
+
+        return v
+
     @field_validator("extras", mode="before")
     def convert_extras_to_dict(cls, v):
         if isinstance(v, dict):


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/pull/3157 introduced a placeholder id field to fix an issue where Pydantic chose the wrong model in a type union. However, if it receives an empty string, instead of coercing that to `None`, it tries to coerce it to a `UUID` (which fails). This PR adds an explicit validator.

This issue presents itself when parsing a recipe, if you try to click the button to create a missing food/unit based on the parse result. I can't seem to find anywhere else where that happens (the data management page, for example, doesn't do that).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Raised in Discord

## Special notes for your reviewer:

_(fill-in or delete this section)_

I tried to poke around and see where else this might be an issue, but I couldn't find any other `id: UUID4 | None` situations that don't work as expected ¯\\\_(ツ)_/¯

## Testing

_(fill-in or delete this section)_

Manually
