### PR TITLE
fix: URL-Encode Postgres Password

### DIFF
--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -45,28 +45,15 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
     @property
     def db_url(self) -> str:
         host = f"{self.POSTGRES_SERVER}:{self.POSTGRES_PORT}"
-        try:
-            url = PostgresDsn.build(
+        return str(
+            PostgresDsn.build(
                 scheme="postgresql",
                 username=self.POSTGRES_USER,
-                password=self.POSTGRES_PASSWORD,
+                password=urlparse.quote_plus(self.POSTGRES_PASSWORD),
                 host=host,
                 path=f"{self.POSTGRES_DB or ''}",
             )
-        except ValueError as outer_error:
-            try:
-                # if the password contains special characters, it needs to be URL encoded
-                url = PostgresDsn.build(
-                    scheme="postgresql",
-                    username=self.POSTGRES_USER,
-                    password=urlparse.quote_plus(self.POSTGRES_PASSWORD),
-                    host=host,
-                    path=f"{self.POSTGRES_DB or ''}",
-                )
-            except Exception:
-                raise outer_error
-
-        return str(url)
+        )
 
     @property
     def db_url_public(self) -> str:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -38,6 +38,15 @@ def test_pg_connection_args(monkeypatch):
     assert app_settings.DB_URL == "postgresql://mealie:mealie@postgres:5432/mealie"
 
 
+def test_pg_connection_url_encode_password(monkeypatch):
+    monkeypatch.setenv("DB_ENGINE", "postgres")
+    monkeypatch.setenv("POSTGRES_SERVER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "please,url#encode/this?password")
+    get_app_settings.cache_clear()
+    app_settings = get_app_settings()
+    assert app_settings.DB_URL == "postgresql://mealie:please%2Curl%23encode%2Fthis%3Fpassword@postgres:5432/mealie"
+
+
 @dataclass(slots=True)
 class SMTPValidationCase:
     host: str


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

There's a bug in Pydantic V2 that doesn't properly URL-encode Postgres passwords. They used to work fine in V1, for whatever reason. This specifically affects passwords with any of these characters, at a minimum: `,#/?` (see the linked ticket below).

~~This PR attempts to create the Postgres URL normally, and if it fails, attempts to URL parse it ourselves. I did it this way in case there's some unintended side-effect, I didn't want to bork any other users.~~ apparently using urllib.parse.quote_plus is the right way to do it: https://stackoverflow.com/questions/1423804/writing-a-connection-string-when-password-contains-special-characters

The related Pydantic bug: https://github.com/pydantic/pydantic/issues/8061

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, raised in Discord

## Special notes for your reviewer:

_(fill-in or delete this section)_

Hopefully this covers all use-cases, but worst-case users can choose passwords without problematic characters (though I fully understand why we want to avoid that, since postgres does support them).

## Testing

_(fill-in or delete this section)_

Added a test