### PR TITLE
fix: Remove permissions block, so it doesn't override what is inherited from parent workflow

### DIFF
--- a/.github/workflows/partial-builder.yml
+++ b/.github/workflows/partial-builder.yml
@@ -18,8 +18,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

Fix a permissions issue with the change introduced by https://github.com/mealie-recipes/mealie/pull/3172, which can be seen in this [action run](https://github.com/mealie-recipes/mealie/actions/runs/7898542454/job/21556315587).

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

None.

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Testing

Tested in my fork that removing the permission from the workflow doesn't cause problems, as that permission is inherited from the nightly config. [This action run shows that](https://github.com/boc-the-git/mealie/actions/runs/7898864040/job/21557347807).

<!--
  Describe how you tested this change.
-->
