### PR TITLE
fix: Display recipe rating on mealplan

### DIFF
--- a/frontend/pages/group/mealplan/planner/view.vue
+++ b/frontend/pages/group/mealplan/planner/view.vue
@@ -39,6 +39,7 @@
             :recipe-id="mealplan.recipe ? mealplan.recipe.id : ''"
             class="mb-2"
             :route="mealplan.recipe ? true : false"
+            :rating="mealplan.recipe ? mealplan.recipe.rating : 0"
             :slug="mealplan.recipe ? mealplan.recipe.slug : mealplan.title"
             :description="mealplan.recipe ? mealplan.recipe.description : mealplan.text"
             :name="mealplan.recipe ? mealplan.recipe.name : mealplan.title"


### PR DESCRIPTION
## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- bug
- feature

## What this PR does / why we need it:

Displays recipe rating on the meal planner, as opposed to always displaying as unrated.

Before / After:
![image](https://github.com/mealie-recipes/mealie/assets/3479092/fba18f22-d611-4eff-97b0-87bedbbcfbda) 
![image](https://github.com/mealie-recipes/mealie/assets/3479092/39f251e3-226e-442e-bfe6-f41eb68be452)



Credit to @Grygon, this is broken off from his PR https://github.com/mealie-recipes/mealie/pull/2497

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #2256

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Testing

Manual - see screenshots.