### PR TITLE
feat: Only run docker build and discord notify on the main repo (not forks)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
       # https://github.com/orgs/community/discussions/76409#discussioncomment-8131390
       id-token: write
     name: Build Tagged Release
+    if: github.repository == 'mealie-recipes/mealie'
     uses: ./.github/workflows/partial-builder.yml
     needs:
       - frontend-tests
@@ -40,6 +41,7 @@ jobs:
 
   notify-discord:
     name: Notify Discord
+    if: github.repository == 'mealie-recipes/mealie'
     needs:
       - build-release
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- cleanup
- feature

## What this PR does / why we need it:

This will minimise the noise we get as developers working in our own forks. With the current setup, syncing from the main repo into fork runs the jobs, which fail because they can't access Discord for instance.
Documentation on the `if` functionality: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

None.

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Testing

I merged [effectively this same PR](https://github.com/boc-the-git/mealie/pull/8) into my fork and observed it skipping those jobs, per [this action run](https://github.com/boc-the-git/mealie/actions/runs/7914785085).

![image](https://github.com/mealie-recipes/mealie/assets/3479092/445092de-2623-4adb-a078-793966f802d6)
