### PR TITLE
fix: Broken Recipe Organizer Filters

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -140,7 +140,11 @@ class RepositoryRecipes(RepositoryGeneric[Recipe, RecipeModel]):
             if isinstance(i, UUID):
                 ids.append(i)
             else:
-                slugs.append(i)
+                try:
+                    i_as_uuid = UUID(i)
+                    ids.append(i_as_uuid)
+                except ValueError:
+                    slugs.append(i)
         additional_ids = self.session.execute(select(model.id).filter(model.slug.in_(slugs))).scalars().all()
         return ids + additional_ids
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

As seen in the Pydantic V2 upgrade (https://github.com/mealie-recipes/mealie/pull/3134), something changed with how UUID strings are coerced into UUIDs (or, rather, how they used to be, and are not anymore). While https://github.com/mealie-recipes/mealie/pull/3134 fixed most of these instances, it missed this one.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3188

## Testing

_(fill-in or delete this section)_

Added tests. I'm surprised we didn't have any already, to be honest.