### PR TITLE
Fix broken docs links and nested Markdown list

### DIFF
--- a/docs/docs/contributors/developers-guide/code-contributions.md
+++ b/docs/docs/contributors/developers-guide/code-contributions.md
@@ -5,8 +5,8 @@
 ## We Develop with Github
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
-Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+## We Use [Github Flow](https://docs.github.com/en/get-started/using-github/github-flow), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://docs.github.com/en/get-started/using-github/github-flow)). We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `mealie-next`.
 2. Checkout the Discord, the PRs page, or the Projects page to get an idea of what's already being worked on.
@@ -28,8 +28,8 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 
 - A quick summary and/or background
 - Steps to reproduce
-  - Be specific!
-  - Give sample code if you can. [This stackoverflow question](http://stackoverflow.com/q/12488905/180626) includes sample code that *anyone* with a base R setup can run to reproduce what I was seeing
+    * Be specific!
+    * Give sample code if you can. [This stackoverflow question](http://stackoverflow.com/q/12488905/180626) includes sample code that *anyone* with a base R setup can run to reproduce what I was seeing
 - What you expected would happen
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
@@ -41,4 +41,4 @@ People *love* thorough bug reports. I'm not even kidding.
 By contributing, you agree that your contributions will be licensed under its AGPL License.
 
 ## References
-This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md)
+This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebookarchive/draft-js/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- documentation

## What this PR does / why we need it:

`/docs/docs/contributors/developers-guide/code-contributions.md`: 
- Fix Github Flow broken links: [current links](https://guides.github.com/introduction/flow/index.html) are no longer valid and redirect to Github's home page. I replaced them with what I believe is their [new version](https://docs.github.com/en/get-started/using-github/github-flow).
- Fix Facebook's Draft broken link: **I'm not too sure about this one** since the [current link](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md) points at a specific version of the CONTRIBUTING.md of Facebook's draft-js repo, and this version is no longer available.
Instead, I chose to target the link to [the version on the main branch](https://github.com/facebookarchive/draft-js/blob/main/CONTRIBUTING.md) of the now-archived repository. Since it is now read-only, this shouldn't be an issue. If you believe I should do it differently, please let me know :)
- Fix a Mardown list that should've been nested according to the indentation in the source file (it also makes more sense this way), but is currently rendered at the top level instead.

## Which issue(s) this PR fixes:

No linked issue, let me know if I should create one!

## Testing

I tested the code locally (dev container) with `mkdocs serve` to make sure the links and nested list were rendering as expected.