### PR TITLE
fix: Invalid Pydantic Definition On Group Model

### DIFF
--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import UUID4, ConfigDict, Field, StringConstraints, field_validator

--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -12,6 +12,7 @@ from mealie.db.models.users import User
 from mealie.db.models.users.users import AuthMethod
 from mealie.schema._mealie import MealieModel
 from mealie.schema.group.group_preferences import ReadGroupPreferences
+from mealie.schema.group.webhook import CreateWebhook, ReadWebhook
 from mealie.schema.recipe import RecipeSummary
 from mealie.schema.response.pagination import PaginationBase
 
@@ -180,12 +181,14 @@ class UpdateGroup(GroupBase):
     slug: str
     categories: list[CategoryBase] | None = []
 
-    webhooks: list[Any] = []
+    webhooks: list[CreateWebhook] = []
 
 
 class GroupInDB(UpdateGroup):
     users: list[UserOut] | None = None
     preferences: ReadGroupPreferences | None = None
+    webhooks: list[ReadWebhook] = []
+
     model_config = ConfigDict(from_attributes=True)
 
     @staticmethod


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

This week on "how did this used to work?", we replaced an invalid model field definition:
```python
webhooks: list[Any] = []
```

...with two new ones:
```python
class UpdateGroup(GroupBase):
  ...
  webhooks: list[CreateWebhook] = []

class GroupInDB(UpdateGroup):
  ...
  webhooks: list[ReadWebhook] = []
```

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3260

## Special notes for your reviewer:

_(fill-in or delete this section)_

Maybe Pydantic used to automatically serialize unknown models into dicts? I have no idea.

## Testing

_(fill-in or delete this section)_

Through the frontend I created a group, added/updated webhooks, and updated the group.
