### PR TITLE
fix: Allow UserOut to accept list of slugs for recipe favorites

### DIFF
--- a/mealie/schema/user/user.py
+++ b/mealie/schema/user/user.py
@@ -107,7 +107,7 @@ class UserOut(UserBase):
     group_slug: str
     tokens: list[LongLiveTokenOut] | None = None
     cache_key: str
-    favorite_recipes: Annotated[list[str] | None, Field(validate_default=True)] = []
+    favorite_recipes: Annotated[list[str], Field(validate_default=True)] = []
     model_config = ConfigDict(from_attributes=True)
 
     @property
@@ -119,8 +119,18 @@ class UserOut(UserBase):
         return [joinedload(User.group), joinedload(User.favorite_recipes), joinedload(User.tokens)]
 
     @field_validator("favorite_recipes", mode="before")
-    def convert_favorite_recipes_to_slugs(cls, v):
-        return [recipe.slug for recipe in v] if v else v
+    def convert_favorite_recipes_to_slugs(cls, v: list[str | RecipeSummary] | None):
+        if not v:
+            return []
+
+        slugs: list[str] = []
+        for recipe in v:
+            if isinstance(recipe, str):
+                slugs.append(recipe)
+            else:
+                slugs.append(recipe.slug)
+
+        return slugs
 
 
 class UserPagination(PaginationBase):


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/pull/3134 adapted previous Pydantic V1 behavior with getter dicts by converting recipes to their slugs using a validator. However, sometimes a list of slugs is passed directly, which doesn't work anymore. This fixes that.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3282

## Testing

_(fill-in or delete this section)_

Manually added/removed recipe favorites and updated other unrelated user settings (as shown in https://github.com/mealie-recipes/mealie/issues/3282)