### PR TITLE
fix: Only call store APIs once

### DIFF
--- a/frontend/composables/partials/use-actions-factory.ts
+++ b/frontend/composables/partials/use-actions-factory.ts
@@ -37,6 +37,7 @@ export function usePublicStoreActions<T extends BoundT>(
     loading.value = true;
     const allItems = useAsync(async () => {
       const { data } = await api.getAll(page, perPage, params);
+      loading.value = false;
 
       if (data && allRef) {
         allRef.value = data.items;
@@ -49,7 +50,6 @@ export function usePublicStoreActions<T extends BoundT>(
       }
     }, useAsyncKey());
 
-    loading.value = false;
     return allItems;
   }
 
@@ -88,6 +88,7 @@ export function useStoreActions<T extends BoundT>(
     loading.value = true;
     const allItems = useAsync(async () => {
       const { data } = await api.getAll(page, perPage, params);
+      loading.value = false;
 
       if (data && allRef) {
         allRef.value = data.items;
@@ -100,7 +101,6 @@ export function useStoreActions<T extends BoundT>(
       }
     }, useAsyncKey());
 
-    loading.value = false;
     return allItems;
   }
 

--- a/frontend/composables/store/use-category-store.ts
+++ b/frontend/composables/store/use-category-store.ts
@@ -5,6 +5,8 @@ import { useUserApi } from "~/composables/api";
 import { RecipeCategory } from "~/lib/api/types/admin";
 
 const categoryStore: Ref<RecipeCategory[]> = ref([]);
+const publicStoreLoading = ref(false);
+const storeLoading = ref(false);
 
 export function useCategoryData() {
   const data = reactive({
@@ -27,7 +29,7 @@ export function useCategoryData() {
 
 export function usePublicCategoryStore(groupSlug: string) {
   const api = usePublicExploreApi(groupSlug).explore;
-  const loading = ref(false);
+  const loading = publicStoreLoading;
 
   const actions = {
     ...usePublicStoreActions<RecipeCategory>(api.categories, categoryStore, loading),
@@ -36,7 +38,7 @@ export function usePublicCategoryStore(groupSlug: string) {
     },
   };
 
-  if (!categoryStore.value || categoryStore.value?.length === 0) {
+  if (!loading.value && (!categoryStore.value || categoryStore.value?.length === 0)) {
     actions.getAll();
   }
 
@@ -50,7 +52,7 @@ export function usePublicCategoryStore(groupSlug: string) {
 export function useCategoryStore() {
   // passing the group slug switches to using the public API
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions<RecipeCategory>(api.categories, categoryStore, loading),
@@ -59,7 +61,7 @@ export function useCategoryStore() {
     },
   };
 
-  if (!categoryStore.value || categoryStore.value?.length === 0) {
+  if (!loading.value && (!categoryStore.value || categoryStore.value?.length === 0)) {
     actions.getAll();
   }
 

--- a/frontend/composables/store/use-food-store.ts
+++ b/frontend/composables/store/use-food-store.ts
@@ -5,6 +5,8 @@ import { useUserApi } from "~/composables/api";
 import { IngredientFood } from "~/lib/api/types/recipe";
 
 let foodStore: Ref<IngredientFood[] | null> = ref([]);
+const publicStoreLoading = ref(false);
+const storeLoading = ref(false);
 
 /**
  * useFoodData returns a template reactive object
@@ -34,7 +36,7 @@ export const useFoodData = function () {
 
 export const usePublicFoodStore = function (groupSlug: string) {
   const api = usePublicExploreApi(groupSlug).explore;
-  const loading = ref(false);
+  const loading = publicStoreLoading;
 
   const actions = {
     ...usePublicStoreActions(api.foods, foodStore, loading),
@@ -43,7 +45,7 @@ export const usePublicFoodStore = function (groupSlug: string) {
     },
   };
 
-  if (!foodStore.value || foodStore.value.length === 0) {
+  if (!loading.value && (!foodStore.value || foodStore.value.length === 0)) {
     foodStore = actions.getAll();
   }
 
@@ -52,7 +54,7 @@ export const usePublicFoodStore = function (groupSlug: string) {
 
 export const useFoodStore = function () {
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions(api.foods, foodStore, loading),
@@ -61,7 +63,7 @@ export const useFoodStore = function () {
     },
   };
 
-  if (!foodStore.value || foodStore.value.length === 0) {
+  if (!loading.value && (!foodStore.value || foodStore.value.length === 0)) {
     foodStore = actions.getAll();
   }
 

--- a/frontend/composables/store/use-label-store.ts
+++ b/frontend/composables/store/use-label-store.ts
@@ -4,6 +4,7 @@ import { MultiPurposeLabelOut } from "~/lib/api/types/labels";
 import { useUserApi } from "~/composables/api";
 
 let labelStore: Ref<MultiPurposeLabelOut[] | null> = ref([]);
+const storeLoading = ref(false);
 
 export function useLabelData() {
   const data = reactive({
@@ -28,7 +29,7 @@ export function useLabelData() {
 
 export function useLabelStore() {
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions<MultiPurposeLabelOut>(api.multiPurposeLabels, labelStore, loading),
@@ -37,7 +38,7 @@ export function useLabelStore() {
     },
   };
 
-  if (!labelStore.value || labelStore.value?.length === 0) {
+  if (!loading.value && (!labelStore.value || labelStore.value?.length === 0)) {
     labelStore = actions.getAll();
   }
 

--- a/frontend/composables/store/use-tag-store.ts
+++ b/frontend/composables/store/use-tag-store.ts
@@ -5,6 +5,8 @@ import { useUserApi } from "~/composables/api";
 import { RecipeTag } from "~/lib/api/types/admin";
 
 const items: Ref<RecipeTag[]> = ref([]);
+const publicStoreLoading = ref(false);
+const storeLoading = ref(false);
 
 export function useTagData() {
   const data = reactive({
@@ -27,7 +29,7 @@ export function useTagData() {
 
 export function usePublicTagStore(groupSlug: string) {
   const api = usePublicExploreApi(groupSlug).explore;
-  const loading = ref(false);
+  const loading = publicStoreLoading;
 
   const actions = {
     ...usePublicStoreActions<RecipeTag>(api.tags, items, loading),
@@ -36,7 +38,7 @@ export function usePublicTagStore(groupSlug: string) {
     },
   };
 
-  if (!items.value || items.value?.length === 0) {
+  if (!loading.value && (!items.value || items.value?.length === 0)) {
     actions.getAll();
   }
 
@@ -49,7 +51,7 @@ export function usePublicTagStore(groupSlug: string) {
 
 export function useTagStore() {
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions<RecipeTag>(api.tags, items, loading),
@@ -58,7 +60,7 @@ export function useTagStore() {
     },
   };
 
-  if (!items.value || items.value?.length === 0) {
+  if (!loading.value && (!items.value || items.value?.length === 0)) {
     actions.getAll();
   }
 

--- a/frontend/composables/store/use-tool-store.ts
+++ b/frontend/composables/store/use-tool-store.ts
@@ -5,6 +5,8 @@ import { useUserApi } from "~/composables/api";
 import { RecipeTool } from "~/lib/api/types/recipe";
 
 const toolStore: Ref<RecipeTool[]> = ref([]);
+const publicStoreLoading = ref(false);
+const storeLoading = ref(false);
 
 export function useToolData() {
   const data = reactive({
@@ -29,7 +31,7 @@ export function useToolData() {
 
 export function usePublicToolStore(groupSlug: string) {
   const api = usePublicExploreApi(groupSlug).explore;
-  const loading = ref(false);
+  const loading = publicStoreLoading;
 
   const actions = {
     ...usePublicStoreActions<RecipeTool>(api.tools, toolStore, loading),
@@ -38,7 +40,7 @@ export function usePublicToolStore(groupSlug: string) {
     },
   };
 
-  if (!toolStore.value || toolStore.value?.length === 0) {
+  if (!loading.value && (!toolStore.value || toolStore.value?.length === 0)) {
     actions.getAll();
   }
 
@@ -51,7 +53,7 @@ export function usePublicToolStore(groupSlug: string) {
 
 export function useToolStore() {
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions<RecipeTool>(api.tools, toolStore, loading),
@@ -60,7 +62,7 @@ export function useToolStore() {
     },
   };
 
-  if (!toolStore.value || toolStore.value?.length === 0) {
+  if (!loading.value && (!toolStore.value || toolStore.value?.length === 0)) {
     actions.getAll();
   }
 

--- a/frontend/composables/store/use-unit-store.ts
+++ b/frontend/composables/store/use-unit-store.ts
@@ -4,6 +4,7 @@ import { useUserApi } from "~/composables/api";
 import { IngredientUnit } from "~/lib/api/types/recipe";
 
 let unitStore: Ref<IngredientUnit[] | null> = ref([]);
+const storeLoading = ref(false);
 
 /**
  * useUnitData returns a template reactive object
@@ -35,7 +36,7 @@ export const useUnitData = function () {
 
 export const useUnitStore = function () {
   const api = useUserApi();
-  const loading = ref(false);
+  const loading = storeLoading;
 
   const actions = {
     ...useStoreActions<IngredientUnit>(api.units, unitStore, loading),
@@ -44,7 +45,7 @@ export const useUnitStore = function () {
     },
   };
 
-  if (!unitStore.value || unitStore.value.length === 0) {
+  if (!loading.value && (!unitStore.value || unitStore.value.length === 0)) {
     unitStore = actions.getAll();
   }
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently our frontend stores (e.g. foods store) shares the store state globally so changes in one component effect another (e.g. if a food is created, it should appear on other components). What's not shared, however, is the loading variable. While in most situations this doesn't matter much, when initializing the store every single component makes an API call to populate the store data (and all of them overwrite each other).

This is most egregious on the recipe editor. If, for instance, you have 20 ingredients, you're making 20 API calls to the food and unit stores and serializing _the entire store_ 20 times. Here is a snapshot of API calls from simply clicking edit _once_ on a single recipe with 20 ingredients (I can't fit the whole thing in a reasonably-sized screenshot):

![image](https://github.com/mealie-recipes/mealie/assets/71845777/428d51f0-d5d6-4b58-8969-804d3f5f1873)

This PR adds a shared loading state so the API is only called once per store. Here is a snapshot of the same recipe with these changes (this time with every API call in the image):

![image](https://github.com/mealie-recipes/mealie/assets/71845777/c87414e1-bcb6-400b-a352-cab656adc062)

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

Interestingly, while we did have a "loading" variable already, it wasn't being set correctly (it was set outside of the async function so it toggles immediately back to `false`) and it wasn't ever being referenced, it was only ever declared and updated. However, even _if_ we fixed all of those things, it still wasn't shared, so each instance of the store had its own loading value.

## Testing

_(fill-in or delete this section)_

Other than the above screenshots, I went and touched all the other stores (e.g. the data management page) and confirmed it works as expected. I can't see any side-effects of a shared loading state since the store _always_ uses the default params (no filters, return all items without pagination). If we used variable params this wouldn't work without some modification.
