### PR TITLE
feat: cookbook editor on cookbook page

### DIFF
--- a/frontend/components/Domain/Cookbook/CookbookPage.vue
+++ b/frontend/components/Domain/Cookbook/CookbookPage.vue
@@ -23,6 +23,7 @@
         <v-toolbar-title class="headline"> {{ book.name }} </v-toolbar-title>
         <v-spacer></v-spacer>
         <BaseButton
+          v-if="isOwnGroup"
           class="mx-1"
           :edit="true"
           @click="handleEditCookbook"
@@ -115,6 +116,7 @@
         recipes,
         removeRecipe,
         replaceRecipes,
+        isOwnGroup,
         dialogStates,
         editTarget,
         handleEditCookbook,

--- a/frontend/components/Domain/Cookbook/CookbookPage.vue
+++ b/frontend/components/Domain/Cookbook/CookbookPage.vue
@@ -1,8 +1,32 @@
 <template>
+  <div>
+    <!-- Edit Dialog -->
+    <BaseDialog
+      v-if="editTarget"
+      v-model="dialogStates.edit"
+      :width="650"
+      :icon="$globals.icons.pages"
+      :title="$t('general.edit')"
+      :submit-icon="$globals.icons.save"
+      :submit-text="$tc('general.save')"
+      @submit="editCookbook"
+    >
+      <v-card-text>
+        <CookbookEditor :cookbook="editTarget" :actions="actions" />
+      </v-card-text>
+    </BaseDialog>
+
+    <!-- Page -->
     <v-container v-if="book" fluid>
-      <v-app-bar color="transparent" flat class="mt-n1 rounded">
+      <v-app-bar color="transparent" flat class="mt-n1">
         <v-icon large left> {{ $globals.icons.pages }} </v-icon>
         <v-toolbar-title class="headline"> {{ book.name }} </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <BaseButton
+          class="mx-1"
+          :edit="true"
+          @click="handleEditCookbook"
+        />
       </v-app-bar>
       <v-card flat>
         <v-card-text class="py-0">
@@ -22,17 +46,20 @@
         />
       </v-container>
     </v-container>
-  </template>
+  </div>
+</template>
 
   <script lang="ts">
-  import { computed, defineComponent, useRoute, ref, useContext, useMeta } from "@nuxtjs/composition-api";
+  import { computed, defineComponent, useRoute, ref, useContext, useMeta, reactive, useRouter } from "@nuxtjs/composition-api";
   import { useLazyRecipes } from "~/composables/recipes";
   import RecipeCardSection from "@/components/Domain/Recipe/RecipeCardSection.vue";
-  import { useCookbook } from "~/composables/use-group-cookbooks";
+  import { useCookbook, useCookbooks } from "~/composables/use-group-cookbooks";
   import { useLoggedInState } from "~/composables/use-logged-in-state";
+  import { RecipeCookBook } from "~/lib/api/types/cookbook";
+  import CookbookEditor from "~/components/Domain/Cookbook/CookbookEditor.vue";
 
   export default defineComponent({
-    components: { RecipeCardSection },
+    components: { RecipeCardSection, CookbookEditor },
     setup() {
       const { $auth } = useContext();
       const { isOwnGroup } = useLoggedInState();
@@ -43,9 +70,35 @@
       const { recipes, appendRecipes, assignSorted, removeRecipe, replaceRecipes } = useLazyRecipes(isOwnGroup.value ? null : groupSlug.value);
       const slug = route.value.params.slug;
       const { getOne } = useCookbook(isOwnGroup.value ? null : groupSlug.value);
+      const { actions } = useCookbooks();
+      const router = useRouter();
 
       const tab = ref(null);
       const book = getOne(slug);
+
+      const dialogStates = reactive({
+        edit: false,
+      });
+
+      const editTarget = ref<RecipeCookBook | null>(null);
+      function handleEditCookbook() {
+        dialogStates.edit = true;
+        editTarget.value = book.value;
+      }
+
+      async function editCookbook() {
+        if (!editTarget.value) {
+          return;
+        }
+        const response = await actions.updateOne(editTarget.value);
+
+        // if name changed, redirect to new slug
+        if (response?.slug && book.value?.slug !== response?.slug) {
+          router.push(`/g/${route.value.params.groupSlug}/cookbooks/${response?.slug}`);
+        }
+        dialogStates.edit = false;
+        editTarget.value = null;
+      }
 
       useMeta(() => {
         return {
@@ -62,6 +115,11 @@
         recipes,
         removeRecipe,
         replaceRecipes,
+        dialogStates,
+        editTarget,
+        handleEditCookbook,
+        editCookbook,
+        actions,
       };
     },
     head: {}, // Must include for useMeta

--- a/frontend/components/Domain/Recipe/RecipeOrganizerSelector.vue
+++ b/frontend/components/Domain/Recipe/RecipeOrganizerSelector.vue
@@ -13,7 +13,7 @@
       $globals.icons.tags"
     return-object
     v-bind="inputAttrs"
-    auto-select-first="true"
+    auto-select-first
     :search-input.sync="searchInput"
     @change="resetSearchInput"
   >

--- a/frontend/composables/use-group-cookbooks.ts
+++ b/frontend/composables/use-group-cookbooks.ts
@@ -122,6 +122,7 @@ export const useCookbooks = function () {
         this.refreshAll();
       }
       loading.value = false;
+      return data;
     },
 
     async updateOrder() {


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds the functionality to edit the cookbook on the cookbook page itself, instead of having to go to the overview page. Redirects to new slug when the slug is updated because of a name change. 

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

Also removed a bug from a previous PR of mine that resulted in some errors being thrown. 

## Testing

Manual