### PR TITLE
fix: TLS fingerprinting prevents scraping #2888

### DIFF
--- a/mealie/services/recipe/recipe_data_service.py
+++ b/mealie/services/recipe/recipe_data_service.py
@@ -10,6 +10,8 @@ from mealie.schema.recipe.recipe import Recipe
 from mealie.services._base_service import BaseService
 
 _FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
+# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the chance of scraping an avif image.
+_ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
 _BROWSER_TO_IMPERSONATE = "chrome101"
 
 
@@ -31,7 +33,9 @@ async def largest_content_len(urls: list[str]) -> tuple[str, int]:
     largest_len = 0
 
     async def do(client: AsyncSession, url: str) -> Response:
-        return await client.head(url, headers={"User-Agent": _FIREFOX_UA}, impersonate=_BROWSER_TO_IMPERSONATE)
+        return await client.head(
+            url, headers={"User-Agent": _FIREFOX_UA, "Accept": _ACCEPT_HEADER}, impersonate=_BROWSER_TO_IMPERSONATE
+        )
 
     async with AsyncSession() as client:
         tasks = [do(client, url) for url in urls]
@@ -147,7 +151,11 @@ class RecipeDataService(BaseService):
 
         async with AsyncSession() as client:
             try:
-                r = await client.get(image_url, headers={"User-Agent": _FIREFOX_UA}, impersonate=_BROWSER_TO_IMPERSONATE)
+                r = await client.get(
+                    image_url,
+                    headers={"User-Agent": _FIREFOX_UA, "Accept": _ACCEPT_HEADER},
+                    impersonate=_BROWSER_TO_IMPERSONATE,
+                )
             except Exception:
                 self.logger.exception("Fatal Image Request Exception")
                 return None

--- a/mealie/services/recipe/recipe_data_service.py
+++ b/mealie/services/recipe/recipe_data_service.py
@@ -10,7 +10,8 @@ from mealie.schema.recipe.recipe import Recipe
 from mealie.services._base_service import BaseService
 
 _FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
-# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the chance of scraping an avif image.
+# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the
+# chance of scraping an avif image.
 _ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
 _BROWSER_TO_IMPERSONATE = "chrome101"
 

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -18,6 +18,8 @@ from mealie.services.scraper.scraped_extras import ScrapedExtras
 from . import cleaner
 
 _FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
+# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the chance of scraping an avif image.
+_ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
 _BROWSER_TO_IMPERSONATE = "chrome101"
 SCRAPER_TIMEOUT = 15
 
@@ -34,7 +36,13 @@ async def safe_scrape_html(url: str) -> str:
     """
     async with AsyncSession() as client:
         html_bytes = b""
-        async with client.stream("GET", url, timeout=SCRAPER_TIMEOUT, headers={"User-Agent": _FIREFOX_UA}, impersonate=_BROWSER_TO_IMPERSONATE) as resp:
+        async with client.stream(
+            "GET",
+            url,
+            timeout=SCRAPER_TIMEOUT,
+            headers={"User-Agent": _FIREFOX_UA, "Accept": _ACCEPT_HEADER},
+            impersonate=_BROWSER_TO_IMPERSONATE,
+        ) as resp:
             start_time = time.time()
 
             async for chunk in resp.aiter_content(chunk_size=1024):

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -4,8 +4,8 @@ from collections.abc import Callable
 from typing import Any
 
 import extruct
-from fastapi import HTTPException, status
 from curl_cffi.requests import AsyncSession
+from fastapi import HTTPException, status
 from recipe_scrapers import NoSchemaFoundInWildMode, SchemaScraperFactory, scrape_html
 from slugify import slugify
 from w3lib.html import get_base_url
@@ -18,7 +18,8 @@ from mealie.services.scraper.scraped_extras import ScrapedExtras
 from . import cleaner
 
 _FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
-# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the chance of scraping an avif image.
+# Since Pillow does not support AVIF image the Accept header excludes image/avif to reduce the
+# chance of scraping an avif image.
 _ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
 _BROWSER_TO_IMPERSONATE = "chrome101"
 SCRAPER_TIMEOUT = 15

--- a/poetry.lock
+++ b/poetry.lock
@@ -588,6 +588,31 @@ test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "curl-cffi"
+version = "0.6.2"
+description = "libcurl ffi bindings for Python, with impersonation support"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "curl_cffi-0.6.2-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:23b8a2872b160718c04b06b1f8aa4fb1a2f4f94bce7040493515e081a27cad19"},
+    {file = "curl_cffi-0.6.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad3c1cf5360810825ec4bc3da425f26ee4098878a615dab9d309a99afd883ba9"},
+    {file = "curl_cffi-0.6.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d01de6ed737ad1924aaa0198195b9020c38e77ce90ea3d72b9eacf4938c7adf"},
+    {file = "curl_cffi-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37e513cc149d024a2d625e202f2cc9d4423d2937343ea2e06f797d99779e62dc"},
+    {file = "curl_cffi-0.6.2-cp38-abi3-win32.whl", hash = "sha256:12e829af97cbf7c1d5afef177e786f6f404ddf163b08897a1ed087cadbeb4837"},
+    {file = "curl_cffi-0.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:3791b7a9ae4cb1298165300f2dc2d60a86779f055570ae83163fc2d8a74bf714"},
+    {file = "curl_cffi-0.6.2.tar.gz", hash = "sha256:9ee519e960b5fc6e0bbf13d0ecba9ce5f6306cb929354504bf03cc30f59a8f63"},
+]
+
+[package.dependencies]
+certifi = "*"
+cffi = ">=1.12.0"
+
+[package.extras]
+build = ["cibuildwheel", "wheel"]
+dev = ["autoflake (==1.4)", "coverage (==6.4.1)", "cryptography (==38.0.3)", "flake8 (==6.0.0)", "flake8-bugbear (==22.7.1)", "flake8-pie (==0.15.0)", "httpx (==0.23.1)", "mypy (==0.971)", "nest-asyncio (==1.6.0)", "pytest (==7.1.2)", "pytest-asyncio (==0.19.0)", "pytest-trio (==0.7.0)", "ruff (==0.1.14)", "trio (==0.21.0)", "trio-typing (==0.7.0)", "trustme (==0.9.0)", "types-certifi (==2021.10.8.2)", "uvicorn (==0.18.3)", "websockets (==11.0.3)"]
+test = ["cryptography (==38.0.3)", "fastapi (==0.100.0)", "httpx (==0.23.1)", "nest-asyncio (==1.6.0)", "proxy.py (==2.4.3)", "pytest (==7.1.2)", "pytest-asyncio (==0.19.0)", "pytest-trio (==0.7.0)", "python-multipart (==0.0.6)", "trio (==0.21.0)", "trio-typing (==0.7.0)", "trustme (==0.9.0)", "types-certifi (==2021.10.8.2)", "uvicorn (==0.18.3)", "websockets (==11.0.3)"]
+
+[[package]]
 name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
@@ -3170,4 +3195,4 @@ pgsql = ["psycopg2-binary"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "78284368031f012f6e4edcbb6cc3c25db58f570474e0939e5ed3948c01b9d798"
+content-hash = "f84c3d0251d4ccec6d09f7800aadc22447ff77ce3bbb6259a336ff2d265e76ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ authlib = "^1.3.0"
 html2text = "^2024.0.0"
 paho-mqtt = "^1.6.1"
 pydantic-settings = "^2.1.0"
+curl-cffi = "^0.6.2"
 
 [tool.poetry.group.postgres.dependencies]
 psycopg2-binary = { version = "^2.9.1" }


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

TLS fingerprinting* detection can be used to protect websites from (scraper)bots. Cloudflare provides this service for example** 

https://www.ah.nl/allerhande became unavailable since this technique was used. Using a TLS spoofing technique this is countered. 
To do so httpx is replaced with curl-cffi  (https://pypi.org/project/curl-cffi/0.2.1)

* https://fingerprint.com/blog/what-is-tls-fingerprinting-transport-layer-security/
** https://developers.cloudflare.com/bots/concepts/ja3-fingerprint/

## Which issue(s) this PR fixes:
fixes #2888

## Special notes for your reviewer:

## Testing

_(fill-in or delete this section)_
A docker build was used to build the project. afterwards only the import of recipies from urls was tested using ah.nl/allerhande, lidl-kochen.de and various random other sites.