### PR TITLE
feat: PostgresProvider - Add POSTGRES_URL_OVERRIDE

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -35,7 +35,7 @@
 | POSTGRES_SERVER   | postgres | Postgres database server address |
 | POSTGRES_PORT     |   5432   | Postgres database port           |
 | POSTGRES_DB       |  mealie  | Postgres database name           |
-| POSTGRES_URL_OVERRIDE |   None   | Optional Postgres URL override to use instead of POSTGRES_* variables. |
+| POSTGRES_URL_OVERRIDE |   None   | Optional Postgres URL override to use instead of POSTGRES_* variables |
 
 ### Email
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -33,7 +33,7 @@
 | POSTGRES_SERVER   | postgres | Postgres database server address |
 | POSTGRES_PORT     |   5432   | Postgres database port           |
 | POSTGRES_DB       |  mealie  | Postgres database name           |
-| POSTGRES_URL      |   None   | Postgres URL override. Must be used with DB_ENGINE: postgres |
+| POSTGRES_URL_OVERRIDE |   None   | Postgres URL override. Must be used with DB_ENGINE: postgres |
 
 ### Email
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -33,7 +33,7 @@
 | POSTGRES_SERVER   | postgres | Postgres database server address |
 | POSTGRES_PORT     |   5432   | Postgres database port           |
 | POSTGRES_DB       |  mealie  | Postgres database name           |
-| POSTGRES_URL_OVERRIDE |   None   | Postgres URL override. Must be used with DB_ENGINE: postgres |
+| POSTGRES_URL_OVERRIDE |   None   | Optional Postgres URL override to use instead of POSTGRES_* variables. Must be used in conjunction with DB_ENGINE: postgres to have an effect. |
 
 ### Email
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -33,6 +33,7 @@
 | POSTGRES_SERVER   | postgres | Postgres database server address |
 | POSTGRES_PORT     |   5432   | Postgres database port           |
 | POSTGRES_DB       |  mealie  | Postgres database name           |
+| POSTGRES_URL      |   None   | Postgres URL override. Must be used with DB_ENGINE: postgres |
 
 ### Email
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -35,7 +35,7 @@
 | POSTGRES_SERVER   | postgres | Postgres database server address |
 | POSTGRES_PORT     |   5432   | Postgres database port           |
 | POSTGRES_DB       |  mealie  | Postgres database name           |
-| POSTGRES_URL_OVERRIDE |   None   | Optional Postgres URL override to use instead of POSTGRES_* variables. Must be used in conjunction with DB_ENGINE: postgres to have an effect. |
+| POSTGRES_URL_OVERRIDE |   None   | Optional Postgres URL override to use instead of POSTGRES_* variables. |
 
 ### Email
 

--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -26,16 +26,14 @@ services:
       PGID: 1000
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
-      BASE_URL: http://localhost # (4)
+      BASE_URL: https://mealie.yourdomain.com
       # Database Settings
       DB_ENGINE: postgres
-      POSTGRES_URL: 'postgres://mealie:mealie@postgres/mealie' # (5)
-      # The following variables are supported if you do not specify POSTGRES_URL
-      # POSTGRES_USER: mealie
-      # POSTGRES_PASSWORD: mealie
-      # POSTGRES_SERVER: postgres
-      # POSTGRES_PORT: 5432
-      # POSTGRES_DB: mealie
+      POSTGRES_USER: mealie
+      POSTGRES_PASSWORD: mealie
+      POSTGRES_SERVER: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: mealie
     depends_on:
       postgres:
         condition: service_healthy
@@ -65,8 +63,3 @@ volumes:
 1.  To access the mealie interface you only need to expose port 9000 on the mealie container. Here we expose port 9925 on the host, but feel free to change this to any port you like.
 2.  Setting an explicit memory limit is recommended. Python can pre-allocate larger amounts of memory than is necessary if you have a machine with a lot of RAM. This can cause the container to idle at a high memory usage. Setting a memory limit will improve idle performance.
 3.  You should double check this value isn't out of date when setting up for the first time; check the README and use the value from the "latest release" badge at the top - the format should be `vX.Y.Z`. Whilst a 'latest' tag is available, the Mealie team advises specifying a specific version tag and consciously updating to newer versions when you have time to read the release notes and ensure you follow any manual actions required (which should be rare).
-4. You should replace this with your domain eg. mealie.yourdomain.com
-5. When set, this variable will override POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_SERVER,
-POSTGRES_PORT, and POSTGRES_DB. It must be used in conjunction with DB_ENGINE: postgres.
-The format is 'postgresql://POSTGRES_USER:POSTGRES_PASSWORD@POSTGRES_SERVER:POSTGRES_PORT/POSTGRES_DB'
-You may pass in a UNIX socket with the following format: postgresql://POSTGRES_USER:POSTGRES_PASSWORD@/POSTGRES_DB?host=/run/postgresql', where the path at the end is the parent directory of the socket.

--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -5,40 +5,41 @@ PostgreSQL might be considered if you need to support many concurrent users. In 
 **For Environment Variable Configuration, see** [Backend Configuration](./backend-config.md)
 
 ```yaml
----
-version: "3.7"
 services:
   mealie:
-    image: ghcr.io/mealie-recipes/mealie:v1.3.2 # (3)
+    image: ghcr.io/mealie-recipes/mealie:1.3.2 # (3)
     container_name: mealie
+    restart: always
     ports:
         - "9925:9000" # (1)
     deploy:
       resources:
         limits:
           memory: 1000M # (2)
-    depends_on:
-      - postgres
     volumes:
       - mealie-data:/app/data/
+      - /etc/timezone:/etc/timezone:ro
     environment:
-    # Set Backend ENV Variables Here
-      - ALLOW_SIGNUP=true
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Anchorage
-      - MAX_WORKERS=1
-      - WEB_CONCURRENCY=1
-      - BASE_URL=https://mealie.yourdomain.com
+      # Set Backend ENV Variables Here
+      ALLOW_SIGNUP: true
+      PUID: 1000
+      PGID: 1000
+      MAX_WORKERS: 1
+      WEB_CONCURRENCY: 1
+      BASE_URL: http://localhost # (4)
+      # Database Settings
+      DB_ENGINE: postgres
+      POSTGRES_URL: 'postgres://mealie:mealie@postgres/mealie' # (5)
+      # The following variables are supported if you do not specify POSTGRES_URL
+      # POSTGRES_USER: mealie
+      # POSTGRES_PASSWORD: mealie
+      # POSTGRES_SERVER: postgres
+      # POSTGRES_PORT: 5432
+      # POSTGRES_DB: mealie
+    depends_on:
+      postgres:
+        condition: service_healthy
 
-    # Database Settings
-      - DB_ENGINE=postgres
-      - POSTGRES_USER=mealie
-      - POSTGRES_PASSWORD=mealie
-      - POSTGRES_SERVER=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=mealie
-    restart: always
   postgres:
     container_name: postgres
     image: postgres:15
@@ -48,12 +49,15 @@ services:
     environment:
       POSTGRES_PASSWORD: mealie
       POSTGRES_USER: mealie
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
 
 volumes:
   mealie-data:
-    driver: local
   mealie-pgdata:
-    driver: local
 ```
 
 <!-- Updating This? Be Sure to also update the SQLite Annotations -->
@@ -61,3 +65,8 @@ volumes:
 1.  To access the mealie interface you only need to expose port 9000 on the mealie container. Here we expose port 9925 on the host, but feel free to change this to any port you like.
 2.  Setting an explicit memory limit is recommended. Python can pre-allocate larger amounts of memory than is necessary if you have a machine with a lot of RAM. This can cause the container to idle at a high memory usage. Setting a memory limit will improve idle performance.
 3.  You should double check this value isn't out of date when setting up for the first time; check the README and use the value from the "latest release" badge at the top - the format should be `vX.Y.Z`. Whilst a 'latest' tag is available, the Mealie team advises specifying a specific version tag and consciously updating to newer versions when you have time to read the release notes and ensure you follow any manual actions required (which should be rare).
+4. You should replace this with your domain eg. mealie.yourdomain.com
+5. When set, this variable will override POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_SERVER,
+POSTGRES_PORT, and POSTGRES_DB. It must be used in conjunction with DB_ENGINE: postgres.
+The format is 'postgresql://POSTGRES_USER:POSTGRES_PASSWORD@POSTGRES_SERVER:POSTGRES_PORT/POSTGRES_DB'
+You may pass in a UNIX socket with the following format: postgresql://POSTGRES_USER:POSTGRES_PASSWORD@/POSTGRES_DB?host=/run/postgresql', where the path at the end is the parent directory of the socket.

--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -7,7 +7,7 @@ PostgreSQL might be considered if you need to support many concurrent users. In 
 ```yaml
 services:
   mealie:
-    image: ghcr.io/mealie-recipes/mealie:1.3.2 # (3)
+    image: ghcr.io/mealie-recipes/mealie:v1.3.2 # (3)
     container_name: mealie
     restart: always
     ports:

--- a/docs/docs/documentation/getting-started/installation/postgres.md
+++ b/docs/docs/documentation/getting-started/installation/postgres.md
@@ -18,12 +18,12 @@ services:
           memory: 1000M # (2)
     volumes:
       - mealie-data:/app/data/
-      - /etc/timezone:/etc/timezone:ro
     environment:
       # Set Backend ENV Variables Here
       ALLOW_SIGNUP: true
       PUID: 1000
       PGID: 1000
+      TZ: America/Anchorage
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
       BASE_URL: https://mealie.yourdomain.com

--- a/docs/docs/documentation/getting-started/installation/sqlite.md
+++ b/docs/docs/documentation/getting-started/installation/sqlite.md
@@ -9,7 +9,6 @@ SQLite is a popular, open source, self-contained, zero-configuration database th
 **For Environment Variable Configuration, see** [Backend Configuration](./backend-config.md)
 
 ```yaml
----
 services:
   mealie:
     image: ghcr.io/mealie-recipes/mealie:v1.3.2 # (3)
@@ -31,10 +30,7 @@ services:
       PGID: 1000
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
-      BASE_URL: http://localhost # (4)
-    depends_on:
-      postgres:
-        condition: service_healthy
+      BASE_URL: https://mealie.yourdomain.com
 
 volumes:
   mealie-data:
@@ -45,4 +41,3 @@ volumes:
 1.  To access the mealie interface you only need to expose port 9000 on the container. Here we expose port 9925 on the host, but feel free to change this to any port you like.
 2.  Setting an explicit memory limit is recommended. Python can pre-allocate larger amounts of memory than is necessary if you have a machine with a lot of RAM. This can cause the container to idle at a high memory usage. Setting a memory limit will improve idle performance.
 3.  You should double check this value isn't out of date when setting up for the first time; check the README and use the value from the "latest release" badge at the top - the format should be `vX.Y.Z`. Whilst a 'latest' tag is available, the Mealie team advises specifying a specific version tag and consciously updating to newer versions when you have time to read the release notes and ensure you follow any manual actions required (which should be rare).
-4. You should replace this with your domain eg. mealie.yourdomain.com

--- a/docs/docs/documentation/getting-started/installation/sqlite.md
+++ b/docs/docs/documentation/getting-started/installation/sqlite.md
@@ -10,11 +10,11 @@ SQLite is a popular, open source, self-contained, zero-configuration database th
 
 ```yaml
 ---
-version: "3.7"
 services:
   mealie:
-    image: ghcr.io/mealie-recipes/mealie:v1.3.2 # (3)
+    image: ghcr.io/mealie-recipes/mealie:1.3.2 # (3)
     container_name: mealie
+    restart: always
     ports:
         - "9925:9000" # (1)
     deploy:
@@ -23,20 +23,21 @@ services:
           memory: 1000M # (2)
     volumes:
       - mealie-data:/app/data/
+      - /etc/timezone:/etc/timezone:ro
     environment:
-    # Set Backend ENV Variables Here
-      - ALLOW_SIGNUP=true
-      - PUID=1000
-      - PGID=1000
-      - TZ=America/Anchorage
-      - MAX_WORKERS=1
-      - WEB_CONCURRENCY=1
-      - BASE_URL=https://mealie.yourdomain.com
-    restart: always
+      # Set Backend ENV Variables Here
+      ALLOW_SIGNUP: true
+      PUID: 1000
+      PGID: 1000
+      MAX_WORKERS: 1
+      WEB_CONCURRENCY: 1
+      BASE_URL: http://localhost # (4)
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   mealie-data:
-    driver: local
 ```
 
 <!-- Updating This? Be Sure to also update the Postgres Annotations -->
@@ -44,3 +45,4 @@ volumes:
 1.  To access the mealie interface you only need to expose port 9000 on the container. Here we expose port 9925 on the host, but feel free to change this to any port you like.
 2.  Setting an explicit memory limit is recommended. Python can pre-allocate larger amounts of memory than is necessary if you have a machine with a lot of RAM. This can cause the container to idle at a high memory usage. Setting a memory limit will improve idle performance.
 3.  You should double check this value isn't out of date when setting up for the first time; check the README and use the value from the "latest release" badge at the top - the format should be `vX.Y.Z`. Whilst a 'latest' tag is available, the Mealie team advises specifying a specific version tag and consciously updating to newer versions when you have time to read the release notes and ensure you follow any manual actions required (which should be rare).
+4. You should replace this with your domain eg. mealie.yourdomain.com

--- a/docs/docs/documentation/getting-started/installation/sqlite.md
+++ b/docs/docs/documentation/getting-started/installation/sqlite.md
@@ -22,12 +22,12 @@ services:
           memory: 1000M # (2)
     volumes:
       - mealie-data:/app/data/
-      - /etc/timezone:/etc/timezone:ro
     environment:
       # Set Backend ENV Variables Here
       ALLOW_SIGNUP: true
       PUID: 1000
       PGID: 1000
+      TZ: America/Anchorage
       MAX_WORKERS: 1
       WEB_CONCURRENCY: 1
       BASE_URL: https://mealie.yourdomain.com

--- a/docs/docs/documentation/getting-started/installation/sqlite.md
+++ b/docs/docs/documentation/getting-started/installation/sqlite.md
@@ -12,7 +12,7 @@ SQLite is a popular, open source, self-contained, zero-configuration database th
 ---
 services:
   mealie:
-    image: ghcr.io/mealie-recipes/mealie:1.3.2 # (3)
+    image: ghcr.io/mealie-recipes/mealie:v1.3.2 # (3)
     container_name: mealie
     restart: always
     ports:

--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -46,7 +46,11 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
     @property
     def db_url(self) -> str:
         if self.POSTGRES_URL_OVERRIDE:
-            return self.POSTGRES_URL_OVERRIDE
+            url = PostgresDsn(url=self.POSTGRES_URL_OVERRIDE)
+            if not url.scheme == ("postgresql"):
+                raise ValueError("POSTGRES_URL_OVERRIDE scheme must be postgresql")
+
+            return str(url)
 
         return str(
             PostgresDsn.build(

--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -48,7 +48,7 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
         if self.POSTGRES_URL:
             return self.POSTGRES_URL
 
-        self.db_url: str = str(
+        self.POSTGRES_URL = str(
             PostgresDsn.build(
                 scheme="postgresql",
                 username=self.POSTGRES_USER,

--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -39,16 +39,16 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
     POSTGRES_SERVER: str = "postgres"
     POSTGRES_PORT: str = "5432"
     POSTGRES_DB: str = "mealie"
-    POSTGRES_URL: str = ""
+    POSTGRES_URL_OVERRIDE: str | None = None
 
     model_config = SettingsConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     @property
     def db_url(self) -> str:
-        if self.POSTGRES_URL:
-            return self.POSTGRES_URL
+        if self.POSTGRES_URL_OVERRIDE:
+            return self.POSTGRES_URL_OVERRIDE
 
-        self.POSTGRES_URL = str(
+        return str(
             PostgresDsn.build(
                 scheme="postgresql",
                 username=self.POSTGRES_USER,
@@ -57,8 +57,6 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
                 path=f"{self.POSTGRES_DB or ''}",
             )
         )
-
-        return self.POSTGRES_URL
 
     @property
     def db_url_public(self) -> str:

--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -39,21 +39,26 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
     POSTGRES_SERVER: str = "postgres"
     POSTGRES_PORT: str = "5432"
     POSTGRES_DB: str = "mealie"
+    POSTGRES_URL: str = ""
 
     model_config = SettingsConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     @property
     def db_url(self) -> str:
-        host = f"{self.POSTGRES_SERVER}:{self.POSTGRES_PORT}"
-        return str(
+        if self.POSTGRES_URL:
+            return self.POSTGRES_URL
+
+        self.db_url: str = str(
             PostgresDsn.build(
                 scheme="postgresql",
                 username=self.POSTGRES_USER,
                 password=urlparse.quote_plus(self.POSTGRES_PASSWORD),
-                host=host,
+                host=f"{self.POSTGRES_SERVER}:{self.POSTGRES_PORT}",
                 path=f"{self.POSTGRES_DB or ''}",
             )
         )
+
+        return self.POSTGRES_URL
 
     @property
     def db_url_public(self) -> str:


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?
<!--
  Delete any of the following that do not apply:
 -->

- bug
- cleanup
- documentation
- feature

## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

- Added POSTGRES_URL to PostgresProvider as an override for the individual POSTGRES_* variables currently in use.
- PostgresProvider.db_url no longer rebuilds the db url on every call.
- Updated the documentation to reflect the new variable and it's usage.
- The override can be used to specify a UNIX socket for postgres.

## Which issue(s) this PR fixes:

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

Fixes #3392 

## Testing

<!--
  Describe how you tested this change.
-->

1). Installed postgres locally into a mealie devcontainer.
2). Created a database for mealie
3). Tested multiple values of POSTGRES_URL (omitted, specified using default config, specified using file socket). using task dev:services and task py:postgres for more complete testing.