### PR TITLE
fix: make groups private by default

### DIFF
--- a/mealie/schema/group/group_preferences.py
+++ b/mealie/schema/group/group_preferences.py
@@ -6,7 +6,7 @@ from mealie.schema._mealie import MealieModel
 
 
 class UpdateGroupPreferences(MealieModel):
-    private_group: bool = False
+    private_group: bool = True
     first_day_of_week: int = 0
 
     # Recipe Defaults

--- a/tests/integration_tests/user_group_tests/test_group_preferences.py
+++ b/tests/integration_tests/user_group_tests/test_group_preferences.py
@@ -31,7 +31,7 @@ def test_preferences_in_group(api_client: TestClient, unique_user: TestUser) -> 
 
 
 def test_update_preferences(api_client: TestClient, unique_user: TestUser) -> None:
-    new_data = UpdateGroupPreferences(recipe_public=True, recipe_show_nutrition=True)
+    new_data = UpdateGroupPreferences(recipe_public=False, recipe_show_nutrition=True)
 
     response = api_client.put(api_routes.groups_preferences, json=new_data.model_dump(), headers=unique_user.token)
 
@@ -40,7 +40,7 @@ def test_update_preferences(api_client: TestClient, unique_user: TestUser) -> No
     preferences = response.json()
 
     assert preferences is not None
-    assert preferences["recipePublic"] is True
+    assert preferences["recipePublic"] is False
     assert preferences["recipeShowNutrition"] is True
 
     assert_ignore_keys(new_data.model_dump(by_alias=True), preferences, ["id", "groupId"])

--- a/tests/integration_tests/user_group_tests/test_group_preferences.py
+++ b/tests/integration_tests/user_group_tests/test_group_preferences.py
@@ -31,7 +31,7 @@ def test_preferences_in_group(api_client: TestClient, unique_user: TestUser) -> 
 
 
 def test_update_preferences(api_client: TestClient, unique_user: TestUser) -> None:
-    new_data = UpdateGroupPreferences(recipe_public=False, recipe_show_nutrition=True)
+    new_data = UpdateGroupPreferences(recipe_public=True, recipe_show_nutrition=True)
 
     response = api_client.put(api_routes.groups_preferences, json=new_data.model_dump(), headers=unique_user.token)
 
@@ -40,7 +40,7 @@ def test_update_preferences(api_client: TestClient, unique_user: TestUser) -> No
     preferences = response.json()
 
     assert preferences is not None
-    assert preferences["recipePublic"] is False
+    assert preferences["recipePublic"] is True
     assert preferences["recipeShowNutrition"] is True
 
     assert_ignore_keys(new_data.model_dump(by_alias=True), preferences, ["id", "groupId"])


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- fix

## What this PR does / why we need it:

As mentionned in https://github.com/mealie-recipes/mealie/pull/3368#issuecomment-2024924163, I suggest to change group visibility by default to "private". This is an additional security measure and also when using Mealie for the first time the user would be redirected to the login/welcome page instead of the empty group.

This does not affect groups already created and I have not seen any impacts in the frontend.

## Which issue(s) this PR fixes:

N/A

## Testing
- manual testing via interface (during initial configuration and on the management groups page)
- pytest runs successfully