### PR TITLE
fix: Bad Recipe Rating Calc Preventing App Startup

### DIFF
--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -260,13 +260,12 @@ def receive_description(target: RecipeModel, value: str, oldvalue, initiator):
 @event.listens_for(RecipeModel, "before_update")
 def calculate_rating(mapper, connection, target: RecipeModel):
     session = object_session(target)
-    if not session:
+    if not (session and session.is_modified(target, "rating")):
         return
 
-    if session.is_modified(target, "rating"):
-        history = get_history(target, "rating")
-        old_value = history.deleted[0] if history.deleted else None
-        new_value = history.added[0] if history.added else None
+    history = get_history(target, "rating")
+    old_value = history.deleted[0] if history.deleted else None
+    new_value = history.added[0] if history.added else None
     if old_value == new_value:
         return
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Fixes a bug when calculating a recipe's average rating.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Raised in Discord

## Testing

_(fill-in or delete this section)_

User in Discord DM'd me their sqlite db and I confirmed it loads fine with this fix.