### PR TITLE
OIDC - Specifically check for 401 status before resetting

### DIFF
--- a/frontend/schemes/DynamicOpenIDConnectScheme.js
+++ b/frontend/schemes/DynamicOpenIDConnectScheme.js
@@ -77,8 +77,10 @@ export default class DynamicOpenIDConnectScheme extends OpenIDConnectScheme {
         })
         // Update tokens with mealie token
         this.updateTokens(response)
-      } catch {
-        this.$auth.reset()
+      } catch (e) {
+        if (e.response?.status === 401) {
+          this.$auth.reset()
+        }
         const currentUrl = new URL(window.location.href)
         if (currentUrl.pathname === "/login" && currentUrl.searchParams.has("direct")) {
           return


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Nightly image does not allow signing into Mealie on mobile (iPhone) devices, but web (multiple browsers) works just fine

## Which issue(s) this PR fixes:

Fixes #3499

## Special notes for your reviewer:

Pulled down the nightly image this morning and found I couldn't log in on my mobile device (iPhone), but it was fine on web (multiple browsers). I assumed it was due to the previous fix for the infinite redirect. Through some debugging, I tracked the issue down to this one specific line where we reset the auth if there is an error. I honestly think there was some sort of race condition, but adding a check to look if the response was specifically a 401 before resetting seems to have fixed the problem.

## Testing

Manual testing on mobile device and web
