### PR TITLE
Add time-based caching for JWKS fetching

### DIFF
--- a/mealie/core/security/providers/openid_provider.py
+++ b/mealie/core/security/providers/openid_provider.py
@@ -80,7 +80,7 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
         self._logger.warning("[OIDC] Found user but their AuthMethod does not match OIDC")
         return None
 
-    def get_claims(self, settings: AppSettings, retry=False) -> JWTClaims | None:
+    def get_claims(self, settings: AppSettings) -> JWTClaims | None:
         """Get the claims from the ID token and check if the required claims are present"""
         required_claims = {"preferred_username", "name", "email", settings.OIDC_USER_CLAIM}
         jwks = OpenIDProvider.get_jwks(self.get_ttl_hash())  # cache the key set for 30 minutes

--- a/mealie/core/security/providers/openid_provider.py
+++ b/mealie/core/security/providers/openid_provider.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from functools import lru_cache
 
 import requests
 from authlib.jose import JsonWebKey, JsonWebToken, JWTClaims, KeySet
@@ -113,7 +112,6 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
             return None
         return claims
 
-    @lru_cache
     @staticmethod
     def get_jwks() -> KeySet | None:
         """Get the key set from the open id configuration"""

--- a/mealie/core/security/providers/openid_provider.py
+++ b/mealie/core/security/providers/openid_provider.py
@@ -1,4 +1,6 @@
+import time
 from datetime import timedelta
+from functools import lru_cache
 
 import requests
 from authlib.jose import JsonWebKey, JsonWebToken, JWTClaims, KeySet
@@ -78,10 +80,10 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
         self._logger.warning("[OIDC] Found user but their AuthMethod does not match OIDC")
         return None
 
-    def get_claims(self, settings: AppSettings) -> JWTClaims | None:
+    def get_claims(self, settings: AppSettings, retry=False) -> JWTClaims | None:
         """Get the claims from the ID token and check if the required claims are present"""
         required_claims = {"preferred_username", "name", "email", settings.OIDC_USER_CLAIM}
-        jwks = OpenIDProvider.get_jwks()
+        jwks = OpenIDProvider.get_jwks(self.get_ttl_hash())  # cache the key set for 30 minutes
         if not jwks:
             return None
 
@@ -112,9 +114,11 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
             return None
         return claims
 
+    @lru_cache
     @staticmethod
-    def get_jwks() -> KeySet | None:
-        """Get the key set from the open id configuration"""
+    def get_jwks(ttl_hash=None) -> KeySet | None:
+        """Get the key set from the openid configuration"""
+        del ttl_hash  # ttl_hash is used for caching only
         settings = get_app_settings()
 
         if not (settings.OIDC_READY and settings.OIDC_CONFIGURATION_URL):
@@ -143,3 +147,6 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
         response.raise_for_status()
         session.close()
         return JsonWebKey.import_key_set(response.json())
+
+    def get_ttl_hash(self, seconds=1800):
+        return time.time() // seconds


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

We currently cache the output from getting the JSON Web Key Set (JWKS) from a user's OIDC configuration indefinitely. This causes login issues when the key set is rotated and the key set that is cached is no longer valid. This PR just removed the caching on the method, which should be fine since the requests shouldn't be very heavy or that frequent. 

## Which issue(s) this PR fixes:

Fixes #3562 

## Special notes for your reviewer:

I considered switching the lru cache to a TTL cache from [cachetools](https://pypi.org/project/cachetools/), but didn't see one built in and didn't want to add another dependency to the project

## Testing

Manually and E2E
