### PR TITLE
fix: Set the daily schedule to a specific time, rather than 24hr from start up

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -17,7 +17,7 @@
 | ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                    |
 | LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                  |
 | LOG_LEVEL                     |         info          | Logging level configured                                                            |
-| DAILY_SCHEDULE_TIME           |        23:45          | The time of day to run the daily tasks.                                |
+| DAILY_SCHEDULE_TIME           |        23:45          | The time of day to run the daily tasks.                                             |
 
 <super>\*</super> Starting in v1.4.0 this was changed to default to `false` as apart of a security review of the application.
 

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -16,7 +16,8 @@
 | TZ                            |          UTC          | Must be set to get correct date/time on the server                                  |
 | ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                    |
 | LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                  |
-| LOG_LEVEL                     |         info          | logging level configured                                                            |
+| LOG_LEVEL                     |         info          | Logging level configured                                                            |
+| DAILY_SCHEDULE_TIME           |        23:45          | The time of day to run the daily tasks.                                |
 
 <super>\*</super> Starting in v1.4.0 this was changed to default to `false` as apart of a security review of the application.
 

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -57,6 +57,8 @@ class AppSettings(BaseSettings):
 
     ALLOW_SIGNUP: bool = False
 
+    DAILY_SCHEDULE_TIME: str = "23:45"
+
     # ===============================================
     # Security Configuration
 
@@ -199,7 +201,11 @@ class AppSettings(BaseSettings):
     def OIDC_READY(self) -> bool:
         """Validates OIDC settings are all set"""
 
-        required = {self.OIDC_CLIENT_ID, self.OIDC_CONFIGURATION_URL, self.OIDC_USER_CLAIM}
+        required = {
+            self.OIDC_CLIENT_ID,
+            self.OIDC_CONFIGURATION_URL,
+            self.OIDC_USER_CLAIM,
+        }
         not_none = None not in required
         valid_group_claim = True
         if (not self.OIDC_USER_GROUP or not self.OIDC_ADMIN_GROUP) and not self.OIDC_GROUPS_CLAIM:

--- a/mealie/services/scheduler/scheduler_service.py
+++ b/mealie/services/scheduler/scheduler_service.py
@@ -35,8 +35,12 @@ async def schedule_daily():
         str(now),
         daily_schedule_time,
     )
-    hour_target = int(daily_schedule_time.split(":")[0])
-    minute_target = int(daily_schedule_time.split(":")[1])
+    try:
+        hour_target, minute_target = _parse_daily_schedule_time(daily_schedule_time)
+    except Exception as e:
+        logger.exception(f"Unable to parse {daily_schedule_time=}")
+        hour_target = 23
+        minute_target = 45
 
     hours_until = ((hour_target - now.hour) % 24) or 24
     minutes_until = (minute_target - now.minute) % 60
@@ -48,6 +52,12 @@ async def schedule_daily():
     wait_seconds = (target_time - now).total_seconds()
     await asyncio.sleep(wait_seconds)
     await run_daily()
+
+
+def _parse_daily_schedule_time(time):
+    hour_target = int(time.split(":")[0])
+    minute_target = int(time.split(":")[1])
+    return hour_target, minute_target
 
 
 def _scheduled_task_wrapper(callable):

--- a/mealie/services/scheduler/scheduler_service.py
+++ b/mealie/services/scheduler/scheduler_service.py
@@ -1,6 +1,9 @@
+import asyncio
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from mealie.core import root_logger
+from mealie.core.config import get_app_settings
 from mealie.services.scheduler.runner import repeat_every
 
 from .scheduler_registry import SchedulerRegistry
@@ -18,18 +21,43 @@ class SchedulerService:
     @staticmethod
     async def start():
         await run_minutely()
-        await run_daily()
         await run_hourly()
+
+        # Wait to trigger our daily run until our given "daily time", so having asyncio handle it.
+        asyncio.create_task(schedule_daily())
+
+
+async def schedule_daily():
+    now = datetime.now()
+    daily_schedule_time = get_app_settings().DAILY_SCHEDULE_TIME
+    logger.debug(
+        "Current time is %s and DAILY_SCHEDULE_TIME is %s",
+        str(now),
+        daily_schedule_time,
+    )
+    hour_target = int(daily_schedule_time.split(":")[0])
+    minute_target = int(daily_schedule_time.split(":")[1])
+
+    hours_until = ((hour_target - now.hour) % 24) or 24
+    minutes_until = (minute_target - now.minute) % 60
+    logger.debug("Hours until %s and minutes until %s", str(hours_until), str(minutes_until))
+
+    delta = timedelta(hours=hours_until, minutes=minutes_until)
+    target_time = (now + delta).replace(microsecond=0, second=0)
+    logger.info("Daily tasks scheduled for %s", str(target_time))
+    wait_seconds = (target_time - now).total_seconds()
+    await asyncio.sleep(wait_seconds)
+    await run_daily()
 
 
 def _scheduled_task_wrapper(callable):
     try:
         callable()
     except Exception as e:
-        logger.error(f"Error in scheduled task func='{callable.__name__}': exception='{e}'")
+        logger.error("Error in scheduled task func='%s': exception='%s'", callable.__name__, e)
 
 
-@repeat_every(minutes=MINUTES_DAY, wait_first=True, logger=logger)
+@repeat_every(minutes=MINUTES_DAY, wait_first=False, logger=logger)
 def run_daily():
     logger.debug("Running daily callbacks")
     for func in SchedulerRegistry._daily:

--- a/mealie/services/scheduler/scheduler_service.py
+++ b/mealie/services/scheduler/scheduler_service.py
@@ -37,7 +37,7 @@ async def schedule_daily():
     )
     try:
         hour_target, minute_target = _parse_daily_schedule_time(daily_schedule_time)
-    except Exception as e:
+    except Exception:
         logger.exception(f"Unable to parse {daily_schedule_time=}")
         hour_target = 23
         minute_target = 45


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

The previous logic for running daily tasks was that at container start it would NOT run, but sleep for 24hrs and then run. For people (like me) who might restart their container daily for backups, or who regularly update their image, this means they effectively never get the daily tasks run.
This change makes it so the daily tasks are scheduled to run at the next 23:45 (or other configured time). Meaning if a container is started at 22:00, it'll run 1:45 later (as opposed to 24:00 later).

This uses changes by @Grygon on https://github.com/mealie-recipes/mealie/pull/2497 as its basis.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Maybe fixes #3454; it's the reason I noticed this.

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

Some comments will be added against the code.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Have done a bit on my prod system.

Realistic case:
```
mealie  | DEBUG    2024-05-24T20:37:46 - Current time is 2024-05-24 20:37:46.042663 and DAILY_SCHEDULE_TIME is 23:45
mealie  | DEBUG    2024-05-24T20:37:46 - Hours until 3 and minutes until 8
mealie  | INFO     2024-05-24T20:37:46 - Daily tasks scheduled for 2024-05-24 23:45:00
```

Test case, showing it rolls to next day as needed:
```
mealie  | DEBUG    2024-05-24T19:47:06 - Current time is 2024-05-24 19:47:06.369710 and target time is 18:45
mealie  | DEBUG    2024-05-24T19:47:06 - Hours until 23 and minutes until 58
mealie  | INFO     2024-05-24T19:47:06 - Daily tasks scheduled for 2024-05-25 19:45:00
```

Multi day Production run (note changes were implemented at 2024-05-24T20:37:46). This shows that the daily tasks are being run every 23:45 as expected despite, importantly, my container restarting at 1am each day.
```
mealie  | INFO     2024-05-24T19:30:07 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | INFO     2024-05-24T19:45:32 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | INFO     2024-05-24T19:47:06 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | INFO     2024-05-24T20:07:01 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | INFO     2024-05-24T20:17:42 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | INFO     2024-05-24T20:37:46 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | DEBUG    2024-05-24T23:45:00 - Running daily callbacks
mealie  | INFO     2024-05-25T01:00:14 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
mealie  | DEBUG    2024-05-25T23:45:00 - Running daily callbacks
mealie  | INFO     2024-05-26T01:00:15 - Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
```