### PR TITLE
fix: Broken Data Management Tabs

### DIFF
--- a/frontend/components/global/BaseOverflowButton.vue
+++ b/frontend/components/global/BaseOverflowButton.vue
@@ -38,7 +38,7 @@
             </v-list-item-icon>
             <v-list-item-title>{{ item.text }}</v-list-item-title>
             </v-list-item>
-            <v-divider v-if="item.divider" :key="`divider-${index}`" class="my-1" ></v-divider>\
+            <v-divider v-if="item.divider" :key="`divider-${index}`" class="my-1" ></v-divider>
           </div>
         </template>
       </v-list-item-group>

--- a/frontend/components/global/BaseOverflowButton.vue
+++ b/frontend/components/global/BaseOverflowButton.vue
@@ -80,7 +80,7 @@ export interface MenuItem {
   value?: string;
   event?: string;
   divider?: boolean;
-  hide?:boolean;
+  hide?: boolean;
 }
 
 export default defineComponent({

--- a/frontend/pages/group/data.vue
+++ b/frontend/pages/group/data.vue
@@ -54,44 +54,44 @@ export default defineComponent({
 
     const DATA_TYPE_OPTIONS = computed(() => [
       {
-        text: i18n.t("general.recipes"),
+        text: i18n.tc("general.recipes"),
         value: "new",
         to: "/group/data/recipes",
       },
       {
-        text: i18n.t("recipe.recipe-actions"),
+        text: i18n.tc("recipe.recipe-actions"),
         value: "new",
         to: "/group/data/recipe-actions",
         divider: true,
       },
       {
-        text: i18n.t("general.foods"),
+        text: i18n.tc("general.foods"),
         value: "url",
         to: "/group/data/foods",
       },
       {
-        text: i18n.t("general.units"),
+        text: i18n.tc("general.units"),
         value: "new",
         to: "/group/data/units",
       },
       {
-        text: i18n.t("data-pages.labels.labels"),
+        text: i18n.tc("data-pages.labels.labels"),
         value: "new",
         to: "/group/data/labels",
         divider: true,
       },
       {
-        text: i18n.t("category.categories"),
+        text: i18n.tc("category.categories"),
         value: "new",
         to: "/group/data/categories",
       },
       {
-        text: i18n.t("tag.tags"),
+        text: i18n.tc("tag.tags"),
         value: "new",
         to: "/group/data/tags",
       },
       {
-        text: i18n.t("tool.tools"),
+        text: i18n.tc("tool.tools"),
         value: "new",
         to: "/group/data/tools",
       }


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

I fat fingered a backslash in [the OpenAI PR](https://github.com/mealie-recipes/mealie/pull/3581/files#diff-379b9c28df3ea9c97f8a9c5bb33aa8f4ea89977314699845386fe8f8bc8fe3d5R41) which caused this:

![image](https://github.com/mealie-recipes/mealie/assets/71845777/eb91b541-709f-44da-bb65-7d68be4c010e)

This PR fixes this:

![image](https://github.com/mealie-recipes/mealie/assets/71845777/8511cf04-0d10-47d8-9f45-3de61b608856)

I also fixed some lint issues.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Manually