### PR TITLE
feat: bulk assign label to foods

### DIFF
--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -210,7 +210,8 @@
     "unsaved-changes": "You have unsaved changes. Do you want to save before leaving? Okay to save, Cancel to discard changes.",
     "clipboard-copy-failure": "Failed to copy to the clipboard.",
     "confirm-delete-generic-items": "Are you sure you want to delete the following items?",
-    "organizers": "Organizers"
+    "organizers": "Organizers",
+    "caution": "Caution"
   },
   "group": {
     "are-you-sure-you-want-to-delete-the-group": "Are you sure you want to delete <b>{groupName}<b/>?",
@@ -983,7 +984,8 @@
       "edit-food": "Edit Food",
       "food-data": "Food Data",
       "example-food-singular": "ex: Onion",
-      "example-food-plural": "ex: Onions"
+      "example-food-plural": "ex: Onions",
+      "label-overwrite-warning": "This will assign the choosen label to all selected foods and potentially overwrite your existing labels."
     },
     "units": {
       "seed-dialog-text": "Seed the database with common units based on your local language.",
@@ -1011,7 +1013,8 @@
       "seed-dialog-text": "Seed the database with common labels based on your local language.",
       "edit-label": "Edit Label",
       "new-label": "New Label",
-      "labels": "Labels"
+      "labels": "Labels",
+      "assign-label": "Assign Label"
     },
     "recipes": {
       "purge-exports": "Purge Exports",

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -185,7 +185,7 @@
       v-model="bulkAssignLabelDialog"
       :title="$tc('data-pages.labels.assign-label')"
       :icon="$globals.icons.tags"
-      @confirm="asignSelected"
+      @confirm="assignSelected"
     >
       <v-card-text>
         <v-card class="mb-4">
@@ -464,7 +464,7 @@ export default defineComponent({
       bulkAssignLabelDialog.value = true;
     }
 
-    async function asignSelected() {
+    async function assignSelected() {
       if (!bulkAssignLabelId.value) {
         return;
       }
@@ -525,7 +525,7 @@ export default defineComponent({
       bulkAssignTarget,
       bulkAssignLabelId,
       bulkAssignEventHandler,
-      asignSelected,
+      assignSelected,
     };
   },
 });

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -180,17 +180,56 @@
       </v-card-text>
     </BaseDialog>
 
+    <!-- Bulk Asign Labels Dialog -->
+    <BaseDialog
+      v-model="bulkAssignLabelDialog"
+      :title="$tc('data-pages.labels.assign-label')"
+      :icon="$globals.icons.tags"
+      @confirm="asignSelected"
+    >
+      <v-card-text>
+        <v-card class="mb-4">
+          <v-card-title>{{ $tc("general.caution") }}</v-card-title>
+          <v-card-text>{{ $tc("data-pages.foods.label-overwrite-warning") }}</v-card-text>
+        </v-card>
+
+        <v-autocomplete
+          v-model="bulkAssignLabelId"
+          clearable
+          :items="allLabels"
+          item-value="id"
+          item-text="name"
+          :label="$tc('data-pages.foods.food-label')"
+        />
+        <v-card outlined>
+          <v-virtual-scroll height="400" item-height="25" :items="bulkAssignTarget">
+            <template #default="{ item }">
+              <v-list-item class="pb-2">
+                <v-list-item-content>
+                  <v-list-item-title>{{ item.name }}</v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+            </template>
+          </v-virtual-scroll>
+        </v-card>
+      </v-card-text>
+    </BaseDialog>
+
     <!-- Data Table -->
     <BaseCardSectionTitle :icon="$globals.icons.foods" section :title="$tc('data-pages.foods.food-data')"> </BaseCardSectionTitle>
     <CrudTable
       :table-config="tableConfig"
       :headers.sync="tableHeaders"
       :data="foods || []"
-      :bulk-actions="[{icon: $globals.icons.delete, text: $tc('general.delete'), event: 'delete-selected'}]"
+      :bulk-actions="[
+        {icon: $globals.icons.delete, text: $tc('general.delete'), event: 'delete-selected'},
+        {icon: $globals.icons.tags, text: $tc('data-pages.labels.assign-label'), event: 'assign-selected'}
+      ]"
       @delete-one="deleteEventHandler"
       @edit-one="editEventHandler"
       @create-one="createEventHandler"
       @delete-selected="bulkDeleteEventHandler"
+      @assign-selected="bulkAssignEventHandler"
     >
       <template #button-row>
         <BaseButton create @click="createDialog = true" />
@@ -414,6 +453,32 @@ export default defineComponent({
       }
     }
 
+    // ============================================================
+    // Bulk Assign Labels
+    const bulkAssignLabelDialog = ref(false);
+    const bulkAssignTarget = ref<IngredientFood[]>([]);
+    const bulkAssignLabelId = ref<string | undefined>();
+
+    function bulkAssignEventHandler(selection: IngredientFood[]) {
+      bulkAssignTarget.value = selection;
+      bulkAssignLabelDialog.value = true;
+    }
+
+    async function asignSelected() {
+      if (!bulkAssignLabelId.value) {
+        return;
+      }
+      for (const item of bulkAssignTarget.value) {
+        item.labelId = bulkAssignLabelId.value;
+        await foodStore.actions.updateOne(item);
+      }
+      bulkAssignTarget.value = [];
+      bulkAssignLabelId.value = undefined;
+      foodStore.actions.refresh();
+      // reload page, because foodStore.actions.refresh() does not update the table, reactivity for this seems to be broken (again)
+      document.location.reload();
+    }
+
     return {
       tableConfig,
       tableHeaders,
@@ -455,6 +520,12 @@ export default defineComponent({
       locales,
       seedDialog,
       seedDatabase,
+      // Bulk Assign Labels
+      bulkAssignLabelDialog,
+      bulkAssignTarget,
+      bulkAssignLabelId,
+      bulkAssignEventHandler,
+      asignSelected,
     };
   },
 });


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This adds the possibility to assign multiple foods the same label at once. 
I come accross this quite frequently when we try some new fancy recipe and have to create around 5 new foods for it and many of them belong to the same category. So this allows the user to select multiple foods and assign a single label to all of them. 

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

Reactivity for the Manage Data Tabels seems to be somewhat broken again. So i just reloaded the page afterwards. If there is a better way to do this please let me know. 

## Testing

Manual 

## Screenshots
![image](https://github.com/mealie-recipes/mealie/assets/24235032/d0348723-4174-400a-9965-a1ea808892f7)
