### PR TITLE
fix: Comments Disappear After Edit

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -72,7 +72,7 @@
     </div>
 
     <RecipePageComments
-      v-if="isOwnGroup && !recipe.settings.disableComments && !isEditForm && !isCookMode"
+      v-if="!recipe.settings.disableComments && !isEditForm && !isCookMode"
       :recipe="recipe"
       class="px-1 my-4 d-print-none"
     />

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
@@ -30,7 +30,7 @@
         </BaseButton>
       </div>
     </div>
-    <div v-for="comment in comments" :key="comment.id" class="d-flex my-2" style="gap: 10px">
+    <div v-for="comment in recipe.comments" :key="comment.id" class="d-flex my-2" style="gap: 10px">
       <UserAvatar size="40" :user-id="comment.userId" />
       <v-card outlined class="flex-grow-1">
         <v-card-text class="pa-3 pb-0">
@@ -54,9 +54,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, toRefs, onMounted, reactive } from "@nuxtjs/composition-api";
+import { defineComponent, toRefs, reactive } from "@nuxtjs/composition-api";
 import { useUserApi } from "~/composables/api";
-import { Recipe, RecipeCommentOut } from "~/lib/api/types/recipe";
+import { Recipe } from "~/lib/api/types/recipe";
 import UserAvatar from "~/components/Domain/User/UserAvatar.vue";
 import { NoUndefinedField } from "~/lib/api/types/non-generated";
 import { usePageUser } from "~/composables/recipe-page/shared-state";
@@ -76,20 +76,10 @@ export default defineComponent({
   setup(props) {
     const api = useUserApi();
 
-    const comments = ref<RecipeCommentOut[]>([]);
-
     const { user } = usePageUser();
 
     const state = reactive({
       comment: "",
-    });
-
-    onMounted(async () => {
-      const { data } = await api.recipes.comments.byRecipe(props.recipe.slug);
-
-      if (data) {
-        comments.value = data;
-      }
     });
 
     async function submitComment() {
@@ -99,7 +89,8 @@ export default defineComponent({
       });
 
       if (data) {
-        comments.value.push(data);
+        // @ts-ignore username is always populated here
+        props.recipe.comments.push(data);
       }
 
       state.comment = "";
@@ -109,11 +100,11 @@ export default defineComponent({
       const { response } = await api.recipes.comments.deleteOne(id);
 
       if (response?.status === 200) {
-        comments.value = comments.value.filter((comment) => comment.id !== id);
+        props.recipe.comments = props.recipe.comments.filter((comment) => comment.id !== id);
       }
     }
 
-    return { api, comments, ...toRefs(state), submitComment, deleteComment, user };
+    return { api, ...toRefs(state), submitComment, deleteComment, user };
   },
 });
 </script>

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
@@ -39,7 +39,7 @@
         </v-card-text>
         <v-card-actions class="justify-end mt-0 pt-0">
           <v-btn
-            v-if="user.id == comment.user.id || user.admin"
+            v-if="user.id == comment.user.id || (user.admin && user.groupId === recipe.groupId)"
             color="error"
             text
             x-small

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageComments.vue
@@ -39,7 +39,7 @@
         </v-card-text>
         <v-card-actions class="justify-end mt-0 pt-0">
           <v-btn
-            v-if="user.id == comment.user.id || (user.admin && user.groupId === recipe.groupId)"
+            v-if="user.id == comment.user.id || user.admin"
             color="error"
             text
             x-small


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug
- feature

## What this PR does / why we need it:

_(REQUIRED)_

As reported in https://github.com/mealie-recipes/mealie/issues/3766, comments don't update properly if they're created/updated right before another recipe edit. This is because the recipe's state isn't updated, so when it sends the `PUT` request it sends the old data.

I noticed while testing that comments are hidden to anonymous users, so I re-enabled them. They still can't post their own comment, of course. There is a consequence to our logic though: if another user from a different group visits the recipe, they can comment (since they're logged-in). I think this makes sense? I don't see a reason to prevent this behavior.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3766

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

Manually, including the cross-group comment.