### PR TITLE
fix: Open AI Parsing Fails When Group Has No Units

### DIFF
--- a/mealie/services/parser_services/openai/parser.py
+++ b/mealie/services/parser_services/openai/parser.py
@@ -45,7 +45,7 @@ class OpenAIParser(ABCIngredientParser):
             ),
         ]
 
-        if service.send_db_data:
+        if service.send_db_data and self.units_by_alias:
             data_injections.extend(
                 [
                     OpenAIDataInjection(


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

By default, we pass all units to OpenAI when parsing. This increases parser accuracy by giving the LLM sample units. We don't check if the group actually _has_ any units, and we can't send nothing (we raise a Pydantic validation error if we try to). This PR skips the injection in this case.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, raised in Discord

## Testing

_(fill-in or delete this section)_

I had the user try adding one unit before trying to parse and that fixed their issue.