### PR TITLE
fix: Prevent Dragging Ingredients to Instructions and Vice Versa

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
@@ -7,7 +7,7 @@
       handle=".handle"
       v-bind="{
         animation: 200,
-        group: 'description',
+        group: 'recipe-ingredients',
         disabled: false,
         ghostClass: 'ghost',
       }"

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -79,7 +79,7 @@
       handle=".handle"
       v-bind="{
         animation: 200,
-        group: 'description',
+        group: 'recipe-instructions',
         ghostClass: 'ghost',
       }"
       @input="updateIndex"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently you can drag an ingredient to an instruction, or vice versa. This is due to a non-unique group attribute on the draggable. This PR makes the groups unique.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3746

## Testing

_(fill-in or delete this section)_

Manually