### PR TITLE
feat: Add Additional Plan To Eat Columns To Import

### DIFF
--- a/mealie/services/migrations/plantoeat.py
+++ b/mealie/services/migrations/plantoeat.py
@@ -98,7 +98,7 @@ class PlanToEatMigrator(BaseMigrator):
         return tags
 
     def _process_recipe_row(self, row: dict) -> dict:
-        """Reads a single recipe's row, parses its nutrition, and converts it to a dictionary"""
+        """Reads a single recipe's row, merges columns, and converts the row to a dictionary"""
 
         recipe_dict: dict = row
 

--- a/mealie/services/migrations/plantoeat.py
+++ b/mealie/services/migrations/plantoeat.py
@@ -58,7 +58,6 @@ class PlanToEatMigrator(BaseMigrator):
             MigrationAlias(key="prepTime", alias="Prep Time"),
             MigrationAlias(key="performTime", alias="Cook Time"),
             MigrationAlias(key="totalTime", alias="Total Time"),
-            MigrationAlias(key="tags", alias="Tags", func=split_by_comma),
             MigrationAlias(key="dateAdded", alias="Created At", func=lambda x: x[: x.find(" ")]),
         ]
 
@@ -77,11 +76,34 @@ class PlanToEatMigrator(BaseMigrator):
 
         return cleaner.clean_nutrition(nut_dict)
 
+    def _get_categories_from_row(self, row: dict) -> list[str]:
+        """Parses various category-like columns into categories"""
+
+        categories: list[str] = []
+        columns = ["Course", "Cuisine"]
+        for column in columns:
+            value = get_value_as_string_or_none(row, column)
+            if value:
+                categories.append(value)
+
+        return categories
+
+    def _get_tags_from_row(self, row: dict) -> list[str]:
+        tag_str = get_value_as_string_or_none(row, "Tags")
+        tags = split_by_comma(tag_str) or []
+        main_ingredient = get_value_as_string_or_none(row, "Main Ingredient")
+        if main_ingredient:
+            tags.append(main_ingredient)
+
+        return tags
+
     def _process_recipe_row(self, row: dict) -> dict:
         """Reads a single recipe's row, parses its nutrition, and converts it to a dictionary"""
 
         recipe_dict: dict = row
 
+        recipe_dict["recipeCategory"] = self._get_categories_from_row(row)
+        recipe_dict["tags"] = self._get_tags_from_row(row)
         recipe_dict["nutrition"] = self._parse_recipe_nutrition_from_row(row)
 
         return recipe_dict


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Adds "Course" and "Cuisine" to the recipe categories during Plan To Eat migration, as well as "Main Ingredient" to the tags.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, discussed on Discord.

## Testing

_(fill-in or delete this section)_

Imported our test data, works as expected.
