### PR TITLE
feat: Auto-label new shopping list items

### DIFF
--- a/mealie/services/group_services/shopping_lists.py
+++ b/mealie/services/group_services/shopping_lists.py
@@ -17,7 +17,11 @@ from mealie.schema.group.group_shopping_list import (
     ShoppingListMultiPurposeLabelCreate,
     ShoppingListSave,
 )
-from mealie.schema.recipe.recipe_ingredient import IngredientFood, IngredientUnit, RecipeIngredient
+from mealie.schema.recipe.recipe_ingredient import (
+    IngredientFood,
+    IngredientUnit,
+    RecipeIngredient,
+)
 from mealie.schema.response.pagination import OrderDirection, PaginationQuery
 from mealie.schema.user.user import GroupInDB, UserOut
 
@@ -160,15 +164,8 @@ class ShoppingListService:
 
             filtered_create_items.append(create_item)
 
-        created_items = cast(
-            list[ShoppingListItemOut],
-            self.list_items.create_many(filtered_create_items) if filtered_create_items else [],  # type: ignore
-        )
-
-        updated_items = cast(
-            list[ShoppingListItemOut],
-            self.list_items.update_many(update_items) if update_items else [],  # type: ignore
-        )
+        created_items = self.list_items.create_many(filtered_create_items) if filtered_create_items else []
+        updated_items = self.list_items.update_many(update_items) if update_items else []
 
         for list_id in set(item.shopping_list_id for item in created_items + updated_items):
             self.remove_unused_recipe_references(list_id)

--- a/mealie/services/openai/openai.py
+++ b/mealie/services/openai/openai.py
@@ -42,7 +42,7 @@ class OpenAIDataInjection(BaseModel):
 class OpenAIService(BaseService):
     PROMPTS_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "prompts"
 
-    def __init__(self) -> None:
+    def __init__(self, timeout: int = 10) -> None:
         settings = get_app_settings()
         if not settings.OPENAI_ENABLED:
             raise ValueError("OpenAI is not enabled")
@@ -54,6 +54,7 @@ class OpenAIService(BaseService):
         self.get_client = lambda: AsyncOpenAI(
             base_url=settings.OPENAI_BASE_URL,
             api_key=settings.OPENAI_API_KEY,
+            timeout=timeout,
         )
 
         super().__init__()

--- a/mealie/services/openai/openai.py
+++ b/mealie/services/openai/openai.py
@@ -42,7 +42,7 @@ class OpenAIDataInjection(BaseModel):
 class OpenAIService(BaseService):
     PROMPTS_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "prompts"
 
-    def __init__(self, timeout: int = 10) -> None:
+    def __init__(self) -> None:
         settings = get_app_settings()
         if not settings.OPENAI_ENABLED:
             raise ValueError("OpenAI is not enabled")
@@ -54,7 +54,6 @@ class OpenAIService(BaseService):
         self.get_client = lambda: AsyncOpenAI(
             base_url=settings.OPENAI_BASE_URL,
             api_key=settings.OPENAI_API_KEY,
-            timeout=timeout,
         )
 
         super().__init__()

--- a/mealie/services/parser_services/brute/process.py
+++ b/mealie/services/parser_services/brute/process.py
@@ -194,7 +194,7 @@ def parse(ing_str, parser) -> BruteParsedIngredient:
         # try to parse as unit and ingredient (e.g. "a tblsp salt"), with unit in first three tokens
         # won't work for units that have spaces
         for index, token in enumerate(tokens[:3]):
-            if parser.find_unit_match(token):
+            if parser.data_matcher.find_unit_match(token):
                 unit = token
                 ingredient, note = parse_ingredient(tokens[index + 1 :])
                 break

--- a/mealie/services/parser_services/openai/parser.py
+++ b/mealie/services/parser_services/openai/parser.py
@@ -45,7 +45,7 @@ class OpenAIParser(ABCIngredientParser):
             ),
         ]
 
-        if service.send_db_data and self.units_by_alias:
+        if service.send_db_data and self.data_matcher.units_by_alias:
             data_injections.extend(
                 [
                     OpenAIDataInjection(
@@ -55,7 +55,7 @@ class OpenAIParser(ABCIngredientParser):
                             "find a unit in the input that does not exist in this list. This should not prevent "
                             "you from parsing that text as a unit, however it may lower your confidence level."
                         ),
-                        value=list(set(self.units_by_alias)),
+                        value=list(set(self.data_matcher.units_by_alias)),
                     ),
                 ]
             )


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

This PR automatically adds a label to a shopping list item if it isn't provided. [We already did similar work for this a while ago](https://github.com/mealie-recipes/mealie/pull/2535) for the ingredient parser, so I extracted that into its own service and used it here.

We don't want to autocorrect the user's input (since we could be wrong), so we only use the result to choose the label, rather than assign the food. See below, where I spell "oranges" wrong; the proper label is assigned, but the word is still as-written:

![2024-06-26_10h54_11](https://github.com/mealie-recipes/mealie/assets/71845777/6ebc0f58-f7a3-4c70-898c-f29f7de79080)

This only works on item creation, so if a user decides "nah I don't want a label on this" and removes it, it stays removed. In general I don't know why you _wouldn't_ want to try to apply a label to an item, hence the PR. This is similar to other shopping lists which auto-categorize your items (e.g. the Alexa shopping list does this).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

I've actually been using this logic for a year or so now as a part of my [Unified Shopping List](https://github.com/michael-genson/Unified-Shopping-List/blob/45e1deebe09e8290e6c4463b8feec7aff41fa027/AppLambda/src/services/mealie.py#L89-L107). I've been meaning to get it into Mealie. Now that [Amazon is killing all shopping list integrations for Alexa](https://developer.amazon.com/en-US/docs/alexa/custom-skills/access-the-alexa-shopping-and-to-do-lists.html), I felt now was a good time to get this in here.

## Testing

_(fill-in or delete this section)_

Added tests for the new feature and manually tested the parser to make sure I didn't break anything with the refactor.