### PR TITLE
feat: Show recipe tags on mobile view and meal plan

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardMobile.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardMobile.vue
@@ -36,6 +36,9 @@
           <v-list-item-subtitle>
             <SafeMarkdown :source="description" />
           </v-list-item-subtitle>
+          <div class="d-flex flex-wrap justify-start">
+            <RecipeChips :truncate="true" :items="tags" :title="false" :limit="2" :small="true" url-prefix="tags" />
+          </div>
           <div class="d-flex flex-wrap justify-end align-center">
             <slot name="actions">
               <RecipeFavoriteBadge v-if="isOwnGroup && showRecipeContent" :recipe-id="recipeId" show-always />
@@ -83,6 +86,7 @@ import RecipeFavoriteBadge from "./RecipeFavoriteBadge.vue";
 import RecipeContextMenu from "./RecipeContextMenu.vue";
 import RecipeCardImage from "./RecipeCardImage.vue";
 import RecipeRating from "./RecipeRating.vue";
+import RecipeChips from "./RecipeChips.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 
 export default defineComponent({
@@ -91,6 +95,7 @@ export default defineComponent({
     RecipeContextMenu,
     RecipeRating,
     RecipeCardImage,
+    RecipeChips,
   },
   props: {
     name: {
@@ -113,6 +118,10 @@ export default defineComponent({
       type: String,
       required: false,
       default: "abc123",
+    },
+    tags: {
+      type: Array,
+      default: () => [],
     },
     recipeId: {
       type: String,

--- a/frontend/pages/group/mealplan/planner/view.vue
+++ b/frontend/pages/group/mealplan/planner/view.vue
@@ -42,6 +42,7 @@
             :slug="mealplan.recipe ? mealplan.recipe.slug : mealplan.title"
             :description="mealplan.recipe ? mealplan.recipe.description : mealplan.text"
             :name="mealplan.recipe ? mealplan.recipe.name : mealplan.title"
+            :tags="mealplan.recipe ? mealplan.recipe.tags : []"
           />
         </div>
       </v-col>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

This change makes it so that tags on a recipe will show in mobile view as well as on the meal plan for both mobile and desktop.

Meal plan - mobile
![Screenshot 2024-07-07 at 9 18 05 AM](https://github.com/mealie-recipes/mealie/assets/3384072/3b83a87e-7d4b-4518-bfac-b4e05537dbbc)

Meal plan - desktop
![Screenshot 2024-07-07 at 9 18 26 AM](https://github.com/mealie-recipes/mealie/assets/3384072/1b4e8a7b-92b7-437c-81e6-a40fc8fcf188)

## Which issue(s) this PR fixes:

N/A

## Testing

Manual testing with example recipes. Created recipes with no tags, single tags and multiple (3) tags to ensure all show as expected.