### PR TITLE
fix: Add a default value of list when a user's group is None

### DIFF
--- a/mealie/core/security/providers/openid_provider.py
+++ b/mealie/core/security/providers/openid_provider.py
@@ -38,7 +38,7 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
         user = self.try_get_user(claims.get(settings.OIDC_USER_CLAIM))
         is_admin = False
         if settings.OIDC_USER_GROUP or settings.OIDC_ADMIN_GROUP:
-            group_claim = claims.get(settings.OIDC_GROUPS_CLAIM, [])
+            group_claim = claims.get(settings.OIDC_GROUPS_CLAIM, []) or []
             is_admin = settings.OIDC_ADMIN_GROUP in group_claim if settings.OIDC_ADMIN_GROUP else False
             is_valid_user = settings.OIDC_USER_GROUP in group_claim if settings.OIDC_USER_GROUP else True
 
@@ -82,7 +82,12 @@ class OpenIDProvider(AuthProvider[OIDCRequest]):
 
     def get_claims(self, settings: AppSettings) -> JWTClaims | None:
         """Get the claims from the ID token and check if the required claims are present"""
-        required_claims = {"preferred_username", "name", "email", settings.OIDC_USER_CLAIM}
+        required_claims = {
+            "preferred_username",
+            "name",
+            "email",
+            settings.OIDC_USER_CLAIM,
+        }
         jwks = OpenIDProvider.get_jwks(self.get_ttl_hash())  # cache the key set for 30 minutes
         if not jwks:
             return None


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

If a OIDC user has no groups and tries to log in when only `OIDC_ADMIN_GROUP` is defined, then Mealie blows up. It was an oversight that the groups claim value could be null instead of an empty list

## Which issue(s) this PR fixes:

Fixes #3871 


## Testing

Manually, Existing E2E tests
