### PR TITLE
fix: preLaunchTask from "Init Database" to Starting Frontend and Backend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
       },
       "justMyCode": false,
       "jinja": true,
-      "preLaunchTask": "Init Database"
+      "preLaunchTask": "Dev: Start Frontend"
     }
   ]
 }


### PR DESCRIPTION
## What type of PR is this?
<!--
  Delete any of the following that do not apply:
 -->

- bug
- cleanup

## What this PR does / why we need it:

Allows clone of mealie repo and Docker container to run smoothly for new users.

In the launch.json file, the old "Init Database" was changed to "Dev: Start Frontend" so the server can start without fuss and confusion.

## Which issue(s) this PR fixes:
Old task "Init Database" no longer exists and causes problems for users trying to run start the frontend.

