### PR TITLE
fix: Convert Daily Schedule Time to UTC

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -4,20 +4,20 @@
 
 ### General
 
-| Variables                     |        Default        | Description                                                                         |
-| ----------------------------- | :-------------------: | ----------------------------------------------------------------------------------- |
-| PUID                          |          911          | UserID permissions between host OS and container                                    |
-| PGID                          |          911          | GroupID permissions between host OS and container                                   |
-| DEFAULT_GROUP                 |         Home          | The default group for users                                                         |
-| BASE_URL                      | http://localhost:8080 | Used for Notifications                                                              |
-| TOKEN_TIME                    |          48           | The time in hours that a login/auth token is valid                                  |
-| API_PORT                      |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker** |
-| API_DOCS                      |         True          | Turns on/off access to the API documentation locally.                               |
-| TZ                            |          UTC          | Must be set to get correct date/time on the server                                  |
-| ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                    |
-| LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                  |
-| LOG_LEVEL                     |         info          | Logging level (e.g. critical, error, warning, info, debug, trace)                   |
-| DAILY_SCHEDULE_TIME           |         23:45         | The time of day to run the daily tasks.                                             |
+| Variables                     |        Default        | Description                                                                                               |
+| ----------------------------- | :-------------------: | --------------------------------------------------------------------------------------------------------- |
+| PUID                          |          911          | UserID permissions between host OS and container                                                          |
+| PGID                          |          911          | GroupID permissions between host OS and container                                                         |
+| DEFAULT_GROUP                 |         Home          | The default group for users                                                                               |
+| BASE_URL                      | http://localhost:8080 | Used for Notifications                                                                                    |
+| TOKEN_TIME                    |          48           | The time in hours that a login/auth token is valid                                                        |
+| API_PORT                      |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker**                       |
+| API_DOCS                      |         True          | Turns on/off access to the API documentation locally                                                      |
+| TZ                            |          UTC          | Must be set to get correct date/time on the server                                                        |
+| ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                                          |
+| LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                                        |
+| LOG_LEVEL                     |         info          | Logging level (e.g. critical, error, warning, info, debug, trace)                                         |
+| DAILY_SCHEDULE_TIME           |         23:45         | The time of day to run daily server tasks, in HH:MM format. Use the server's local time, *not* UTC        |
 
 <super>\*</super> Starting in v1.4.0 this was changed to default to `false` as apart of a security review of the application.
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug
- cleanup
- documentation

## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/pull/3847 changed Mealie to use explicitly UTC on the server. However, previously we assumed the `DAILY_SCHEDULE_TIME` ENV var was local time, not UTC. This PR maintains that assumption and provides a parsed "UTC" version (stored in `DAILY_SCHEDULE_TIME_UTC`).

Docs are also updated to reflect this and make the assumption explicit.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes issue reported on Discord.

## Special notes for your reviewer:

_(fill-in or delete this section)_

At first I thought we should just re-define daily schedule time to inherently mean UTC, but since this is being defined in the ENV vars (where we already need to define the TZ) I think it's clearer to define the daily time in local time, rather than UTC. That's also how we think about it naturally anyway (e.g. "run tasks at 11pm").

Another approach that could have worked was to do the scheduler calculation in local time (replacing `datetime.now(timezone.utc)` with the local tz instead), but IMO converting it to UTC upfront is a lot clearer (since everything else in the app uses UTC now).

## Testing

_(fill-in or delete this section)_

Added/updated logs to verify conversions are happening properly.
