### PR TITLE
feat: control reading `/run/secrets` via USE_SECRETS_DIR env var

### DIFF
--- a/mealie/core/config.py
+++ b/mealie/core/config.py
@@ -16,6 +16,7 @@ dotenv.load_dotenv(ENV)
 PRODUCTION = os.getenv("PRODUCTION", "True").lower() in ["true", "1"]
 TESTING = os.getenv("TESTING", "False").lower() in ["true", "1"]
 DATA_DIR = os.getenv("DATA_DIR")
+USE_SECRETS_DIR = os.getenv("USE_SECRETS_DIR", "True").lower() in ["true", "1"]
 
 
 def determine_data_dir() -> Path:
@@ -37,4 +38,9 @@ def get_app_dirs() -> AppDirectories:
 
 @lru_cache
 def get_app_settings() -> AppSettings:
-    return app_settings_constructor(env_file=ENV, production=PRODUCTION, data_dir=determine_data_dir())
+    return app_settings_constructor(
+        env_file=ENV,
+        production=PRODUCTION,
+        data_dir=determine_data_dir(),
+        secrets_dir="/run/secrets" if USE_SECRETS_DIR else None,
+    )

--- a/mealie/core/settings/db_providers.py
+++ b/mealie/core/settings/db_providers.py
@@ -86,8 +86,14 @@ class PostgresProvider(AbstractDBProvider, BaseSettings):
         )
 
 
-def db_provider_factory(provider_name: str, data_dir: Path, env_file: Path, env_encoding="utf-8") -> AbstractDBProvider:
+def db_provider_factory(
+    provider_name: str,
+    data_dir: Path,
+    secrets_dir: str | Path | None,
+    env_file: Path,
+    env_encoding="utf-8",
+) -> AbstractDBProvider:
     if provider_name == "postgres":
-        return PostgresProvider(_env_file=env_file, _env_file_encoding=env_encoding)
+        return PostgresProvider(_env_file=env_file, _env_file_encoding=env_encoding, _secrets_dir=secrets_dir)
     else:
         return SQLiteProvider(data_dir=data_dir)

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -307,10 +307,16 @@ class AppSettings(BaseSettings):
     # Testing Config
 
     TESTING: bool = False
-    model_config = SettingsConfigDict(arbitrary_types_allowed=True, extra="allow", secrets_dir="/run/secrets")
+    model_config = SettingsConfigDict(arbitrary_types_allowed=True, extra="allow")
 
 
-def app_settings_constructor(data_dir: Path, production: bool, env_file: Path, env_encoding="utf-8") -> AppSettings:
+def app_settings_constructor(
+    data_dir: Path,
+    secrets_dir: str | Path | None,
+    production: bool,
+    env_file: Path,
+    env_encoding="utf-8",
+) -> AppSettings:
     """
     app_settings_constructor is a factory function that returns an AppSettings object. It is used to inject the
     required dependencies into the AppSettings object and nested child objects. AppSettings should not be substantiated
@@ -319,12 +325,14 @@ def app_settings_constructor(data_dir: Path, production: bool, env_file: Path, e
     app_settings = AppSettings(
         _env_file=env_file,  # type: ignore
         _env_file_encoding=env_encoding,  # type: ignore
+        _secrets_dir=secrets_dir,
         **{"SECRET": determine_secrets(data_dir, production)},
     )
 
     app_settings.DB_PROVIDER = db_provider_factory(
         app_settings.DB_ENGINE or "sqlite",
         data_dir,
+        secrets_dir,
         env_file=env_file,
         env_encoding=env_encoding,
     )


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds a new environment variable called `USE_SECRETS_DIR` that controls whether secrets are loaded from `/run/secrets`. It is enabled by default to maintain the existing behaviour.

This prevents issues in non-Docker environments where `/run/secrets` may not exist or be readable by the current user.

## Which issue(s) this PR fixes:

Fixes #3852 

## Testing

For each scenario, a new dev container environment was created.

`/run/secrets` is readable and contains a file for `LDAP_SERVER_URL`:
- verified `LDAP_SERVER_URL` is populated when `USE_SECRETS_DIR=true` or is not explicitly set
- verified `LDAP_SERVER_URL` is not populated when `USE_SECRETS_DIR=false`

`/run/secrets` is not readable (follow instructions in issue) and contains a file for `LDAP_SERVER_URL`:
- verified `task py` raises the error from the issue when `USE_SECRETS_DIR=true` or is not explicitly set
- verified `LDAP_SERVER_URL` is not populated when `USE_SECRETS_DIR=false`

`/run/secrets` does not exist:
- verified a Pydantic warning is raised when `USE_SECRETS_DIR=true` or is not explicitly set
- verified no warning is raised when `USE_SECRETS_DIR=false`
