### PR TITLE
fix: Reduce search tolerance on organizers page

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
@@ -114,9 +114,9 @@ export default defineComponent({
       options: {
         ignoreLocation: true,
         shouldSort: true,
-        threshold: 0.6,
+        threshold: 0.2,
         location: 0,
-        distance: 100,
+        distance: 20,
         findAllMatches: true,
         maxPatternLength: 32,
         minMatchCharLength: 1,


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently it's pretty much impossible to search for anything on the organizers page due to false positives. Here's an example:

![2024-07-27_20h15_07](https://github.com/user-attachments/assets/9e7447ea-00b7-413e-9295-e6b71e5fa3f0)

Here's what it looks like with the reduced tolerance:

![2024-07-27_20h15_30](https://github.com/user-attachments/assets/0002cfa2-0f7a-4db0-90cf-2e67c3f284b0)

It's still reasonably forgiving on minor typos.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Manually
