### PR TITLE
fix: Make recipe scraper cleaner more fault tolerant

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -110,11 +110,11 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
         case [str(_), *_]:
             return [x for x in image if x]  # Only return non-null strings in list
         case [{"url": str(_)}, *_]:
-            return [x["url"] for x in image]
+            return [x["url"] for x in image if "url" in x]
         case {"url": str(image)}:
             return [image]
         case [{"@id": str(_)}, *_]:
-            return [x["@id"] for x in image]
+            return [x["@id"] for x in image if "@id" in x]
         case _:
             logger.exception(f"Unexpected type for image: {type(image)}, {image}")
             return [default]
@@ -149,7 +149,7 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
             return [
                 {"text": _sanitize_instruction_text(instruction["text"])}
                 for instruction in steps_object
-                if instruction["text"].strip()
+                if "text" in instruction and instruction["text"].strip()
             ]
         case {0: {"text": str()}} | {"0": {"text": str()}} | {1: {"text": str()}} | {"1": {"text": str()}}:
             # Some recipes have a dict with a string key representing the index, unsure if these can


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/issues/3964 shows a weird cleaner error where only some of the scraped data matches the case/match statement. We assume the data looks like this:
```
[
  {"text": ...},
  {"text": ...},
  {"text": ...},
  ...
]
```

But technically this matches too:
```
[
  {"text": ...},
  {"text": ...},
  {"somethingElse": ...},
  ...
]
```

This PR just adds extra guard clauses for these scenarios.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3964

## Special notes for your reviewer:

_(fill-in or delete this section)_

I'm getting weirdly inconsistent behavior between the demo and mealie-next (it worked before this PR locally), so maybe it was an issue with recipe scrapers that got fixed, but either way this PR should prevent anything like that on other sites with weird/bad data.

## Testing

_(fill-in or delete this section)_

Imported recipes from https://github.com/mealie-recipes/mealie/issues/3964
