### PR TITLE
fix: recipe clean_time function missing translator argument on recursion 

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -368,9 +368,9 @@ def clean_time(time_entry: str | timedelta | None, translator: Translator) -> No
         case timedelta():
             return pretty_print_timedelta(time_entry, translator)
         case {"minValue": str(value)}:
-            return clean_time(value)
+            return clean_time(value, translator)
         case [str(), *_]:
-            return clean_time(time_entry[0])
+            return clean_time(time_entry[0], translator)
         case datetime():
             # TODO: Not sure what to do here
             return str(time_entry)


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The clean_time function does rely on the translator being passed as an argument. 

## Which issue(s) this PR fixes:

- Fixes #3900 

## Special notes for your reviewer:

Funnily enough i was the person that messed this up and this was i think the first or at least one of my first PRs into mealie. 

## Testing

Tested with the provided recipe. 
