### PR TITLE
fix: removed version line from docker compose yml files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   mailpit:
     image: axllent/mailpit:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   mealie:
     container_name: mealie


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Removed line 1 "_version: "3.4"_" in docker compose files. Version is now obsolete in Docker Compose and will throw a warning when launching with docker compose up.