### PR TITLE
fix: PWA respects orientation lock

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -492,7 +492,6 @@ export default {
       ],
       prefer_related_applications: false,
       handle_links: "preferred",
-      orientation: "any",
       categories: [
         "food"
       ],


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Previous is you had your phone locked into portrait it would go landscape when you rotated your phone.

## Which issue(s) this PR fixes:

Fixes #4136 

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

I have tested this on Android but have no idea how it performs on iOS

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Tested it with and without rotation lock and it no longer switches orientation when it should be locked.
