### PR TITLE
feat: Reorder ShoppingListItemEditor

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -3,14 +3,9 @@
     <v-card outlined>
       <v-card-text class="pb-3 pt-1">
         <div v-if="listItem.isFood" class="d-md-flex align-center mb-2" style="gap: 20px">
-          <InputLabelType
-            v-model="listItem.food"
-            :items="foods"
-            :item-id.sync="listItem.foodId"
-            :label="$t('shopping-list.food')"
-            :icon="$globals.icons.foods"
-            @create="createAssignFood"
-          />
+          <div>
+            <InputQuantity v-model="listItem.quantity" />
+          </div>
           <InputLabelType
             v-model="listItem.unit"
             :items="units"
@@ -19,8 +14,20 @@
             :icon="$globals.icons.units"
             @create="createAssignUnit"
           />
+          <InputLabelType
+            v-model="listItem.food"
+            :items="foods"
+            :item-id.sync="listItem.foodId"
+            :label="$t('shopping-list.food')"
+            :icon="$globals.icons.foods"
+            @create="createAssignFood"
+          />
+
         </div>
         <div class="d-md-flex align-center" style="gap: 20px">
+          <div v-if="!listItem.isFood">
+              <InputQuantity v-model="listItem.quantity" />
+            </div>
           <v-textarea
             v-model="listItem.note"
             hide-details
@@ -32,9 +39,7 @@
         </div>
         <div class="d-flex flex-wrap align-end" style="gap: 20px">
           <div class="d-flex align-end">
-            <div>
-              <InputQuantity v-model="listItem.quantity" />
-            </div>
+
             <div style="max-width: 300px" class="mt-3 mr-auto">
               <InputLabelType
                 v-model="listItem.label"


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

The ShoppingListItemEditor field order does not make much sense from an input sense (Especially for the Food input)

The current order to add a food is: Food ➡️ Unit ➡️ Note ➡️ Quantity

I reordered it to use a more logical input order of: Quantity ➡️ Unit ➡️ Food ➡️ Note, while also keeping Quantity, Unit and Food in one row. 
This has the added benefit that it is way easier to read the edit field is now matching the displayed order of the shopping list making edits of existing field more intuitive. 

The current order to add a Note is: Note ➡️ Quantity which i changed arround to have it match the shoping list item. 

Screenshots 

| Type | Old | New |
| --- | --- | --- |
| Food |  ![image](https://github.com/user-attachments/assets/01c6239a-b7b7-4219-b317-3a0781667fa3)| ![image](https://github.com/user-attachments/assets/2dda4cc1-b6ab-49f6-8fcd-b5726b57922c) |
| Note | ![image](https://github.com/user-attachments/assets/490d250d-cbb3-432d-8c5f-2bdbd3861751)  | ![image](https://github.com/user-attachments/assets/b55c5e78-9f8e-4c14-80da-91b7928195ec) |



## Which issue(s) this PR fixes:

None

## Testing

Manual testing, i pretty much just reordered things so it **should** be fine.