### PR TITLE
fix: revert shopping list items - increased width 

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -140,7 +140,7 @@ export default defineComponent({
   setup(props, context) {
     const { i18n } = useContext();
     const displayRecipeRefs = ref(false);
-    const itemLabelCols = ref<string>(props.value.checked ? "auto" : props.showLabel ? "8" : "9");
+    const itemLabelCols = ref<string>(props.value.checked ? "auto" : props.showLabel ? "4" : "6");
 
     const contextMenu: actions[] = [
       {


### PR DESCRIPTION
## What type of PR is this?
- fix

## What this PR does / why we need it:

A recent PR increased the width of the shopping list item text. 

If the user is in the _not grouped by label view_ the increased with of the text pushes the action buttons of screen to the right. 
During the review i did not toggle to the not grouped by label view so this slipped through the cracks. 
 
## Which issue(s) this PR fixes:

Reverts changes made in #4237 