### PR TITLE
feat: Install `mealie` as CLI command

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -41,4 +41,4 @@ init
 # Start API
 HOST_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
 
-exec python /app/mealie/main.py
+exec mealie

--- a/mealie/main.py
+++ b/mealie/main.py
@@ -6,7 +6,7 @@ from mealie.core.logger.config import log_config
 
 def main():
     uvicorn.run(
-        "app:app",
+        "mealie.app:app",
         host=settings.API_HOST,
         port=settings.API_PORT,
         log_level=settings.LOG_LEVEL.lower(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "mealie"
 version = "2.1.0"
 
 [tool.poetry.scripts]
-start = "mealie.app:main"
+mealie = "mealie.main:main"
 
 [tool.poetry.dependencies]
 Jinja2 = "^3.1.2"


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

Add a CLI command, `mealie`, that is created when the project is installed via Poetry or Pip. This command runs the main mealie app, (almost) the same as running `python3 mealie/main.py`.

The command is used in the Docker image to start mealie, ensuring it works there too.

Additional changes:
* Remove assumption about the root of the mealie package being on the Python path (change "app:app" -> "mealie.app:app" in `main.py`).
* Remove `start` entrypoint because it is not used and the name "start" is too generic.`


## Which issue(s) this PR fixes:

This is one task from discussion #4322.

## Testing

I built and ran the Docker container.

I ran `poetry install` followed by `poetry run mealie`.