### PR TITLE
fix: recipe scaling

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeScaleEditButton.vue
+++ b/frontend/components/Domain/Recipe/RecipeScaleEditButton.vue
@@ -102,7 +102,7 @@ export default defineComponent({
     const numberParsed = !!props.basicYieldNum;
 
     watch(() => numerator.value, () => {
-      scale.value = parseFloat((numerator.value / denominator).toFixed(3));
+      scale.value = parseFloat((numerator.value / denominator).toFixed(32));
     });
     const disableDecrement = computed(() => {
       return numerator.value <= 1;


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This update changes the scale value of the recipe scaler to be rounded to 32 digits instead of 3. This addresses an issue where scaling a larger number up or down by one (e.g. 24 -> 23) would result in a rounded number (e.g. 22.992 instead of 23) rather than the correct value. Since the scale is based on 1 and the servings are calculated by multiplying the scale by the number of servings, more precise rounding is required. The value 32 is chosen to match the precision used in the backend for numbers requiring greater accuracy.

## Which issue(s) this PR fixes:

None 