### PR TITLE
dev: add internal dev section to release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
   - `fix: `
   - `docs: `
   - `chore: `
+  - `dev:`
 
   If a section of the PR template does not apply to this PR, then delete that section.
 
@@ -27,10 +28,11 @@ _(REQUIRED)_
   Delete any of the following that do not apply:
  -->
 
-- bug
-- cleanup
-- documentation
 - feature
+- bug
+- documentation
+- cleanup
+- dev (Internal development)
 
 ## What this PR does / why we need it:
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,13 +25,13 @@ categories:
   - title: "📚 Documentation"
     labels:
       - "documentation"
+  - title: "🔨 Internal development"
+    labels:
+      - "dev"
   - title: "⬆️ Dependency updates"
     collapse-after: 3
     labels:
       - "dependencies"
-  - title: "🔨 Internal development"
-    labels:
-      - "dev"
 
 version-resolver:
   major:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,6 +29,9 @@ categories:
     collapse-after: 3
     labels:
       - "dependencies"
+  - title: "🔨 Internal development"
+    labels:
+      - "dev"
 
 version-resolver:
   major:
@@ -47,6 +50,7 @@ version-resolver:
       - "dependencies"
       - "documentation"
       - "l10n"
+      - "dev"
   default: patch
 
 template: |
@@ -69,3 +73,6 @@ autolabeler:
   - label: 'chore'
     title:
       - '/chore:/i'
+  - label: 'dev'
+    title:
+      - '/dev:/i'

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -20,10 +20,11 @@ jobs:
           # Configure which types are allowed (newline-delimited).
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
-            fix
-            feat
-            docs
-            chore
+            feature
+            bug
+            documentation
+            cleanup
+            dev
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -20,10 +20,10 @@ jobs:
           # Configure which types are allowed (newline-delimited).
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
-            feature
-            bug
-            documentation
-            cleanup
+            feat
+            fix
+            docs
+            chore
             dev
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.


### PR DESCRIPTION
## What type of PR is this?

- dev

## What this PR does / why we need it:

This pull request introduces a new section in our release notes dedicated to internal development PRs. This change will help separate pull requests that don't alter Mealie itself.

I reordered the PR types in the Pull request template to match the PR title section which seemed more logical to me. 
Once this is merged, I will update the titles of unreleased PRs to ensure they are categorized correctly.

## Which issue(s) this PR fixes:

None