### PR TITLE
dev: add secondary db to trivy 

### DIFF
--- a/.github/workflows/partial-trivy-container-scanning.yml
+++ b/.github/workflows/partial-trivy-container-scanning.yml
@@ -24,6 +24,8 @@ jobs:
           image-ref: "mealie"
           format: "sarif"
           output: "trivy-results.sarif"
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## What type of PR is this?

- dev (Internal development)

## What this PR does / why we need it:

This adds a secondary db for trivy to use. This might help put a bandage on the flakeyness of that workflow. 

## Which issue(s) this PR fixes:

I hope a lot - but officially None
