### PR TITLE
fix: Add SMTP Timeout

### DIFF
--- a/mealie/services/email/email_senders.py
+++ b/mealie/services/email/email_senders.py
@@ -10,6 +10,9 @@ from html2text import html2text
 
 from mealie.services._base_service import BaseService
 
+SMTP_TIMEOUT = 10
+"""Timeout in seconds for SMTP connection"""
+
 
 @dataclass(slots=True)
 class EmailOptions:
@@ -55,13 +58,13 @@ class Message:
         msg["MIME-Version"] = "1.0"
 
         if smtp.ssl:
-            with smtplib.SMTP_SSL(smtp.host, smtp.port) as server:
+            with smtplib.SMTP_SSL(smtp.host, smtp.port, timeout=SMTP_TIMEOUT) as server:
                 if smtp.username and smtp.password:
                     server.login(smtp.username, smtp.password)
 
                 errors = server.send_message(msg)
         else:
-            with smtplib.SMTP(smtp.host, smtp.port) as server:
+            with smtplib.SMTP(smtp.host, smtp.port, timeout=SMTP_TIMEOUT) as server:
                 if smtp.tls:
                     server.starttls()
                 if smtp.username and smtp.password:


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Adds a timeout to the SMTP connection so Mealie doesn't hang if the connection hangs.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/4017
