### PR TITLE
fix: Add Touch Delay to Draggable on Touch Pads

### DIFF
--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -5,6 +5,8 @@
         <draggable
           :value="fields"
           handle=".handle"
+          delay="250"
+          delay-on-touch-only
           v-bind="{
             animation: 200,
             group: 'recipe-instructions',

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
@@ -5,6 +5,8 @@
       v-if="recipe.recipeIngredient.length > 0"
       v-model="recipe.recipeIngredient"
       handle=".handle"
+      delay="250"
+      delay-on-touch-only
       v-bind="{
         animation: 200,
         group: 'recipe-ingredients',

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -77,6 +77,8 @@
       :disabled="!isEditForm"
       :value="value"
       handle=".handle"
+      delay="250"
+      delay-on-touch-only
       v-bind="{
         animation: 200,
         group: 'recipe-instructions',

--- a/frontend/pages/g/_groupSlug/cookbooks/index.vue
+++ b/frontend/pages/g/_groupSlug/cookbooks/index.vue
@@ -53,7 +53,14 @@
 
       <!-- Cookbook List -->
       <v-expansion-panels class="mt-2">
-        <draggable v-model="cookbooks" handle=".handle" style="width: 100%" @change="actions.updateOrder()">
+        <draggable
+          v-model="cookbooks"
+          handle=".handle"
+          delay="250"
+          delay-on-touch-only
+          style="width: 100%"
+          @change="actions.updateOrder()"
+        >
           <v-expansion-panel v-for="cookbook in cookbooks" :key="cookbook.id" class="my-2 left-border rounded">
             <v-expansion-panel-header disable-icon-rotate class="headline">
               <div class="d-flex align-center">

--- a/frontend/pages/g/_groupSlug/r/_slug/ingredient-parser.vue
+++ b/frontend/pages/g/_groupSlug/r/_slug/ingredient-parser.vue
@@ -46,6 +46,8 @@
             v-if="parsedIng.length > 0"
             v-model="parsedIng"
             handle=".handle"
+            delay="250"
+            delay-on-touch-only
             :style="{ width: '100%' }"
             ghost-class="ghost"
           >

--- a/frontend/pages/household/mealplan/planner/edit.vue
+++ b/frontend/pages/household/mealplan/planner/edit.vue
@@ -100,6 +100,8 @@
         <draggable
           tag="div"
           handle=".handle"
+          delay="250"
+          delay-on-touch-only
           :value="plan.meals"
           group="meals"
           :data-index="index"

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -97,7 +97,15 @@
         @submit="saveLabelOrder"
         @close="cancelLabelOrder">
         <v-card height="fit-content" max-height="70vh" style="overflow-y: auto;">
-          <draggable v-if="localLabels" :value="localLabels" handle=".handle" class="my-2" @input="updateLabelOrder">
+          <draggable
+            v-if="localLabels"
+            :value="localLabels"
+            handle=".handle"
+            delay="250"
+            delay-on-touch-only
+            class="my-2"
+            @input="updateLabelOrder"
+          >
             <div v-for="(labelSetting, index) in localLabels" :key="labelSetting.id">
               <MultiPurposeLabelSection v-model="localLabels[index]" use-color />
             </div>


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently most draggable elements block scrolling on touch pads. This adds a small (250ms) delay so touch pad users can scroll even if they touch a draggable element.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3703

## Testing

_(fill-in or delete this section)_

Tested using FF dev tools.