### PR TITLE
fix: Images Using Wrong Content Type

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -131,7 +131,6 @@ HEALTHCHECK CMD python $MEALIE_HOME/mealie/scripts/healthcheck.py || exit 1
 # ----------------------------------
 # Copy Frontend
 
-# copying caddy into image
 ENV STATIC_FILES=/spa/static
 COPY --from=builder /app/dist  ${STATIC_FILES}
 

--- a/docs/docs/documentation/getting-started/installation/security.md
+++ b/docs/docs/documentation/getting-started/installation/security.md
@@ -29,7 +29,6 @@ If you'd like to mitigate this risk, we suggest that you rate limit the API in g
 
 - [Traefik](https://doc.traefik.io/traefik/middlewares/http/ratelimit/)
 - [Nginx](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html)
-- [Caddy](https://caddyserver.com/docs/modules/http.handlers.rate_limit)
 
 ## Server Side Request Forgery
 

--- a/docs/docs/documentation/getting-started/installation/security.md
+++ b/docs/docs/documentation/getting-started/installation/security.md
@@ -29,6 +29,7 @@ If you'd like to mitigate this risk, we suggest that you rate limit the API in g
 
 - [Traefik](https://doc.traefik.io/traefik/middlewares/http/ratelimit/)
 - [Nginx](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html)
+- [Caddy](https://caddyserver.com/docs/modules/http.handlers.rate_limit)
 
 ## Server Side Request Forgery
 

--- a/mealie/routes/media/media_recipe.py
+++ b/mealie/routes/media/media_recipe.py
@@ -7,12 +7,7 @@ from starlette.responses import FileResponse
 from mealie.schema.recipe import Recipe
 from mealie.schema.recipe.recipe_timeline_events import RecipeTimelineEventOut
 
-"""
-These routes are for development only! These assets are served by Caddy when not
-in development mode. If you make changes, be sure to test the production container.
-"""
-
-router = APIRouter(prefix="/recipes", include_in_schema=False)
+router = APIRouter(prefix="/recipes")
 
 
 class ImageType(str, Enum):

--- a/mealie/routes/media/media_recipe.py
+++ b/mealie/routes/media/media_recipe.py
@@ -25,7 +25,7 @@ async def get_recipe_img(recipe_id: str, file_name: ImageType = ImageType.origin
     recipe_image = Recipe.directory_from_id(recipe_id).joinpath("images", file_name.value)
 
     if recipe_image.exists():
-        return FileResponse(recipe_image)
+        return FileResponse(recipe_image, media_type="image/webp")
     else:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
 
@@ -43,7 +43,7 @@ async def get_recipe_timeline_event_img(
     )
 
     if timeline_event_image.exists():
-        return FileResponse(timeline_event_image)
+        return FileResponse(timeline_event_image, media_type="image/webp")
     else:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
 

--- a/mealie/routes/media/media_user.py
+++ b/mealie/routes/media/media_user.py
@@ -4,12 +4,7 @@ from starlette.responses import FileResponse
 
 from mealie.schema.user import PrivateUser
 
-"""
-These routes are for development only! These assets are served by Caddy when not
-in development mode. If you make changes, be sure to test the production container.
-"""
-
-router = APIRouter(prefix="/users", include_in_schema=False)
+router = APIRouter(prefix="/users")
 
 
 @router.get("/{user_id}/{file_name}", response_class=FileResponse)


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

When we used to use Caddy with the split containers, it used to do its own magic to serve the correct content type for images. Since we ditched the split container design we (probably inadvertently) switched to the "dev" media routes which don't specify content type.

This PR removes references to Caddy, unhides the "dev" media routes (because they actually get used), and explicitly adds the content type to said routes.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3599
Fixes https://github.com/mealie-recipes/mealie/issues/4144

## Testing

_(fill-in or delete this section)_

Tested locally. I struggled to test https://github.com/mealie-recipes/mealie/issues/3599 locally, but the error raised (before this fix) makes me pretty confident this is the issue:
`ERROR    Content-Type: text/plain; charset=utf-8 is not an image`