### PR TITLE
docs: properly set site_url for docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Mealie
 demo_url: https://demo.mealie.io
-site_url: https://hay-kot.github.io/mealie/
+site_url: https://docs.mealie.io
 use_directory_urls: true
 theme:
   palette:


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- documentation

## What this PR does / why we need it:

_(REQUIRED)_

Fixes the broken /404 page on the docs site by updating the `site_url` property in mkdocs config. 

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #3772

## Special notes for your reviewer:

I'm _pretty_ sure this will work but don't know how to test without merging 🤷 

## Testing

N/A
