### PR TITLE
fix: Add cacertfile to client args when provided

### DIFF
--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -30,12 +30,16 @@ if settings.OIDC_READY:
     oauth = OAuth()
     groups_claim = settings.OIDC_GROUPS_CLAIM if settings.OIDC_REQUIRES_GROUP_CLAIM else ""
     scope = f"openid email profile {groups_claim}"
+    client_args = {"scope": scope.rstrip()}
+    if settings.OIDC_TLS_CACERTFILE:
+        client_args["verify"] = settings.OIDC_TLS_CACERTFILE
+
     oauth.register(
         "oidc",
         client_id=settings.OIDC_CLIENT_ID,
         client_secret=settings.OIDC_CLIENT_SECRET,
         server_metadata_url=settings.OIDC_CONFIGURATION_URL,
-        client_kwargs={"scope": scope.rstrip()},
+        client_kwargs=client_args,
         code_challenge_method="S256",
     )
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

When migrating the OIDC to use a new client for v2, I forgot to pass the custom CA cert file when it is passed into the environment.

## Which issue(s) this PR fixes:

Fixes #4449

## Testing

Tested manually the following cases
- without specifying a file (continues to work)
- specifying a file which does not exist (blows up as expected)
- specifying a valid ca cert file bundle (performed by @Haennetz)
