### PR TITLE
fix: Drag Delay Only Apply On Touch

### DIFF
--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -6,7 +6,7 @@
           :value="fields"
           handle=".handle"
           delay="250"
-          delay-on-touch-only
+          :delay-on-touch-only="true"
           v-bind="{
             animation: 200,
             group: 'recipe-instructions',

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
@@ -6,7 +6,7 @@
       v-model="recipe.recipeIngredient"
       handle=".handle"
       delay="250"
-      delay-on-touch-only
+      :delay-on-touch-only="true"
       v-bind="{
         animation: 200,
         group: 'recipe-ingredients',

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -78,7 +78,7 @@
       :value="value"
       handle=".handle"
       delay="250"
-      delay-on-touch-only
+      :delay-on-touch-only="true"
       v-bind="{
         animation: 200,
         group: 'recipe-instructions',

--- a/frontend/pages/g/_groupSlug/cookbooks/index.vue
+++ b/frontend/pages/g/_groupSlug/cookbooks/index.vue
@@ -57,7 +57,7 @@
           v-model="cookbooks"
           handle=".handle"
           delay="250"
-          delay-on-touch-only
+          :delay-on-touch-only="true"
           style="width: 100%"
           @change="actions.updateOrder()"
         >

--- a/frontend/pages/g/_groupSlug/r/_slug/ingredient-parser.vue
+++ b/frontend/pages/g/_groupSlug/r/_slug/ingredient-parser.vue
@@ -47,7 +47,7 @@
             v-model="parsedIng"
             handle=".handle"
             delay="250"
-            delay-on-touch-only
+            :delay-on-touch-only="true"
             :style="{ width: '100%' }"
             ghost-class="ghost"
           >

--- a/frontend/pages/household/mealplan/planner/edit.vue
+++ b/frontend/pages/household/mealplan/planner/edit.vue
@@ -101,7 +101,7 @@
           tag="div"
           handle=".handle"
           delay="250"
-          delay-on-touch-only
+          :delay-on-touch-only="true"
           :value="plan.meals"
           group="meals"
           :data-index="index"

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -108,7 +108,7 @@
             :value="localLabels"
             handle=".handle"
             delay="250"
-            delay-on-touch-only
+            :delay-on-touch-only="true"
             class="my-2"
             @input="updateLabelOrder"
           >


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Apparently there's a bug with Vue Draggable's `delay-on-touch-only` boolean; you have to set it to `true` to get it to work (usually just putting `my-bool-val` works, but instead we have to do `:my-bool-val="true"`).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A