### PR TITLE
fix: recipe scaler throwing error on empty serving size

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeScaleEditButton.vue
+++ b/frontend/components/Domain/Recipe/RecipeScaleEditButton.vue
@@ -97,8 +97,8 @@ export default defineComponent({
       },
     });
 
-    const numerator = ref<number>(parseFloat(props.basicYieldNum.toFixed(3)) ?? 1);
-    const denominator = parseFloat(props.basicYieldNum.toFixed(32)) ?? 1;
+    const numerator = ref<number>(props.basicYieldNum != null ? parseFloat(props.basicYieldNum.toFixed(3)) : 1);
+    const denominator = props.basicYieldNum != null ? parseFloat(props.basicYieldNum.toFixed(32)) : 1;
     const numberParsed = !!props.basicYieldNum;
 
     watch(() => numerator.value, () => {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The scaler was trying to parse the recipe serving size to determine the numerator / denominator. This moves the check on wheter basic yield is null to before the rounding of the number so we never try to round a null value. 

When executed on a null value errors were thrown to the console in production and i had 404 pages pop up for recipes with missing serving sizes in dev. 

## Which issue(s) this PR fixes:

None

## Testing

Verrified issue was no longer present on recipes that were throwing errors manually.
