### PR TITLE
fix: set useFractions on Unit creation to true by default

### DIFF
--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -323,7 +323,7 @@ export default defineComponent({
     // we explicitly set booleans to false since forms don't POST unchecked boxes
     const createTarget = ref<CreateIngredientUnit>({
       name: "",
-      fraction: false,
+      fraction: true,
       useAbbreviation: false,
     });
 


### PR DESCRIPTION
## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

I think it makes sense to have the "Display as Fraction" checkbox enabled by default on Unit creation. This is enabled for all seed data and we should try to have a unified default when merging and seeding units.


## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

This is barely a PR 

## Testing

Created a unit. 
