### PR TITLE
fix: round ingredient amounts when not using fractions

### DIFF
--- a/frontend/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.ts
@@ -54,7 +54,7 @@ export function useParsedIngredientText(ingredient: RecipeIngredient, disableAmo
   // casting to number is required as sometimes quantity is a string
   if (quantity && Number(quantity) !== 0) {
     if (unit && !unit.fraction) {
-      returnQty = (quantity * scale).toString();
+      returnQty = Number((quantity * scale).toPrecision(3)).toString();
     } else {
       const fraction = frac(quantity * scale, 10, true);
       if (fraction[0] !== undefined && fraction[0] > 0) {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Ingredient amounts were not rounded when Fractions were turned of for that specific unit. This leads to unnecessairy precision described in #4465. This rounds the number to [three significant digits](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision). 

Resulting in the following output for the 400 / 160 scaled from 6 to 7 in the issue linked above. 

```
467 Testingredient
187 Testingredient
```

Happy to tune the precision if somebody sees a case where this would not be enough. Couldn't think of one.


## Which issue(s) this PR fixes:

- fixes #4465 

## Special notes for your reviewer:

I had to do some back and forth casting to between Numbers and Strings to: 
- remove e.g. 1.33e^5 representation returned by toPrecision
- remove trailing 0 after the comma returned by toPrecision
- to allow for numbers that are greater than 3 digits after scaling (e.g. 1600ml of Water)

If there is a better method please let me know. 

## Testing

Manual testing with the example described in #4465 


