### PR TITLE
fix: Added Nutrients Suffix to the PrintView and some formatting to that

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -98,7 +98,7 @@
               <tr v-for="(value, key) in recipe.nutrition" :key="key">
                 <template v-if="value">
                   <td>{{ labels[key].label }}</td>
-                  <td>{{ value || '-' }}</td>
+                  <td>{{ value ? (labels[key].suffix ? `${value} ${labels[key].suffix}` : value) : '-' }}</td>
                 </template>
               </tr>
             </tbody>
@@ -322,10 +322,32 @@ li {
 }
 
 .nutrition-table {
-  width: 25%;
+  max-width: 80%;
   border-collapse: collapse;
 }
 
+.nutrition-table th,
+.nutrition-table td {
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+  font-size: 14px;
+}
+
+.nutrition-table th {
+  font-weight: bold;
+  padding-bottom: 10px;
+}
+
+.nutrition-table td:first-child {
+  width: 70%;
+  font-weight: bold;
+}
+
+.nutrition-table td:last-child {
+  width: 30%;
+  text-align: right;
+}
 .nutrition-table td {
   padding: 2px;
   text-align: left;


### PR DESCRIPTION
fix: Added the nutrition suffix to the print view, so it will be printed, added few CSS stylings to it…added few CSS stylings to it

## What type of PR is this?
- bug

## What this PR does / why we need it:

This PR adds the suffix for each nutrition label to the print view so that when the user prints the recipe, the nutrition label is printed properly and with the correct formatting.

Here is how it was before:
![WhatsApp Image 2024-11-01 at 14 35 20](https://github.com/user-attachments/assets/8e3c3267-122b-42df-aefe-6dbf39222d43)


Here is how it looks now:
![WhatsApp Image 2024-11-01 at 14 36 01](https://github.com/user-attachments/assets/e950f754-32fd-472d-9766-ae2a2ea5efae)




## Which issue(s) this PR fixes:

Fixes #4125 

## Special notes for your reviewer:

I have changed the ReciepePrintView.vue file, added styling for the nutrition table and added the suffix variable in the table

## Testing

Tested this by importing a recipe with nutrition details and then after importing, tried to print the recipe, it prints the nutrition label properly.
