### PR TITLE
fix: Prevent Users From Being Created With Missing Group/Household

### DIFF
--- a/mealie/db/models/users/users.py
+++ b/mealie/db/models/users/users.py
@@ -152,10 +152,10 @@ class User(SqlAlchemyBase, BaseMixins):
             self.household = None
 
         if self.group is None:
-            raise ValueError(f"Group {settings.DEFAULT_GROUP} does not exist; cannot create user")
+            raise ValueError(f"Group {group} does not exist; cannot create user")
         if self.household is None:
             raise ValueError(
-                f'Household "{settings.DEFAULT_HOUSEHOLD}" does not exist on group '
+                f'Household "{household}" does not exist on group '
                 f'"{self.group.name}" ({self.group.id}); cannot create user'
             )
 

--- a/mealie/db/models/users/users.py
+++ b/mealie/db/models/users/users.py
@@ -151,6 +151,13 @@ class User(SqlAlchemyBase, BaseMixins):
         else:
             self.household = None
 
+        if self.group is None:
+            raise ValueError(f"Group {settings.DEFAULT_GROUP} does not exist; cannot create user")
+        if self.household is None:
+            raise ValueError(
+                f'Household "{settings.DEFAULT_HOUSEHOLD}" does not exist on group "{self.group}"; cannot create user'
+            )
+
         self.rated_recipes = []
 
         self.password = password

--- a/mealie/db/models/users/users.py
+++ b/mealie/db/models/users/users.py
@@ -155,7 +155,8 @@ class User(SqlAlchemyBase, BaseMixins):
             raise ValueError(f"Group {settings.DEFAULT_GROUP} does not exist; cannot create user")
         if self.household is None:
             raise ValueError(
-                f'Household "{settings.DEFAULT_HOUSEHOLD}" does not exist on group "{self.group}"; cannot create user'
+                f'Household "{settings.DEFAULT_HOUSEHOLD}" does not exist on group '
+                f'"{self.group.name}" ({self.group.id}); cannot create user'
             )
 
         self.rated_recipes = []


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Currently there are a couple of ways of creating users with invalid groups/households. This puts the app into a broken state where it won't run (because Pydantic complains about the missing group/household). This PR catches this issue at the db level so at least users/developers are aware of why (and when) this happens.

Now upon user creation, if the group or household is invalid a `ValueError` is raised:
```
# Invalid Group
Group "GROUPNAME" does not exist; cannot create user

# Invalid Household on a valid Group
Household "HOUSEHOLDNAME" does not exist on group "GROUPNAME" (GROUPID); cannot create user
```

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/4480

## Special notes for your reviewer:

_(fill-in or delete this section)_

@cmintey as far as I know this mostly only impacts LDAP/OIDC user creation. If possible/reasonable it's probably worth addressing this in a more user-friendly way (unsure if it's possible to configure a group/household using the user's auth service?) but at least this will prevent bad things from happening. It also gives the user a reasonable log to work with.

## Testing

_(fill-in or delete this section)_

Added tests to LDAP and OpenID which trigger this issue. Users are no longer created in a bad state.
