### PR TITLE
fix: JSON Mode Resets Page State

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -96,7 +96,13 @@ import RecipePageTitleContent from "./RecipePageParts/RecipePageTitleContent.vue
 import RecipePageComments from "./RecipePageParts/RecipePageComments.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import RecipePrintContainer from "~/components/Domain/Recipe/RecipePrintContainer.vue";
-import { EditorMode, PageMode, usePageState, usePageUser } from "~/composables/recipe-page/shared-state";
+import {
+  clearPageState,
+  EditorMode,
+  PageMode,
+  usePageState,
+  usePageUser,
+} from "~/composables/recipe-page/shared-state";
 import { NoUndefinedField } from "~/lib/api/types/non-generated";
 import { Recipe } from "~/lib/api/types/recipe";
 import { useRouteQuery } from "~/composables/use-router";
@@ -170,6 +176,9 @@ export default defineComponent({
         }
       }
       deactivateNavigationWarning();
+
+      clearPageState(props.recipe.slug || "");
+      console.debug("reset RecipePage state during unmount");
     });
 
     /** =============================================================

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
@@ -32,8 +32,8 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onUnmounted } from "@nuxtjs/composition-api";
-import { clearPageState, usePageState, usePageUser } from "~/composables/recipe-page/shared-state";
+import { computed, defineComponent } from "@nuxtjs/composition-api";
+import { usePageState, usePageUser } from "~/composables/recipe-page/shared-state";
 import { NoUndefinedField } from "~/lib/api/types/non-generated";
 import { Recipe } from "~/lib/api/types/recipe";
 import { useUserApi } from "~/composables/api";
@@ -75,10 +75,6 @@ export default defineComponent({
       return households.value.find((h) => h.id === owner.householdId);
     });
 
-    onUnmounted(() => {
-      clearPageState(props.recipe.slug);
-      console.debug("reset RecipePage state during unmount");
-    });
     async function uploadImage(fileObject: File) {
       if (!props.recipe || !props.recipe.slug) {
         return;


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

We have a cleanup function `clearPageState` which runs when we leave the recipe page. However, it actually runs when a particular component is unmounted, rather than the page itself. In most instances this is fine because the component isn't unmounted until leaving edit mode, except JSON mode unmounts the component too.  This causes the page state to reset prematurely, which has some funky effects (namely instructions are no longer editable).

This PR moves the cleanup method to the page component, ensuring it doesn't run until the user actually leaves the recipe page.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/4509#issuecomment-2460841417

## Special notes for your reviewer:

_(fill-in or delete this section)_

Took some work to diagnose this one, but was otherwise a pretty simple fix.

## Testing

_(fill-in or delete this section)_

Manually.
