### PR TITLE
fix: Add support for HTTPS in healthcheck

### DIFF
--- a/mealie/scripts/healthcheck.py
+++ b/mealie/scripts/healthcheck.py
@@ -10,9 +10,15 @@ def main():
     if port is None:
         port = 9000
 
-    url = f"http://127.0.0.1:{port}/api/app/about"
+    if all([os.getenv(x) for x in ["TLS_CERTIFICATE_PATH", "TLS_PRIVATE_KEY_PATH"]]):
+        proto = "https"
+    else:
+        proto = "http"
 
-    r = requests.get(url)
+    url = f"{proto}://127.0.0.1:{port}/api/app/about"
+
+    # TLS certificate is likely not issued for 127.0.0.1 so don't verify
+    r = requests.get(url, verify=False)
 
     if r.status_code == 200:
         sys.exit(0)

--- a/mealie/scripts/healthcheck.py
+++ b/mealie/scripts/healthcheck.py
@@ -10,7 +10,7 @@ def main():
     if port is None:
         port = 9000
 
-    if all([os.getenv(x) for x in ["TLS_CERTIFICATE_PATH", "TLS_PRIVATE_KEY_PATH"]]):
+    if all(os.getenv(x) for x in ["TLS_CERTIFICATE_PATH", "TLS_PRIVATE_KEY_PATH"]):
         proto = "https"
     else:
         proto = "http"


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The current healthcheck is hardcoded to use "http" which causes an error - thus failing the healthcheck - if the new TLS support is used.

## Which issue(s) this PR fixes:

Fixes #4537 

## Special notes for your reviewer:

I could have also wrapped the `requests.get()` in a try/except, caught the TLS error case, and retried with TLS but thought checking for the relevant environment variables was cleaner.

## Testing

I substituted the proposed healthcheck.py in my TLS-enabled install and it began passing the healthcheck. I also disabled TLS support and the proposed healthcheck.py still worked.

