### PR TITLE
fix: Cookmode hide additional ingredients if all ingredients are linked

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -104,8 +104,9 @@
         :recipe="recipe"
         :scale="scale"
       />
-      <v-divider></v-divider>
-      <div class="px-2 px-md-4 pb-4 ">
+
+      <div v-if="notLinkedIngredients.length > 0" class="px-2 px-md-4 pb-4 ">
+        <v-divider></v-divider>
         <v-card flat>
           <v-card-title>{{ $t('recipe.not-linked-ingredients') }}</v-card-title>
             <RecipeIngredients
@@ -214,12 +215,10 @@ export default defineComponent({
       usePageState(props.recipe.slug);
     const { deactivateNavigationWarning } = useNavigationWarning();
     const notLinkedIngredients = computed(() => {
-      console.log("inst",props.recipe.recipeInstruction);
       return props.recipe.recipeIngredient.filter((ingredient) => {
         return !props.recipe.recipeInstructions.some((step) => step.ingredientReferences?.map((ref) => ref.referenceId).includes(ingredient.referenceId));
       })
     })
-    console.log(notLinkedIngredients);
 
     /** =============================================================
      * Recipe Snapshot on Mount

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -338,7 +338,7 @@ export default defineComponent({
   },
 
   setup(props, context) {
-    const { i18n, req, $vuetify } = useContext();
+    const { i18n, req } = useContext();
     const BASE_URL = detectServerBaseUrl(req);
 
     const { isCookMode, toggleCookMode, isEditForm } = usePageState(props.recipe.slug);


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The headline for additional ingredients in the new cookmode was shown regardless of whether there were any ingredients or not. This fixes that

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

Also removed the remaining console logs that slipped under my radar. 

## Testing

Manual