### PR TITLE
fix: Wakelock Toggle Broken

### DIFF
--- a/frontend/components/global/WakelockSwitch.vue
+++ b/frontend/components/global/WakelockSwitch.vue
@@ -16,7 +16,7 @@ export default defineComponent({
     setup() {
         const { isSupported: wakeIsSupported, isActive, request, release } = useWakeLock();
         const wakeLock = computed({
-            get: () => isActive,
+            get: () => isActive.value,
             set: () => {
                 if (isActive.value) {
                     unlockScreen();

--- a/frontend/components/global/WakelockSwitch.vue
+++ b/frontend/components/global/WakelockSwitch.vue
@@ -27,13 +27,13 @@ export default defineComponent({
         });
         async function lockScreen() {
             if (wakeIsSupported) {
-                console.log("Wake Lock Requested");
+                console.debug("Wake Lock Requested");
                 await request("screen");
             }
         }
         async function unlockScreen() {
             if (wakeIsSupported || isActive) {
-                console.log("Wake Lock Released");
+                console.debug("Wake Lock Released");
                 await release();
             }
         }


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Our computed wakelock state doesn't use the `isActive` correctly. This fixes that.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/4553
