### PR TITLE
fix: Incorrect date format in Add to mealplan modal

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -51,8 +51,6 @@
             <v-text-field
               v-model="newMealdate"
               :label="$t('general.date')"
-              :hint="$t('recipe.date-format-hint-yyyy-mm-dd')"
-              persistent-hint
               :prepend-icon="$globals.icons.calendar"
               v-bind="attrs"
               readonly

--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -51,7 +51,7 @@
             <v-text-field
               v-model="newMealdate"
               :label="$t('general.date')"
-              :hint="$t('recipe.date-format-hint')"
+              :hint="$t('recipe.date-format-hint-yyyy-mm-dd')"
               persistent-hint
               :prepend-icon="$globals.icons.calendar"
               v-bind="attrs"


### PR DESCRIPTION
## What type of PR is this?

bug

## What this PR does / why we need it:

This PR resolves an issue with the date field hint in the "Add to Plan" dialog box. The hint initially displayed the date format as `MM/DD/YYYY`, which was inconsistent with the actual date format (`YYYY-MM-DD`). This inconsistency could confuse users, especially since the field is `readonly` and uses a date picker. 

The hint has now been completely removed to simplify the UI and avoid redundancy.

## Changes made:

- Removed the `:hint` and `persistent-hint` properties from the `<v-text-field>` component for the date picker in the "Add to Plan" dialog box.
- Simplified the UI by removing the unnecessary hint, as the field is not intended for manual input.

## Which issue(s) this PR fixes:

Fixes #4598

## Special notes for your reviewer:

- Please verify that removing the hint does not introduce any regressions in other parts of the application.
- Ensure that the date picker functionality works as expected across different languages and locales.

## Testing:

- Tested on the demo site using Firefox 128.4.0esr on Windows 11.
- Verified that the hint has been successfully removed.
- Confirmed that the date picker field remains `readonly` and continues to function as intended.
