### PR TITLE
fix: Cocktail Builder Enhancements

### DIFF
--- a/frontend/pages/g/_groupSlug/recipes/finder/index.vue
+++ b/frontend/pages/g/_groupSlug/recipes/finder/index.vue
@@ -369,7 +369,7 @@ export default defineComponent({
         includeFoodsOnHand: preferences.value.includeFoodsOnHand,
         includeToolsOnHand: preferences.value.includeToolsOnHand,
         queryFilter: preferences.value.queryFilter,
-        limit: 10,
+        limit: 20,
       },
     });
 

--- a/frontend/pages/g/_groupSlug/recipes/finder/index.vue
+++ b/frontend/pages/g/_groupSlug/recipes/finder/index.vue
@@ -417,31 +417,41 @@ export default defineComponent({
     const selectedFoods = ref<IngredientFood[]>([]);
     function addFood(food: IngredientFood) {
       selectedFoods.value.push(food);
+      handleFoodUpdates();
     }
     function removeFood(food: IngredientFood) {
       selectedFoods.value = selectedFoods.value.filter((f) => f.id !== food.id);
+      handleFoodUpdates();
+    }
+    function handleFoodUpdates() {
+      selectedFoods.value.sort((a, b) => (a.pluralName || a.name).localeCompare(b.pluralName || b.name));
+      preferences.value.foodIds = selectedFoods.value.map((food) => food.id);
     }
     watch(
       () => selectedFoods.value,
       () => {
-        selectedFoods.value.sort((a, b) => (a.pluralName || a.name).localeCompare(b.pluralName || b.name));
-        preferences.value.foodIds = selectedFoods.value.map((food) => food.id);
-      }
+        handleFoodUpdates();
+      },
     )
 
     const toolStore = isOwnGroup.value ? useToolStore() : usePublicToolStore(groupSlug.value);
     const selectedTools = ref<RecipeTool[]>([]);
     function addTool(tool: RecipeTool) {
       selectedTools.value.push(tool);
+      handleToolUpdates();
     }
     function removeTool(tool: RecipeTool) {
       selectedTools.value = selectedTools.value.filter((t) => t.id !== tool.id);
+      handleToolUpdates();
+    }
+    function handleToolUpdates() {
+      selectedTools.value.sort((a, b) => a.name.localeCompare(b.name));
+      preferences.value.toolIds = selectedTools.value.map((tool) => tool.id);
     }
     watch(
       () => selectedTools.value,
       () => {
-        selectedTools.value.sort((a, b) => a.name.localeCompare(b.name));
-        preferences.value.toolIds = selectedTools.value.map((tool) => tool.id);
+        handleToolUpdates();
       }
     )
 

--- a/frontend/pages/g/_groupSlug/recipes/finder/index.vue
+++ b/frontend/pages/g/_groupSlug/recipes/finder/index.vue
@@ -220,7 +220,7 @@
             </v-row>
           </v-container>
         </v-col>
-        <v-col :cols="useMobile ? 12 : 9" style="max-height: 70vh; overflow-y: auto">
+        <v-col :cols="useMobile ? 12 : 9" :style="useMobile ? '' : 'max-height: 70vh; overflow-y: auto'">
           <v-container
             v-if="recipeSuggestions.readyToMake.length || recipeSuggestions.missingItems.length"
             class="ma-0 pa-0"

--- a/frontend/pages/g/_groupSlug/recipes/finder/index.vue
+++ b/frontend/pages/g/_groupSlug/recipes/finder/index.vue
@@ -220,7 +220,7 @@
             </v-row>
           </v-container>
         </v-col>
-        <v-col :cols="useMobile ? 12 : 9">
+        <v-col :cols="useMobile ? 12 : 9" style="max-height: 70vh; overflow-y: auto">
           <v-container
             v-if="recipeSuggestions.readyToMake.length || recipeSuggestions.missingItems.length"
             class="ma-0 pa-0"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

Fixes an issue with the cocktail builder when you add ingredients via the checkbox on the recipe card; it wasn't sorting/saving those foods/tools properly.

Also increases the results limit, and pins the size of the recipes so the recipes scroll, rather than the entire page (effectively pinning the filters so they're always in-view). The pinning is only on desktop.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A