### PR TITLE
fix: remove import button from recipe data view

### DIFF
--- a/frontend/pages/group/data/recipes.vue
+++ b/frontend/pages/group/data/recipes.vue
@@ -136,12 +136,6 @@
       <v-card>
         <RecipeDataTable v-model="selected" :loading="loading" :recipes="allRecipes" :show-headers="headers" />
         <v-card-actions class="justify-end">
-          <BaseButton color="info">
-            <template #icon>
-              {{ $globals.icons.database }}
-            </template>
-            {{ $t('general.import') }}
-          </BaseButton>
           <BaseButton
             color="info"
             @click="


### PR DESCRIPTION
## What type of PR is this?

- fix
- cleanup

## What this PR does / why we need it:

This PR removes the non-functional button for importing recipe data from the group data view. Since this does nothing currently it is confusing to leave on the screen.

Additionally, I don't think this ever needs to get implemented on our end. Having an easy way to export data is great and I think this _should_ be kept, however I am viewing that as a way to _exit_ mealie and not a way to back-up or move data from one instance to another.

Since we have very strong backup and restore mechanism that work across versions I don't see a need to implement this anymore. 

## Which issue(s) this PR fixes:

_(REQUIRED)_

Closes #2802 - as not planned


## Testing

Visual inspection