### PR TITLE
fix: Markdown paragraph spacing issue in recipe notes

### DIFF
--- a/frontend/components/global/SafeMarkdown.vue
+++ b/frontend/components/global/SafeMarkdown.vue
@@ -1,5 +1,6 @@
 <template>
-  <VueMarkdown :source="sanitizeMarkdown(source)"></VueMarkdown>
+  <!-- Pass the preporcessed and sanitized Markdown source to VueMarkdown -->
+  <VueMarkdown :source="sanitizeMarkdown(preprocessMarkdown(source))"></VueMarkdown>
 </template>
 
 <script lang="ts">
@@ -19,6 +20,15 @@ export default defineComponent({
     },
   },
   setup() {
+
+    // Preprocess the Markdown source to handle single-line breaks
+    function preprocessMarkdown(rawMarkdown: string | null | undefined): string {
+      if(!rawMarkdown) {
+        return "";
+      }
+      return rawMarkdown.replace(/\n/g, " <br>");
+    }
+
     function sanitizeMarkdown(rawHtml: string | null | undefined): string {
       if (!rawHtml) {
         return "";
@@ -43,6 +53,7 @@ export default defineComponent({
     }
 
     return {
+      preprocessMarkdown,
       sanitizeMarkdown,
     };
   },


### PR DESCRIPTION

## What type of PR is this?
- bug

## What this PR does / why we need it:
This PR addresses an issue where single-line breaks in recipe notes caused incorrect paragraph spacing. The following changes were made:

Added a preprocessMarkdown function to `RecipeNotes.vue` to convert single line breaks into double line breaks for proper Markdown rendering.
Updated SafeMarkdown usage in` RecipeNotes.vue` to preprocess text before rendering.
These changes ensure that paragraphs are spaced correctly when rendering recipe notes.

**Before:**
![Screenshot 2024-12-02 at 10 58 28 PM](https://github.com/user-attachments/assets/aeb49c46-c014-4b1f-bee5-55efddf62874)
![Screenshot 2024-12-02 at 10 58 14 PM](https://github.com/user-attachments/assets/adcfb554-089c-4224-af00-1871eda805af)

**After:**
![Screenshot 2024-12-02 at 10 51 27 PM](https://github.com/user-attachments/assets/cc9517b5-e1eb-4b43-8e35-dac2fb6605e0)
![Screenshot 2024-12-02 at 10 51 41 PM](https://github.com/user-attachments/assets/d9f3c1f3-5baa-495f-bdee-1d15fcf1983f)
-->

## Which issue(s) this PR fixes:

Fixes #2854
Fixes #2846


## Special notes for your reviewer:
_This PR is a continuation of #4664 which I  mistakenly closed while trying to make some changes based on reviewers notes._ 

## Testing
Since this was a UI improvement, I just observed the changes. 
