### PR TITLE
fix: Add Formatting for Markdown Tables

### DIFF
--- a/frontend/components/global/SafeMarkdown.vue
+++ b/frontend/components/global/SafeMarkdown.vue
@@ -48,3 +48,20 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+::v-deep table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+::v-deep th, ::v-deep td {
+  border: 1px solid;
+  padding: 8px;
+  text-align: left;
+}
+
+::v-deep th {
+  font-weight: bold;
+}
+</style>


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

We currently support markdown in most places (recipe ingredients, steps, description, notes, etc.). Technically this includes markdown tables, but they're basically useless in their current form due to formatting:

```markdown

| First Header  | Second Header |
| ------------- | ------------- |
| Content Cell  | Content Cell  |
| Content Cell  | Content Cell  |
```
![image](https://github.com/user-attachments/assets/7d08a463-349b-433b-8698-076e3115fd53)

This PR adds some formatting to make them look like how you'd expect:
![image](https://github.com/user-attachments/assets/afe2dbf6-c4b7-4501-b557-a6ee7b4ab204)
![image](https://github.com/user-attachments/assets/96c73b5f-5905-4937-9f5b-85db2d9c1676)

And in other places:
![image](https://github.com/user-attachments/assets/cf62a2ed-88a1-434a-8cf6-902a4c64898b)
![image](https://github.com/user-attachments/assets/324d29de-4384-4e71-a4a8-a508482ad0b1)

An example from GH:
![image](https://github.com/user-attachments/assets/09489f0d-5037-4ec8-9791-3ca9ca827447)

This is only applied to the `SafeMarkdown` component, so if we use tables elsewhere (e.g. nutrition on the print view) the styling won't be affected.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Closes https://github.com/mealie-recipes/mealie/discussions/4702

## Testing

_(fill-in or delete this section)_

Tested using the examples above