### PR TITLE
feat: Add new labels and foods for en-US language. Update all locale seeding files and seeding logic to parse the new format  Only add new labels, units, and foods during seeding (checking against existing names)

### DIFF
--- a/dev/scripts/convert_seed_files_to_new_format.py
+++ b/dev/scripts/convert_seed_files_to_new_format.py
@@ -1,0 +1,76 @@
+import glob
+import json
+import pathlib
+
+
+def get_seed_locale_names() -> set[str]:
+    """Find all locales in the seed/resources/ folder
+
+    Returns:
+        A set of every file name where there's both a seed label and seed food file
+    """
+
+    LABELS_PATH = "/workspaces/mealie/mealie/repos/seed/resources/labels/locales/"
+    FOODS_PATH = "/workspaces/mealie/mealie/repos/seed/resources/foods/locales/"
+    label_locales = glob.glob("*.json", root_dir=LABELS_PATH)
+    foods_locales = glob.glob("*.json", root_dir=FOODS_PATH)
+
+    # ensure that a locale has both a label and a food seed file
+    return set(label_locales).intersection(foods_locales)
+
+
+def get_labels_from_file(locale: str) -> list[str]:
+    """Query a locale to get all of the labels so that they can be added to the new foods seed format
+
+    Returns:
+        All of the labels found within the seed file for a given locale
+    """
+
+    locale_path = pathlib.Path(
+        "/workspaces/mealie/mealie/repos/seed/resources/labels/locales/" + locale)
+    label_names = [label["name"] for label in json.loads(
+        locale_path.read_text(encoding="utf-8"))]
+    return label_names
+
+
+def transform_foods(locale: str):
+    """
+    Convert the current food seed file for a locale into a new format which maps each food to a label
+
+    Existing format of foods seed file is a dictionary where each key is a food name and the values are a dictionary
+        of attributes such as name and plural_name
+
+    New format maps each food to a label. The top-level dictionary has each key as a label e.g. "Fruits".
+        Each label key as a value that is a dictionary with an element called "foods"
+        "Foods" is a dictionary of each food for that label, with a key of the english food name e.g. "baking-soda"
+        and a value of attributes, including the translated name of the item e.g. "bicarbonate of soda" for en-GB.
+    """
+
+    locale_path = pathlib.Path(
+        "/workspaces/mealie/mealie/repos/seed/resources/foods/locales/" + locale)
+
+    with open(locale_path, encoding="utf-8") as infile:
+        data = json.load(infile)
+
+    transformed_data = {"": {"foods": dict(data.items())}}
+
+    # Seeding for labels now pulls from the foods file and parses the labels from there (as top-level keys),
+    #   thus we need to add all of the existing labels to the new food seed file and give them an empty foods dictionary
+    label_names = get_labels_from_file(locale)
+    for label in label_names:
+        transformed_data[label] = {"foods": {}}
+
+    with open(locale_path, "w", encoding="utf-8") as outfile:
+        json.dump(transformed_data, outfile, indent=4, ensure_ascii=False)
+
+
+def main():
+    override = ["da-DK.json", "hu-HU.json",
+                "it-IT.json", "ro-RO.json", "sv-SE.json"]
+    # for locale in get_seed_locale_names():
+    for locale in override:
+        transform_foods(locale)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/scripts/convert_seed_files_to_new_format.py
+++ b/dev/scripts/convert_seed_files_to_new_format.py
@@ -26,10 +26,8 @@ def get_labels_from_file(locale: str) -> list[str]:
         All of the labels found within the seed file for a given locale
     """
 
-    locale_path = pathlib.Path(
-        "/workspaces/mealie/mealie/repos/seed/resources/labels/locales/" + locale)
-    label_names = [label["name"] for label in json.loads(
-        locale_path.read_text(encoding="utf-8"))]
+    locale_path = pathlib.Path("/workspaces/mealie/mealie/repos/seed/resources/labels/locales/" + locale)
+    label_names = [label["name"] for label in json.loads(locale_path.read_text(encoding="utf-8"))]
     return label_names
 
 
@@ -46,8 +44,7 @@ def transform_foods(locale: str):
         and a value of attributes, including the translated name of the item e.g. "bicarbonate of soda" for en-GB.
     """
 
-    locale_path = pathlib.Path(
-        "/workspaces/mealie/mealie/repos/seed/resources/foods/locales/" + locale)
+    locale_path = pathlib.Path("/workspaces/mealie/mealie/repos/seed/resources/foods/locales/" + locale)
 
     with open(locale_path, encoding="utf-8") as infile:
         data = json.load(infile)
@@ -65,10 +62,7 @@ def transform_foods(locale: str):
 
 
 def main():
-    override = ["da-DK.json", "hu-HU.json",
-                "it-IT.json", "ro-RO.json", "sv-SE.json"]
-    # for locale in get_seed_locale_names():
-    for locale in override:
+    for locale in get_seed_locale_names():
         transform_foods(locale)
 
 

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -1050,8 +1050,8 @@
     "foods": {
       "merge-dialog-text": "Combining the selected foods will merge the source food and target food into a single food. The source food will be deleted and all of the references to the source food will be updated to point to the target food.",
       "merge-food-example": "Merging {food1} into {food2}",
-      "seed-dialog-text": "Seed the database with foods based on your local language. This will create 200+ common foods that can be used to organize your database. Foods are translated via a community effort.",
-      "seed-dialog-warning": "You have already have some items in your database. This action will not reconcile duplicates, you will have to manage them manually.",
+      "seed-dialog-text": "Seed the database with foods based on your local language. This will create ~2700 common foods that can be used to organize your database. Foods are translated via a community effort.",
+      "seed-dialog-warning": "You already have some items in your database. A new item will not be added if an item with the same name already exists.",
       "combine-food": "Combine Food",
       "source-food": "Source Food",
       "target-food": "Target Food",

--- a/mealie/repos/seed/resources/foods/locales/af-ZA.json
+++ b/mealie/repos/seed/resources/foods/locales/af-ZA.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "akkersap"
-	},
-	"alfalfa-sprouts": {
-		"name": "lusernspruite"
-	},
-	"anchovies": {
-		"name": "ansjovis"
-	},
-	"apples": {
-		"name": "appels",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artisjok"
-	},
-	"arugula": {
-		"name": "rucola"
-	},
-	"asparagus": {
-		"name": "aspersies"
-	},
-	"avocado": {
-		"name": "avokadopeer",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "spek"
-	},
-	"baking-powder": {
-		"name": "bakpoeier"
-	},
-	"baking-soda": {
-		"name": "koeksoda"
-	},
-	"baking-sugar": {
-		"name": "baksuiker"
-	},
-	"bar-sugar": {
-		"name": "suikerriet"
-	},
-	"basil": {
-		"name": "basiliekruid"
-	},
-	"beans": {
-		"name": "boontjies"
-	},
-	"bell-peppers": {
-		"name": "soetrissies",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "swartbessies"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "kool"
-	},
-	"bread": {
-		"name": "brood"
-	},
-	"breadfruit": {
-		"name": "broodvrug"
-	},
-	"broccoflower": {
-		"name": "romanesco"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "bruinsuiker"
-	},
-	"brussels-sprouts": {
-		"name": "brusselse spruite"
-	},
-	"butter": {
-		"name": "botter"
-	},
-	"butternut-pumpkin": {
-		"name": "botterskorsie pampoen"
-	},
-	"butternut-squash": {
-		"name": "botterskorsie"
-	},
-	"cabbage": {
-		"name": "kool",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "kaktus, eetbaar"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "suikerriet"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "komyn"
-	},
-	"carrot": {
-		"name": "wortel",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "strooisuiker"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "blomkool",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "rooipeper"
-	},
-	"celeriac": {
-		"name": "seldery wortel"
-	},
-	"celery": {
-		"name": "seldery"
-	},
-	"cereal-grains": {
-		"name": "ontbytgraan"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "kaas"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese kool"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "galisiese kool"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead varing",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "vrugte suiker"
-	},
-	"ful": {
-		"name": "peul"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "knoffel",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "skorsies"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "hoender binnegoed"
-	},
-	"ginger": {
-		"name": "gemmer"
-	},
-	"grains": {
-		"name": "graankosse"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "druiwepitolie"
-	},
-	"green-onion": {
-		"name": "groenui",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "hart van palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hennep"
-	},
-	"herbs": {
-		"name": "kruie"
-	},
-	"honey": {
-		"name": "heuning"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "konfyt"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artisjok"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "boerenkool"
-	},
-	"kohlrabi": {
-		"name": "koolrabi"
-	},
-	"kumara": {
-		"name": "patat"
-	},
-	"leavening-agents": {
-		"name": "rysmiddels"
-	},
-	"leek": {
-		"name": "prei",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "peulgewasse"
-	},
-	"lemongrass": {
-		"name": "sitroengras"
-	},
-	"lentils": {
-		"name": "lensies"
-	},
-	"lettuce": {
-		"name": "blaarslaai"
-	},
-	"liver": {
-		"name": "lewer",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "mielies"
-	},
-	"maple-syrup": {
-		"name": "esdoringstroop"
-	},
-	"meat": {
-		"name": "vleis"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "sampioen",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mossels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar bakmengsel"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "neutmuskaat"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "gisvlokkies"
-	},
-	"nuts": {
-		"name": "neute"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "origanum"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "pietersielie"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "peer",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "ertjies"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "aartappel",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rys"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "jerusalem artisjok",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "soetpatat",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "suikermielies",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "versoeters"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "abessiniese liefdesgras"
-	},
-	"tomato": {
-		"name": "tamatie",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "wortelgroente",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "raap",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "ongeraffineerde suiker"
-	},
-	"vanilla": {
-		"name": "vanielje"
-	},
-	"vegetables": {
-		"name": "groente"
-	},
-	"watercress": {
-		"name": "waterkers"
-	},
-	"watermelon": {
-		"name": "waatlemoen",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "wit sampioen",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "wit suiker"
-	},
-	"xanthan-gum": {
-		"name": "xanthan kougom"
-	},
-	"yam": {
-		"name": "patat",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "gis"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "akkersap"
+            },
+            "alfalfa-sprouts": {
+                "name": "lusernspruite"
+            },
+            "anchovies": {
+                "name": "ansjovis"
+            },
+            "apples": {
+                "name": "appels",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artisjok"
+            },
+            "arugula": {
+                "name": "rucola"
+            },
+            "asparagus": {
+                "name": "aspersies"
+            },
+            "avocado": {
+                "name": "avokadopeer",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "spek"
+            },
+            "baking-powder": {
+                "name": "bakpoeier"
+            },
+            "baking-soda": {
+                "name": "koeksoda"
+            },
+            "baking-sugar": {
+                "name": "baksuiker"
+            },
+            "bar-sugar": {
+                "name": "suikerriet"
+            },
+            "basil": {
+                "name": "basiliekruid"
+            },
+            "beans": {
+                "name": "boontjies"
+            },
+            "bell-peppers": {
+                "name": "soetrissies",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "swartbessies"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "kool"
+            },
+            "bread": {
+                "name": "brood"
+            },
+            "breadfruit": {
+                "name": "broodvrug"
+            },
+            "broccoflower": {
+                "name": "romanesco"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "bruinsuiker"
+            },
+            "brussels-sprouts": {
+                "name": "brusselse spruite"
+            },
+            "butter": {
+                "name": "botter"
+            },
+            "butternut-pumpkin": {
+                "name": "botterskorsie pampoen"
+            },
+            "butternut-squash": {
+                "name": "botterskorsie"
+            },
+            "cabbage": {
+                "name": "kool",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "kaktus, eetbaar"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "suikerriet"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "komyn"
+            },
+            "carrot": {
+                "name": "wortel",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "strooisuiker"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "blomkool",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "rooipeper"
+            },
+            "celeriac": {
+                "name": "seldery wortel"
+            },
+            "celery": {
+                "name": "seldery"
+            },
+            "cereal-grains": {
+                "name": "ontbytgraan"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "kaas"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese kool"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "galisiese kool"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead varing",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "vrugte suiker"
+            },
+            "ful": {
+                "name": "peul"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "knoffel",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "skorsies"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "hoender binnegoed"
+            },
+            "ginger": {
+                "name": "gemmer"
+            },
+            "grains": {
+                "name": "graankosse"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "druiwepitolie"
+            },
+            "green-onion": {
+                "name": "groenui",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "hart van palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hennep"
+            },
+            "herbs": {
+                "name": "kruie"
+            },
+            "honey": {
+                "name": "heuning"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "konfyt"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artisjok"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "boerenkool"
+            },
+            "kohlrabi": {
+                "name": "koolrabi"
+            },
+            "kumara": {
+                "name": "patat"
+            },
+            "leavening-agents": {
+                "name": "rysmiddels"
+            },
+            "leek": {
+                "name": "prei",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "peulgewasse"
+            },
+            "lemongrass": {
+                "name": "sitroengras"
+            },
+            "lentils": {
+                "name": "lensies"
+            },
+            "lettuce": {
+                "name": "blaarslaai"
+            },
+            "liver": {
+                "name": "lewer",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "mielies"
+            },
+            "maple-syrup": {
+                "name": "esdoringstroop"
+            },
+            "meat": {
+                "name": "vleis"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "sampioen",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mossels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar bakmengsel"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "neutmuskaat"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "gisvlokkies"
+            },
+            "nuts": {
+                "name": "neute"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "origanum"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "pietersielie"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "peer",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "ertjies"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "aartappel",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rys"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "jerusalem artisjok",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "soetpatat",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "suikermielies",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "versoeters"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "abessiniese liefdesgras"
+            },
+            "tomato": {
+                "name": "tamatie",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "wortelgroente",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "raap",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "ongeraffineerde suiker"
+            },
+            "vanilla": {
+                "name": "vanielje"
+            },
+            "vegetables": {
+                "name": "groente"
+            },
+            "watercress": {
+                "name": "waterkers"
+            },
+            "watermelon": {
+                "name": "waatlemoen",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "wit sampioen",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "wit suiker"
+            },
+            "xanthan-gum": {
+                "name": "xanthan kougom"
+            },
+            "yam": {
+                "name": "patat",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "gis"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Produkte": {
+        "foods": {}
+    },
+    "Graankosse": {
+        "foods": {}
+    },
+    "Vrugte": {
+        "foods": {}
+    },
+    "Groente": {
+        "foods": {}
+    },
+    "Vleis": {
+        "foods": {}
+    },
+    "Seekos": {
+        "foods": {}
+    },
+    "Drinkgoed": {
+        "foods": {}
+    },
+    "Gebakte goedere": {
+        "foods": {}
+    },
+    "Geblikte goedere": {
+        "foods": {}
+    },
+    "Geurmiddels": {
+        "foods": {}
+    },
+    "Soetgoed": {
+        "foods": {}
+    },
+    "Suiwelprodukte": {
+        "foods": {}
+    },
+    "Bevrore kosse": {
+        "foods": {}
+    },
+    "Gesondheidskos": {
+        "foods": {}
+    },
+    "Huishouding": {
+        "foods": {}
+    },
+    "Vleis produkte": {
+        "foods": {}
+    },
+    "Peuselhappies": {
+        "foods": {}
+    },
+    "Speserye": {
+        "foods": {}
+    },
+    "Lekkers": {
+        "foods": {}
+    },
+    "Drank": {
+        "foods": {}
+    },
+    "Ander": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ar-SA.json
+++ b/mealie/repos/seed/resources/foods/locales/ar-SA.json
@@ -1,692 +1,756 @@
 {
-    "acorn-squash": {
-        "name": "acorn squash"
-    },
-    "alfalfa-sprouts": {
-        "name": "alfalfa sprouts"
-    },
-    "anchovies": {
-        "name": "anchovies"
-    },
-    "apples": {
-        "name": "تفاح",
-        "plural_name": "apples"
-    },
-    "artichoke": {
-        "name": "خرشوف"
-    },
-    "arugula": {
-        "name": "جرجير"
-    },
-    "asparagus": {
-        "name": "asparagus"
-    },
-    "avocado": {
-        "name": "اﻷفوكادو",
-        "plural_name": "avocado"
-    },
-    "bacon": {
-        "name": "bacon"
-    },
-    "baking-powder": {
-        "name": "مسحوق الخبز"
-    },
-    "baking-soda": {
-        "name": "baking soda"
-    },
-    "baking-sugar": {
-        "name": "سكر الخبز"
-    },
-    "bar-sugar": {
-        "name": "bar sugar"
-    },
-    "basil": {
-        "name": "ريحان"
-    },
-    "beans": {
-        "name": "beans"
-    },
-    "bell-peppers": {
-        "name": "bell peppers",
-        "plural_name": "bell peppers"
-    },
-    "blackberries": {
-        "name": "توت الأسود"
-    },
-    "bok-choy": {
-        "name": "bok choy"
-    },
-    "brassicas": {
-        "name": "brassicas"
-    },
-    "bread": {
-        "name": "خبز"
-    },
-    "breadfruit": {
-        "name": "ثمرة الخبز"
-    },
-    "broccoflower": {
-        "name": "بروكلي"
-    },
-    "broccoli": {
-        "name": "بروكلي"
-    },
-    "broccoli-rabe": {
-        "name": "ربيع البروكلي"
-    },
-    "broccolini": {
-        "name": "بروكوليني"
-    },
-    "brown-sugar": {
-        "name": "سكر بني"
-    },
-    "brussels-sprouts": {
-        "name": "brussels sprouts"
-    },
-    "butter": {
-        "name": "زبدة"
-    },
-    "butternut-pumpkin": {
-        "name": "butternut pumpkin"
-    },
-    "butternut-squash": {
-        "name": "butternut squash"
-    },
-    "cabbage": {
-        "name": "كرنب",
-        "plural_name": "cabbages"
-    },
-    "cactus-edible": {
-        "name": "cactus, edible"
-    },
-    "calabrese": {
-        "name": "كالابريس"
-    },
-    "cane-sugar": {
-        "name": "cane sugar"
-    },
-    "cannabis": {
-        "name": "القنب"
-    },
-    "capsicum": {
-        "name": "capsicum"
-    },
-    "caraway": {
-        "name": "caraway"
-    },
-    "carrot": {
-        "name": "جزر",
-        "plural_name": "carrots"
-    },
-    "caster-sugar": {
-        "name": "caster sugar"
-    },
-    "castor-sugar": {
-        "name": "castor sugar"
-    },
-    "catfish": {
-        "name": "catfish"
-    },
-    "cauliflower": {
-        "name": "قرنبيط",
-        "plural_name": "cauliflowers"
-    },
-    "cayenne-pepper": {
-        "name": "فلفل الكايين"
-    },
-    "celeriac": {
-        "name": "celery root"
-    },
-    "celery": {
-        "name": "كرفس"
-    },
-    "cereal-grains": {
-        "name": "cereal grains"
-    },
-    "chard": {
-        "name": "chard"
-    },
-    "cheese": {
-        "name": "جبن"
-    },
-    "chicory": {
-        "name": "chicory"
-    },
-    "chilli-peppers": {
-        "name": "chilli pepper",
-        "plural_name": "chilli peppers"
-    },
-    "chinese-leaves": {
-        "name": "chinese leaves"
-    },
-    "chives": {
-        "name": "chives"
-    },
-    "chocolate": {
-        "name": "بالشوكولاتة"
-    },
-    "cilantro": {
-        "name": "كزبرة"
-    },
-    "cinnamon": {
-        "name": "قرفة"
-    },
-    "clarified-butter": {
-        "name": "clarified butter"
-    },
-    "coconut": {
-        "name": "جوز الهند",
-        "plural_name": "coconuts"
-    },
-    "coconut-milk": {
-        "name": "حليب جوز الهند"
-    },
-    "cod": {
-        "name": "cod"
-    },
-    "coffee": {
-        "name": "قهوة"
-    },
-    "collard-greens": {
-        "name": "collard greens"
-    },
-    "confectioners-sugar": {
-        "name": "confectioners' sugar"
-    },
-    "coriander": {
-        "name": "كزبرة"
-    },
-    "corn": {
-        "name": "ذرة",
-        "plural_name": "corns"
-    },
-    "corn-syrup": {
-        "name": "corn syrup"
-    },
-    "cottonseed-oil": {
-        "name": "cottonseed oil"
-    },
-    "courgette": {
-        "name": "courgette"
-    },
-    "cream-of-tartar": {
-        "name": "cream of tartar"
-    },
-    "cucumber": {
-        "name": "خيار",
-        "plural_name": "cucumbers"
-    },
-    "cumin": {
-        "name": "كمون"
-    },
-    "daikon": {
-        "name": "daikon",
-        "plural_name": "daikons"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "dairy products and dairy substitutes"
-    },
-    "dandelion": {
-        "name": "dandelion"
-    },
-    "demerara-sugar": {
-        "name": "demerara sugar"
-    },
-    "dough": {
-        "name": "dough"
-    },
-    "edible-cactus": {
-        "name": "edible cactus"
-    },
-    "eggplant": {
-        "name": "باذنجان",
-        "plural_name": "eggplants"
-    },
-    "eggs": {
-        "name": "بيض",
-        "plural_name": "eggs"
-    },
-    "endive": {
-        "name": "endive",
-        "plural_name": "endives"
-    },
-    "fats": {
-        "name": "fats"
-    },
-    "fava-beans": {
-        "name": "fava beans"
-    },
-    "fiddlehead": {
-        "name": "fiddlehead"
-    },
-    "fiddlehead-fern": {
-        "name": "fiddlehead fern",
-        "plural_name": "fiddlehead ferns"
-    },
-    "fish": {
-        "name": "سَمَكٌ"
-    },
-    "five-spice-powder": {
-        "name": "مسحوق التوابل 5"
-    },
-    "flour": {
-        "name": "دقيق"
-    },
-    "frisee": {
-        "name": "frisee"
-    },
-    "fructose": {
-        "name": "fructose"
-    },
-    "fruit": {
-        "name": "فاكهة"
-    },
-    "fruit-sugar": {
-        "name": "fruit sugar"
-    },
-    "ful": {
-        "name": "ful"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "ثوم",
-        "plural_name": "garlics"
-    },
-    "gem-squash": {
-        "name": "gem squash"
-    },
-    "ghee": {
-        "name": "ghee"
-    },
-    "giblets": {
-        "name": "giblets"
-    },
-    "ginger": {
-        "name": "ginger"
-    },
-    "grains": {
-        "name": "grains"
-    },
-    "granulated-sugar": {
-        "name": "granulated sugar"
-    },
-    "grape-seed-oil": {
-        "name": "grape seed oil"
-    },
-    "green-onion": {
-        "name": "green onion",
-        "plural_name": "green onions"
-    },
-    "heart-of-palm": {
-        "name": "heart of palm",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "hemp"
-    },
-    "herbs": {
-        "name": "أعشاب"
-    },
-    "honey": {
-        "name": "honey"
-    },
-    "isomalt": {
-        "name": "isomalt"
-    },
-    "jackfruit": {
-        "name": "jackfruit",
-        "plural_name": "jackfruits"
-    },
-    "jaggery": {
-        "name": "jaggery"
-    },
-    "jams": {
-        "name": "jams"
-    },
-    "jellies": {
-        "name": "jellies"
-    },
-    "jerusalem-artichoke": {
-        "name": "jerusalem artichoke"
-    },
-    "jicama": {
-        "name": "jicama"
-    },
-    "kale": {
-        "name": "kale"
-    },
-    "kohlrabi": {
-        "name": "kohlrabi"
-    },
-    "kumara": {
-        "name": "kumara"
-    },
-    "leavening-agents": {
-        "name": "leavening agents"
-    },
-    "leek": {
-        "name": "leek",
-        "plural_name": "leeks"
-    },
-    "legumes": {
-        "name": "legumes"
-    },
-    "lemongrass": {
-        "name": "lemongrass"
-    },
-    "lentils": {
-        "name": "lentils"
-    },
-    "lettuce": {
-        "name": "خس"
-    },
-    "liver": {
-        "name": "كبد",
-        "plural_name": "livers"
-    },
-    "maize": {
-        "name": "maize"
-    },
-    "maple-syrup": {
-        "name": "maple syrup"
-    },
-    "meat": {
-        "name": "لحم"
-    },
-    "milk": {
-        "name": "حليب"
-    },
-    "mortadella": {
-        "name": "الموتادلا"
-    },
-    "mushroom": {
-        "name": "فطر",
-        "plural_name": "mushrooms"
-    },
-    "mussels": {
-        "name": "بلح البحر"
-    },
-    "nanaimo-bar-mix": {
-        "name": "nanaimo bar mix"
-    },
-    "nori": {
-        "name": "nori"
-    },
-    "nutmeg": {
-        "name": "nutmeg"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "nutritional yeast flakes"
-    },
-    "nuts": {
-        "name": "nuts"
-    },
-    "octopuses": {
-        "name": "octopus",
-        "plural_name": "octopuses"
-    },
-    "oils": {
-        "name": "زيوت"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "زيتون"
-    },
-    "olive-oil": {
-        "name": "زيت الزيتون"
-    },
-    "onion": {
-        "name": "بصل"
-    },
-    "onion-family": {
-        "name": "عائلة البصل"
-    },
-    "orange-blossom-water": {
-        "name": "orange blossom water"
-    },
-    "oranges": {
-        "name": "برتقال",
-        "plural_name": "oranges"
-    },
-    "oregano": {
-        "name": "توابل اوريجانو"
-    },
-    "oysters": {
-        "name": "محار"
-    },
-    "panch-puran": {
-        "name": "panch puran"
-    },
-    "paprika": {
-        "name": "paprika"
-    },
-    "parsley": {
-        "name": "parsley"
-    },
-    "parsnip": {
-        "name": "parsnip",
-        "plural_name": "parsnips"
-    },
-    "pear": {
-        "name": "كمثرى",
-        "plural_name": "pears"
-    },
-    "peas": {
-        "name": "peas"
-    },
-    "pepper": {
-        "name": "فلفل",
-        "plural_name": "peppers"
-    },
-    "pineapple": {
-        "name": "أناناس",
-        "plural_name": "pineapples"
-    },
-    "plantain": {
-        "name": "plantain",
-        "plural_name": "plantains"
-    },
-    "poppy-seeds": {
-        "name": "بذور الخشخاش"
-    },
-    "potato": {
-        "name": "potato",
-        "plural_name": "potatoes"
-    },
-    "poultry": {
-        "name": "دواجن"
-    },
-    "powdered-sugar": {
-        "name": "سكر مسحوق"
-    },
-    "pumpkin": {
-        "name": "pumpkin",
-        "plural_name": "pumpkins"
-    },
-    "pumpkin-seeds": {
-        "name": "pumpkin seeds"
-    },
-    "radish": {
-        "name": "radish",
-        "plural_name": "radishes"
-    },
-    "raw-sugar": {
-        "name": "السكر الخام"
-    },
-    "refined-sugar": {
-        "name": "refined sugar"
-    },
-    "rice": {
-        "name": "أرز"
-    },
-    "rice-flour": {
-        "name": "دقيق الأرز"
-    },
-    "rock-sugar": {
-        "name": "rock sugar"
-    },
-    "rum": {
-        "name": "rum"
-    },
-    "salmon": {
-        "name": "سمك السالمون"
-    },
-    "salt": {
-        "name": "ملح"
-    },
-    "salt-cod": {
-        "name": "salt cod"
-    },
-    "scallion": {
-        "name": "scallion",
-        "plural_name": "scallions"
-    },
-    "seafood": {
-        "name": "المأكولات البحرية"
-    },
-    "seeds": {
-        "name": "بذور"
-    },
-    "sesame-seeds": {
-        "name": "بذور السمسم"
-    },
-    "shallot": {
-        "name": "shallot",
-        "plural_name": "shallots"
-    },
-    "skate": {
-        "name": "skate"
-    },
-    "soda": {
-        "name": "soda"
-    },
-    "soda-baking": {
-        "name": "soda, baking"
-    },
-    "soybean": {
-        "name": "soybean"
-    },
-    "spaghetti-squash": {
-        "name": "spaghetti squash",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "speck"
-    },
-    "spices": {
-        "name": "spices"
-    },
-    "spinach": {
-        "name": "spinach"
-    },
-    "spring-onion": {
-        "name": "البصل الأخضر",
-        "plural_name": "spring onions"
-    },
-    "squash": {
-        "name": "squash",
-        "plural_name": "squashes"
-    },
-    "squash-family": {
-        "name": "squash family"
-    },
-    "stockfish": {
-        "name": "stockfish"
-    },
-    "sugar": {
-        "name": "sugar"
-    },
-    "sunchoke": {
-        "name": "sunchoke",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "بذور عباد الشمس"
-    },
-    "superfine-sugar": {
-        "name": "superfine sugar"
-    },
-    "sweet-potato": {
-        "name": "sweet potato",
-        "plural_name": "sweet potatoes"
-    },
-    "sweetcorn": {
-        "name": "sweetcorn",
-        "plural_name": "sweetcorns"
-    },
-    "sweeteners": {
-        "name": "sweeteners"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "taro",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "teff"
-    },
-    "tomato": {
-        "name": "طماطم",
-        "plural_name": "tomatoes"
-    },
-    "trout": {
-        "name": "سمك السلمون المرقط"
-    },
-    "tubers": {
-        "name": "tuber",
-        "plural_name": "tubers"
-    },
-    "tuna": {
-        "name": "تونة"
-    },
-    "turbanado-sugar": {
-        "name": "turbanado sugar"
-    },
-    "turnip": {
-        "name": "turnip",
-        "plural_name": "turnips"
-    },
-    "unrefined-sugar": {
-        "name": "unrefined sugar"
-    },
-    "vanilla": {
-        "name": "vanilla"
-    },
-    "vegetables": {
-        "name": "vegetables"
-    },
-    "watercress": {
-        "name": "watercress"
-    },
-    "watermelon": {
-        "name": "watermelon",
-        "plural_name": "watermelons"
-    },
-    "white-mushroom": {
-        "name": "الفطر الأبيض",
-        "plural_name": "white mushrooms"
-    },
-    "white-sugar": {
-        "name": "white sugar"
-    },
-    "xanthan-gum": {
-        "name": "xanthan gum"
-    },
-    "yam": {
-        "name": "yam",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "yeast"
-    },
-    "zucchini": {
-        "name": "zucchini",
-        "plural_name": "zucchinis"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "تفاح",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "خرشوف"
+            },
+            "arugula": {
+                "name": "جرجير"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "اﻷفوكادو",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "مسحوق الخبز"
+            },
+            "baking-soda": {
+                "name": "baking soda"
+            },
+            "baking-sugar": {
+                "name": "سكر الخبز"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "ريحان"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell peppers",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "توت الأسود"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "خبز"
+            },
+            "breadfruit": {
+                "name": "ثمرة الخبز"
+            },
+            "broccoflower": {
+                "name": "بروكلي"
+            },
+            "broccoli": {
+                "name": "بروكلي"
+            },
+            "broccoli-rabe": {
+                "name": "ربيع البروكلي"
+            },
+            "broccolini": {
+                "name": "بروكوليني"
+            },
+            "brown-sugar": {
+                "name": "سكر بني"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "زبدة"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "كرنب",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "كالابريس"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "القنب"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "جزر",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "قرنبيط",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "فلفل الكايين"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "كرفس"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "جبن"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "بالشوكولاتة"
+            },
+            "cilantro": {
+                "name": "كزبرة"
+            },
+            "cinnamon": {
+                "name": "قرفة"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "جوز الهند",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "حليب جوز الهند"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "قهوة"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "كزبرة"
+            },
+            "corn": {
+                "name": "ذرة",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "خيار",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "كمون"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "باذنجان",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "بيض",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "سَمَكٌ"
+            },
+            "five-spice-powder": {
+                "name": "مسحوق التوابل 5"
+            },
+            "flour": {
+                "name": "دقيق"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "فاكهة"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ثوم",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "أعشاب"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "خس"
+            },
+            "liver": {
+                "name": "كبد",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "لحم"
+            },
+            "milk": {
+                "name": "حليب"
+            },
+            "mortadella": {
+                "name": "الموتادلا"
+            },
+            "mushroom": {
+                "name": "فطر",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "بلح البحر"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "زيوت"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "زيتون"
+            },
+            "olive-oil": {
+                "name": "زيت الزيتون"
+            },
+            "onion": {
+                "name": "بصل"
+            },
+            "onion-family": {
+                "name": "عائلة البصل"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "برتقال",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "توابل اوريجانو"
+            },
+            "oysters": {
+                "name": "محار"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "كمثرى",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "فلفل",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "أناناس",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "بذور الخشخاش"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "دواجن"
+            },
+            "powdered-sugar": {
+                "name": "سكر مسحوق"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "السكر الخام"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "أرز"
+            },
+            "rice-flour": {
+                "name": "دقيق الأرز"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "سمك السالمون"
+            },
+            "salt": {
+                "name": "ملح"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "المأكولات البحرية"
+            },
+            "seeds": {
+                "name": "بذور"
+            },
+            "sesame-seeds": {
+                "name": "بذور السمسم"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "البصل الأخضر",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "بذور عباد الشمس"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "طماطم",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "سمك السلمون المرقط"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "تونة"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "الفطر الأبيض",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "المنتج": {
+        "foods": {}
+    },
+    "الحبوب": {
+        "foods": {}
+    },
+    "آلفواكه": {
+        "foods": {}
+    },
+    "الخضراوات": {
+        "foods": {}
+    },
+    "اللحوم": {
+        "foods": {}
+    },
+    "المأكولات البحرية": {
+        "foods": {}
+    },
+    "المشروبات": {
+        "foods": {}
+    },
+    "المخبوزات": {
+        "foods": {}
+    },
+    "المعلبات": {
+        "foods": {}
+    },
+    "الباهرات": {
+        "foods": {}
+    },
+    "الحَلْوَيَات": {
+        "foods": {}
+    },
+    "منتجات الألبان": {
+        "foods": {}
+    },
+    "الأطعمة المجمدة": {
+        "foods": {}
+    },
+    "الأغذية الصحية": {
+        "foods": {}
+    },
+    "المنزل": {
+        "foods": {}
+    },
+    "منتجات اللحوم": {
+        "foods": {}
+    },
+    "الوجبات الخفيفة": {
+        "foods": {}
+    },
+    "التوابل": {
+        "foods": {}
+    },
+    "الكحول": {
+        "foods": {}
+    },
+    "أخرى": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/ar-SA.json
+++ b/mealie/repos/seed/resources/foods/locales/ar-SA.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "تفاح",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "خرشوف"
-	},
-	"arugula": {
-		"name": "جرجير"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "اﻷفوكادو",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "مسحوق الخبز"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "سكر الخبز"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "ريحان"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "توت الأسود"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "خبز"
-	},
-	"breadfruit": {
-		"name": "ثمرة الخبز"
-	},
-	"broccoflower": {
-		"name": "بروكلي"
-	},
-	"broccoli": {
-		"name": "بروكلي"
-	},
-	"broccoli-rabe": {
-		"name": "ربيع البروكلي"
-	},
-	"broccolini": {
-		"name": "بروكوليني"
-	},
-	"brown-sugar": {
-		"name": "سكر بني"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "زبدة"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "كرنب",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "كالابريس"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "القنب"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "جزر",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "قرنبيط",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "فلفل الكايين"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "كرفس"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "جبن"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "بالشوكولاتة"
-	},
-	"cilantro": {
-		"name": "كزبرة"
-	},
-	"cinnamon": {
-		"name": "قرفة"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "جوز الهند",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "حليب جوز الهند"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "قهوة"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "كزبرة"
-	},
-	"corn": {
-		"name": "ذرة",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "خيار",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "كمون"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "باذنجان",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "بيض",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "سَمَكٌ"
-	},
-	"five-spice-powder": {
-		"name": "مسحوق التوابل 5"
-	},
-	"flour": {
-		"name": "دقيق"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "فاكهة"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ثوم",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "أعشاب"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "خس"
-	},
-	"liver": {
-		"name": "كبد",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "لحم"
-	},
-	"milk": {
-		"name": "حليب"
-	},
-	"mortadella": {
-		"name": "الموتادلا"
-	},
-	"mushroom": {
-		"name": "فطر",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "بلح البحر"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "زيوت"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "زيتون"
-	},
-	"olive-oil": {
-		"name": "زيت الزيتون"
-	},
-	"onion": {
-		"name": "بصل"
-	},
-	"onion-family": {
-		"name": "عائلة البصل"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "برتقال",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "توابل اوريجانو"
-	},
-	"oysters": {
-		"name": "محار"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "كمثرى",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "فلفل",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "أناناس",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "بذور الخشخاش"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "دواجن"
-	},
-	"powdered-sugar": {
-		"name": "سكر مسحوق"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "السكر الخام"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "أرز"
-	},
-	"rice-flour": {
-		"name": "دقيق الأرز"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "سمك السالمون"
-	},
-	"salt": {
-		"name": "ملح"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "المأكولات البحرية"
-	},
-	"seeds": {
-		"name": "بذور"
-	},
-	"sesame-seeds": {
-		"name": "بذور السمسم"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "البصل الأخضر",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "بذور عباد الشمس"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "طماطم",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "سمك السلمون المرقط"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "تونة"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "الفطر الأبيض",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "acorn-squash": {
+        "name": "acorn squash"
+    },
+    "alfalfa-sprouts": {
+        "name": "alfalfa sprouts"
+    },
+    "anchovies": {
+        "name": "anchovies"
+    },
+    "apples": {
+        "name": "تفاح",
+        "plural_name": "apples"
+    },
+    "artichoke": {
+        "name": "خرشوف"
+    },
+    "arugula": {
+        "name": "جرجير"
+    },
+    "asparagus": {
+        "name": "asparagus"
+    },
+    "avocado": {
+        "name": "اﻷفوكادو",
+        "plural_name": "avocado"
+    },
+    "bacon": {
+        "name": "bacon"
+    },
+    "baking-powder": {
+        "name": "مسحوق الخبز"
+    },
+    "baking-soda": {
+        "name": "baking soda"
+    },
+    "baking-sugar": {
+        "name": "سكر الخبز"
+    },
+    "bar-sugar": {
+        "name": "bar sugar"
+    },
+    "basil": {
+        "name": "ريحان"
+    },
+    "beans": {
+        "name": "beans"
+    },
+    "bell-peppers": {
+        "name": "bell peppers",
+        "plural_name": "bell peppers"
+    },
+    "blackberries": {
+        "name": "توت الأسود"
+    },
+    "bok-choy": {
+        "name": "bok choy"
+    },
+    "brassicas": {
+        "name": "brassicas"
+    },
+    "bread": {
+        "name": "خبز"
+    },
+    "breadfruit": {
+        "name": "ثمرة الخبز"
+    },
+    "broccoflower": {
+        "name": "بروكلي"
+    },
+    "broccoli": {
+        "name": "بروكلي"
+    },
+    "broccoli-rabe": {
+        "name": "ربيع البروكلي"
+    },
+    "broccolini": {
+        "name": "بروكوليني"
+    },
+    "brown-sugar": {
+        "name": "سكر بني"
+    },
+    "brussels-sprouts": {
+        "name": "brussels sprouts"
+    },
+    "butter": {
+        "name": "زبدة"
+    },
+    "butternut-pumpkin": {
+        "name": "butternut pumpkin"
+    },
+    "butternut-squash": {
+        "name": "butternut squash"
+    },
+    "cabbage": {
+        "name": "كرنب",
+        "plural_name": "cabbages"
+    },
+    "cactus-edible": {
+        "name": "cactus, edible"
+    },
+    "calabrese": {
+        "name": "كالابريس"
+    },
+    "cane-sugar": {
+        "name": "cane sugar"
+    },
+    "cannabis": {
+        "name": "القنب"
+    },
+    "capsicum": {
+        "name": "capsicum"
+    },
+    "caraway": {
+        "name": "caraway"
+    },
+    "carrot": {
+        "name": "جزر",
+        "plural_name": "carrots"
+    },
+    "caster-sugar": {
+        "name": "caster sugar"
+    },
+    "castor-sugar": {
+        "name": "castor sugar"
+    },
+    "catfish": {
+        "name": "catfish"
+    },
+    "cauliflower": {
+        "name": "قرنبيط",
+        "plural_name": "cauliflowers"
+    },
+    "cayenne-pepper": {
+        "name": "فلفل الكايين"
+    },
+    "celeriac": {
+        "name": "celery root"
+    },
+    "celery": {
+        "name": "كرفس"
+    },
+    "cereal-grains": {
+        "name": "cereal grains"
+    },
+    "chard": {
+        "name": "chard"
+    },
+    "cheese": {
+        "name": "جبن"
+    },
+    "chicory": {
+        "name": "chicory"
+    },
+    "chilli-peppers": {
+        "name": "chilli pepper",
+        "plural_name": "chilli peppers"
+    },
+    "chinese-leaves": {
+        "name": "chinese leaves"
+    },
+    "chives": {
+        "name": "chives"
+    },
+    "chocolate": {
+        "name": "بالشوكولاتة"
+    },
+    "cilantro": {
+        "name": "كزبرة"
+    },
+    "cinnamon": {
+        "name": "قرفة"
+    },
+    "clarified-butter": {
+        "name": "clarified butter"
+    },
+    "coconut": {
+        "name": "جوز الهند",
+        "plural_name": "coconuts"
+    },
+    "coconut-milk": {
+        "name": "حليب جوز الهند"
+    },
+    "cod": {
+        "name": "cod"
+    },
+    "coffee": {
+        "name": "قهوة"
+    },
+    "collard-greens": {
+        "name": "collard greens"
+    },
+    "confectioners-sugar": {
+        "name": "confectioners' sugar"
+    },
+    "coriander": {
+        "name": "كزبرة"
+    },
+    "corn": {
+        "name": "ذرة",
+        "plural_name": "corns"
+    },
+    "corn-syrup": {
+        "name": "corn syrup"
+    },
+    "cottonseed-oil": {
+        "name": "cottonseed oil"
+    },
+    "courgette": {
+        "name": "courgette"
+    },
+    "cream-of-tartar": {
+        "name": "cream of tartar"
+    },
+    "cucumber": {
+        "name": "خيار",
+        "plural_name": "cucumbers"
+    },
+    "cumin": {
+        "name": "كمون"
+    },
+    "daikon": {
+        "name": "daikon",
+        "plural_name": "daikons"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "dairy products and dairy substitutes"
+    },
+    "dandelion": {
+        "name": "dandelion"
+    },
+    "demerara-sugar": {
+        "name": "demerara sugar"
+    },
+    "dough": {
+        "name": "dough"
+    },
+    "edible-cactus": {
+        "name": "edible cactus"
+    },
+    "eggplant": {
+        "name": "باذنجان",
+        "plural_name": "eggplants"
+    },
+    "eggs": {
+        "name": "بيض",
+        "plural_name": "eggs"
+    },
+    "endive": {
+        "name": "endive",
+        "plural_name": "endives"
+    },
+    "fats": {
+        "name": "fats"
+    },
+    "fava-beans": {
+        "name": "fava beans"
+    },
+    "fiddlehead": {
+        "name": "fiddlehead"
+    },
+    "fiddlehead-fern": {
+        "name": "fiddlehead fern",
+        "plural_name": "fiddlehead ferns"
+    },
+    "fish": {
+        "name": "سَمَكٌ"
+    },
+    "five-spice-powder": {
+        "name": "مسحوق التوابل 5"
+    },
+    "flour": {
+        "name": "دقيق"
+    },
+    "frisee": {
+        "name": "frisee"
+    },
+    "fructose": {
+        "name": "fructose"
+    },
+    "fruit": {
+        "name": "فاكهة"
+    },
+    "fruit-sugar": {
+        "name": "fruit sugar"
+    },
+    "ful": {
+        "name": "ful"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "ثوم",
+        "plural_name": "garlics"
+    },
+    "gem-squash": {
+        "name": "gem squash"
+    },
+    "ghee": {
+        "name": "ghee"
+    },
+    "giblets": {
+        "name": "giblets"
+    },
+    "ginger": {
+        "name": "ginger"
+    },
+    "grains": {
+        "name": "grains"
+    },
+    "granulated-sugar": {
+        "name": "granulated sugar"
+    },
+    "grape-seed-oil": {
+        "name": "grape seed oil"
+    },
+    "green-onion": {
+        "name": "green onion",
+        "plural_name": "green onions"
+    },
+    "heart-of-palm": {
+        "name": "heart of palm",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "hemp"
+    },
+    "herbs": {
+        "name": "أعشاب"
+    },
+    "honey": {
+        "name": "honey"
+    },
+    "isomalt": {
+        "name": "isomalt"
+    },
+    "jackfruit": {
+        "name": "jackfruit",
+        "plural_name": "jackfruits"
+    },
+    "jaggery": {
+        "name": "jaggery"
+    },
+    "jams": {
+        "name": "jams"
+    },
+    "jellies": {
+        "name": "jellies"
+    },
+    "jerusalem-artichoke": {
+        "name": "jerusalem artichoke"
+    },
+    "jicama": {
+        "name": "jicama"
+    },
+    "kale": {
+        "name": "kale"
+    },
+    "kohlrabi": {
+        "name": "kohlrabi"
+    },
+    "kumara": {
+        "name": "kumara"
+    },
+    "leavening-agents": {
+        "name": "leavening agents"
+    },
+    "leek": {
+        "name": "leek",
+        "plural_name": "leeks"
+    },
+    "legumes": {
+        "name": "legumes"
+    },
+    "lemongrass": {
+        "name": "lemongrass"
+    },
+    "lentils": {
+        "name": "lentils"
+    },
+    "lettuce": {
+        "name": "خس"
+    },
+    "liver": {
+        "name": "كبد",
+        "plural_name": "livers"
+    },
+    "maize": {
+        "name": "maize"
+    },
+    "maple-syrup": {
+        "name": "maple syrup"
+    },
+    "meat": {
+        "name": "لحم"
+    },
+    "milk": {
+        "name": "حليب"
+    },
+    "mortadella": {
+        "name": "الموتادلا"
+    },
+    "mushroom": {
+        "name": "فطر",
+        "plural_name": "mushrooms"
+    },
+    "mussels": {
+        "name": "بلح البحر"
+    },
+    "nanaimo-bar-mix": {
+        "name": "nanaimo bar mix"
+    },
+    "nori": {
+        "name": "nori"
+    },
+    "nutmeg": {
+        "name": "nutmeg"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "nutritional yeast flakes"
+    },
+    "nuts": {
+        "name": "nuts"
+    },
+    "octopuses": {
+        "name": "octopus",
+        "plural_name": "octopuses"
+    },
+    "oils": {
+        "name": "زيوت"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "زيتون"
+    },
+    "olive-oil": {
+        "name": "زيت الزيتون"
+    },
+    "onion": {
+        "name": "بصل"
+    },
+    "onion-family": {
+        "name": "عائلة البصل"
+    },
+    "orange-blossom-water": {
+        "name": "orange blossom water"
+    },
+    "oranges": {
+        "name": "برتقال",
+        "plural_name": "oranges"
+    },
+    "oregano": {
+        "name": "توابل اوريجانو"
+    },
+    "oysters": {
+        "name": "محار"
+    },
+    "panch-puran": {
+        "name": "panch puran"
+    },
+    "paprika": {
+        "name": "paprika"
+    },
+    "parsley": {
+        "name": "parsley"
+    },
+    "parsnip": {
+        "name": "parsnip",
+        "plural_name": "parsnips"
+    },
+    "pear": {
+        "name": "كمثرى",
+        "plural_name": "pears"
+    },
+    "peas": {
+        "name": "peas"
+    },
+    "pepper": {
+        "name": "فلفل",
+        "plural_name": "peppers"
+    },
+    "pineapple": {
+        "name": "أناناس",
+        "plural_name": "pineapples"
+    },
+    "plantain": {
+        "name": "plantain",
+        "plural_name": "plantains"
+    },
+    "poppy-seeds": {
+        "name": "بذور الخشخاش"
+    },
+    "potato": {
+        "name": "potato",
+        "plural_name": "potatoes"
+    },
+    "poultry": {
+        "name": "دواجن"
+    },
+    "powdered-sugar": {
+        "name": "سكر مسحوق"
+    },
+    "pumpkin": {
+        "name": "pumpkin",
+        "plural_name": "pumpkins"
+    },
+    "pumpkin-seeds": {
+        "name": "pumpkin seeds"
+    },
+    "radish": {
+        "name": "radish",
+        "plural_name": "radishes"
+    },
+    "raw-sugar": {
+        "name": "السكر الخام"
+    },
+    "refined-sugar": {
+        "name": "refined sugar"
+    },
+    "rice": {
+        "name": "أرز"
+    },
+    "rice-flour": {
+        "name": "دقيق الأرز"
+    },
+    "rock-sugar": {
+        "name": "rock sugar"
+    },
+    "rum": {
+        "name": "rum"
+    },
+    "salmon": {
+        "name": "سمك السالمون"
+    },
+    "salt": {
+        "name": "ملح"
+    },
+    "salt-cod": {
+        "name": "salt cod"
+    },
+    "scallion": {
+        "name": "scallion",
+        "plural_name": "scallions"
+    },
+    "seafood": {
+        "name": "المأكولات البحرية"
+    },
+    "seeds": {
+        "name": "بذور"
+    },
+    "sesame-seeds": {
+        "name": "بذور السمسم"
+    },
+    "shallot": {
+        "name": "shallot",
+        "plural_name": "shallots"
+    },
+    "skate": {
+        "name": "skate"
+    },
+    "soda": {
+        "name": "soda"
+    },
+    "soda-baking": {
+        "name": "soda, baking"
+    },
+    "soybean": {
+        "name": "soybean"
+    },
+    "spaghetti-squash": {
+        "name": "spaghetti squash",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "speck"
+    },
+    "spices": {
+        "name": "spices"
+    },
+    "spinach": {
+        "name": "spinach"
+    },
+    "spring-onion": {
+        "name": "البصل الأخضر",
+        "plural_name": "spring onions"
+    },
+    "squash": {
+        "name": "squash",
+        "plural_name": "squashes"
+    },
+    "squash-family": {
+        "name": "squash family"
+    },
+    "stockfish": {
+        "name": "stockfish"
+    },
+    "sugar": {
+        "name": "sugar"
+    },
+    "sunchoke": {
+        "name": "sunchoke",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "بذور عباد الشمس"
+    },
+    "superfine-sugar": {
+        "name": "superfine sugar"
+    },
+    "sweet-potato": {
+        "name": "sweet potato",
+        "plural_name": "sweet potatoes"
+    },
+    "sweetcorn": {
+        "name": "sweetcorn",
+        "plural_name": "sweetcorns"
+    },
+    "sweeteners": {
+        "name": "sweeteners"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "taro",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "teff"
+    },
+    "tomato": {
+        "name": "طماطم",
+        "plural_name": "tomatoes"
+    },
+    "trout": {
+        "name": "سمك السلمون المرقط"
+    },
+    "tubers": {
+        "name": "tuber",
+        "plural_name": "tubers"
+    },
+    "tuna": {
+        "name": "تونة"
+    },
+    "turbanado-sugar": {
+        "name": "turbanado sugar"
+    },
+    "turnip": {
+        "name": "turnip",
+        "plural_name": "turnips"
+    },
+    "unrefined-sugar": {
+        "name": "unrefined sugar"
+    },
+    "vanilla": {
+        "name": "vanilla"
+    },
+    "vegetables": {
+        "name": "vegetables"
+    },
+    "watercress": {
+        "name": "watercress"
+    },
+    "watermelon": {
+        "name": "watermelon",
+        "plural_name": "watermelons"
+    },
+    "white-mushroom": {
+        "name": "الفطر الأبيض",
+        "plural_name": "white mushrooms"
+    },
+    "white-sugar": {
+        "name": "white sugar"
+    },
+    "xanthan-gum": {
+        "name": "xanthan gum"
+    },
+    "yam": {
+        "name": "yam",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "yeast"
+    },
+    "zucchini": {
+        "name": "zucchini",
+        "plural_name": "zucchinis"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/bg-BG.json
+++ b/mealie/repos/seed/resources/foods/locales/bg-BG.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "цикория"
-	},
-	"alfalfa-sprouts": {
-		"name": "алфалфа кълнове"
-	},
-	"anchovies": {
-		"name": "аншоа"
-	},
-	"apples": {
-		"name": "ябълки",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "артишок"
-	},
-	"arugula": {
-		"name": "рукола"
-	},
-	"asparagus": {
-		"name": "аспержи"
-	},
-	"avocado": {
-		"name": "авокадо",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "бекон"
-	},
-	"baking-powder": {
-		"name": "бакпулвер"
-	},
-	"baking-soda": {
-		"name": "сода за хляб"
-	},
-	"baking-sugar": {
-		"name": "захар"
-	},
-	"bar-sugar": {
-		"name": "захар"
-	},
-	"basil": {
-		"name": "босилек"
-	},
-	"beans": {
-		"name": "боб"
-	},
-	"bell-peppers": {
-		"name": "камби",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "къпини"
-	},
-	"bok-choy": {
-		"name": "бок чой"
-	},
-	"brassicas": {
-		"name": "семейство Кръстоцветни"
-	},
-	"bread": {
-		"name": "хляб"
-	},
-	"breadfruit": {
-		"name": "плод от хлебно дърво"
-	},
-	"broccoflower": {
-		"name": "романеско"
-	},
-	"broccoli": {
-		"name": "броколи"
-	},
-	"broccoli-rabe": {
-		"name": "броколи рабе"
-	},
-	"broccolini": {
-		"name": "броколини"
-	},
-	"brown-sugar": {
-		"name": "кафява захар"
-	},
-	"brussels-sprouts": {
-		"name": "брюкселско зеле"
-	},
-	"butter": {
-		"name": "масло"
-	},
-	"butternut-pumpkin": {
-		"name": "тиква цигулка (Матилда)"
-	},
-	"butternut-squash": {
-		"name": "тиква цигулка (Матилда)"
-	},
-	"cabbage": {
-		"name": "зеле",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "ядлив кактус"
-	},
-	"calabrese": {
-		"name": "ит. салам Калабрезе"
-	},
-	"cane-sugar": {
-		"name": "тръстикова захар"
-	},
-	"cannabis": {
-		"name": "канабис"
-	},
-	"capsicum": {
-		"name": "кит. люта чушка, подобна на хабанеро"
-	},
-	"caraway": {
-		"name": "кимион"
-	},
-	"carrot": {
-		"name": "морков",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "захар"
-	},
-	"castor-sugar": {
-		"name": "захар"
-	},
-	"catfish": {
-		"name": "сом"
-	},
-	"cauliflower": {
-		"name": "карфиол",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "лют червен пипер"
-	},
-	"celeriac": {
-		"name": "целина"
-	},
-	"celery": {
-		"name": "целина"
-	},
-	"cereal-grains": {
-		"name": "житни зърна"
-	},
-	"chard": {
-		"name": "манголд"
-	},
-	"cheese": {
-		"name": "кашкавал"
-	},
-	"chicory": {
-		"name": "цикория"
-	},
-	"chilli-peppers": {
-		"name": "лют пипер",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "китайско зеле"
-	},
-	"chives": {
-		"name": "див лук"
-	},
-	"chocolate": {
-		"name": "шоколад"
-	},
-	"cilantro": {
-		"name": "кориандър"
-	},
-	"cinnamon": {
-		"name": "канела"
-	},
-	"clarified-butter": {
-		"name": "избистрено масло"
-	},
-	"coconut": {
-		"name": "кокос",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "кокосово мляко"
-	},
-	"cod": {
-		"name": "треска"
-	},
-	"coffee": {
-		"name": "кафе"
-	},
-	"collard-greens": {
-		"name": "коуард (вид зеле)"
-	},
-	"confectioners-sugar": {
-		"name": "пудра захар"
-	},
-	"coriander": {
-		"name": "кориандър"
-	},
-	"corn": {
-		"name": "царевица",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "царевичен сироп"
-	},
-	"cottonseed-oil": {
-		"name": "масло от памучно семе"
-	},
-	"courgette": {
-		"name": "тиквичка"
-	},
-	"cream-of-tartar": {
-		"name": "крем от тартар"
-	},
-	"cucumber": {
-		"name": "краставица",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "кимион"
-	},
-	"daikon": {
-		"name": "ряпа дайкон",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "млечни продукти и млечни заместители"
-	},
-	"dandelion": {
-		"name": "глухарче"
-	},
-	"demerara-sugar": {
-		"name": "захар"
-	},
-	"dough": {
-		"name": "тесто"
-	},
-	"edible-cactus": {
-		"name": "ядлив кактус"
-	},
-	"eggplant": {
-		"name": "патладжан",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "яйца",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "ендивия",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "мазнини"
-	},
-	"fava-beans": {
-		"name": "боб бакла"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "цигулкова папрат",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "риба"
-	},
-	"five-spice-powder": {
-		"name": "микс от пет китайски подправки на прах"
-	},
-	"flour": {
-		"name": "брашно"
-	},
-	"frisee": {
-		"name": "фризе"
-	},
-	"fructose": {
-		"name": "фруктоза"
-	},
-	"fruit": {
-		"name": "плод"
-	},
-	"fruit-sugar": {
-		"name": "фруктоза"
-	},
-	"ful": {
-		"name": "фул"
-	},
-	"garam-masala": {
-		"name": "гарам масала"
-	},
-	"garlic": {
-		"name": "чесън",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "тиква (тъмнозелена)"
-	},
-	"ghee": {
-		"name": "масло Гхи"
-	},
-	"giblets": {
-		"name": "карантия"
-	},
-	"ginger": {
-		"name": "джинджифил"
-	},
-	"grains": {
-		"name": "зърнени култури"
-	},
-	"granulated-sugar": {
-		"name": "гранулирана захар"
-	},
-	"grape-seed-oil": {
-		"name": "масло от гроздови семки"
-	},
-	"green-onion": {
-		"name": "зелен лук",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "сърцевина от палма",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "коноп"
-	},
-	"herbs": {
-		"name": "подравки"
-	},
-	"honey": {
-		"name": "мед"
-	},
-	"isomalt": {
-		"name": "изомалт"
-	},
-	"jackfruit": {
-		"name": "джакфрут",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "тръстикова захар"
-	},
-	"jams": {
-		"name": "плодово сладко"
-	},
-	"jellies": {
-		"name": "мармалад"
-	},
-	"jerusalem-artichoke": {
-		"name": "йерусалимски артишок"
-	},
-	"jicama": {
-		"name": "джикама (мексикански картоф)"
-	},
-	"kale": {
-		"name": "кейл"
-	},
-	"kohlrabi": {
-		"name": "алабаш"
-	},
-	"kumara": {
-		"name": "кумара"
-	},
-	"leavening-agents": {
-		"name": "набухватели"
-	},
-	"leek": {
-		"name": "праз лук",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "варива"
-	},
-	"lemongrass": {
-		"name": "лимонена трева"
-	},
-	"lentils": {
-		"name": "леща"
-	},
-	"lettuce": {
-		"name": "маруля"
-	},
-	"liver": {
-		"name": "черен дроб",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "царевица"
-	},
-	"maple-syrup": {
-		"name": "кленов сироп"
-	},
-	"meat": {
-		"name": "месо"
-	},
-	"milk": {
-		"name": "прясно мляко"
-	},
-	"mortadella": {
-		"name": "салам Мортадела"
-	},
-	"mushroom": {
-		"name": "гъба",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "миди"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo бар микс"
-	},
-	"nori": {
-		"name": "нори"
-	},
-	"nutmeg": {
-		"name": "индийско орехче"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "хранителна мая на люспи"
-	},
-	"nuts": {
-		"name": "ядки"
-	},
-	"octopuses": {
-		"name": "октопод",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "масла"
-	},
-	"okra": {
-		"name": "бамя"
-	},
-	"olive": {
-		"name": "маслина"
-	},
-	"olive-oil": {
-		"name": "зехтин"
-	},
-	"onion": {
-		"name": "лук"
-	},
-	"onion-family": {
-		"name": "семейство Лучени"
-	},
-	"orange-blossom-water": {
-		"name": "вода от портокалов цвят"
-	},
-	"oranges": {
-		"name": "портокали",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "риган"
-	},
-	"oysters": {
-		"name": "стриди"
-	},
-	"panch-puran": {
-		"name": "пет пурани (микс от пет индийски подправки)"
-	},
-	"paprika": {
-		"name": "червен пипер"
-	},
-	"parsley": {
-		"name": "магданоз"
-	},
-	"parsnip": {
-		"name": "пащърнак",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "круша",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "грах"
-	},
-	"pepper": {
-		"name": "черен пипер",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ананас",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "живовляк",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "маково семе"
-	},
-	"potato": {
-		"name": "картоф",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "птиче месо"
-	},
-	"powdered-sugar": {
-		"name": "пудра захар"
-	},
-	"pumpkin": {
-		"name": "тиква",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "тиквени семки"
-	},
-	"radish": {
-		"name": "ряпа",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "захар"
-	},
-	"refined-sugar": {
-		"name": "рафинирана захар"
-	},
-	"rice": {
-		"name": "ориз"
-	},
-	"rice-flour": {
-		"name": "оризово брашно"
-	},
-	"rock-sugar": {
-		"name": "захар на бучки"
-	},
-	"rum": {
-		"name": "ром"
-	},
-	"salmon": {
-		"name": "сьомга"
-	},
-	"salt": {
-		"name": "сол"
-	},
-	"salt-cod": {
-		"name": "осолена треска"
-	},
-	"scallion": {
-		"name": "зелен лук",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "морска храна"
-	},
-	"seeds": {
-		"name": "семена"
-	},
-	"sesame-seeds": {
-		"name": "сусамово семе"
-	},
-	"shallot": {
-		"name": "шалот (дребен лук)",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "морска лисица"
-	},
-	"soda": {
-		"name": "сода"
-	},
-	"soda-baking": {
-		"name": "сода за хляб"
-	},
-	"soybean": {
-		"name": "соеви зърна"
-	},
-	"spaghetti-squash": {
-		"name": "спагетена тиква",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "италиански бекон Спек"
-	},
-	"spices": {
-		"name": "подправки"
-	},
-	"spinach": {
-		"name": "спанак"
-	},
-	"spring-onion": {
-		"name": "пресен лук",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "скуош",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "семейство тикви"
-	},
-	"stockfish": {
-		"name": "студено сушена риба"
-	},
-	"sugar": {
-		"name": "захар"
-	},
-	"sunchoke": {
-		"name": "йерусалимски артишок",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "слънчогледово семе"
-	},
-	"superfine-sugar": {
-		"name": "фина захар"
-	},
-	"sweet-potato": {
-		"name": "сладък картоф",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "сладка царевица",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "подсладители"
-	},
-	"tahini": {
-		"name": "тахан"
-	},
-	"taro": {
-		"name": "таро",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "теф"
-	},
-	"tomato": {
-		"name": "домат",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "пъстърва"
-	},
-	"tubers": {
-		"name": "трюфели",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "риба тон"
-	},
-	"turbanado-sugar": {
-		"name": "турбинадо захар"
-	},
-	"turnip": {
-		"name": "ряпа",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "нерафинирана захар"
-	},
-	"vanilla": {
-		"name": "ванилия"
-	},
-	"vegetables": {
-		"name": "зеленчуци"
-	},
-	"watercress": {
-		"name": "кресон"
-	},
-	"watermelon": {
-		"name": "диня",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "бяла гъба",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "бяла захар"
-	},
-	"xanthan-gum": {
-		"name": "ксантанова гума"
-	},
-	"yam": {
-		"name": "картоф ям",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "мая"
-	},
-	"zucchini": {
-		"name": "тиквичка",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "цикория"
+            },
+            "alfalfa-sprouts": {
+                "name": "алфалфа кълнове"
+            },
+            "anchovies": {
+                "name": "аншоа"
+            },
+            "apples": {
+                "name": "ябълки",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "артишок"
+            },
+            "arugula": {
+                "name": "рукола"
+            },
+            "asparagus": {
+                "name": "аспержи"
+            },
+            "avocado": {
+                "name": "авокадо",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "бекон"
+            },
+            "baking-powder": {
+                "name": "бакпулвер"
+            },
+            "baking-soda": {
+                "name": "сода за хляб"
+            },
+            "baking-sugar": {
+                "name": "захар"
+            },
+            "bar-sugar": {
+                "name": "захар"
+            },
+            "basil": {
+                "name": "босилек"
+            },
+            "beans": {
+                "name": "боб"
+            },
+            "bell-peppers": {
+                "name": "камби",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "къпини"
+            },
+            "bok-choy": {
+                "name": "бок чой"
+            },
+            "brassicas": {
+                "name": "семейство Кръстоцветни"
+            },
+            "bread": {
+                "name": "хляб"
+            },
+            "breadfruit": {
+                "name": "плод от хлебно дърво"
+            },
+            "broccoflower": {
+                "name": "романеско"
+            },
+            "broccoli": {
+                "name": "броколи"
+            },
+            "broccoli-rabe": {
+                "name": "броколи рабе"
+            },
+            "broccolini": {
+                "name": "броколини"
+            },
+            "brown-sugar": {
+                "name": "кафява захар"
+            },
+            "brussels-sprouts": {
+                "name": "брюкселско зеле"
+            },
+            "butter": {
+                "name": "масло"
+            },
+            "butternut-pumpkin": {
+                "name": "тиква цигулка (Матилда)"
+            },
+            "butternut-squash": {
+                "name": "тиква цигулка (Матилда)"
+            },
+            "cabbage": {
+                "name": "зеле",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "ядлив кактус"
+            },
+            "calabrese": {
+                "name": "ит. салам Калабрезе"
+            },
+            "cane-sugar": {
+                "name": "тръстикова захар"
+            },
+            "cannabis": {
+                "name": "канабис"
+            },
+            "capsicum": {
+                "name": "кит. люта чушка, подобна на хабанеро"
+            },
+            "caraway": {
+                "name": "кимион"
+            },
+            "carrot": {
+                "name": "морков",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "захар"
+            },
+            "castor-sugar": {
+                "name": "захар"
+            },
+            "catfish": {
+                "name": "сом"
+            },
+            "cauliflower": {
+                "name": "карфиол",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "лют червен пипер"
+            },
+            "celeriac": {
+                "name": "целина"
+            },
+            "celery": {
+                "name": "целина"
+            },
+            "cereal-grains": {
+                "name": "житни зърна"
+            },
+            "chard": {
+                "name": "манголд"
+            },
+            "cheese": {
+                "name": "кашкавал"
+            },
+            "chicory": {
+                "name": "цикория"
+            },
+            "chilli-peppers": {
+                "name": "лют пипер",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "китайско зеле"
+            },
+            "chives": {
+                "name": "див лук"
+            },
+            "chocolate": {
+                "name": "шоколад"
+            },
+            "cilantro": {
+                "name": "кориандър"
+            },
+            "cinnamon": {
+                "name": "канела"
+            },
+            "clarified-butter": {
+                "name": "избистрено масло"
+            },
+            "coconut": {
+                "name": "кокос",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "кокосово мляко"
+            },
+            "cod": {
+                "name": "треска"
+            },
+            "coffee": {
+                "name": "кафе"
+            },
+            "collard-greens": {
+                "name": "коуард (вид зеле)"
+            },
+            "confectioners-sugar": {
+                "name": "пудра захар"
+            },
+            "coriander": {
+                "name": "кориандър"
+            },
+            "corn": {
+                "name": "царевица",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "царевичен сироп"
+            },
+            "cottonseed-oil": {
+                "name": "масло от памучно семе"
+            },
+            "courgette": {
+                "name": "тиквичка"
+            },
+            "cream-of-tartar": {
+                "name": "крем от тартар"
+            },
+            "cucumber": {
+                "name": "краставица",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "кимион"
+            },
+            "daikon": {
+                "name": "ряпа дайкон",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "млечни продукти и млечни заместители"
+            },
+            "dandelion": {
+                "name": "глухарче"
+            },
+            "demerara-sugar": {
+                "name": "захар"
+            },
+            "dough": {
+                "name": "тесто"
+            },
+            "edible-cactus": {
+                "name": "ядлив кактус"
+            },
+            "eggplant": {
+                "name": "патладжан",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "яйца",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "ендивия",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "мазнини"
+            },
+            "fava-beans": {
+                "name": "боб бакла"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "цигулкова папрат",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "риба"
+            },
+            "five-spice-powder": {
+                "name": "микс от пет китайски подправки на прах"
+            },
+            "flour": {
+                "name": "брашно"
+            },
+            "frisee": {
+                "name": "фризе"
+            },
+            "fructose": {
+                "name": "фруктоза"
+            },
+            "fruit": {
+                "name": "плод"
+            },
+            "fruit-sugar": {
+                "name": "фруктоза"
+            },
+            "ful": {
+                "name": "фул"
+            },
+            "garam-masala": {
+                "name": "гарам масала"
+            },
+            "garlic": {
+                "name": "чесън",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "тиква (тъмнозелена)"
+            },
+            "ghee": {
+                "name": "масло Гхи"
+            },
+            "giblets": {
+                "name": "карантия"
+            },
+            "ginger": {
+                "name": "джинджифил"
+            },
+            "grains": {
+                "name": "зърнени култури"
+            },
+            "granulated-sugar": {
+                "name": "гранулирана захар"
+            },
+            "grape-seed-oil": {
+                "name": "масло от гроздови семки"
+            },
+            "green-onion": {
+                "name": "зелен лук",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "сърцевина от палма",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "коноп"
+            },
+            "herbs": {
+                "name": "подравки"
+            },
+            "honey": {
+                "name": "мед"
+            },
+            "isomalt": {
+                "name": "изомалт"
+            },
+            "jackfruit": {
+                "name": "джакфрут",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "тръстикова захар"
+            },
+            "jams": {
+                "name": "плодово сладко"
+            },
+            "jellies": {
+                "name": "мармалад"
+            },
+            "jerusalem-artichoke": {
+                "name": "йерусалимски артишок"
+            },
+            "jicama": {
+                "name": "джикама (мексикански картоф)"
+            },
+            "kale": {
+                "name": "кейл"
+            },
+            "kohlrabi": {
+                "name": "алабаш"
+            },
+            "kumara": {
+                "name": "кумара"
+            },
+            "leavening-agents": {
+                "name": "набухватели"
+            },
+            "leek": {
+                "name": "праз лук",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "варива"
+            },
+            "lemongrass": {
+                "name": "лимонена трева"
+            },
+            "lentils": {
+                "name": "леща"
+            },
+            "lettuce": {
+                "name": "маруля"
+            },
+            "liver": {
+                "name": "черен дроб",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "царевица"
+            },
+            "maple-syrup": {
+                "name": "кленов сироп"
+            },
+            "meat": {
+                "name": "месо"
+            },
+            "milk": {
+                "name": "прясно мляко"
+            },
+            "mortadella": {
+                "name": "салам Мортадела"
+            },
+            "mushroom": {
+                "name": "гъба",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "миди"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo бар микс"
+            },
+            "nori": {
+                "name": "нори"
+            },
+            "nutmeg": {
+                "name": "индийско орехче"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "хранителна мая на люспи"
+            },
+            "nuts": {
+                "name": "ядки"
+            },
+            "octopuses": {
+                "name": "октопод",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "масла"
+            },
+            "okra": {
+                "name": "бамя"
+            },
+            "olive": {
+                "name": "маслина"
+            },
+            "olive-oil": {
+                "name": "зехтин"
+            },
+            "onion": {
+                "name": "лук"
+            },
+            "onion-family": {
+                "name": "семейство Лучени"
+            },
+            "orange-blossom-water": {
+                "name": "вода от портокалов цвят"
+            },
+            "oranges": {
+                "name": "портокали",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "риган"
+            },
+            "oysters": {
+                "name": "стриди"
+            },
+            "panch-puran": {
+                "name": "пет пурани (микс от пет индийски подправки)"
+            },
+            "paprika": {
+                "name": "червен пипер"
+            },
+            "parsley": {
+                "name": "магданоз"
+            },
+            "parsnip": {
+                "name": "пащърнак",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "круша",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "грах"
+            },
+            "pepper": {
+                "name": "черен пипер",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ананас",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "живовляк",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "маково семе"
+            },
+            "potato": {
+                "name": "картоф",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "птиче месо"
+            },
+            "powdered-sugar": {
+                "name": "пудра захар"
+            },
+            "pumpkin": {
+                "name": "тиква",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "тиквени семки"
+            },
+            "radish": {
+                "name": "ряпа",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "захар"
+            },
+            "refined-sugar": {
+                "name": "рафинирана захар"
+            },
+            "rice": {
+                "name": "ориз"
+            },
+            "rice-flour": {
+                "name": "оризово брашно"
+            },
+            "rock-sugar": {
+                "name": "захар на бучки"
+            },
+            "rum": {
+                "name": "ром"
+            },
+            "salmon": {
+                "name": "сьомга"
+            },
+            "salt": {
+                "name": "сол"
+            },
+            "salt-cod": {
+                "name": "осолена треска"
+            },
+            "scallion": {
+                "name": "зелен лук",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "морска храна"
+            },
+            "seeds": {
+                "name": "семена"
+            },
+            "sesame-seeds": {
+                "name": "сусамово семе"
+            },
+            "shallot": {
+                "name": "шалот (дребен лук)",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "морска лисица"
+            },
+            "soda": {
+                "name": "сода"
+            },
+            "soda-baking": {
+                "name": "сода за хляб"
+            },
+            "soybean": {
+                "name": "соеви зърна"
+            },
+            "spaghetti-squash": {
+                "name": "спагетена тиква",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "италиански бекон Спек"
+            },
+            "spices": {
+                "name": "подправки"
+            },
+            "spinach": {
+                "name": "спанак"
+            },
+            "spring-onion": {
+                "name": "пресен лук",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "скуош",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "семейство тикви"
+            },
+            "stockfish": {
+                "name": "студено сушена риба"
+            },
+            "sugar": {
+                "name": "захар"
+            },
+            "sunchoke": {
+                "name": "йерусалимски артишок",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "слънчогледово семе"
+            },
+            "superfine-sugar": {
+                "name": "фина захар"
+            },
+            "sweet-potato": {
+                "name": "сладък картоф",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "сладка царевица",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "подсладители"
+            },
+            "tahini": {
+                "name": "тахан"
+            },
+            "taro": {
+                "name": "таро",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "теф"
+            },
+            "tomato": {
+                "name": "домат",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "пъстърва"
+            },
+            "tubers": {
+                "name": "трюфели",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "риба тон"
+            },
+            "turbanado-sugar": {
+                "name": "турбинадо захар"
+            },
+            "turnip": {
+                "name": "ряпа",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "нерафинирана захар"
+            },
+            "vanilla": {
+                "name": "ванилия"
+            },
+            "vegetables": {
+                "name": "зеленчуци"
+            },
+            "watercress": {
+                "name": "кресон"
+            },
+            "watermelon": {
+                "name": "диня",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "бяла гъба",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "бяла захар"
+            },
+            "xanthan-gum": {
+                "name": "ксантанова гума"
+            },
+            "yam": {
+                "name": "картоф ям",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "мая"
+            },
+            "zucchini": {
+                "name": "тиквичка",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Пресни плодове&зеленчуци": {
+        "foods": {}
+    },
+    "Зърнени култури": {
+        "foods": {}
+    },
+    "Плодове": {
+        "foods": {}
+    },
+    "Зеленчуци": {
+        "foods": {}
+    },
+    "Месо": {
+        "foods": {}
+    },
+    "Морски дарове": {
+        "foods": {}
+    },
+    "Напитки": {
+        "foods": {}
+    },
+    "Печива": {
+        "foods": {}
+    },
+    "Консерви": {
+        "foods": {}
+    },
+    "Допълнения": {
+        "foods": {}
+    },
+    "Сладкарски изделия": {
+        "foods": {}
+    },
+    "Млечни продукти": {
+        "foods": {}
+    },
+    "Замразени храни": {
+        "foods": {}
+    },
+    "Здравословни храни": {
+        "foods": {}
+    },
+    "Домакинство": {
+        "foods": {}
+    },
+    "Местни продукти": {
+        "foods": {}
+    },
+    "Лека закуски": {
+        "foods": {}
+    },
+    "Подправки": {
+        "foods": {}
+    },
+    "Сладко": {
+        "foods": {}
+    },
+    "Алкохол": {
+        "foods": {}
+    },
+    "Други": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ca-ES.json
+++ b/mealie/repos/seed/resources/foods/locales/ca-ES.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "carabassa de pelegrí"
-	},
-	"alfalfa-sprouts": {
-		"name": "brots d'alfals"
-	},
-	"anchovies": {
-		"name": "anxoves"
-	},
-	"apples": {
-		"name": "pomes",
-		"plural_name": "pomes"
-	},
-	"artichoke": {
-		"name": "carxofa"
-	},
-	"arugula": {
-		"name": "ruca"
-	},
-	"asparagus": {
-		"name": "espàrrec"
-	},
-	"avocado": {
-		"name": "alvocat",
-		"plural_name": "alvocat"
-	},
-	"bacon": {
-		"name": "cansalada"
-	},
-	"baking-powder": {
-		"name": "rent"
-	},
-	"baking-soda": {
-		"name": "bicarbonat sòdic"
-	},
-	"baking-sugar": {
-		"name": "sucre blanc"
-	},
-	"bar-sugar": {
-		"name": "sucre de canya"
-	},
-	"basil": {
-		"name": "alfàbrega"
-	},
-	"beans": {
-		"name": "fesols/mongetes"
-	},
-	"bell-peppers": {
-		"name": "pebrot",
-		"plural_name": "pebrots vermells"
-	},
-	"blackberries": {
-		"name": "mores"
-	},
-	"bok-choy": {
-		"name": "bleda xinesa (pak choi)"
-	},
-	"brassicas": {
-		"name": "floricol"
-	},
-	"bread": {
-		"name": "pa"
-	},
-	"breadfruit": {
-		"name": "fruit del pa"
-	},
-	"broccoflower": {
-		"name": "romanesco"
-	},
-	"broccoli": {
-		"name": "bròcoli"
-	},
-	"broccoli-rabe": {
-		"name": "grelos"
-	},
-	"broccolini": {
-		"name": "bimi"
-	},
-	"brown-sugar": {
-		"name": "sucre morè"
-	},
-	"brussels-sprouts": {
-		"name": "col de Brussel·les"
-	},
-	"butter": {
-		"name": "mantega"
-	},
-	"butternut-pumpkin": {
-		"name": "carabassa de cacauet"
-	},
-	"butternut-squash": {
-		"name": "carabassa de cacauet"
-	},
-	"cabbage": {
-		"name": "col",
-		"plural_name": "cols"
-	},
-	"cactus-edible": {
-		"name": "figues de pala"
-	},
-	"calabrese": {
-		"name": "bròcoli"
-	},
-	"cane-sugar": {
-		"name": "sucre de canya"
-	},
-	"cannabis": {
-		"name": "cànnabis"
-	},
-	"capsicum": {
-		"name": "nyora"
-	},
-	"caraway": {
-		"name": "comí"
-	},
-	"carrot": {
-		"name": "carlota",
-		"plural_name": "pastanagues"
-	},
-	"caster-sugar": {
-		"name": "sucre de remolatxa"
-	},
-	"castor-sugar": {
-		"name": "sucre"
-	},
-	"catfish": {
-		"name": "siluriformes"
-	},
-	"cauliflower": {
-		"name": "floricol",
-		"plural_name": "coliflors"
-	},
-	"cayenne-pepper": {
-		"name": "caiena"
-	},
-	"celeriac": {
-		"name": "api-rave"
-	},
-	"celery": {
-		"name": "api"
-	},
-	"cereal-grains": {
-		"name": "cereals en gra"
-	},
-	"chard": {
-		"name": "bledes"
-	},
-	"cheese": {
-		"name": "formatge"
-	},
-	"chicory": {
-		"name": "xicoira"
-	},
-	"chilli-peppers": {
-		"name": "vitxo/vitet",
-		"plural_name": "bitxos"
-	},
-	"chinese-leaves": {
-		"name": "col xinesa"
-	},
-	"chives": {
-		"name": "cibulet"
-	},
-	"chocolate": {
-		"name": "xocolata"
-	},
-	"cilantro": {
-		"name": "coriandre"
-	},
-	"cinnamon": {
-		"name": "canyella"
-	},
-	"clarified-butter": {
-		"name": "mantega clarificada"
-	},
-	"coconut": {
-		"name": "coco",
-		"plural_name": "cocos"
-	},
-	"coconut-milk": {
-		"name": "llet de coco"
-	},
-	"cod": {
-		"name": "bacallà"
-	},
-	"coffee": {
-		"name": "cafè"
-	},
-	"collard-greens": {
-		"name": "col de cabdell"
-	},
-	"confectioners-sugar": {
-		"name": "sucre glacé"
-	},
-	"coriander": {
-		"name": "coriandre"
-	},
-	"corn": {
-		"name": "blat de moro",
-		"plural_name": "panissos de blat de moro"
-	},
-	"corn-syrup": {
-		"name": "xarop de dacsa"
-	},
-	"cottonseed-oil": {
-		"name": "oli de cotó"
-	},
-	"courgette": {
-		"name": "carabasseta"
-	},
-	"cream-of-tartar": {
-		"name": "crema de tàrtar"
-	},
-	"cucumber": {
-		"name": "cogombre",
-		"plural_name": "cogombres"
-	},
-	"cumin": {
-		"name": "comí"
-	},
-	"daikon": {
-		"name": "daikon (rave japonés)",
-		"plural_name": "raves blancs"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "lactis i substituts"
-	},
-	"dandelion": {
-		"name": "xicoia"
-	},
-	"demerara-sugar": {
-		"name": "sucre negre"
-	},
-	"dough": {
-		"name": "massa"
-	},
-	"edible-cactus": {
-		"name": "figa palera"
-	},
-	"eggplant": {
-		"name": "albergínia",
-		"plural_name": "albergínies"
-	},
-	"eggs": {
-		"name": "ous",
-		"plural_name": "ous"
-	},
-	"endive": {
-		"name": "endívia",
-		"plural_name": "endívia"
-	},
-	"fats": {
-		"name": "greixos"
-	},
-	"fava-beans": {
-		"name": "faves"
-	},
-	"fiddlehead": {
-		"name": "brots de falguera"
-	},
-	"fiddlehead-fern": {
-		"name": "brots de falguera",
-		"plural_name": "brots de falguera"
-	},
-	"fish": {
-		"name": "peix"
-	},
-	"five-spice-powder": {
-		"name": "cinc espècies (espècies xineses)"
-	},
-	"flour": {
-		"name": "farina"
-	},
-	"frisee": {
-		"name": "enciam arrissat"
-	},
-	"fructose": {
-		"name": "fructosa"
-	},
-	"fruit": {
-		"name": "fruita"
-	},
-	"fruit-sugar": {
-		"name": "fructosa"
-	},
-	"ful": {
-		"name": "faves"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "all",
-		"plural_name": "alls"
-	},
-	"gem-squash": {
-		"name": "carabassa gem"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "vísceres d'au"
-	},
-	"ginger": {
-		"name": "gingebre"
-	},
-	"grains": {
-		"name": "cereals"
-	},
-	"granulated-sugar": {
-		"name": "sucre granulat"
-	},
-	"grape-seed-oil": {
-		"name": "oli de llavors de raïm"
-	},
-	"green-onion": {
-		"name": "ceba tendra",
-		"plural_name": "cebes tendres"
-	},
-	"heart-of-palm": {
-		"name": "cor de palmera",
-		"plural_name": "cor de palmera"
-	},
-	"hemp": {
-		"name": "cànem"
-	},
-	"herbs": {
-		"name": "herbes"
-	},
-	"honey": {
-		"name": "mel"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "fruita del pa",
-		"plural_name": "jaca"
-	},
-	"jaggery": {
-		"name": "sucre de canya"
-	},
-	"jams": {
-		"name": "melmelada"
-	},
-	"jellies": {
-		"name": "gominoles"
-	},
-	"jerusalem-artichoke": {
-		"name": "nyàmera"
-	},
-	"jicama": {
-		"name": "jícama"
-	},
-	"kale": {
-		"name": "col arrissada"
-	},
-	"kohlrabi": {
-		"name": "colrave"
-	},
-	"kumara": {
-		"name": "moniato"
-	},
-	"leavening-agents": {
-		"name": "gasificant"
-	},
-	"leek": {
-		"name": "porro",
-		"plural_name": "porros"
-	},
-	"legumes": {
-		"name": "llegums"
-	},
-	"lemongrass": {
-		"name": "herba llimonera"
-	},
-	"lentils": {
-		"name": "llentilles"
-	},
-	"lettuce": {
-		"name": "lletuga/enciam"
-	},
-	"liver": {
-		"name": "fetge",
-		"plural_name": "fetges"
-	},
-	"maize": {
-		"name": "dacsa"
-	},
-	"maple-syrup": {
-		"name": "xarop d'auró"
-	},
-	"meat": {
-		"name": "carn"
-	},
-	"milk": {
-		"name": "llet"
-	},
-	"mortadella": {
-		"name": "mortadel·la"
-	},
-	"mushroom": {
-		"name": "xampinyó",
-		"plural_name": "bolets"
-	},
-	"mussels": {
-		"name": "clòxitnes/musclos"
-	},
-	"nanaimo-bar-mix": {
-		"name": "barreja de barra nanaimo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nou moscada"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "llevat nutricional"
-	},
-	"nuts": {
-		"name": "fruita de closca"
-	},
-	"octopuses": {
-		"name": "pops",
-		"plural_name": "pops"
-	},
-	"oils": {
-		"name": "olis"
-	},
-	"okra": {
-		"name": "ocra"
-	},
-	"olive": {
-		"name": "oliva"
-	},
-	"olive-oil": {
-		"name": "oli d'oliva"
-	},
-	"onion": {
-		"name": "ceba"
-	},
-	"onion-family": {
-		"name": "cebes"
-	},
-	"orange-blossom-water": {
-		"name": "aigua de tarongina"
-	},
-	"oranges": {
-		"name": "taronges",
-		"plural_name": "taronges"
-	},
-	"oregano": {
-		"name": "orenga"
-	},
-	"oysters": {
-		"name": "ostres"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "pebre dolç"
-	},
-	"parsley": {
-		"name": "julivert"
-	},
-	"parsnip": {
-		"name": "xirivia",
-		"plural_name": "xirivia"
-	},
-	"pear": {
-		"name": "pera",
-		"plural_name": "peres"
-	},
-	"peas": {
-		"name": "pèsols"
-	},
-	"pepper": {
-		"name": "pimentó/bajoca",
-		"plural_name": "pebrots"
-	},
-	"pineapple": {
-		"name": "pinya",
-		"plural_name": "pinyes"
-	},
-	"plantain": {
-		"name": "plàtan de cuinar",
-		"plural_name": "plàtans"
-	},
-	"poppy-seeds": {
-		"name": "llavors de rosella"
-	},
-	"potato": {
-		"name": "creïlla",
-		"plural_name": "patates"
-	},
-	"poultry": {
-		"name": "aviram"
-	},
-	"powdered-sugar": {
-		"name": "sucre en pols"
-	},
-	"pumpkin": {
-		"name": "carabassa",
-		"plural_name": "carabasses"
-	},
-	"pumpkin-seeds": {
-		"name": "pipes de carabassa"
-	},
-	"radish": {
-		"name": "rave",
-		"plural_name": "raves"
-	},
-	"raw-sugar": {
-		"name": "sucre integral"
-	},
-	"refined-sugar": {
-		"name": "sucre blanc"
-	},
-	"rice": {
-		"name": "arròs"
-	},
-	"rice-flour": {
-		"name": "farina d'arròs"
-	},
-	"rock-sugar": {
-		"name": "sucre candi"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "salmó"
-	},
-	"salt": {
-		"name": "sal"
-	},
-	"salt-cod": {
-		"name": "bacallà salat"
-	},
-	"scallion": {
-		"name": "calçots",
-		"plural_name": "cebes tendres"
-	},
-	"seafood": {
-		"name": "marisc"
-	},
-	"seeds": {
-		"name": "llavors"
-	},
-	"sesame-seeds": {
-		"name": "llavors de sèsam"
-	},
-	"shallot": {
-		"name": "escalunya",
-		"plural_name": "escalunyes"
-	},
-	"skate": {
-		"name": "raids"
-	},
-	"soda": {
-		"name": "refrescs"
-	},
-	"soda-baking": {
-		"name": "soda gasificant"
-	},
-	"soybean": {
-		"name": "faves de soja"
-	},
-	"spaghetti-squash": {
-		"name": "carabassa de torrar",
-		"plural_name": "carabassa de torrar"
-	},
-	"speck": {
-		"name": "speck (pernil)"
-	},
-	"spices": {
-		"name": "espècies"
-	},
-	"spinach": {
-		"name": "espinacs"
-	},
-	"spring-onion": {
-		"name": "ceba tendra",
-		"plural_name": "cebes tendres"
-	},
-	"squash": {
-		"name": "carabassa cabell d'àngel",
-		"plural_name": "carabassa cabell d'àngel"
-	},
-	"squash-family": {
-		"name": "carabasses"
-	},
-	"stockfish": {
-		"name": "peix assecat"
-	},
-	"sugar": {
-		"name": "sucre"
-	},
-	"sunchoke": {
-		"name": "nyàmera",
-		"plural_name": "nyàmeres"
-	},
-	"sunflower-seeds": {
-		"name": "pipes de gira-sol"
-	},
-	"superfine-sugar": {
-		"name": "sucre extrafí"
-	},
-	"sweet-potato": {
-		"name": "moniato",
-		"plural_name": "moniatos"
-	},
-	"sweetcorn": {
-		"name": "dacsa dolça",
-		"plural_name": "dacsa dolça"
-	},
-	"sweeteners": {
-		"name": "edulcorants"
-	},
-	"tahini": {
-		"name": "tahina"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "pituques"
-	},
-	"teff": {
-		"name": "tef"
-	},
-	"tomato": {
-		"name": "tomata",
-		"plural_name": "tomàquets"
-	},
-	"trout": {
-		"name": "truita"
-	},
-	"tubers": {
-		"name": "tubèrculs",
-		"plural_name": "tubèrculs"
-	},
-	"tuna": {
-		"name": "tonyina"
-	},
-	"turbanado-sugar": {
-		"name": "sucre"
-	},
-	"turnip": {
-		"name": "nap",
-		"plural_name": "naps"
-	},
-	"unrefined-sugar": {
-		"name": "sucre integral"
-	},
-	"vanilla": {
-		"name": "vainilla"
-	},
-	"vegetables": {
-		"name": "verdures"
-	},
-	"watercress": {
-		"name": "creixen"
-	},
-	"watermelon": {
-		"name": "meló d'Alger/síndria",
-		"plural_name": "síndires"
-	},
-	"white-mushroom": {
-		"name": "xampinyó blanc",
-		"plural_name": "bolets blancs"
-	},
-	"white-sugar": {
-		"name": "sucre blanc"
-	},
-	"xanthan-gum": {
-		"name": "goma xantana"
-	},
-	"yam": {
-		"name": "nyam",
-		"plural_name": "nyams"
-	},
-	"yeast": {
-		"name": "llevat"
-	},
-	"zucchini": {
-		"name": "carabassot",
-		"plural_name": "carabassots"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "carabassa de pelegrí"
+            },
+            "alfalfa-sprouts": {
+                "name": "brots d'alfals"
+            },
+            "anchovies": {
+                "name": "anxoves"
+            },
+            "apples": {
+                "name": "pomes",
+                "plural_name": "pomes"
+            },
+            "artichoke": {
+                "name": "carxofa"
+            },
+            "arugula": {
+                "name": "ruca"
+            },
+            "asparagus": {
+                "name": "espàrrec"
+            },
+            "avocado": {
+                "name": "alvocat",
+                "plural_name": "alvocat"
+            },
+            "bacon": {
+                "name": "cansalada"
+            },
+            "baking-powder": {
+                "name": "rent"
+            },
+            "baking-soda": {
+                "name": "bicarbonat sòdic"
+            },
+            "baking-sugar": {
+                "name": "sucre blanc"
+            },
+            "bar-sugar": {
+                "name": "sucre de canya"
+            },
+            "basil": {
+                "name": "alfàbrega"
+            },
+            "beans": {
+                "name": "fesols/mongetes"
+            },
+            "bell-peppers": {
+                "name": "pebrot",
+                "plural_name": "pebrots vermells"
+            },
+            "blackberries": {
+                "name": "mores"
+            },
+            "bok-choy": {
+                "name": "bleda xinesa (pak choi)"
+            },
+            "brassicas": {
+                "name": "floricol"
+            },
+            "bread": {
+                "name": "pa"
+            },
+            "breadfruit": {
+                "name": "fruit del pa"
+            },
+            "broccoflower": {
+                "name": "romanesco"
+            },
+            "broccoli": {
+                "name": "bròcoli"
+            },
+            "broccoli-rabe": {
+                "name": "grelos"
+            },
+            "broccolini": {
+                "name": "bimi"
+            },
+            "brown-sugar": {
+                "name": "sucre morè"
+            },
+            "brussels-sprouts": {
+                "name": "col de Brussel·les"
+            },
+            "butter": {
+                "name": "mantega"
+            },
+            "butternut-pumpkin": {
+                "name": "carabassa de cacauet"
+            },
+            "butternut-squash": {
+                "name": "carabassa de cacauet"
+            },
+            "cabbage": {
+                "name": "col",
+                "plural_name": "cols"
+            },
+            "cactus-edible": {
+                "name": "figues de pala"
+            },
+            "calabrese": {
+                "name": "bròcoli"
+            },
+            "cane-sugar": {
+                "name": "sucre de canya"
+            },
+            "cannabis": {
+                "name": "cànnabis"
+            },
+            "capsicum": {
+                "name": "nyora"
+            },
+            "caraway": {
+                "name": "comí"
+            },
+            "carrot": {
+                "name": "carlota",
+                "plural_name": "pastanagues"
+            },
+            "caster-sugar": {
+                "name": "sucre de remolatxa"
+            },
+            "castor-sugar": {
+                "name": "sucre"
+            },
+            "catfish": {
+                "name": "siluriformes"
+            },
+            "cauliflower": {
+                "name": "floricol",
+                "plural_name": "coliflors"
+            },
+            "cayenne-pepper": {
+                "name": "caiena"
+            },
+            "celeriac": {
+                "name": "api-rave"
+            },
+            "celery": {
+                "name": "api"
+            },
+            "cereal-grains": {
+                "name": "cereals en gra"
+            },
+            "chard": {
+                "name": "bledes"
+            },
+            "cheese": {
+                "name": "formatge"
+            },
+            "chicory": {
+                "name": "xicoira"
+            },
+            "chilli-peppers": {
+                "name": "vitxo/vitet",
+                "plural_name": "bitxos"
+            },
+            "chinese-leaves": {
+                "name": "col xinesa"
+            },
+            "chives": {
+                "name": "cibulet"
+            },
+            "chocolate": {
+                "name": "xocolata"
+            },
+            "cilantro": {
+                "name": "coriandre"
+            },
+            "cinnamon": {
+                "name": "canyella"
+            },
+            "clarified-butter": {
+                "name": "mantega clarificada"
+            },
+            "coconut": {
+                "name": "coco",
+                "plural_name": "cocos"
+            },
+            "coconut-milk": {
+                "name": "llet de coco"
+            },
+            "cod": {
+                "name": "bacallà"
+            },
+            "coffee": {
+                "name": "cafè"
+            },
+            "collard-greens": {
+                "name": "col de cabdell"
+            },
+            "confectioners-sugar": {
+                "name": "sucre glacé"
+            },
+            "coriander": {
+                "name": "coriandre"
+            },
+            "corn": {
+                "name": "blat de moro",
+                "plural_name": "panissos de blat de moro"
+            },
+            "corn-syrup": {
+                "name": "xarop de dacsa"
+            },
+            "cottonseed-oil": {
+                "name": "oli de cotó"
+            },
+            "courgette": {
+                "name": "carabasseta"
+            },
+            "cream-of-tartar": {
+                "name": "crema de tàrtar"
+            },
+            "cucumber": {
+                "name": "cogombre",
+                "plural_name": "cogombres"
+            },
+            "cumin": {
+                "name": "comí"
+            },
+            "daikon": {
+                "name": "daikon (rave japonés)",
+                "plural_name": "raves blancs"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "lactis i substituts"
+            },
+            "dandelion": {
+                "name": "xicoia"
+            },
+            "demerara-sugar": {
+                "name": "sucre negre"
+            },
+            "dough": {
+                "name": "massa"
+            },
+            "edible-cactus": {
+                "name": "figa palera"
+            },
+            "eggplant": {
+                "name": "albergínia",
+                "plural_name": "albergínies"
+            },
+            "eggs": {
+                "name": "ous",
+                "plural_name": "ous"
+            },
+            "endive": {
+                "name": "endívia",
+                "plural_name": "endívia"
+            },
+            "fats": {
+                "name": "greixos"
+            },
+            "fava-beans": {
+                "name": "faves"
+            },
+            "fiddlehead": {
+                "name": "brots de falguera"
+            },
+            "fiddlehead-fern": {
+                "name": "brots de falguera",
+                "plural_name": "brots de falguera"
+            },
+            "fish": {
+                "name": "peix"
+            },
+            "five-spice-powder": {
+                "name": "cinc espècies (espècies xineses)"
+            },
+            "flour": {
+                "name": "farina"
+            },
+            "frisee": {
+                "name": "enciam arrissat"
+            },
+            "fructose": {
+                "name": "fructosa"
+            },
+            "fruit": {
+                "name": "fruita"
+            },
+            "fruit-sugar": {
+                "name": "fructosa"
+            },
+            "ful": {
+                "name": "faves"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "all",
+                "plural_name": "alls"
+            },
+            "gem-squash": {
+                "name": "carabassa gem"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "vísceres d'au"
+            },
+            "ginger": {
+                "name": "gingebre"
+            },
+            "grains": {
+                "name": "cereals"
+            },
+            "granulated-sugar": {
+                "name": "sucre granulat"
+            },
+            "grape-seed-oil": {
+                "name": "oli de llavors de raïm"
+            },
+            "green-onion": {
+                "name": "ceba tendra",
+                "plural_name": "cebes tendres"
+            },
+            "heart-of-palm": {
+                "name": "cor de palmera",
+                "plural_name": "cor de palmera"
+            },
+            "hemp": {
+                "name": "cànem"
+            },
+            "herbs": {
+                "name": "herbes"
+            },
+            "honey": {
+                "name": "mel"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "fruita del pa",
+                "plural_name": "jaca"
+            },
+            "jaggery": {
+                "name": "sucre de canya"
+            },
+            "jams": {
+                "name": "melmelada"
+            },
+            "jellies": {
+                "name": "gominoles"
+            },
+            "jerusalem-artichoke": {
+                "name": "nyàmera"
+            },
+            "jicama": {
+                "name": "jícama"
+            },
+            "kale": {
+                "name": "col arrissada"
+            },
+            "kohlrabi": {
+                "name": "colrave"
+            },
+            "kumara": {
+                "name": "moniato"
+            },
+            "leavening-agents": {
+                "name": "gasificant"
+            },
+            "leek": {
+                "name": "porro",
+                "plural_name": "porros"
+            },
+            "legumes": {
+                "name": "llegums"
+            },
+            "lemongrass": {
+                "name": "herba llimonera"
+            },
+            "lentils": {
+                "name": "llentilles"
+            },
+            "lettuce": {
+                "name": "lletuga/enciam"
+            },
+            "liver": {
+                "name": "fetge",
+                "plural_name": "fetges"
+            },
+            "maize": {
+                "name": "dacsa"
+            },
+            "maple-syrup": {
+                "name": "xarop d'auró"
+            },
+            "meat": {
+                "name": "carn"
+            },
+            "milk": {
+                "name": "llet"
+            },
+            "mortadella": {
+                "name": "mortadel·la"
+            },
+            "mushroom": {
+                "name": "xampinyó",
+                "plural_name": "bolets"
+            },
+            "mussels": {
+                "name": "clòxitnes/musclos"
+            },
+            "nanaimo-bar-mix": {
+                "name": "barreja de barra nanaimo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nou moscada"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "llevat nutricional"
+            },
+            "nuts": {
+                "name": "fruita de closca"
+            },
+            "octopuses": {
+                "name": "pops",
+                "plural_name": "pops"
+            },
+            "oils": {
+                "name": "olis"
+            },
+            "okra": {
+                "name": "ocra"
+            },
+            "olive": {
+                "name": "oliva"
+            },
+            "olive-oil": {
+                "name": "oli d'oliva"
+            },
+            "onion": {
+                "name": "ceba"
+            },
+            "onion-family": {
+                "name": "cebes"
+            },
+            "orange-blossom-water": {
+                "name": "aigua de tarongina"
+            },
+            "oranges": {
+                "name": "taronges",
+                "plural_name": "taronges"
+            },
+            "oregano": {
+                "name": "orenga"
+            },
+            "oysters": {
+                "name": "ostres"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "pebre dolç"
+            },
+            "parsley": {
+                "name": "julivert"
+            },
+            "parsnip": {
+                "name": "xirivia",
+                "plural_name": "xirivia"
+            },
+            "pear": {
+                "name": "pera",
+                "plural_name": "peres"
+            },
+            "peas": {
+                "name": "pèsols"
+            },
+            "pepper": {
+                "name": "pimentó/bajoca",
+                "plural_name": "pebrots"
+            },
+            "pineapple": {
+                "name": "pinya",
+                "plural_name": "pinyes"
+            },
+            "plantain": {
+                "name": "plàtan de cuinar",
+                "plural_name": "plàtans"
+            },
+            "poppy-seeds": {
+                "name": "llavors de rosella"
+            },
+            "potato": {
+                "name": "creïlla",
+                "plural_name": "patates"
+            },
+            "poultry": {
+                "name": "aviram"
+            },
+            "powdered-sugar": {
+                "name": "sucre en pols"
+            },
+            "pumpkin": {
+                "name": "carabassa",
+                "plural_name": "carabasses"
+            },
+            "pumpkin-seeds": {
+                "name": "pipes de carabassa"
+            },
+            "radish": {
+                "name": "rave",
+                "plural_name": "raves"
+            },
+            "raw-sugar": {
+                "name": "sucre integral"
+            },
+            "refined-sugar": {
+                "name": "sucre blanc"
+            },
+            "rice": {
+                "name": "arròs"
+            },
+            "rice-flour": {
+                "name": "farina d'arròs"
+            },
+            "rock-sugar": {
+                "name": "sucre candi"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "salmó"
+            },
+            "salt": {
+                "name": "sal"
+            },
+            "salt-cod": {
+                "name": "bacallà salat"
+            },
+            "scallion": {
+                "name": "calçots",
+                "plural_name": "cebes tendres"
+            },
+            "seafood": {
+                "name": "marisc"
+            },
+            "seeds": {
+                "name": "llavors"
+            },
+            "sesame-seeds": {
+                "name": "llavors de sèsam"
+            },
+            "shallot": {
+                "name": "escalunya",
+                "plural_name": "escalunyes"
+            },
+            "skate": {
+                "name": "raids"
+            },
+            "soda": {
+                "name": "refrescs"
+            },
+            "soda-baking": {
+                "name": "soda gasificant"
+            },
+            "soybean": {
+                "name": "faves de soja"
+            },
+            "spaghetti-squash": {
+                "name": "carabassa de torrar",
+                "plural_name": "carabassa de torrar"
+            },
+            "speck": {
+                "name": "speck (pernil)"
+            },
+            "spices": {
+                "name": "espècies"
+            },
+            "spinach": {
+                "name": "espinacs"
+            },
+            "spring-onion": {
+                "name": "ceba tendra",
+                "plural_name": "cebes tendres"
+            },
+            "squash": {
+                "name": "carabassa cabell d'àngel",
+                "plural_name": "carabassa cabell d'àngel"
+            },
+            "squash-family": {
+                "name": "carabasses"
+            },
+            "stockfish": {
+                "name": "peix assecat"
+            },
+            "sugar": {
+                "name": "sucre"
+            },
+            "sunchoke": {
+                "name": "nyàmera",
+                "plural_name": "nyàmeres"
+            },
+            "sunflower-seeds": {
+                "name": "pipes de gira-sol"
+            },
+            "superfine-sugar": {
+                "name": "sucre extrafí"
+            },
+            "sweet-potato": {
+                "name": "moniato",
+                "plural_name": "moniatos"
+            },
+            "sweetcorn": {
+                "name": "dacsa dolça",
+                "plural_name": "dacsa dolça"
+            },
+            "sweeteners": {
+                "name": "edulcorants"
+            },
+            "tahini": {
+                "name": "tahina"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "pituques"
+            },
+            "teff": {
+                "name": "tef"
+            },
+            "tomato": {
+                "name": "tomata",
+                "plural_name": "tomàquets"
+            },
+            "trout": {
+                "name": "truita"
+            },
+            "tubers": {
+                "name": "tubèrculs",
+                "plural_name": "tubèrculs"
+            },
+            "tuna": {
+                "name": "tonyina"
+            },
+            "turbanado-sugar": {
+                "name": "sucre"
+            },
+            "turnip": {
+                "name": "nap",
+                "plural_name": "naps"
+            },
+            "unrefined-sugar": {
+                "name": "sucre integral"
+            },
+            "vanilla": {
+                "name": "vainilla"
+            },
+            "vegetables": {
+                "name": "verdures"
+            },
+            "watercress": {
+                "name": "creixen"
+            },
+            "watermelon": {
+                "name": "meló d'Alger/síndria",
+                "plural_name": "síndires"
+            },
+            "white-mushroom": {
+                "name": "xampinyó blanc",
+                "plural_name": "bolets blancs"
+            },
+            "white-sugar": {
+                "name": "sucre blanc"
+            },
+            "xanthan-gum": {
+                "name": "goma xantana"
+            },
+            "yam": {
+                "name": "nyam",
+                "plural_name": "nyams"
+            },
+            "yeast": {
+                "name": "llevat"
+            },
+            "zucchini": {
+                "name": "carabassot",
+                "plural_name": "carabassots"
+            }
+        }
+    },
+    "Producte fresc": {
+        "foods": {}
+    },
+    "Cereals": {
+        "foods": {}
+    },
+    "Fruita": {
+        "foods": {}
+    },
+    "Verdures": {
+        "foods": {}
+    },
+    "Carn": {
+        "foods": {}
+    },
+    "Pescateria": {
+        "foods": {}
+    },
+    "Begudes": {
+        "foods": {}
+    },
+    "Forn": {
+        "foods": {}
+    },
+    "Conserves": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Llepolies": {
+        "foods": {}
+    },
+    "Productes lactis": {
+        "foods": {}
+    },
+    "Congelats": {
+        "foods": {}
+    },
+    "Menjars saludables": {
+        "foods": {}
+    },
+    "Llar": {
+        "foods": {}
+    },
+    "Productes càrnics": {
+        "foods": {}
+    },
+    "Entremesos": {
+        "foods": {}
+    },
+    "Espècies": {
+        "foods": {}
+    },
+    "Dolços": {
+        "foods": {}
+    },
+    "Celler": {
+        "foods": {}
+    },
+    "Altres": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/cs-CZ.json
+++ b/mealie/repos/seed/resources/foods/locales/cs-CZ.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "tykev"
-	},
-	"alfalfa-sprouts": {
-		"name": "vojtěškové klíčky"
-	},
-	"anchovies": {
-		"name": "ančovičky"
-	},
-	"apples": {
-		"name": "jablka",
-		"plural_name": "jablka"
-	},
-	"artichoke": {
-		"name": "artyčok"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "chřest"
-	},
-	"avocado": {
-		"name": "avokádo",
-		"plural_name": "avokádo"
-	},
-	"bacon": {
-		"name": "slanina"
-	},
-	"baking-powder": {
-		"name": "prášek na pečení"
-	},
-	"baking-soda": {
-		"name": "pekařská soda"
-	},
-	"baking-sugar": {
-		"name": "cukr na pečení"
-	},
-	"bar-sugar": {
-		"name": "cukr"
-	},
-	"basil": {
-		"name": "bazalka"
-	},
-	"beans": {
-		"name": "fazole"
-	},
-	"bell-peppers": {
-		"name": "papriky",
-		"plural_name": "papriky"
-	},
-	"blackberries": {
-		"name": "ostružiny"
-	},
-	"bok-choy": {
-		"name": "brukev čínská"
-	},
-	"brassicas": {
-		"name": "brukev"
-	},
-	"bread": {
-		"name": "chléb"
-	},
-	"breadfruit": {
-		"name": "chlebovník"
-	},
-	"broccoflower": {
-		"name": "zelený květák"
-	},
-	"broccoli": {
-		"name": "brokolice"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "brokolice"
-	},
-	"brown-sugar": {
-		"name": "hnědý cukr"
-	},
-	"brussels-sprouts": {
-		"name": "růžičková kapusta"
-	},
-	"butter": {
-		"name": "máslo"
-	},
-	"butternut-pumpkin": {
-		"name": "muškátová dýně"
-	},
-	"butternut-squash": {
-		"name": "tykev muškátová"
-	},
-	"cabbage": {
-		"name": "zelí",
-		"plural_name": "zelí"
-	},
-	"cactus-edible": {
-		"name": "kaktus, jedlý"
-	},
-	"calabrese": {
-		"name": "kalábrijský"
-	},
-	"cane-sugar": {
-		"name": "třtinový cukr"
-	},
-	"cannabis": {
-		"name": "konopí"
-	},
-	"capsicum": {
-		"name": "kapie"
-	},
-	"caraway": {
-		"name": "kmín"
-	},
-	"carrot": {
-		"name": "mrkev",
-		"plural_name": "mrkve"
-	},
-	"caster-sugar": {
-		"name": "cukr krupice"
-	},
-	"castor-sugar": {
-		"name": "cukr moučka"
-	},
-	"catfish": {
-		"name": "sumec"
-	},
-	"cauliflower": {
-		"name": "květák",
-		"plural_name": "květáky"
-	},
-	"cayenne-pepper": {
-		"name": "kayenský pepř"
-	},
-	"celeriac": {
-		"name": "bulva celeru"
-	},
-	"celery": {
-		"name": "celer"
-	},
-	"cereal-grains": {
-		"name": "obilniny"
-	},
-	"chard": {
-		"name": "mangold"
-	},
-	"cheese": {
-		"name": "sýr"
-	},
-	"chicory": {
-		"name": "čekanka"
-	},
-	"chilli-peppers": {
-		"name": "čili papričky",
-		"plural_name": "čili papričky"
-	},
-	"chinese-leaves": {
-		"name": "pekingské zelí"
-	},
-	"chives": {
-		"name": "pažitka"
-	},
-	"chocolate": {
-		"name": "čokoláda"
-	},
-	"cilantro": {
-		"name": "koriandr"
-	},
-	"cinnamon": {
-		"name": "skořice"
-	},
-	"clarified-butter": {
-		"name": "přepuštěné máslo"
-	},
-	"coconut": {
-		"name": "kokosový ořech",
-		"plural_name": "kokosové ořechy"
-	},
-	"coconut-milk": {
-		"name": "kokosové mléko"
-	},
-	"cod": {
-		"name": "treska"
-	},
-	"coffee": {
-		"name": "káva"
-	},
-	"collard-greens": {
-		"name": "kapustové listy"
-	},
-	"confectioners-sugar": {
-		"name": "cukr moučka"
-	},
-	"coriander": {
-		"name": "koriandr"
-	},
-	"corn": {
-		"name": "kukuřice",
-		"plural_name": "kukuřice"
-	},
-	"corn-syrup": {
-		"name": "kukuřičný sirup"
-	},
-	"cottonseed-oil": {
-		"name": "bavlníkový olej"
-	},
-	"courgette": {
-		"name": "cuketa"
-	},
-	"cream-of-tartar": {
-		"name": "vinný kámen"
-	},
-	"cucumber": {
-		"name": "okurka",
-		"plural_name": "okurky"
-	},
-	"cumin": {
-		"name": "římský kmín"
-	},
-	"daikon": {
-		"name": "ředkev bílá",
-		"plural_name": "ředkve bílé"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mléčné výrobky a mléčné náhražky"
-	},
-	"dandelion": {
-		"name": "pampeliška"
-	},
-	"demerara-sugar": {
-		"name": "třtinový cukr"
-	},
-	"dough": {
-		"name": "těsto"
-	},
-	"edible-cactus": {
-		"name": "jedlý kaktus"
-	},
-	"eggplant": {
-		"name": "lilek",
-		"plural_name": "lilky"
-	},
-	"eggs": {
-		"name": "vejce",
-		"plural_name": "vejce"
-	},
-	"endive": {
-		"name": "čekanka",
-		"plural_name": "čekanky"
-	},
-	"fats": {
-		"name": "tuky"
-	},
-	"fava-beans": {
-		"name": "fava fazole"
-	},
-	"fiddlehead": {
-		"name": "kapradiny"
-	},
-	"fiddlehead-fern": {
-		"name": "kapradina",
-		"plural_name": "kapradiny"
-	},
-	"fish": {
-		"name": "ryba"
-	},
-	"five-spice-powder": {
-		"name": "směs pěti koření"
-	},
-	"flour": {
-		"name": "mouka"
-	},
-	"frisee": {
-		"name": "čekanka štěrbák"
-	},
-	"fructose": {
-		"name": "fruktóza"
-	},
-	"fruit": {
-		"name": "ovoce"
-	},
-	"fruit-sugar": {
-		"name": "ovocný cukr"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "česnek",
-		"plural_name": "česneky"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghí"
-	},
-	"giblets": {
-		"name": "droby"
-	},
-	"ginger": {
-		"name": "zázvor"
-	},
-	"grains": {
-		"name": "zrna"
-	},
-	"granulated-sugar": {
-		"name": "granulovaný cukr"
-	},
-	"grape-seed-oil": {
-		"name": "olej z hroznů"
-	},
-	"green-onion": {
-		"name": "zelená cibule",
-		"plural_name": "zelené cibule"
-	},
-	"heart-of-palm": {
-		"name": "palmové srdce",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "konopí"
-	},
-	"herbs": {
-		"name": "bylinky"
-	},
-	"honey": {
-		"name": "med"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruit"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "džemy"
-	},
-	"jellies": {
-		"name": "želé"
-	},
-	"jerusalem-artichoke": {
-		"name": "artyčok jeruzalémský"
-	},
-	"jicama": {
-		"name": "mexický tuřín"
-	},
-	"kale": {
-		"name": "kapusta"
-	},
-	"kohlrabi": {
-		"name": "kedluben"
-	},
-	"kumara": {
-		"name": "povijnice batátová"
-	},
-	"leavening-agents": {
-		"name": "kypřící prášek"
-	},
-	"leek": {
-		"name": "pórek",
-		"plural_name": "pórky"
-	},
-	"legumes": {
-		"name": "luštěniny"
-	},
-	"lemongrass": {
-		"name": "citronová tráva"
-	},
-	"lentils": {
-		"name": "čočka"
-	},
-	"lettuce": {
-		"name": "hlávkový salát"
-	},
-	"liver": {
-		"name": "játra",
-		"plural_name": "játra"
-	},
-	"maize": {
-		"name": "kukuřice"
-	},
-	"maple-syrup": {
-		"name": "javorový syrup"
-	},
-	"meat": {
-		"name": "maso"
-	},
-	"milk": {
-		"name": "mléko"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "houba",
-		"plural_name": "houby"
-	},
-	"mussels": {
-		"name": "mušle"
-	},
-	"nanaimo-bar-mix": {
-		"name": "směs tyčinek nanaimo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muškátový oříšek"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutriční kvasnice vločky"
-	},
-	"nuts": {
-		"name": "ořechy"
-	},
-	"octopuses": {
-		"name": "chobotnice",
-		"plural_name": "chobotnice"
-	},
-	"oils": {
-		"name": "oleje"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olivy"
-	},
-	"olive-oil": {
-		"name": "olivový olej"
-	},
-	"onion": {
-		"name": "cibule"
-	},
-	"onion-family": {
-		"name": "cibule"
-	},
-	"orange-blossom-water": {
-		"name": "voda z pomerančových květů"
-	},
-	"oranges": {
-		"name": "pomeranče",
-		"plural_name": "pomeranče"
-	},
-	"oregano": {
-		"name": "dobromysl"
-	},
-	"oysters": {
-		"name": "ústřice"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "petržel"
-	},
-	"parsnip": {
-		"name": "pastinák",
-		"plural_name": "pastináky"
-	},
-	"pear": {
-		"name": "hruška",
-		"plural_name": "hrušky"
-	},
-	"peas": {
-		"name": "hrášek"
-	},
-	"pepper": {
-		"name": "pepř",
-		"plural_name": "papriky"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananasy"
-	},
-	"plantain": {
-		"name": "plantýn",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "maková semena"
-	},
-	"potato": {
-		"name": "brambor",
-		"plural_name": "brambory"
-	},
-	"poultry": {
-		"name": "drůbež"
-	},
-	"powdered-sugar": {
-		"name": "moučkový cukr"
-	},
-	"pumpkin": {
-		"name": "dýně",
-		"plural_name": "dýně"
-	},
-	"pumpkin-seeds": {
-		"name": "dýňová semínka"
-	},
-	"radish": {
-		"name": "ředkvička",
-		"plural_name": "ředkvičky"
-	},
-	"raw-sugar": {
-		"name": "hnědý cukr"
-	},
-	"refined-sugar": {
-		"name": "rafinovaný cukr"
-	},
-	"rice": {
-		"name": "rýže"
-	},
-	"rice-flour": {
-		"name": "rýžová mouka"
-	},
-	"rock-sugar": {
-		"name": "cukr krystal"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "losos"
-	},
-	"salt": {
-		"name": "sůl"
-	},
-	"salt-cod": {
-		"name": "solená treska"
-	},
-	"scallion": {
-		"name": "jarní cibulka",
-		"plural_name": "jarní cibulky"
-	},
-	"seafood": {
-		"name": "mořské plody"
-	},
-	"seeds": {
-		"name": "semínka"
-	},
-	"sesame-seeds": {
-		"name": "sezamová semena"
-	},
-	"shallot": {
-		"name": "šalotka",
-		"plural_name": "šalotky"
-	},
-	"skate": {
-		"name": "rejnok"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, pečení"
-	},
-	"soybean": {
-		"name": "sójové boby"
-	},
-	"spaghetti-squash": {
-		"name": "špagetová dýně",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "špek"
-	},
-	"spices": {
-		"name": "koření"
-	},
-	"spinach": {
-		"name": "špenát"
-	},
-	"spring-onion": {
-		"name": "jarní cibulka",
-		"plural_name": "jarní cibulky"
-	},
-	"squash": {
-		"name": "dýně",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "dýně"
-	},
-	"stockfish": {
-		"name": "treska"
-	},
-	"sugar": {
-		"name": "cukr"
-	},
-	"sunchoke": {
-		"name": "slunečnice topinambur",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "slunečnicová semena"
-	},
-	"superfine-sugar": {
-		"name": "cukr krupice"
-	},
-	"sweet-potato": {
-		"name": "batát",
-		"plural_name": "batáty"
-	},
-	"sweetcorn": {
-		"name": "kukuřice cukrová",
-		"plural_name": "kukuřice cukrová"
-	},
-	"sweeteners": {
-		"name": "sladidla"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "kolokázie jedlá",
-		"plural_name": "taro"
-	},
-	"teff": {
-		"name": "milička abesínska"
-	},
-	"tomato": {
-		"name": "rajče",
-		"plural_name": "rajčata"
-	},
-	"trout": {
-		"name": "pstruh"
-	},
-	"tubers": {
-		"name": "hlízy",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuňák"
-	},
-	"turbanado-sugar": {
-		"name": "nerafinovaný třtinový cukr"
-	},
-	"turnip": {
-		"name": "tuřín",
-		"plural_name": "tuříny"
-	},
-	"unrefined-sugar": {
-		"name": "nerafinovaný cukr"
-	},
-	"vanilla": {
-		"name": "vanilka"
-	},
-	"vegetables": {
-		"name": "zelenina"
-	},
-	"watercress": {
-		"name": "potočnice lékařská"
-	},
-	"watermelon": {
-		"name": "vodní meloun",
-		"plural_name": "vodní melouny"
-	},
-	"white-mushroom": {
-		"name": "bílý žampion",
-		"plural_name": "bílé žampiony"
-	},
-	"white-sugar": {
-		"name": "bílý cukr"
-	},
-	"xanthan-gum": {
-		"name": "xanthanová guma"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "kvasnice"
-	},
-	"zucchini": {
-		"name": "cuketa",
-		"plural_name": "cukety"
-	}
+    "acorn-squash": {
+        "name": "tykev"
+    },
+    "alfalfa-sprouts": {
+        "name": "vojtěškové klíčky"
+    },
+    "anchovies": {
+        "name": "ančovičky"
+    },
+    "apples": {
+        "name": "jablka",
+        "plural_name": "jablka"
+    },
+    "artichoke": {
+        "name": "artyčok"
+    },
+    "arugula": {
+        "name": "rukola"
+    },
+    "asparagus": {
+        "name": "chřest"
+    },
+    "avocado": {
+        "name": "avokádo",
+        "plural_name": "avokádo"
+    },
+    "bacon": {
+        "name": "slanina"
+    },
+    "baking-powder": {
+        "name": "prášek na pečení"
+    },
+    "baking-soda": {
+        "name": "pekařská soda"
+    },
+    "baking-sugar": {
+        "name": "cukr na pečení"
+    },
+    "bar-sugar": {
+        "name": "cukr"
+    },
+    "basil": {
+        "name": "bazalka"
+    },
+    "beans": {
+        "name": "fazole"
+    },
+    "bell-peppers": {
+        "name": "papriky",
+        "plural_name": "papriky"
+    },
+    "blackberries": {
+        "name": "ostružiny"
+    },
+    "bok-choy": {
+        "name": "brukev čínská"
+    },
+    "brassicas": {
+        "name": "brukev"
+    },
+    "bread": {
+        "name": "chléb"
+    },
+    "breadfruit": {
+        "name": "chlebovník"
+    },
+    "broccoflower": {
+        "name": "zelený květák"
+    },
+    "broccoli": {
+        "name": "brokolice"
+    },
+    "broccoli-rabe": {
+        "name": "rapini"
+    },
+    "broccolini": {
+        "name": "brokolice"
+    },
+    "brown-sugar": {
+        "name": "hnědý cukr"
+    },
+    "brussels-sprouts": {
+        "name": "růžičková kapusta"
+    },
+    "butter": {
+        "name": "máslo"
+    },
+    "butternut-pumpkin": {
+        "name": "muškátová dýně"
+    },
+    "butternut-squash": {
+        "name": "tykev muškátová"
+    },
+    "cabbage": {
+        "name": "zelí",
+        "plural_name": "zelí"
+    },
+    "cactus-edible": {
+        "name": "kaktus, jedlý"
+    },
+    "calabrese": {
+        "name": "kalábrijský"
+    },
+    "cane-sugar": {
+        "name": "třtinový cukr"
+    },
+    "cannabis": {
+        "name": "konopí"
+    },
+    "capsicum": {
+        "name": "kapie"
+    },
+    "caraway": {
+        "name": "kmín"
+    },
+    "carrot": {
+        "name": "mrkev",
+        "plural_name": "mrkve"
+    },
+    "caster-sugar": {
+        "name": "cukr krupice"
+    },
+    "castor-sugar": {
+        "name": "cukr moučka"
+    },
+    "catfish": {
+        "name": "sumec"
+    },
+    "cauliflower": {
+        "name": "květák",
+        "plural_name": "květáky"
+    },
+    "cayenne-pepper": {
+        "name": "kayenský pepř"
+    },
+    "celeriac": {
+        "name": "bulva celeru"
+    },
+    "celery": {
+        "name": "celer"
+    },
+    "cereal-grains": {
+        "name": "obilniny"
+    },
+    "chard": {
+        "name": "mangold"
+    },
+    "cheese": {
+        "name": "sýr"
+    },
+    "chicory": {
+        "name": "čekanka"
+    },
+    "chilli-peppers": {
+        "name": "čili papričky",
+        "plural_name": "čili papričky"
+    },
+    "chinese-leaves": {
+        "name": "pekingské zelí"
+    },
+    "chives": {
+        "name": "pažitka"
+    },
+    "chocolate": {
+        "name": "čokoláda"
+    },
+    "cilantro": {
+        "name": "koriandr"
+    },
+    "cinnamon": {
+        "name": "skořice"
+    },
+    "clarified-butter": {
+        "name": "přepuštěné máslo"
+    },
+    "coconut": {
+        "name": "kokosový ořech",
+        "plural_name": "kokosové ořechy"
+    },
+    "coconut-milk": {
+        "name": "kokosové mléko"
+    },
+    "cod": {
+        "name": "treska"
+    },
+    "coffee": {
+        "name": "káva"
+    },
+    "collard-greens": {
+        "name": "kapustové listy"
+    },
+    "confectioners-sugar": {
+        "name": "cukr moučka"
+    },
+    "coriander": {
+        "name": "koriandr"
+    },
+    "corn": {
+        "name": "kukuřice",
+        "plural_name": "kukuřice"
+    },
+    "corn-syrup": {
+        "name": "kukuřičný sirup"
+    },
+    "cottonseed-oil": {
+        "name": "bavlníkový olej"
+    },
+    "courgette": {
+        "name": "cuketa"
+    },
+    "cream-of-tartar": {
+        "name": "vinný kámen"
+    },
+    "cucumber": {
+        "name": "okurka",
+        "plural_name": "okurky"
+    },
+    "cumin": {
+        "name": "římský kmín"
+    },
+    "daikon": {
+        "name": "ředkev bílá",
+        "plural_name": "ředkve bílé"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "mléčné výrobky a mléčné náhražky"
+    },
+    "dandelion": {
+        "name": "pampeliška"
+    },
+    "demerara-sugar": {
+        "name": "třtinový cukr"
+    },
+    "dough": {
+        "name": "těsto"
+    },
+    "edible-cactus": {
+        "name": "jedlý kaktus"
+    },
+    "eggplant": {
+        "name": "lilek",
+        "plural_name": "lilky"
+    },
+    "eggs": {
+        "name": "vejce",
+        "plural_name": "vejce"
+    },
+    "endive": {
+        "name": "čekanka",
+        "plural_name": "čekanky"
+    },
+    "fats": {
+        "name": "tuky"
+    },
+    "fava-beans": {
+        "name": "fava fazole"
+    },
+    "fiddlehead": {
+        "name": "kapradiny"
+    },
+    "fiddlehead-fern": {
+        "name": "kapradina",
+        "plural_name": "kapradiny"
+    },
+    "fish": {
+        "name": "ryba"
+    },
+    "five-spice-powder": {
+        "name": "směs pěti koření"
+    },
+    "flour": {
+        "name": "mouka"
+    },
+    "frisee": {
+        "name": "čekanka štěrbák"
+    },
+    "fructose": {
+        "name": "fruktóza"
+    },
+    "fruit": {
+        "name": "ovoce"
+    },
+    "fruit-sugar": {
+        "name": "ovocný cukr"
+    },
+    "ful": {
+        "name": "ful"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "česnek",
+        "plural_name": "česneky"
+    },
+    "gem-squash": {
+        "name": "gem squash"
+    },
+    "ghee": {
+        "name": "ghí"
+    },
+    "giblets": {
+        "name": "droby"
+    },
+    "ginger": {
+        "name": "zázvor"
+    },
+    "grains": {
+        "name": "zrna"
+    },
+    "granulated-sugar": {
+        "name": "granulovaný cukr"
+    },
+    "grape-seed-oil": {
+        "name": "olej z hroznů"
+    },
+    "green-onion": {
+        "name": "zelená cibule",
+        "plural_name": "zelené cibule"
+    },
+    "heart-of-palm": {
+        "name": "palmové srdce",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "konopí"
+    },
+    "herbs": {
+        "name": "bylinky"
+    },
+    "honey": {
+        "name": "med"
+    },
+    "isomalt": {
+        "name": "isomalt"
+    },
+    "jackfruit": {
+        "name": "jackfruit",
+        "plural_name": "jackfruit"
+    },
+    "jaggery": {
+        "name": "jaggery"
+    },
+    "jams": {
+        "name": "džemy"
+    },
+    "jellies": {
+        "name": "želé"
+    },
+    "jerusalem-artichoke": {
+        "name": "artyčok jeruzalémský"
+    },
+    "jicama": {
+        "name": "mexický tuřín"
+    },
+    "kale": {
+        "name": "kapusta"
+    },
+    "kohlrabi": {
+        "name": "kedluben"
+    },
+    "kumara": {
+        "name": "povijnice batátová"
+    },
+    "leavening-agents": {
+        "name": "kypřící prášek"
+    },
+    "leek": {
+        "name": "pórek",
+        "plural_name": "pórky"
+    },
+    "legumes": {
+        "name": "luštěniny"
+    },
+    "lemongrass": {
+        "name": "citronová tráva"
+    },
+    "lentils": {
+        "name": "čočka"
+    },
+    "lettuce": {
+        "name": "hlávkový salát"
+    },
+    "liver": {
+        "name": "játra",
+        "plural_name": "játra"
+    },
+    "maize": {
+        "name": "kukuřice"
+    },
+    "maple-syrup": {
+        "name": "javorový syrup"
+    },
+    "meat": {
+        "name": "maso"
+    },
+    "milk": {
+        "name": "mléko"
+    },
+    "mortadella": {
+        "name": "mortadella"
+    },
+    "mushroom": {
+        "name": "houba",
+        "plural_name": "houby"
+    },
+    "mussels": {
+        "name": "mušle"
+    },
+    "nanaimo-bar-mix": {
+        "name": "směs tyčinek nanaimo"
+    },
+    "nori": {
+        "name": "nori"
+    },
+    "nutmeg": {
+        "name": "muškátový oříšek"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "nutriční kvasnice vločky"
+    },
+    "nuts": {
+        "name": "ořechy"
+    },
+    "octopuses": {
+        "name": "chobotnice",
+        "plural_name": "chobotnice"
+    },
+    "oils": {
+        "name": "oleje"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "olivy"
+    },
+    "olive-oil": {
+        "name": "olivový olej"
+    },
+    "onion": {
+        "name": "cibule"
+    },
+    "onion-family": {
+        "name": "cibule"
+    },
+    "orange-blossom-water": {
+        "name": "voda z pomerančových květů"
+    },
+    "oranges": {
+        "name": "pomeranče",
+        "plural_name": "pomeranče"
+    },
+    "oregano": {
+        "name": "dobromysl"
+    },
+    "oysters": {
+        "name": "ústřice"
+    },
+    "panch-puran": {
+        "name": "panch phoron"
+    },
+    "paprika": {
+        "name": "paprika"
+    },
+    "parsley": {
+        "name": "petržel"
+    },
+    "parsnip": {
+        "name": "pastinák",
+        "plural_name": "pastináky"
+    },
+    "pear": {
+        "name": "hruška",
+        "plural_name": "hrušky"
+    },
+    "peas": {
+        "name": "hrášek"
+    },
+    "pepper": {
+        "name": "pepř",
+        "plural_name": "papriky"
+    },
+    "pineapple": {
+        "name": "ananas",
+        "plural_name": "ananasy"
+    },
+    "plantain": {
+        "name": "plantýn",
+        "plural_name": "plantains"
+    },
+    "poppy-seeds": {
+        "name": "maková semena"
+    },
+    "potato": {
+        "name": "brambor",
+        "plural_name": "brambory"
+    },
+    "poultry": {
+        "name": "drůbež"
+    },
+    "powdered-sugar": {
+        "name": "moučkový cukr"
+    },
+    "pumpkin": {
+        "name": "dýně",
+        "plural_name": "dýně"
+    },
+    "pumpkin-seeds": {
+        "name": "dýňová semínka"
+    },
+    "radish": {
+        "name": "ředkvička",
+        "plural_name": "ředkvičky"
+    },
+    "raw-sugar": {
+        "name": "hnědý cukr"
+    },
+    "refined-sugar": {
+        "name": "rafinovaný cukr"
+    },
+    "rice": {
+        "name": "rýže"
+    },
+    "rice-flour": {
+        "name": "rýžová mouka"
+    },
+    "rock-sugar": {
+        "name": "cukr krystal"
+    },
+    "rum": {
+        "name": "rum"
+    },
+    "salmon": {
+        "name": "losos"
+    },
+    "salt": {
+        "name": "sůl"
+    },
+    "salt-cod": {
+        "name": "solená treska"
+    },
+    "scallion": {
+        "name": "jarní cibulka",
+        "plural_name": "jarní cibulky"
+    },
+    "seafood": {
+        "name": "mořské plody"
+    },
+    "seeds": {
+        "name": "semínka"
+    },
+    "sesame-seeds": {
+        "name": "sezamová semena"
+    },
+    "shallot": {
+        "name": "šalotka",
+        "plural_name": "šalotky"
+    },
+    "skate": {
+        "name": "rejnok"
+    },
+    "soda": {
+        "name": "soda"
+    },
+    "soda-baking": {
+        "name": "soda, pečení"
+    },
+    "soybean": {
+        "name": "sójové boby"
+    },
+    "spaghetti-squash": {
+        "name": "špagetová dýně",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "špek"
+    },
+    "spices": {
+        "name": "koření"
+    },
+    "spinach": {
+        "name": "špenát"
+    },
+    "spring-onion": {
+        "name": "jarní cibulka",
+        "plural_name": "jarní cibulky"
+    },
+    "squash": {
+        "name": "dýně",
+        "plural_name": "squashes"
+    },
+    "squash-family": {
+        "name": "dýně"
+    },
+    "stockfish": {
+        "name": "treska"
+    },
+    "sugar": {
+        "name": "cukr"
+    },
+    "sunchoke": {
+        "name": "slunečnice topinambur",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "slunečnicová semena"
+    },
+    "superfine-sugar": {
+        "name": "cukr krupice"
+    },
+    "sweet-potato": {
+        "name": "batát",
+        "plural_name": "batáty"
+    },
+    "sweetcorn": {
+        "name": "kukuřice cukrová",
+        "plural_name": "kukuřice cukrová"
+    },
+    "sweeteners": {
+        "name": "sladidla"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "kolokázie jedlá",
+        "plural_name": "taro"
+    },
+    "teff": {
+        "name": "milička abesínska"
+    },
+    "tomato": {
+        "name": "rajče",
+        "plural_name": "rajčata"
+    },
+    "trout": {
+        "name": "pstruh"
+    },
+    "tubers": {
+        "name": "hlízy",
+        "plural_name": "tubers"
+    },
+    "tuna": {
+        "name": "tuňák"
+    },
+    "turbanado-sugar": {
+        "name": "nerafinovaný třtinový cukr"
+    },
+    "turnip": {
+        "name": "tuřín",
+        "plural_name": "tuříny"
+    },
+    "unrefined-sugar": {
+        "name": "nerafinovaný cukr"
+    },
+    "vanilla": {
+        "name": "vanilka"
+    },
+    "vegetables": {
+        "name": "zelenina"
+    },
+    "watercress": {
+        "name": "potočnice lékařská"
+    },
+    "watermelon": {
+        "name": "vodní meloun",
+        "plural_name": "vodní melouny"
+    },
+    "white-mushroom": {
+        "name": "bílý žampion",
+        "plural_name": "bílé žampiony"
+    },
+    "white-sugar": {
+        "name": "bílý cukr"
+    },
+    "xanthan-gum": {
+        "name": "xanthanová guma"
+    },
+    "yam": {
+        "name": "yam",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "kvasnice"
+    },
+    "zucchini": {
+        "name": "cuketa",
+        "plural_name": "cukety"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/cs-CZ.json
+++ b/mealie/repos/seed/resources/foods/locales/cs-CZ.json
@@ -1,692 +1,756 @@
 {
-    "acorn-squash": {
-        "name": "tykev"
-    },
-    "alfalfa-sprouts": {
-        "name": "vojtěškové klíčky"
-    },
-    "anchovies": {
-        "name": "ančovičky"
-    },
-    "apples": {
-        "name": "jablka",
-        "plural_name": "jablka"
-    },
-    "artichoke": {
-        "name": "artyčok"
-    },
-    "arugula": {
-        "name": "rukola"
-    },
-    "asparagus": {
-        "name": "chřest"
-    },
-    "avocado": {
-        "name": "avokádo",
-        "plural_name": "avokádo"
-    },
-    "bacon": {
-        "name": "slanina"
-    },
-    "baking-powder": {
-        "name": "prášek na pečení"
-    },
-    "baking-soda": {
-        "name": "pekařská soda"
-    },
-    "baking-sugar": {
-        "name": "cukr na pečení"
-    },
-    "bar-sugar": {
-        "name": "cukr"
-    },
-    "basil": {
-        "name": "bazalka"
-    },
-    "beans": {
-        "name": "fazole"
-    },
-    "bell-peppers": {
-        "name": "papriky",
-        "plural_name": "papriky"
-    },
-    "blackberries": {
-        "name": "ostružiny"
-    },
-    "bok-choy": {
-        "name": "brukev čínská"
-    },
-    "brassicas": {
-        "name": "brukev"
-    },
-    "bread": {
-        "name": "chléb"
-    },
-    "breadfruit": {
-        "name": "chlebovník"
-    },
-    "broccoflower": {
-        "name": "zelený květák"
-    },
-    "broccoli": {
-        "name": "brokolice"
-    },
-    "broccoli-rabe": {
-        "name": "rapini"
-    },
-    "broccolini": {
-        "name": "brokolice"
-    },
-    "brown-sugar": {
-        "name": "hnědý cukr"
-    },
-    "brussels-sprouts": {
-        "name": "růžičková kapusta"
-    },
-    "butter": {
-        "name": "máslo"
-    },
-    "butternut-pumpkin": {
-        "name": "muškátová dýně"
-    },
-    "butternut-squash": {
-        "name": "tykev muškátová"
-    },
-    "cabbage": {
-        "name": "zelí",
-        "plural_name": "zelí"
-    },
-    "cactus-edible": {
-        "name": "kaktus, jedlý"
-    },
-    "calabrese": {
-        "name": "kalábrijský"
-    },
-    "cane-sugar": {
-        "name": "třtinový cukr"
-    },
-    "cannabis": {
-        "name": "konopí"
-    },
-    "capsicum": {
-        "name": "kapie"
-    },
-    "caraway": {
-        "name": "kmín"
-    },
-    "carrot": {
-        "name": "mrkev",
-        "plural_name": "mrkve"
-    },
-    "caster-sugar": {
-        "name": "cukr krupice"
-    },
-    "castor-sugar": {
-        "name": "cukr moučka"
-    },
-    "catfish": {
-        "name": "sumec"
-    },
-    "cauliflower": {
-        "name": "květák",
-        "plural_name": "květáky"
-    },
-    "cayenne-pepper": {
-        "name": "kayenský pepř"
-    },
-    "celeriac": {
-        "name": "bulva celeru"
-    },
-    "celery": {
-        "name": "celer"
-    },
-    "cereal-grains": {
-        "name": "obilniny"
-    },
-    "chard": {
-        "name": "mangold"
-    },
-    "cheese": {
-        "name": "sýr"
-    },
-    "chicory": {
-        "name": "čekanka"
-    },
-    "chilli-peppers": {
-        "name": "čili papričky",
-        "plural_name": "čili papričky"
-    },
-    "chinese-leaves": {
-        "name": "pekingské zelí"
-    },
-    "chives": {
-        "name": "pažitka"
-    },
-    "chocolate": {
-        "name": "čokoláda"
-    },
-    "cilantro": {
-        "name": "koriandr"
-    },
-    "cinnamon": {
-        "name": "skořice"
-    },
-    "clarified-butter": {
-        "name": "přepuštěné máslo"
-    },
-    "coconut": {
-        "name": "kokosový ořech",
-        "plural_name": "kokosové ořechy"
-    },
-    "coconut-milk": {
-        "name": "kokosové mléko"
-    },
-    "cod": {
-        "name": "treska"
-    },
-    "coffee": {
-        "name": "káva"
-    },
-    "collard-greens": {
-        "name": "kapustové listy"
-    },
-    "confectioners-sugar": {
-        "name": "cukr moučka"
-    },
-    "coriander": {
-        "name": "koriandr"
-    },
-    "corn": {
-        "name": "kukuřice",
-        "plural_name": "kukuřice"
-    },
-    "corn-syrup": {
-        "name": "kukuřičný sirup"
-    },
-    "cottonseed-oil": {
-        "name": "bavlníkový olej"
-    },
-    "courgette": {
-        "name": "cuketa"
-    },
-    "cream-of-tartar": {
-        "name": "vinný kámen"
-    },
-    "cucumber": {
-        "name": "okurka",
-        "plural_name": "okurky"
-    },
-    "cumin": {
-        "name": "římský kmín"
-    },
-    "daikon": {
-        "name": "ředkev bílá",
-        "plural_name": "ředkve bílé"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "mléčné výrobky a mléčné náhražky"
-    },
-    "dandelion": {
-        "name": "pampeliška"
-    },
-    "demerara-sugar": {
-        "name": "třtinový cukr"
-    },
-    "dough": {
-        "name": "těsto"
-    },
-    "edible-cactus": {
-        "name": "jedlý kaktus"
-    },
-    "eggplant": {
-        "name": "lilek",
-        "plural_name": "lilky"
-    },
-    "eggs": {
-        "name": "vejce",
-        "plural_name": "vejce"
-    },
-    "endive": {
-        "name": "čekanka",
-        "plural_name": "čekanky"
-    },
-    "fats": {
-        "name": "tuky"
-    },
-    "fava-beans": {
-        "name": "fava fazole"
-    },
-    "fiddlehead": {
-        "name": "kapradiny"
-    },
-    "fiddlehead-fern": {
-        "name": "kapradina",
-        "plural_name": "kapradiny"
-    },
-    "fish": {
-        "name": "ryba"
-    },
-    "five-spice-powder": {
-        "name": "směs pěti koření"
-    },
-    "flour": {
-        "name": "mouka"
-    },
-    "frisee": {
-        "name": "čekanka štěrbák"
-    },
-    "fructose": {
-        "name": "fruktóza"
-    },
-    "fruit": {
-        "name": "ovoce"
-    },
-    "fruit-sugar": {
-        "name": "ovocný cukr"
-    },
-    "ful": {
-        "name": "ful"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "česnek",
-        "plural_name": "česneky"
-    },
-    "gem-squash": {
-        "name": "gem squash"
-    },
-    "ghee": {
-        "name": "ghí"
-    },
-    "giblets": {
-        "name": "droby"
-    },
-    "ginger": {
-        "name": "zázvor"
-    },
-    "grains": {
-        "name": "zrna"
-    },
-    "granulated-sugar": {
-        "name": "granulovaný cukr"
-    },
-    "grape-seed-oil": {
-        "name": "olej z hroznů"
-    },
-    "green-onion": {
-        "name": "zelená cibule",
-        "plural_name": "zelené cibule"
-    },
-    "heart-of-palm": {
-        "name": "palmové srdce",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "konopí"
-    },
-    "herbs": {
-        "name": "bylinky"
-    },
-    "honey": {
-        "name": "med"
-    },
-    "isomalt": {
-        "name": "isomalt"
-    },
-    "jackfruit": {
-        "name": "jackfruit",
-        "plural_name": "jackfruit"
-    },
-    "jaggery": {
-        "name": "jaggery"
-    },
-    "jams": {
-        "name": "džemy"
-    },
-    "jellies": {
-        "name": "želé"
-    },
-    "jerusalem-artichoke": {
-        "name": "artyčok jeruzalémský"
-    },
-    "jicama": {
-        "name": "mexický tuřín"
-    },
-    "kale": {
-        "name": "kapusta"
-    },
-    "kohlrabi": {
-        "name": "kedluben"
-    },
-    "kumara": {
-        "name": "povijnice batátová"
-    },
-    "leavening-agents": {
-        "name": "kypřící prášek"
-    },
-    "leek": {
-        "name": "pórek",
-        "plural_name": "pórky"
-    },
-    "legumes": {
-        "name": "luštěniny"
-    },
-    "lemongrass": {
-        "name": "citronová tráva"
-    },
-    "lentils": {
-        "name": "čočka"
-    },
-    "lettuce": {
-        "name": "hlávkový salát"
-    },
-    "liver": {
-        "name": "játra",
-        "plural_name": "játra"
-    },
-    "maize": {
-        "name": "kukuřice"
-    },
-    "maple-syrup": {
-        "name": "javorový syrup"
-    },
-    "meat": {
-        "name": "maso"
-    },
-    "milk": {
-        "name": "mléko"
-    },
-    "mortadella": {
-        "name": "mortadella"
-    },
-    "mushroom": {
-        "name": "houba",
-        "plural_name": "houby"
-    },
-    "mussels": {
-        "name": "mušle"
-    },
-    "nanaimo-bar-mix": {
-        "name": "směs tyčinek nanaimo"
-    },
-    "nori": {
-        "name": "nori"
-    },
-    "nutmeg": {
-        "name": "muškátový oříšek"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "nutriční kvasnice vločky"
-    },
-    "nuts": {
-        "name": "ořechy"
-    },
-    "octopuses": {
-        "name": "chobotnice",
-        "plural_name": "chobotnice"
-    },
-    "oils": {
-        "name": "oleje"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "olivy"
-    },
-    "olive-oil": {
-        "name": "olivový olej"
-    },
-    "onion": {
-        "name": "cibule"
-    },
-    "onion-family": {
-        "name": "cibule"
-    },
-    "orange-blossom-water": {
-        "name": "voda z pomerančových květů"
-    },
-    "oranges": {
-        "name": "pomeranče",
-        "plural_name": "pomeranče"
-    },
-    "oregano": {
-        "name": "dobromysl"
-    },
-    "oysters": {
-        "name": "ústřice"
-    },
-    "panch-puran": {
-        "name": "panch phoron"
-    },
-    "paprika": {
-        "name": "paprika"
-    },
-    "parsley": {
-        "name": "petržel"
-    },
-    "parsnip": {
-        "name": "pastinák",
-        "plural_name": "pastináky"
-    },
-    "pear": {
-        "name": "hruška",
-        "plural_name": "hrušky"
-    },
-    "peas": {
-        "name": "hrášek"
-    },
-    "pepper": {
-        "name": "pepř",
-        "plural_name": "papriky"
-    },
-    "pineapple": {
-        "name": "ananas",
-        "plural_name": "ananasy"
-    },
-    "plantain": {
-        "name": "plantýn",
-        "plural_name": "plantains"
-    },
-    "poppy-seeds": {
-        "name": "maková semena"
-    },
-    "potato": {
-        "name": "brambor",
-        "plural_name": "brambory"
-    },
-    "poultry": {
-        "name": "drůbež"
-    },
-    "powdered-sugar": {
-        "name": "moučkový cukr"
-    },
-    "pumpkin": {
-        "name": "dýně",
-        "plural_name": "dýně"
-    },
-    "pumpkin-seeds": {
-        "name": "dýňová semínka"
-    },
-    "radish": {
-        "name": "ředkvička",
-        "plural_name": "ředkvičky"
-    },
-    "raw-sugar": {
-        "name": "hnědý cukr"
-    },
-    "refined-sugar": {
-        "name": "rafinovaný cukr"
-    },
-    "rice": {
-        "name": "rýže"
-    },
-    "rice-flour": {
-        "name": "rýžová mouka"
-    },
-    "rock-sugar": {
-        "name": "cukr krystal"
-    },
-    "rum": {
-        "name": "rum"
-    },
-    "salmon": {
-        "name": "losos"
-    },
-    "salt": {
-        "name": "sůl"
-    },
-    "salt-cod": {
-        "name": "solená treska"
-    },
-    "scallion": {
-        "name": "jarní cibulka",
-        "plural_name": "jarní cibulky"
-    },
-    "seafood": {
-        "name": "mořské plody"
-    },
-    "seeds": {
-        "name": "semínka"
-    },
-    "sesame-seeds": {
-        "name": "sezamová semena"
-    },
-    "shallot": {
-        "name": "šalotka",
-        "plural_name": "šalotky"
-    },
-    "skate": {
-        "name": "rejnok"
-    },
-    "soda": {
-        "name": "soda"
-    },
-    "soda-baking": {
-        "name": "soda, pečení"
-    },
-    "soybean": {
-        "name": "sójové boby"
-    },
-    "spaghetti-squash": {
-        "name": "špagetová dýně",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "špek"
-    },
-    "spices": {
-        "name": "koření"
-    },
-    "spinach": {
-        "name": "špenát"
-    },
-    "spring-onion": {
-        "name": "jarní cibulka",
-        "plural_name": "jarní cibulky"
-    },
-    "squash": {
-        "name": "dýně",
-        "plural_name": "squashes"
-    },
-    "squash-family": {
-        "name": "dýně"
-    },
-    "stockfish": {
-        "name": "treska"
-    },
-    "sugar": {
-        "name": "cukr"
-    },
-    "sunchoke": {
-        "name": "slunečnice topinambur",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "slunečnicová semena"
-    },
-    "superfine-sugar": {
-        "name": "cukr krupice"
-    },
-    "sweet-potato": {
-        "name": "batát",
-        "plural_name": "batáty"
-    },
-    "sweetcorn": {
-        "name": "kukuřice cukrová",
-        "plural_name": "kukuřice cukrová"
-    },
-    "sweeteners": {
-        "name": "sladidla"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "kolokázie jedlá",
-        "plural_name": "taro"
-    },
-    "teff": {
-        "name": "milička abesínska"
-    },
-    "tomato": {
-        "name": "rajče",
-        "plural_name": "rajčata"
-    },
-    "trout": {
-        "name": "pstruh"
-    },
-    "tubers": {
-        "name": "hlízy",
-        "plural_name": "tubers"
-    },
-    "tuna": {
-        "name": "tuňák"
-    },
-    "turbanado-sugar": {
-        "name": "nerafinovaný třtinový cukr"
-    },
-    "turnip": {
-        "name": "tuřín",
-        "plural_name": "tuříny"
-    },
-    "unrefined-sugar": {
-        "name": "nerafinovaný cukr"
-    },
-    "vanilla": {
-        "name": "vanilka"
-    },
-    "vegetables": {
-        "name": "zelenina"
-    },
-    "watercress": {
-        "name": "potočnice lékařská"
-    },
-    "watermelon": {
-        "name": "vodní meloun",
-        "plural_name": "vodní melouny"
-    },
-    "white-mushroom": {
-        "name": "bílý žampion",
-        "plural_name": "bílé žampiony"
-    },
-    "white-sugar": {
-        "name": "bílý cukr"
-    },
-    "xanthan-gum": {
-        "name": "xanthanová guma"
-    },
-    "yam": {
-        "name": "yam",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "kvasnice"
-    },
-    "zucchini": {
-        "name": "cuketa",
-        "plural_name": "cukety"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "tykev"
+            },
+            "alfalfa-sprouts": {
+                "name": "vojtěškové klíčky"
+            },
+            "anchovies": {
+                "name": "ančovičky"
+            },
+            "apples": {
+                "name": "jablka",
+                "plural_name": "jablka"
+            },
+            "artichoke": {
+                "name": "artyčok"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "chřest"
+            },
+            "avocado": {
+                "name": "avokádo",
+                "plural_name": "avokádo"
+            },
+            "bacon": {
+                "name": "slanina"
+            },
+            "baking-powder": {
+                "name": "prášek na pečení"
+            },
+            "baking-soda": {
+                "name": "pekařská soda"
+            },
+            "baking-sugar": {
+                "name": "cukr na pečení"
+            },
+            "bar-sugar": {
+                "name": "cukr"
+            },
+            "basil": {
+                "name": "bazalka"
+            },
+            "beans": {
+                "name": "fazole"
+            },
+            "bell-peppers": {
+                "name": "papriky",
+                "plural_name": "papriky"
+            },
+            "blackberries": {
+                "name": "ostružiny"
+            },
+            "bok-choy": {
+                "name": "brukev čínská"
+            },
+            "brassicas": {
+                "name": "brukev"
+            },
+            "bread": {
+                "name": "chléb"
+            },
+            "breadfruit": {
+                "name": "chlebovník"
+            },
+            "broccoflower": {
+                "name": "zelený květák"
+            },
+            "broccoli": {
+                "name": "brokolice"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "brokolice"
+            },
+            "brown-sugar": {
+                "name": "hnědý cukr"
+            },
+            "brussels-sprouts": {
+                "name": "růžičková kapusta"
+            },
+            "butter": {
+                "name": "máslo"
+            },
+            "butternut-pumpkin": {
+                "name": "muškátová dýně"
+            },
+            "butternut-squash": {
+                "name": "tykev muškátová"
+            },
+            "cabbage": {
+                "name": "zelí",
+                "plural_name": "zelí"
+            },
+            "cactus-edible": {
+                "name": "kaktus, jedlý"
+            },
+            "calabrese": {
+                "name": "kalábrijský"
+            },
+            "cane-sugar": {
+                "name": "třtinový cukr"
+            },
+            "cannabis": {
+                "name": "konopí"
+            },
+            "capsicum": {
+                "name": "kapie"
+            },
+            "caraway": {
+                "name": "kmín"
+            },
+            "carrot": {
+                "name": "mrkev",
+                "plural_name": "mrkve"
+            },
+            "caster-sugar": {
+                "name": "cukr krupice"
+            },
+            "castor-sugar": {
+                "name": "cukr moučka"
+            },
+            "catfish": {
+                "name": "sumec"
+            },
+            "cauliflower": {
+                "name": "květák",
+                "plural_name": "květáky"
+            },
+            "cayenne-pepper": {
+                "name": "kayenský pepř"
+            },
+            "celeriac": {
+                "name": "bulva celeru"
+            },
+            "celery": {
+                "name": "celer"
+            },
+            "cereal-grains": {
+                "name": "obilniny"
+            },
+            "chard": {
+                "name": "mangold"
+            },
+            "cheese": {
+                "name": "sýr"
+            },
+            "chicory": {
+                "name": "čekanka"
+            },
+            "chilli-peppers": {
+                "name": "čili papričky",
+                "plural_name": "čili papričky"
+            },
+            "chinese-leaves": {
+                "name": "pekingské zelí"
+            },
+            "chives": {
+                "name": "pažitka"
+            },
+            "chocolate": {
+                "name": "čokoláda"
+            },
+            "cilantro": {
+                "name": "koriandr"
+            },
+            "cinnamon": {
+                "name": "skořice"
+            },
+            "clarified-butter": {
+                "name": "přepuštěné máslo"
+            },
+            "coconut": {
+                "name": "kokosový ořech",
+                "plural_name": "kokosové ořechy"
+            },
+            "coconut-milk": {
+                "name": "kokosové mléko"
+            },
+            "cod": {
+                "name": "treska"
+            },
+            "coffee": {
+                "name": "káva"
+            },
+            "collard-greens": {
+                "name": "kapustové listy"
+            },
+            "confectioners-sugar": {
+                "name": "cukr moučka"
+            },
+            "coriander": {
+                "name": "koriandr"
+            },
+            "corn": {
+                "name": "kukuřice",
+                "plural_name": "kukuřice"
+            },
+            "corn-syrup": {
+                "name": "kukuřičný sirup"
+            },
+            "cottonseed-oil": {
+                "name": "bavlníkový olej"
+            },
+            "courgette": {
+                "name": "cuketa"
+            },
+            "cream-of-tartar": {
+                "name": "vinný kámen"
+            },
+            "cucumber": {
+                "name": "okurka",
+                "plural_name": "okurky"
+            },
+            "cumin": {
+                "name": "římský kmín"
+            },
+            "daikon": {
+                "name": "ředkev bílá",
+                "plural_name": "ředkve bílé"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mléčné výrobky a mléčné náhražky"
+            },
+            "dandelion": {
+                "name": "pampeliška"
+            },
+            "demerara-sugar": {
+                "name": "třtinový cukr"
+            },
+            "dough": {
+                "name": "těsto"
+            },
+            "edible-cactus": {
+                "name": "jedlý kaktus"
+            },
+            "eggplant": {
+                "name": "lilek",
+                "plural_name": "lilky"
+            },
+            "eggs": {
+                "name": "vejce",
+                "plural_name": "vejce"
+            },
+            "endive": {
+                "name": "čekanka",
+                "plural_name": "čekanky"
+            },
+            "fats": {
+                "name": "tuky"
+            },
+            "fava-beans": {
+                "name": "fava fazole"
+            },
+            "fiddlehead": {
+                "name": "kapradiny"
+            },
+            "fiddlehead-fern": {
+                "name": "kapradina",
+                "plural_name": "kapradiny"
+            },
+            "fish": {
+                "name": "ryba"
+            },
+            "five-spice-powder": {
+                "name": "směs pěti koření"
+            },
+            "flour": {
+                "name": "mouka"
+            },
+            "frisee": {
+                "name": "čekanka štěrbák"
+            },
+            "fructose": {
+                "name": "fruktóza"
+            },
+            "fruit": {
+                "name": "ovoce"
+            },
+            "fruit-sugar": {
+                "name": "ovocný cukr"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "česnek",
+                "plural_name": "česneky"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghí"
+            },
+            "giblets": {
+                "name": "droby"
+            },
+            "ginger": {
+                "name": "zázvor"
+            },
+            "grains": {
+                "name": "zrna"
+            },
+            "granulated-sugar": {
+                "name": "granulovaný cukr"
+            },
+            "grape-seed-oil": {
+                "name": "olej z hroznů"
+            },
+            "green-onion": {
+                "name": "zelená cibule",
+                "plural_name": "zelené cibule"
+            },
+            "heart-of-palm": {
+                "name": "palmové srdce",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "konopí"
+            },
+            "herbs": {
+                "name": "bylinky"
+            },
+            "honey": {
+                "name": "med"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruit"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "džemy"
+            },
+            "jellies": {
+                "name": "želé"
+            },
+            "jerusalem-artichoke": {
+                "name": "artyčok jeruzalémský"
+            },
+            "jicama": {
+                "name": "mexický tuřín"
+            },
+            "kale": {
+                "name": "kapusta"
+            },
+            "kohlrabi": {
+                "name": "kedluben"
+            },
+            "kumara": {
+                "name": "povijnice batátová"
+            },
+            "leavening-agents": {
+                "name": "kypřící prášek"
+            },
+            "leek": {
+                "name": "pórek",
+                "plural_name": "pórky"
+            },
+            "legumes": {
+                "name": "luštěniny"
+            },
+            "lemongrass": {
+                "name": "citronová tráva"
+            },
+            "lentils": {
+                "name": "čočka"
+            },
+            "lettuce": {
+                "name": "hlávkový salát"
+            },
+            "liver": {
+                "name": "játra",
+                "plural_name": "játra"
+            },
+            "maize": {
+                "name": "kukuřice"
+            },
+            "maple-syrup": {
+                "name": "javorový syrup"
+            },
+            "meat": {
+                "name": "maso"
+            },
+            "milk": {
+                "name": "mléko"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "houba",
+                "plural_name": "houby"
+            },
+            "mussels": {
+                "name": "mušle"
+            },
+            "nanaimo-bar-mix": {
+                "name": "směs tyčinek nanaimo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muškátový oříšek"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutriční kvasnice vločky"
+            },
+            "nuts": {
+                "name": "ořechy"
+            },
+            "octopuses": {
+                "name": "chobotnice",
+                "plural_name": "chobotnice"
+            },
+            "oils": {
+                "name": "oleje"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olivy"
+            },
+            "olive-oil": {
+                "name": "olivový olej"
+            },
+            "onion": {
+                "name": "cibule"
+            },
+            "onion-family": {
+                "name": "cibule"
+            },
+            "orange-blossom-water": {
+                "name": "voda z pomerančových květů"
+            },
+            "oranges": {
+                "name": "pomeranče",
+                "plural_name": "pomeranče"
+            },
+            "oregano": {
+                "name": "dobromysl"
+            },
+            "oysters": {
+                "name": "ústřice"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "petržel"
+            },
+            "parsnip": {
+                "name": "pastinák",
+                "plural_name": "pastináky"
+            },
+            "pear": {
+                "name": "hruška",
+                "plural_name": "hrušky"
+            },
+            "peas": {
+                "name": "hrášek"
+            },
+            "pepper": {
+                "name": "pepř",
+                "plural_name": "papriky"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananasy"
+            },
+            "plantain": {
+                "name": "plantýn",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "maková semena"
+            },
+            "potato": {
+                "name": "brambor",
+                "plural_name": "brambory"
+            },
+            "poultry": {
+                "name": "drůbež"
+            },
+            "powdered-sugar": {
+                "name": "moučkový cukr"
+            },
+            "pumpkin": {
+                "name": "dýně",
+                "plural_name": "dýně"
+            },
+            "pumpkin-seeds": {
+                "name": "dýňová semínka"
+            },
+            "radish": {
+                "name": "ředkvička",
+                "plural_name": "ředkvičky"
+            },
+            "raw-sugar": {
+                "name": "hnědý cukr"
+            },
+            "refined-sugar": {
+                "name": "rafinovaný cukr"
+            },
+            "rice": {
+                "name": "rýže"
+            },
+            "rice-flour": {
+                "name": "rýžová mouka"
+            },
+            "rock-sugar": {
+                "name": "cukr krystal"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "losos"
+            },
+            "salt": {
+                "name": "sůl"
+            },
+            "salt-cod": {
+                "name": "solená treska"
+            },
+            "scallion": {
+                "name": "jarní cibulka",
+                "plural_name": "jarní cibulky"
+            },
+            "seafood": {
+                "name": "mořské plody"
+            },
+            "seeds": {
+                "name": "semínka"
+            },
+            "sesame-seeds": {
+                "name": "sezamová semena"
+            },
+            "shallot": {
+                "name": "šalotka",
+                "plural_name": "šalotky"
+            },
+            "skate": {
+                "name": "rejnok"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, pečení"
+            },
+            "soybean": {
+                "name": "sójové boby"
+            },
+            "spaghetti-squash": {
+                "name": "špagetová dýně",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "špek"
+            },
+            "spices": {
+                "name": "koření"
+            },
+            "spinach": {
+                "name": "špenát"
+            },
+            "spring-onion": {
+                "name": "jarní cibulka",
+                "plural_name": "jarní cibulky"
+            },
+            "squash": {
+                "name": "dýně",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "dýně"
+            },
+            "stockfish": {
+                "name": "treska"
+            },
+            "sugar": {
+                "name": "cukr"
+            },
+            "sunchoke": {
+                "name": "slunečnice topinambur",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "slunečnicová semena"
+            },
+            "superfine-sugar": {
+                "name": "cukr krupice"
+            },
+            "sweet-potato": {
+                "name": "batát",
+                "plural_name": "batáty"
+            },
+            "sweetcorn": {
+                "name": "kukuřice cukrová",
+                "plural_name": "kukuřice cukrová"
+            },
+            "sweeteners": {
+                "name": "sladidla"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "kolokázie jedlá",
+                "plural_name": "taro"
+            },
+            "teff": {
+                "name": "milička abesínska"
+            },
+            "tomato": {
+                "name": "rajče",
+                "plural_name": "rajčata"
+            },
+            "trout": {
+                "name": "pstruh"
+            },
+            "tubers": {
+                "name": "hlízy",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuňák"
+            },
+            "turbanado-sugar": {
+                "name": "nerafinovaný třtinový cukr"
+            },
+            "turnip": {
+                "name": "tuřín",
+                "plural_name": "tuříny"
+            },
+            "unrefined-sugar": {
+                "name": "nerafinovaný cukr"
+            },
+            "vanilla": {
+                "name": "vanilka"
+            },
+            "vegetables": {
+                "name": "zelenina"
+            },
+            "watercress": {
+                "name": "potočnice lékařská"
+            },
+            "watermelon": {
+                "name": "vodní meloun",
+                "plural_name": "vodní melouny"
+            },
+            "white-mushroom": {
+                "name": "bílý žampion",
+                "plural_name": "bílé žampiony"
+            },
+            "white-sugar": {
+                "name": "bílý cukr"
+            },
+            "xanthan-gum": {
+                "name": "xanthanová guma"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "kvasnice"
+            },
+            "zucchini": {
+                "name": "cuketa",
+                "plural_name": "cukety"
+            }
+        }
+    },
+    "Ovoce a Zelenina": {
+        "foods": {}
+    },
+    "Zrna": {
+        "foods": {}
+    },
+    "Ovoce": {
+        "foods": {}
+    },
+    "Zelenina": {
+        "foods": {}
+    },
+    "Maso": {
+        "foods": {}
+    },
+    "Mořské plody": {
+        "foods": {}
+    },
+    "Nápoje": {
+        "foods": {}
+    },
+    "Pečené jídlo": {
+        "foods": {}
+    },
+    "Konzervované jídlo": {
+        "foods": {}
+    },
+    "Koření": {
+        "foods": {}
+    },
+    "Cukrovinky": {
+        "foods": {}
+    },
+    "Mléčné Výrobky": {
+        "foods": {}
+    },
+    "Mražené Potraviny": {
+        "foods": {}
+    },
+    "Zdravá Strava": {
+        "foods": {}
+    },
+    "Domácí": {
+        "foods": {}
+    },
+    "Masné Výrobky": {
+        "foods": {}
+    },
+    "Svačiny": {
+        "foods": {}
+    },
+    "Sladkosti": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Jiné": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/da-DK.json
+++ b/mealie/repos/seed/resources/foods/locales/da-DK.json
@@ -1,692 +1,759 @@
 {
-    "acorn-squash": {
-        "name": "agern squash"
-    },
-    "alfalfa-sprouts": {
-        "name": "lucernespirer"
-    },
-    "anchovies": {
-        "name": "ansjoser"
-    },
-    "apples": {
-        "name": "æble",
-        "plural_name": "æbler"
-    },
-    "artichoke": {
-        "name": "artiskok"
-    },
-    "arugula": {
-        "name": "rucola"
-    },
-    "asparagus": {
-        "name": "asparges"
-    },
-    "avocado": {
-        "name": "avocado",
-        "plural_name": "avocado"
-    },
-    "bacon": {
-        "name": "bacon"
-    },
-    "baking-powder": {
-        "name": "bagepulver"
-    },
-    "baking-soda": {
-        "name": "natron"
-    },
-    "baking-sugar": {
-        "name": "bagesukker"
-    },
-    "bar-sugar": {
-        "name": "sukkerstang"
-    },
-    "basil": {
-        "name": "basilikum"
-    },
-    "beans": {
-        "name": "bønner"
-    },
-    "bell-peppers": {
-        "name": "peberfrugter",
-        "plural_name": "peberfrugter"
-    },
-    "blackberries": {
-        "name": "brombær"
-    },
-    "bok-choy": {
-        "name": "pak choi"
-    },
-    "brassicas": {
-        "name": "havekål"
-    },
-    "bread": {
-        "name": "brød"
-    },
-    "breadfruit": {
-        "name": "brødfrugt"
-    },
-    "broccoflower": {
-        "name": "romanesco"
-    },
-    "broccoli": {
-        "name": "broccoli"
-    },
-    "broccoli-rabe": {
-        "name": "rapini"
-    },
-    "broccolini": {
-        "name": "broccolini"
-    },
-    "brown-sugar": {
-        "name": "brun farin"
-    },
-    "brussels-sprouts": {
-        "name": "rosenkål"
-    },
-    "butter": {
-        "name": "smør"
-    },
-    "butternut-pumpkin": {
-        "name": "moskusgræskar"
-    },
-    "butternut-squash": {
-        "name": "butternut squash"
-    },
-    "cabbage": {
-        "name": "kål",
-        "plural_name": "kål"
-    },
-    "cactus-edible": {
-        "name": "kaktus, spiselig"
-    },
-    "calabrese": {
-        "name": "calabrese"
-    },
-    "cane-sugar": {
-        "name": "rørsukker"
-    },
-    "cannabis": {
-        "name": "kanabis"
-    },
-    "capsicum": {
-        "name": "paprika"
-    },
-    "caraway": {
-        "name": "kommen"
-    },
-    "carrot": {
-        "name": "gulerod",
-        "plural_name": "gulerødder"
-    },
-    "caster-sugar": {
-        "name": "strøsukker"
-    },
-    "castor-sugar": {
-        "name": "ricinussukker"
-    },
-    "catfish": {
-        "name": "havkat"
-    },
-    "cauliflower": {
-        "name": "blomkål",
-        "plural_name": "blomkål"
-    },
-    "cayenne-pepper": {
-        "name": "cayennepeber"
-    },
-    "celeriac": {
-        "name": "knoldselleri"
-    },
-    "celery": {
-        "name": "selleri"
-    },
-    "cereal-grains": {
-        "name": "korn"
-    },
-    "chard": {
-        "name": "bladbede"
-    },
-    "cheese": {
-        "name": "ost"
-    },
-    "chicory": {
-        "name": "cikorie"
-    },
-    "chilli-peppers": {
-        "name": "chilipeber",
-        "plural_name": "chilipeber"
-    },
-    "chinese-leaves": {
-        "name": "kinakål"
-    },
-    "chives": {
-        "name": "purløg"
-    },
-    "chocolate": {
-        "name": "chokolade"
-    },
-    "cilantro": {
-        "name": "koriander"
-    },
-    "cinnamon": {
-        "name": "kanel"
-    },
-    "clarified-butter": {
-        "name": "klaret smør"
-    },
-    "coconut": {
-        "name": "kokosnød",
-        "plural_name": "kokosnødder"
-    },
-    "coconut-milk": {
-        "name": "kokosmælk"
-    },
-    "cod": {
-        "name": "torsk"
-    },
-    "coffee": {
-        "name": "kaffe"
-    },
-    "collard-greens": {
-        "name": "marvkål"
-    },
-    "confectioners-sugar": {
-        "name": "flormelis"
-    },
-    "coriander": {
-        "name": "koriander"
-    },
-    "corn": {
-        "name": "majs",
-        "plural_name": "majs"
-    },
-    "corn-syrup": {
-        "name": "majsirup"
-    },
-    "cottonseed-oil": {
-        "name": "bomuldsfrøolie"
-    },
-    "courgette": {
-        "name": "squash"
-    },
-    "cream-of-tartar": {
-        "name": "eddikepulver"
-    },
-    "cucumber": {
-        "name": "agurk",
-        "plural_name": "agurker"
-    },
-    "cumin": {
-        "name": "spidskommen"
-    },
-    "daikon": {
-        "name": "kinaradise",
-        "plural_name": "kinaradiser"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "mejeriprodukter og mælkeerstatninger"
-    },
-    "dandelion": {
-        "name": "mælkebøtte"
-    },
-    "demerara-sugar": {
-        "name": "rørsukker"
-    },
-    "dough": {
-        "name": "dej"
-    },
-    "edible-cactus": {
-        "name": "spiselig kaktus"
-    },
-    "eggplant": {
-        "name": "aubergine",
-        "plural_name": "aubergine"
-    },
-    "eggs": {
-        "name": "æg",
-        "plural_name": "æg"
-    },
-    "endive": {
-        "name": "endive",
-        "plural_name": "endives"
-    },
-    "fats": {
-        "name": "fedt"
-    },
-    "fava-beans": {
-        "name": "hestebønner"
-    },
-    "fiddlehead": {
-        "name": "bispestav"
-    },
-    "fiddlehead-fern": {
-        "name": "fiddlehead bregne",
-        "plural_name": "fiddlehead ferns"
-    },
-    "fish": {
-        "name": "fisk"
-    },
-    "five-spice-powder": {
-        "name": "femkrydderipulver"
-    },
-    "flour": {
-        "name": "mel"
-    },
-    "frisee": {
-        "name": "friséesalat"
-    },
-    "fructose": {
-        "name": "fruktose"
-    },
-    "fruit": {
-        "name": "frugt"
-    },
-    "fruit-sugar": {
-        "name": "frugtsukker"
-    },
-    "ful": {
-        "name": "ful"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "hvidløg",
-        "plural_name": "hvidløg"
-    },
-    "gem-squash": {
-        "name": "citron squash"
-    },
-    "ghee": {
-        "name": "klaret smør"
-    },
-    "giblets": {
-        "name": "fugleindmad"
-    },
-    "ginger": {
-        "name": "ingefær"
-    },
-    "grains": {
-        "name": "gryn"
-    },
-    "granulated-sugar": {
-        "name": "sukker"
-    },
-    "grape-seed-oil": {
-        "name": "vindruekerneolie"
-    },
-    "green-onion": {
-        "name": "forårsløg",
-        "plural_name": "forårsløg"
-    },
-    "heart-of-palm": {
-        "name": "palmehjerte",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "hamp"
-    },
-    "herbs": {
-        "name": "krydderurter"
-    },
-    "honey": {
-        "name": "honning"
-    },
-    "isomalt": {
-        "name": "isomalt"
-    },
-    "jackfruit": {
-        "name": "jackfrugt",
-        "plural_name": "jackfruits"
-    },
-    "jaggery": {
-        "name": "jaggery"
-    },
-    "jams": {
-        "name": "marmelade"
-    },
-    "jellies": {
-        "name": "gelé"
-    },
-    "jerusalem-artichoke": {
-        "name": "jordskok"
-    },
-    "jicama": {
-        "name": "jicama"
-    },
-    "kale": {
-        "name": "grønkål"
-    },
-    "kohlrabi": {
-        "name": "glaskål"
-    },
-    "kumara": {
-        "name": "sød kartoffel"
-    },
-    "leavening-agents": {
-        "name": "hævemiddel"
-    },
-    "leek": {
-        "name": "porre",
-        "plural_name": "porre"
-    },
-    "legumes": {
-        "name": "bælgplante"
-    },
-    "lemongrass": {
-        "name": "citrongræs"
-    },
-    "lentils": {
-        "name": "linser"
-    },
-    "lettuce": {
-        "name": "salat"
-    },
-    "liver": {
-        "name": "lever",
-        "plural_name": "lever"
-    },
-    "maize": {
-        "name": "majs"
-    },
-    "maple-syrup": {
-        "name": "ahornsirup"
-    },
-    "meat": {
-        "name": "kød"
-    },
-    "milk": {
-        "name": "mælk"
-    },
-    "mortadella": {
-        "name": "mortadella"
-    },
-    "mushroom": {
-        "name": "svamp",
-        "plural_name": "svampe"
-    },
-    "mussels": {
-        "name": "musling"
-    },
-    "nanaimo-bar-mix": {
-        "name": "nanaimo barmix"
-    },
-    "nori": {
-        "name": "tank"
-    },
-    "nutmeg": {
-        "name": "muskatnød"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "gærflager"
-    },
-    "nuts": {
-        "name": "nødder"
-    },
-    "octopuses": {
-        "name": "ottearmede blæksprutter",
-        "plural_name": "blæksprutter"
-    },
-    "oils": {
-        "name": "olier"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "oliven"
-    },
-    "olive-oil": {
-        "name": "olivenolie"
-    },
-    "onion": {
-        "name": "løg"
-    },
-    "onion-family": {
-        "name": "løgfamilien"
-    },
-    "orange-blossom-water": {
-        "name": "orangeblossomvand"
-    },
-    "oranges": {
-        "name": "appelsiner",
-        "plural_name": "appelsiner"
-    },
-    "oregano": {
-        "name": "oregano"
-    },
-    "oysters": {
-        "name": "østers"
-    },
-    "panch-puran": {
-        "name": "panch puran"
-    },
-    "paprika": {
-        "name": "paprika"
-    },
-    "parsley": {
-        "name": "persille"
-    },
-    "parsnip": {
-        "name": "pastinak",
-        "plural_name": "pastinak"
-    },
-    "pear": {
-        "name": "pære",
-        "plural_name": "pærer"
-    },
-    "peas": {
-        "name": "ærter"
-    },
-    "pepper": {
-        "name": "peber",
-        "plural_name": "peberfrugter"
-    },
-    "pineapple": {
-        "name": "ananas",
-        "plural_name": "ananas"
-    },
-    "plantain": {
-        "name": "madbanan",
-        "plural_name": "plantains"
-    },
-    "poppy-seeds": {
-        "name": "birkes"
-    },
-    "potato": {
-        "name": "kartoffel",
-        "plural_name": "kartofler"
-    },
-    "poultry": {
-        "name": "fjerkræ"
-    },
-    "powdered-sugar": {
-        "name": "flormelis"
-    },
-    "pumpkin": {
-        "name": "græskar",
-        "plural_name": "græskar"
-    },
-    "pumpkin-seeds": {
-        "name": "græskarkerner"
-    },
-    "radish": {
-        "name": "radise",
-        "plural_name": "radiser"
-    },
-    "raw-sugar": {
-        "name": "hel rørsukker"
-    },
-    "refined-sugar": {
-        "name": "raffineret sukker"
-    },
-    "rice": {
-        "name": "ri"
-    },
-    "rice-flour": {
-        "name": "rismel"
-    },
-    "rock-sugar": {
-        "name": "kandis"
-    },
-    "rum": {
-        "name": "rom"
-    },
-    "salmon": {
-        "name": "laks"
-    },
-    "salt": {
-        "name": "salt"
-    },
-    "salt-cod": {
-        "name": "saltet torsk"
-    },
-    "scallion": {
-        "name": "forårsløg",
-        "plural_name": "scallions"
-    },
-    "seafood": {
-        "name": "fisk og skaldyr"
-    },
-    "seeds": {
-        "name": "frø"
-    },
-    "sesame-seeds": {
-        "name": "sesamfrø"
-    },
-    "shallot": {
-        "name": "skalotteløg",
-        "plural_name": "skalotteløg"
-    },
-    "skate": {
-        "name": "rokke"
-    },
-    "soda": {
-        "name": "soda"
-    },
-    "soda-baking": {
-        "name": "natron"
-    },
-    "soybean": {
-        "name": "sojabønne"
-    },
-    "spaghetti-squash": {
-        "name": "spaghettisquash",
-        "plural_name": "spaghettisquash"
-    },
-    "speck": {
-        "name": "speck"
-    },
-    "spices": {
-        "name": "krydderier"
-    },
-    "spinach": {
-        "name": "spinat"
-    },
-    "spring-onion": {
-        "name": "forårsløg",
-        "plural_name": "forårsløg"
-    },
-    "squash": {
-        "name": "squash",
-        "plural_name": "squash"
-    },
-    "squash-family": {
-        "name": "squashfamilien"
-    },
-    "stockfish": {
-        "name": "tørfisk"
-    },
-    "sugar": {
-        "name": "sukker"
-    },
-    "sunchoke": {
-        "name": "jordskok",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "solsikkefrø"
-    },
-    "superfine-sugar": {
-        "name": "superfint sukker"
-    },
-    "sweet-potato": {
-        "name": "sød kartoffel",
-        "plural_name": "søde kartofler"
-    },
-    "sweetcorn": {
-        "name": "søde majs",
-        "plural_name": "sukkermajs"
-    },
-    "sweeteners": {
-        "name": "sødemiddel"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "taro",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "teff"
-    },
-    "tomato": {
-        "name": "tomat",
-        "plural_name": "tomater"
-    },
-    "trout": {
-        "name": "ørred"
-    },
-    "tubers": {
-        "name": "knold",
-        "plural_name": "tubers"
-    },
-    "tuna": {
-        "name": "tun"
-    },
-    "turbanado-sugar": {
-        "name": "rørsukker"
-    },
-    "turnip": {
-        "name": "majroe",
-        "plural_name": "majroer"
-    },
-    "unrefined-sugar": {
-        "name": "uraffineret sukker"
-    },
-    "vanilla": {
-        "name": "vanilje"
-    },
-    "vegetables": {
-        "name": "grøntsager"
-    },
-    "watercress": {
-        "name": "brøndkarse"
-    },
-    "watermelon": {
-        "name": "vandmelon",
-        "plural_name": "vandmeloner"
-    },
-    "white-mushroom": {
-        "name": "champignon",
-        "plural_name": "hvide svampe"
-    },
-    "white-sugar": {
-        "name": "hvidt sukker"
-    },
-    "xanthan-gum": {
-        "name": "xanthan gum"
-    },
-    "yam": {
-        "name": "yam",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "gær"
-    },
-    "zucchini": {
-        "name": "sommersquash",
-        "plural_name": "courgette"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "agern squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "lucernespirer"
+            },
+            "anchovies": {
+                "name": "ansjoser"
+            },
+            "apples": {
+                "name": "æble",
+                "plural_name": "æbler"
+            },
+            "artichoke": {
+                "name": "artiskok"
+            },
+            "arugula": {
+                "name": "rucola"
+            },
+            "asparagus": {
+                "name": "asparges"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "bagepulver"
+            },
+            "baking-soda": {
+                "name": "natron"
+            },
+            "baking-sugar": {
+                "name": "bagesukker"
+            },
+            "bar-sugar": {
+                "name": "sukkerstang"
+            },
+            "basil": {
+                "name": "basilikum"
+            },
+            "beans": {
+                "name": "bønner"
+            },
+            "bell-peppers": {
+                "name": "peberfrugter",
+                "plural_name": "peberfrugter"
+            },
+            "blackberries": {
+                "name": "brombær"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "havekål"
+            },
+            "bread": {
+                "name": "brød"
+            },
+            "breadfruit": {
+                "name": "brødfrugt"
+            },
+            "broccoflower": {
+                "name": "romanesco"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brun farin"
+            },
+            "brussels-sprouts": {
+                "name": "rosenkål"
+            },
+            "butter": {
+                "name": "smør"
+            },
+            "butternut-pumpkin": {
+                "name": "moskusgræskar"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "kål",
+                "plural_name": "kål"
+            },
+            "cactus-edible": {
+                "name": "kaktus, spiselig"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "rørsukker"
+            },
+            "cannabis": {
+                "name": "kanabis"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "kommen"
+            },
+            "carrot": {
+                "name": "gulerod",
+                "plural_name": "gulerødder"
+            },
+            "caster-sugar": {
+                "name": "strøsukker"
+            },
+            "castor-sugar": {
+                "name": "ricinussukker"
+            },
+            "catfish": {
+                "name": "havkat"
+            },
+            "cauliflower": {
+                "name": "blomkål",
+                "plural_name": "blomkål"
+            },
+            "cayenne-pepper": {
+                "name": "cayennepeber"
+            },
+            "celeriac": {
+                "name": "knoldselleri"
+            },
+            "celery": {
+                "name": "selleri"
+            },
+            "cereal-grains": {
+                "name": "korn"
+            },
+            "chard": {
+                "name": "bladbede"
+            },
+            "cheese": {
+                "name": "ost"
+            },
+            "chicory": {
+                "name": "cikorie"
+            },
+            "chilli-peppers": {
+                "name": "chilipeber",
+                "plural_name": "chilipeber"
+            },
+            "chinese-leaves": {
+                "name": "kinakål"
+            },
+            "chives": {
+                "name": "purløg"
+            },
+            "chocolate": {
+                "name": "chokolade"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "kanel"
+            },
+            "clarified-butter": {
+                "name": "klaret smør"
+            },
+            "coconut": {
+                "name": "kokosnød",
+                "plural_name": "kokosnødder"
+            },
+            "coconut-milk": {
+                "name": "kokosmælk"
+            },
+            "cod": {
+                "name": "torsk"
+            },
+            "coffee": {
+                "name": "kaffe"
+            },
+            "collard-greens": {
+                "name": "marvkål"
+            },
+            "confectioners-sugar": {
+                "name": "flormelis"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "majs",
+                "plural_name": "majs"
+            },
+            "corn-syrup": {
+                "name": "majsirup"
+            },
+            "cottonseed-oil": {
+                "name": "bomuldsfrøolie"
+            },
+            "courgette": {
+                "name": "squash"
+            },
+            "cream-of-tartar": {
+                "name": "eddikepulver"
+            },
+            "cucumber": {
+                "name": "agurk",
+                "plural_name": "agurker"
+            },
+            "cumin": {
+                "name": "spidskommen"
+            },
+            "daikon": {
+                "name": "kinaradise",
+                "plural_name": "kinaradiser"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mejeriprodukter og mælkeerstatninger"
+            },
+            "dandelion": {
+                "name": "mælkebøtte"
+            },
+            "demerara-sugar": {
+                "name": "rørsukker"
+            },
+            "dough": {
+                "name": "dej"
+            },
+            "edible-cactus": {
+                "name": "spiselig kaktus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "aubergine"
+            },
+            "eggs": {
+                "name": "æg",
+                "plural_name": "æg"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fedt"
+            },
+            "fava-beans": {
+                "name": "hestebønner"
+            },
+            "fiddlehead": {
+                "name": "bispestav"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead bregne",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fisk"
+            },
+            "five-spice-powder": {
+                "name": "femkrydderipulver"
+            },
+            "flour": {
+                "name": "mel"
+            },
+            "frisee": {
+                "name": "friséesalat"
+            },
+            "fructose": {
+                "name": "fruktose"
+            },
+            "fruit": {
+                "name": "frugt"
+            },
+            "fruit-sugar": {
+                "name": "frugtsukker"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "hvidløg",
+                "plural_name": "hvidløg"
+            },
+            "gem-squash": {
+                "name": "citron squash"
+            },
+            "ghee": {
+                "name": "klaret smør"
+            },
+            "giblets": {
+                "name": "fugleindmad"
+            },
+            "ginger": {
+                "name": "ingefær"
+            },
+            "grains": {
+                "name": "gryn"
+            },
+            "granulated-sugar": {
+                "name": "sukker"
+            },
+            "grape-seed-oil": {
+                "name": "vindruekerneolie"
+            },
+            "green-onion": {
+                "name": "forårsløg",
+                "plural_name": "forårsløg"
+            },
+            "heart-of-palm": {
+                "name": "palmehjerte",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hamp"
+            },
+            "herbs": {
+                "name": "krydderurter"
+            },
+            "honey": {
+                "name": "honning"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfrugt",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "marmelade"
+            },
+            "jellies": {
+                "name": "gelé"
+            },
+            "jerusalem-artichoke": {
+                "name": "jordskok"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "grønkål"
+            },
+            "kohlrabi": {
+                "name": "glaskål"
+            },
+            "kumara": {
+                "name": "sød kartoffel"
+            },
+            "leavening-agents": {
+                "name": "hævemiddel"
+            },
+            "leek": {
+                "name": "porre",
+                "plural_name": "porre"
+            },
+            "legumes": {
+                "name": "bælgplante"
+            },
+            "lemongrass": {
+                "name": "citrongræs"
+            },
+            "lentils": {
+                "name": "linser"
+            },
+            "lettuce": {
+                "name": "salat"
+            },
+            "liver": {
+                "name": "lever",
+                "plural_name": "lever"
+            },
+            "maize": {
+                "name": "majs"
+            },
+            "maple-syrup": {
+                "name": "ahornsirup"
+            },
+            "meat": {
+                "name": "kød"
+            },
+            "milk": {
+                "name": "mælk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "svamp",
+                "plural_name": "svampe"
+            },
+            "mussels": {
+                "name": "musling"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo barmix"
+            },
+            "nori": {
+                "name": "tank"
+            },
+            "nutmeg": {
+                "name": "muskatnød"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "gærflager"
+            },
+            "nuts": {
+                "name": "nødder"
+            },
+            "octopuses": {
+                "name": "ottearmede blæksprutter",
+                "plural_name": "blæksprutter"
+            },
+            "oils": {
+                "name": "olier"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliven"
+            },
+            "olive-oil": {
+                "name": "olivenolie"
+            },
+            "onion": {
+                "name": "løg"
+            },
+            "onion-family": {
+                "name": "løgfamilien"
+            },
+            "orange-blossom-water": {
+                "name": "orangeblossomvand"
+            },
+            "oranges": {
+                "name": "appelsiner",
+                "plural_name": "appelsiner"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "østers"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persille"
+            },
+            "parsnip": {
+                "name": "pastinak",
+                "plural_name": "pastinak"
+            },
+            "pear": {
+                "name": "pære",
+                "plural_name": "pærer"
+            },
+            "peas": {
+                "name": "ærter"
+            },
+            "pepper": {
+                "name": "peber",
+                "plural_name": "peberfrugter"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "madbanan",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "birkes"
+            },
+            "potato": {
+                "name": "kartoffel",
+                "plural_name": "kartofler"
+            },
+            "poultry": {
+                "name": "fjerkræ"
+            },
+            "powdered-sugar": {
+                "name": "flormelis"
+            },
+            "pumpkin": {
+                "name": "græskar",
+                "plural_name": "græskar"
+            },
+            "pumpkin-seeds": {
+                "name": "græskarkerner"
+            },
+            "radish": {
+                "name": "radise",
+                "plural_name": "radiser"
+            },
+            "raw-sugar": {
+                "name": "hel rørsukker"
+            },
+            "refined-sugar": {
+                "name": "raffineret sukker"
+            },
+            "rice": {
+                "name": "ri"
+            },
+            "rice-flour": {
+                "name": "rismel"
+            },
+            "rock-sugar": {
+                "name": "kandis"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "laks"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "saltet torsk"
+            },
+            "scallion": {
+                "name": "forårsløg",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "fisk og skaldyr"
+            },
+            "seeds": {
+                "name": "frø"
+            },
+            "sesame-seeds": {
+                "name": "sesamfrø"
+            },
+            "shallot": {
+                "name": "skalotteløg",
+                "plural_name": "skalotteløg"
+            },
+            "skate": {
+                "name": "rokke"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "natron"
+            },
+            "soybean": {
+                "name": "sojabønne"
+            },
+            "spaghetti-squash": {
+                "name": "spaghettisquash",
+                "plural_name": "spaghettisquash"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "krydderier"
+            },
+            "spinach": {
+                "name": "spinat"
+            },
+            "spring-onion": {
+                "name": "forårsløg",
+                "plural_name": "forårsløg"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squash"
+            },
+            "squash-family": {
+                "name": "squashfamilien"
+            },
+            "stockfish": {
+                "name": "tørfisk"
+            },
+            "sugar": {
+                "name": "sukker"
+            },
+            "sunchoke": {
+                "name": "jordskok",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "solsikkefrø"
+            },
+            "superfine-sugar": {
+                "name": "superfint sukker"
+            },
+            "sweet-potato": {
+                "name": "sød kartoffel",
+                "plural_name": "søde kartofler"
+            },
+            "sweetcorn": {
+                "name": "søde majs",
+                "plural_name": "sukkermajs"
+            },
+            "sweeteners": {
+                "name": "sødemiddel"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomat",
+                "plural_name": "tomater"
+            },
+            "trout": {
+                "name": "ørred"
+            },
+            "tubers": {
+                "name": "knold",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tun"
+            },
+            "turbanado-sugar": {
+                "name": "rørsukker"
+            },
+            "turnip": {
+                "name": "majroe",
+                "plural_name": "majroer"
+            },
+            "unrefined-sugar": {
+                "name": "uraffineret sukker"
+            },
+            "vanilla": {
+                "name": "vanilje"
+            },
+            "vegetables": {
+                "name": "grøntsager"
+            },
+            "watercress": {
+                "name": "brøndkarse"
+            },
+            "watermelon": {
+                "name": "vandmelon",
+                "plural_name": "vandmeloner"
+            },
+            "white-mushroom": {
+                "name": "champignon",
+                "plural_name": "hvide svampe"
+            },
+            "white-sugar": {
+                "name": "hvidt sukker"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "gær"
+            },
+            "zucchini": {
+                "name": "sommersquash",
+                "plural_name": "courgette"
+            }
+        }
+    },
+    "Landbrugsprodukt": {
+        "foods": {}
+    },
+    "Gryn": {
+        "foods": {}
+    },
+    "Frugter": {
+        "foods": {}
+    },
+    "Grøntsager": {
+        "foods": {}
+    },
+    "Kød": {
+        "foods": {}
+    },
+    "Fisk og skaldyr": {
+        "foods": {}
+    },
+    "Drikkevarer": {
+        "foods": {}
+    },
+    "Bagværk": {
+        "foods": {}
+    },
+    "Dåsemad": {
+        "foods": {}
+    },
+    "Tilbehør": {
+        "foods": {}
+    },
+    "Konfekt": {
+        "foods": {}
+    },
+    "Mejeriprodukter": {
+        "foods": {}
+    },
+    "Frostvarer": {
+        "foods": {}
+    },
+    "Helseprodukter": {
+        "foods": {}
+    },
+    "Husholdning": {
+        "foods": {}
+    },
+    "Kødprodukter": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Krydderier": {
+        "foods": {}
+    },
+    "Søde sager": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Andet": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/da-DK.json
+++ b/mealie/repos/seed/resources/foods/locales/da-DK.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "agern squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "lucernespirer"
-	},
-	"anchovies": {
-		"name": "ansjoser"
-	},
-	"apples": {
-		"name": "æble",
-		"plural_name": "æbler"
-	},
-	"artichoke": {
-		"name": "artiskok"
-	},
-	"arugula": {
-		"name": "rucola"
-	},
-	"asparagus": {
-		"name": "asparges"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "bagepulver"
-	},
-	"baking-soda": {
-		"name": "natron"
-	},
-	"baking-sugar": {
-		"name": "bagesukker"
-	},
-	"bar-sugar": {
-		"name": "sukkerstang"
-	},
-	"basil": {
-		"name": "basilikum"
-	},
-	"beans": {
-		"name": "bønner"
-	},
-	"bell-peppers": {
-		"name": "peberfrugter",
-		"plural_name": "peberfrugter"
-	},
-	"blackberries": {
-		"name": "brombær"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "havekål"
-	},
-	"bread": {
-		"name": "brød"
-	},
-	"breadfruit": {
-		"name": "brødfrugt"
-	},
-	"broccoflower": {
-		"name": "romanesco"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brun farin"
-	},
-	"brussels-sprouts": {
-		"name": "rosenkål"
-	},
-	"butter": {
-		"name": "smør"
-	},
-	"butternut-pumpkin": {
-		"name": "moskusgræskar"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "kål",
-		"plural_name": "kål"
-	},
-	"cactus-edible": {
-		"name": "kaktus, spiselig"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "rørsukker"
-	},
-	"cannabis": {
-		"name": "kanabis"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "kommen"
-	},
-	"carrot": {
-		"name": "gulerod",
-		"plural_name": "gulerødder"
-	},
-	"caster-sugar": {
-		"name": "strøsukker"
-	},
-	"castor-sugar": {
-		"name": "ricinussukker"
-	},
-	"catfish": {
-		"name": "havkat"
-	},
-	"cauliflower": {
-		"name": "blomkål",
-		"plural_name": "blomkål"
-	},
-	"cayenne-pepper": {
-		"name": "cayennepeber"
-	},
-	"celeriac": {
-		"name": "knoldselleri"
-	},
-	"celery": {
-		"name": "selleri"
-	},
-	"cereal-grains": {
-		"name": "korn"
-	},
-	"chard": {
-		"name": "bladbede"
-	},
-	"cheese": {
-		"name": "ost"
-	},
-	"chicory": {
-		"name": "cikorie"
-	},
-	"chilli-peppers": {
-		"name": "chilipeber",
-		"plural_name": "chilipeber"
-	},
-	"chinese-leaves": {
-		"name": "kinakål"
-	},
-	"chives": {
-		"name": "purløg"
-	},
-	"chocolate": {
-		"name": "chokolade"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "kanel"
-	},
-	"clarified-butter": {
-		"name": "klaret smør"
-	},
-	"coconut": {
-		"name": "kokosnød",
-		"plural_name": "kokosnødder"
-	},
-	"coconut-milk": {
-		"name": "kokosmælk"
-	},
-	"cod": {
-		"name": "torsk"
-	},
-	"coffee": {
-		"name": "kaffe"
-	},
-	"collard-greens": {
-		"name": "marvkål"
-	},
-	"confectioners-sugar": {
-		"name": "flormelis"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "majs",
-		"plural_name": "majs"
-	},
-	"corn-syrup": {
-		"name": "majsirup"
-	},
-	"cottonseed-oil": {
-		"name": "bomuldsfrøolie"
-	},
-	"courgette": {
-		"name": "squash"
-	},
-	"cream-of-tartar": {
-		"name": "eddikepulver"
-	},
-	"cucumber": {
-		"name": "agurk",
-		"plural_name": "agurker"
-	},
-	"cumin": {
-		"name": "spidskommen"
-	},
-	"daikon": {
-		"name": "kinaradise",
-		"plural_name": "kinaradiser"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mejeriprodukter og mælkeerstatninger"
-	},
-	"dandelion": {
-		"name": "mælkebøtte"
-	},
-	"demerara-sugar": {
-		"name": "rørsukker"
-	},
-	"dough": {
-		"name": "dej"
-	},
-	"edible-cactus": {
-		"name": "spiselig kaktus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "aubergine"
-	},
-	"eggs": {
-		"name": "æg",
-		"plural_name": "æg"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fedt"
-	},
-	"fava-beans": {
-		"name": "hestebønner"
-	},
-	"fiddlehead": {
-		"name": "bispestav"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead bregne",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fisk"
-	},
-	"five-spice-powder": {
-		"name": "femkrydderipulver"
-	},
-	"flour": {
-		"name": "mel"
-	},
-	"frisee": {
-		"name": "friséesalat"
-	},
-	"fructose": {
-		"name": "fruktose"
-	},
-	"fruit": {
-		"name": "frugt"
-	},
-	"fruit-sugar": {
-		"name": "frugtsukker"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "hvidløg",
-		"plural_name": "hvidløg"
-	},
-	"gem-squash": {
-		"name": "citron squash"
-	},
-	"ghee": {
-		"name": "klaret smør"
-	},
-	"giblets": {
-		"name": "fugleindmad"
-	},
-	"ginger": {
-		"name": "ingefær"
-	},
-	"grains": {
-		"name": "gryn"
-	},
-	"granulated-sugar": {
-		"name": "sukker"
-	},
-	"grape-seed-oil": {
-		"name": "vindruekerneolie"
-	},
-	"green-onion": {
-		"name": "forårsløg",
-		"plural_name": "forårsløg"
-	},
-	"heart-of-palm": {
-		"name": "palmehjerte",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hamp"
-	},
-	"herbs": {
-		"name": "krydderurter"
-	},
-	"honey": {
-		"name": "honning"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfrugt",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "marmelade"
-	},
-	"jellies": {
-		"name": "gelé"
-	},
-	"jerusalem-artichoke": {
-		"name": "jordskok"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "grønkål"
-	},
-	"kohlrabi": {
-		"name": "glaskål"
-	},
-	"kumara": {
-		"name": "sød kartoffel"
-	},
-	"leavening-agents": {
-		"name": "hævemiddel"
-	},
-	"leek": {
-		"name": "porre",
-		"plural_name": "porre"
-	},
-	"legumes": {
-		"name": "bælgplante"
-	},
-	"lemongrass": {
-		"name": "citrongræs"
-	},
-	"lentils": {
-		"name": "linser"
-	},
-	"lettuce": {
-		"name": "salat"
-	},
-	"liver": {
-		"name": "lever",
-		"plural_name": "lever"
-	},
-	"maize": {
-		"name": "majs"
-	},
-	"maple-syrup": {
-		"name": "ahornsirup"
-	},
-	"meat": {
-		"name": "kød"
-	},
-	"milk": {
-		"name": "mælk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "svamp",
-		"plural_name": "svampe"
-	},
-	"mussels": {
-		"name": "musling"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo barmix"
-	},
-	"nori": {
-		"name": "tank"
-	},
-	"nutmeg": {
-		"name": "muskatnød"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "gærflager"
-	},
-	"nuts": {
-		"name": "nødder"
-	},
-	"octopuses": {
-		"name": "ottearmede blæksprutter",
-		"plural_name": "blæksprutter"
-	},
-	"oils": {
-		"name": "olier"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliven"
-	},
-	"olive-oil": {
-		"name": "olivenolie"
-	},
-	"onion": {
-		"name": "løg"
-	},
-	"onion-family": {
-		"name": "løgfamilien"
-	},
-	"orange-blossom-water": {
-		"name": "orangeblossomvand"
-	},
-	"oranges": {
-		"name": "appelsiner",
-		"plural_name": "appelsiner"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "østers"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persille"
-	},
-	"parsnip": {
-		"name": "pastinak",
-		"plural_name": "pastinak"
-	},
-	"pear": {
-		"name": "pære",
-		"plural_name": "pærer"
-	},
-	"peas": {
-		"name": "ærter"
-	},
-	"pepper": {
-		"name": "peber",
-		"plural_name": "peberfrugter"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "madbanan",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "birkes"
-	},
-	"potato": {
-		"name": "kartoffel",
-		"plural_name": "kartofler"
-	},
-	"poultry": {
-		"name": "fjerkræ"
-	},
-	"powdered-sugar": {
-		"name": "flormelis"
-	},
-	"pumpkin": {
-		"name": "græskar",
-		"plural_name": "græskar"
-	},
-	"pumpkin-seeds": {
-		"name": "græskarkerner"
-	},
-	"radish": {
-		"name": "radise",
-		"plural_name": "radiser"
-	},
-	"raw-sugar": {
-		"name": "hel rørsukker"
-	},
-	"refined-sugar": {
-		"name": "raffineret sukker"
-	},
-	"rice": {
-		"name": "ri"
-	},
-	"rice-flour": {
-		"name": "rismel"
-	},
-	"rock-sugar": {
-		"name": "kandis"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "laks"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "saltet torsk"
-	},
-	"scallion": {
-		"name": "forårsløg",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "fisk og skaldyr"
-	},
-	"seeds": {
-		"name": "frø"
-	},
-	"sesame-seeds": {
-		"name": "sesamfrø"
-	},
-	"shallot": {
-		"name": "skalotteløg",
-		"plural_name": "skalotteløg"
-	},
-	"skate": {
-		"name": "rokke"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "natron"
-	},
-	"soybean": {
-		"name": "sojabønne"
-	},
-	"spaghetti-squash": {
-		"name": "spaghettisquash",
-		"plural_name": "spaghettisquash"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "krydderier"
-	},
-	"spinach": {
-		"name": "spinat"
-	},
-	"spring-onion": {
-		"name": "forårsløg",
-		"plural_name": "forårsløg"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squash"
-	},
-	"squash-family": {
-		"name": "squashfamilien"
-	},
-	"stockfish": {
-		"name": "tørfisk"
-	},
-	"sugar": {
-		"name": "sukker"
-	},
-	"sunchoke": {
-		"name": "jordskok",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "solsikkefrø"
-	},
-	"superfine-sugar": {
-		"name": "superfint sukker"
-	},
-	"sweet-potato": {
-		"name": "sød kartoffel",
-		"plural_name": "søde kartofler"
-	},
-	"sweetcorn": {
-		"name": "søde majs",
-		"plural_name": "sukkermajs"
-	},
-	"sweeteners": {
-		"name": "sødemiddel"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomat",
-		"plural_name": "tomater"
-	},
-	"trout": {
-		"name": "ørred"
-	},
-	"tubers": {
-		"name": "knold",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tun"
-	},
-	"turbanado-sugar": {
-		"name": "rørsukker"
-	},
-	"turnip": {
-		"name": "majroe",
-		"plural_name": "majroer"
-	},
-	"unrefined-sugar": {
-		"name": "uraffineret sukker"
-	},
-	"vanilla": {
-		"name": "vanilje"
-	},
-	"vegetables": {
-		"name": "grøntsager"
-	},
-	"watercress": {
-		"name": "brøndkarse"
-	},
-	"watermelon": {
-		"name": "vandmelon",
-		"plural_name": "vandmeloner"
-	},
-	"white-mushroom": {
-		"name": "champignon",
-		"plural_name": "hvide svampe"
-	},
-	"white-sugar": {
-		"name": "hvidt sukker"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "gær"
-	},
-	"zucchini": {
-		"name": "sommersquash",
-		"plural_name": "courgette"
-	}
+    "acorn-squash": {
+        "name": "agern squash"
+    },
+    "alfalfa-sprouts": {
+        "name": "lucernespirer"
+    },
+    "anchovies": {
+        "name": "ansjoser"
+    },
+    "apples": {
+        "name": "æble",
+        "plural_name": "æbler"
+    },
+    "artichoke": {
+        "name": "artiskok"
+    },
+    "arugula": {
+        "name": "rucola"
+    },
+    "asparagus": {
+        "name": "asparges"
+    },
+    "avocado": {
+        "name": "avocado",
+        "plural_name": "avocado"
+    },
+    "bacon": {
+        "name": "bacon"
+    },
+    "baking-powder": {
+        "name": "bagepulver"
+    },
+    "baking-soda": {
+        "name": "natron"
+    },
+    "baking-sugar": {
+        "name": "bagesukker"
+    },
+    "bar-sugar": {
+        "name": "sukkerstang"
+    },
+    "basil": {
+        "name": "basilikum"
+    },
+    "beans": {
+        "name": "bønner"
+    },
+    "bell-peppers": {
+        "name": "peberfrugter",
+        "plural_name": "peberfrugter"
+    },
+    "blackberries": {
+        "name": "brombær"
+    },
+    "bok-choy": {
+        "name": "pak choi"
+    },
+    "brassicas": {
+        "name": "havekål"
+    },
+    "bread": {
+        "name": "brød"
+    },
+    "breadfruit": {
+        "name": "brødfrugt"
+    },
+    "broccoflower": {
+        "name": "romanesco"
+    },
+    "broccoli": {
+        "name": "broccoli"
+    },
+    "broccoli-rabe": {
+        "name": "rapini"
+    },
+    "broccolini": {
+        "name": "broccolini"
+    },
+    "brown-sugar": {
+        "name": "brun farin"
+    },
+    "brussels-sprouts": {
+        "name": "rosenkål"
+    },
+    "butter": {
+        "name": "smør"
+    },
+    "butternut-pumpkin": {
+        "name": "moskusgræskar"
+    },
+    "butternut-squash": {
+        "name": "butternut squash"
+    },
+    "cabbage": {
+        "name": "kål",
+        "plural_name": "kål"
+    },
+    "cactus-edible": {
+        "name": "kaktus, spiselig"
+    },
+    "calabrese": {
+        "name": "calabrese"
+    },
+    "cane-sugar": {
+        "name": "rørsukker"
+    },
+    "cannabis": {
+        "name": "kanabis"
+    },
+    "capsicum": {
+        "name": "paprika"
+    },
+    "caraway": {
+        "name": "kommen"
+    },
+    "carrot": {
+        "name": "gulerod",
+        "plural_name": "gulerødder"
+    },
+    "caster-sugar": {
+        "name": "strøsukker"
+    },
+    "castor-sugar": {
+        "name": "ricinussukker"
+    },
+    "catfish": {
+        "name": "havkat"
+    },
+    "cauliflower": {
+        "name": "blomkål",
+        "plural_name": "blomkål"
+    },
+    "cayenne-pepper": {
+        "name": "cayennepeber"
+    },
+    "celeriac": {
+        "name": "knoldselleri"
+    },
+    "celery": {
+        "name": "selleri"
+    },
+    "cereal-grains": {
+        "name": "korn"
+    },
+    "chard": {
+        "name": "bladbede"
+    },
+    "cheese": {
+        "name": "ost"
+    },
+    "chicory": {
+        "name": "cikorie"
+    },
+    "chilli-peppers": {
+        "name": "chilipeber",
+        "plural_name": "chilipeber"
+    },
+    "chinese-leaves": {
+        "name": "kinakål"
+    },
+    "chives": {
+        "name": "purløg"
+    },
+    "chocolate": {
+        "name": "chokolade"
+    },
+    "cilantro": {
+        "name": "koriander"
+    },
+    "cinnamon": {
+        "name": "kanel"
+    },
+    "clarified-butter": {
+        "name": "klaret smør"
+    },
+    "coconut": {
+        "name": "kokosnød",
+        "plural_name": "kokosnødder"
+    },
+    "coconut-milk": {
+        "name": "kokosmælk"
+    },
+    "cod": {
+        "name": "torsk"
+    },
+    "coffee": {
+        "name": "kaffe"
+    },
+    "collard-greens": {
+        "name": "marvkål"
+    },
+    "confectioners-sugar": {
+        "name": "flormelis"
+    },
+    "coriander": {
+        "name": "koriander"
+    },
+    "corn": {
+        "name": "majs",
+        "plural_name": "majs"
+    },
+    "corn-syrup": {
+        "name": "majsirup"
+    },
+    "cottonseed-oil": {
+        "name": "bomuldsfrøolie"
+    },
+    "courgette": {
+        "name": "squash"
+    },
+    "cream-of-tartar": {
+        "name": "eddikepulver"
+    },
+    "cucumber": {
+        "name": "agurk",
+        "plural_name": "agurker"
+    },
+    "cumin": {
+        "name": "spidskommen"
+    },
+    "daikon": {
+        "name": "kinaradise",
+        "plural_name": "kinaradiser"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "mejeriprodukter og mælkeerstatninger"
+    },
+    "dandelion": {
+        "name": "mælkebøtte"
+    },
+    "demerara-sugar": {
+        "name": "rørsukker"
+    },
+    "dough": {
+        "name": "dej"
+    },
+    "edible-cactus": {
+        "name": "spiselig kaktus"
+    },
+    "eggplant": {
+        "name": "aubergine",
+        "plural_name": "aubergine"
+    },
+    "eggs": {
+        "name": "æg",
+        "plural_name": "æg"
+    },
+    "endive": {
+        "name": "endive",
+        "plural_name": "endives"
+    },
+    "fats": {
+        "name": "fedt"
+    },
+    "fava-beans": {
+        "name": "hestebønner"
+    },
+    "fiddlehead": {
+        "name": "bispestav"
+    },
+    "fiddlehead-fern": {
+        "name": "fiddlehead bregne",
+        "plural_name": "fiddlehead ferns"
+    },
+    "fish": {
+        "name": "fisk"
+    },
+    "five-spice-powder": {
+        "name": "femkrydderipulver"
+    },
+    "flour": {
+        "name": "mel"
+    },
+    "frisee": {
+        "name": "friséesalat"
+    },
+    "fructose": {
+        "name": "fruktose"
+    },
+    "fruit": {
+        "name": "frugt"
+    },
+    "fruit-sugar": {
+        "name": "frugtsukker"
+    },
+    "ful": {
+        "name": "ful"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "hvidløg",
+        "plural_name": "hvidløg"
+    },
+    "gem-squash": {
+        "name": "citron squash"
+    },
+    "ghee": {
+        "name": "klaret smør"
+    },
+    "giblets": {
+        "name": "fugleindmad"
+    },
+    "ginger": {
+        "name": "ingefær"
+    },
+    "grains": {
+        "name": "gryn"
+    },
+    "granulated-sugar": {
+        "name": "sukker"
+    },
+    "grape-seed-oil": {
+        "name": "vindruekerneolie"
+    },
+    "green-onion": {
+        "name": "forårsløg",
+        "plural_name": "forårsløg"
+    },
+    "heart-of-palm": {
+        "name": "palmehjerte",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "hamp"
+    },
+    "herbs": {
+        "name": "krydderurter"
+    },
+    "honey": {
+        "name": "honning"
+    },
+    "isomalt": {
+        "name": "isomalt"
+    },
+    "jackfruit": {
+        "name": "jackfrugt",
+        "plural_name": "jackfruits"
+    },
+    "jaggery": {
+        "name": "jaggery"
+    },
+    "jams": {
+        "name": "marmelade"
+    },
+    "jellies": {
+        "name": "gelé"
+    },
+    "jerusalem-artichoke": {
+        "name": "jordskok"
+    },
+    "jicama": {
+        "name": "jicama"
+    },
+    "kale": {
+        "name": "grønkål"
+    },
+    "kohlrabi": {
+        "name": "glaskål"
+    },
+    "kumara": {
+        "name": "sød kartoffel"
+    },
+    "leavening-agents": {
+        "name": "hævemiddel"
+    },
+    "leek": {
+        "name": "porre",
+        "plural_name": "porre"
+    },
+    "legumes": {
+        "name": "bælgplante"
+    },
+    "lemongrass": {
+        "name": "citrongræs"
+    },
+    "lentils": {
+        "name": "linser"
+    },
+    "lettuce": {
+        "name": "salat"
+    },
+    "liver": {
+        "name": "lever",
+        "plural_name": "lever"
+    },
+    "maize": {
+        "name": "majs"
+    },
+    "maple-syrup": {
+        "name": "ahornsirup"
+    },
+    "meat": {
+        "name": "kød"
+    },
+    "milk": {
+        "name": "mælk"
+    },
+    "mortadella": {
+        "name": "mortadella"
+    },
+    "mushroom": {
+        "name": "svamp",
+        "plural_name": "svampe"
+    },
+    "mussels": {
+        "name": "musling"
+    },
+    "nanaimo-bar-mix": {
+        "name": "nanaimo barmix"
+    },
+    "nori": {
+        "name": "tank"
+    },
+    "nutmeg": {
+        "name": "muskatnød"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "gærflager"
+    },
+    "nuts": {
+        "name": "nødder"
+    },
+    "octopuses": {
+        "name": "ottearmede blæksprutter",
+        "plural_name": "blæksprutter"
+    },
+    "oils": {
+        "name": "olier"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "oliven"
+    },
+    "olive-oil": {
+        "name": "olivenolie"
+    },
+    "onion": {
+        "name": "løg"
+    },
+    "onion-family": {
+        "name": "løgfamilien"
+    },
+    "orange-blossom-water": {
+        "name": "orangeblossomvand"
+    },
+    "oranges": {
+        "name": "appelsiner",
+        "plural_name": "appelsiner"
+    },
+    "oregano": {
+        "name": "oregano"
+    },
+    "oysters": {
+        "name": "østers"
+    },
+    "panch-puran": {
+        "name": "panch puran"
+    },
+    "paprika": {
+        "name": "paprika"
+    },
+    "parsley": {
+        "name": "persille"
+    },
+    "parsnip": {
+        "name": "pastinak",
+        "plural_name": "pastinak"
+    },
+    "pear": {
+        "name": "pære",
+        "plural_name": "pærer"
+    },
+    "peas": {
+        "name": "ærter"
+    },
+    "pepper": {
+        "name": "peber",
+        "plural_name": "peberfrugter"
+    },
+    "pineapple": {
+        "name": "ananas",
+        "plural_name": "ananas"
+    },
+    "plantain": {
+        "name": "madbanan",
+        "plural_name": "plantains"
+    },
+    "poppy-seeds": {
+        "name": "birkes"
+    },
+    "potato": {
+        "name": "kartoffel",
+        "plural_name": "kartofler"
+    },
+    "poultry": {
+        "name": "fjerkræ"
+    },
+    "powdered-sugar": {
+        "name": "flormelis"
+    },
+    "pumpkin": {
+        "name": "græskar",
+        "plural_name": "græskar"
+    },
+    "pumpkin-seeds": {
+        "name": "græskarkerner"
+    },
+    "radish": {
+        "name": "radise",
+        "plural_name": "radiser"
+    },
+    "raw-sugar": {
+        "name": "hel rørsukker"
+    },
+    "refined-sugar": {
+        "name": "raffineret sukker"
+    },
+    "rice": {
+        "name": "ri"
+    },
+    "rice-flour": {
+        "name": "rismel"
+    },
+    "rock-sugar": {
+        "name": "kandis"
+    },
+    "rum": {
+        "name": "rom"
+    },
+    "salmon": {
+        "name": "laks"
+    },
+    "salt": {
+        "name": "salt"
+    },
+    "salt-cod": {
+        "name": "saltet torsk"
+    },
+    "scallion": {
+        "name": "forårsløg",
+        "plural_name": "scallions"
+    },
+    "seafood": {
+        "name": "fisk og skaldyr"
+    },
+    "seeds": {
+        "name": "frø"
+    },
+    "sesame-seeds": {
+        "name": "sesamfrø"
+    },
+    "shallot": {
+        "name": "skalotteløg",
+        "plural_name": "skalotteløg"
+    },
+    "skate": {
+        "name": "rokke"
+    },
+    "soda": {
+        "name": "soda"
+    },
+    "soda-baking": {
+        "name": "natron"
+    },
+    "soybean": {
+        "name": "sojabønne"
+    },
+    "spaghetti-squash": {
+        "name": "spaghettisquash",
+        "plural_name": "spaghettisquash"
+    },
+    "speck": {
+        "name": "speck"
+    },
+    "spices": {
+        "name": "krydderier"
+    },
+    "spinach": {
+        "name": "spinat"
+    },
+    "spring-onion": {
+        "name": "forårsløg",
+        "plural_name": "forårsløg"
+    },
+    "squash": {
+        "name": "squash",
+        "plural_name": "squash"
+    },
+    "squash-family": {
+        "name": "squashfamilien"
+    },
+    "stockfish": {
+        "name": "tørfisk"
+    },
+    "sugar": {
+        "name": "sukker"
+    },
+    "sunchoke": {
+        "name": "jordskok",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "solsikkefrø"
+    },
+    "superfine-sugar": {
+        "name": "superfint sukker"
+    },
+    "sweet-potato": {
+        "name": "sød kartoffel",
+        "plural_name": "søde kartofler"
+    },
+    "sweetcorn": {
+        "name": "søde majs",
+        "plural_name": "sukkermajs"
+    },
+    "sweeteners": {
+        "name": "sødemiddel"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "taro",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "teff"
+    },
+    "tomato": {
+        "name": "tomat",
+        "plural_name": "tomater"
+    },
+    "trout": {
+        "name": "ørred"
+    },
+    "tubers": {
+        "name": "knold",
+        "plural_name": "tubers"
+    },
+    "tuna": {
+        "name": "tun"
+    },
+    "turbanado-sugar": {
+        "name": "rørsukker"
+    },
+    "turnip": {
+        "name": "majroe",
+        "plural_name": "majroer"
+    },
+    "unrefined-sugar": {
+        "name": "uraffineret sukker"
+    },
+    "vanilla": {
+        "name": "vanilje"
+    },
+    "vegetables": {
+        "name": "grøntsager"
+    },
+    "watercress": {
+        "name": "brøndkarse"
+    },
+    "watermelon": {
+        "name": "vandmelon",
+        "plural_name": "vandmeloner"
+    },
+    "white-mushroom": {
+        "name": "champignon",
+        "plural_name": "hvide svampe"
+    },
+    "white-sugar": {
+        "name": "hvidt sukker"
+    },
+    "xanthan-gum": {
+        "name": "xanthan gum"
+    },
+    "yam": {
+        "name": "yam",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "gær"
+    },
+    "zucchini": {
+        "name": "sommersquash",
+        "plural_name": "courgette"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/de-DE.json
+++ b/mealie/repos/seed/resources/foods/locales/de-DE.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "Eichelkürbis"
-	},
-	"alfalfa-sprouts": {
-		"name": "Alfalfasprossen"
-	},
-	"anchovies": {
-		"name": "Sardellen"
-	},
-	"apples": {
-		"name": "Apfel",
-		"plural_name": "Äpfel"
-	},
-	"artichoke": {
-		"name": "Artischocke"
-	},
-	"arugula": {
-		"name": "Rucola"
-	},
-	"asparagus": {
-		"name": "Spargel"
-	},
-	"avocado": {
-		"name": "Avocado",
-		"plural_name": "Avocados"
-	},
-	"bacon": {
-		"name": "Speck"
-	},
-	"baking-powder": {
-		"name": "Backpulver"
-	},
-	"baking-soda": {
-		"name": "Backnatron"
-	},
-	"baking-sugar": {
-		"name": "Backzucker"
-	},
-	"bar-sugar": {
-		"name": "Rohrzucker"
-	},
-	"basil": {
-		"name": "Basilikum"
-	},
-	"beans": {
-		"name": "Bohnen"
-	},
-	"bell-peppers": {
-		"name": "Paprika",
-		"plural_name": "Paprikas"
-	},
-	"blackberries": {
-		"name": "Brombeeren"
-	},
-	"bok-choy": {
-		"name": "Pak Choi"
-	},
-	"brassicas": {
-		"name": "Kohlarten"
-	},
-	"bread": {
-		"name": "Brot"
-	},
-	"breadfruit": {
-		"name": "Brotfrucht"
-	},
-	"broccoflower": {
-		"name": "Brokkoli"
-	},
-	"broccoli": {
-		"name": "Brokkoli"
-	},
-	"broccoli-rabe": {
-		"name": "Brokkoli"
-	},
-	"broccolini": {
-		"name": "Brokkoli"
-	},
-	"brown-sugar": {
-		"name": "brauner Zucker"
-	},
-	"brussels-sprouts": {
-		"name": "Rosenkohl"
-	},
-	"butter": {
-		"name": "Butter"
-	},
-	"butternut-pumpkin": {
-		"name": "Butternut-Kürbis"
-	},
-	"butternut-squash": {
-		"name": "Butternut-Kürbis"
-	},
-	"cabbage": {
-		"name": "Kohl",
-		"plural_name": "Kohle"
-	},
-	"cactus-edible": {
-		"name": "Kaktus, essbar"
-	},
-	"calabrese": {
-		"name": "Calabrese"
-	},
-	"cane-sugar": {
-		"name": "Rohrzucker"
-	},
-	"cannabis": {
-		"name": "Cannabis"
-	},
-	"capsicum": {
-		"name": "Paprika"
-	},
-	"caraway": {
-		"name": "Kümmel"
-	},
-	"carrot": {
-		"name": "Karotte",
-		"plural_name": "Karotten"
-	},
-	"caster-sugar": {
-		"name": "Backzucker"
-	},
-	"castor-sugar": {
-		"name": "Zucker"
-	},
-	"catfish": {
-		"name": "Wels"
-	},
-	"cauliflower": {
-		"name": "Blumenkohl",
-		"plural_name": "Blumenkohle"
-	},
-	"cayenne-pepper": {
-		"name": "Cayennepfeffer"
-	},
-	"celeriac": {
-		"name": "Sellerieknolle"
-	},
-	"celery": {
-		"name": "Sellerie"
-	},
-	"cereal-grains": {
-		"name": "Getreidekörner"
-	},
-	"chard": {
-		"name": "Mangold"
-	},
-	"cheese": {
-		"name": "Käse"
-	},
-	"chicory": {
-		"name": "Chicorée"
-	},
-	"chilli-peppers": {
-		"name": "Chilischote",
-		"plural_name": "Chilischoten"
-	},
-	"chinese-leaves": {
-		"name": "Chinakohl"
-	},
-	"chives": {
-		"name": "Schnittlauch"
-	},
-	"chocolate": {
-		"name": "Schokolade"
-	},
-	"cilantro": {
-		"name": "Koriander"
-	},
-	"cinnamon": {
-		"name": "Zimt"
-	},
-	"clarified-butter": {
-		"name": "geklärte Butter"
-	},
-	"coconut": {
-		"name": "Kokosnuss",
-		"plural_name": "Kokosnüsse"
-	},
-	"coconut-milk": {
-		"name": "Kokosmilch"
-	},
-	"cod": {
-		"name": "Kabeljau"
-	},
-	"coffee": {
-		"name": "Kaffee"
-	},
-	"collard-greens": {
-		"name": "Kohlblätter"
-	},
-	"confectioners-sugar": {
-		"name": "Konditorzucker"
-	},
-	"coriander": {
-		"name": "Koriander"
-	},
-	"corn": {
-		"name": "Mais",
-		"plural_name": "Mais"
-	},
-	"corn-syrup": {
-		"name": "Maissirup"
-	},
-	"cottonseed-oil": {
-		"name": "Baumwollsaatöl"
-	},
-	"courgette": {
-		"name": "Zucchini"
-	},
-	"cream-of-tartar": {
-		"name": "Weinstein"
-	},
-	"cucumber": {
-		"name": "Gurke",
-		"plural_name": "Gurken"
-	},
-	"cumin": {
-		"name": "Kreuzkümmel"
-	},
-	"daikon": {
-		"name": "Winterrettich",
-		"plural_name": "Winterrettiche"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "Milchprodukte und Milchersatzprodukte"
-	},
-	"dandelion": {
-		"name": "Löwenzahn"
-	},
-	"demerara-sugar": {
-		"name": "Demerara-Zucker"
-	},
-	"dough": {
-		"name": "Teig"
-	},
-	"edible-cactus": {
-		"name": "Speisekaktus"
-	},
-	"eggplant": {
-		"name": "Aubergine",
-		"plural_name": "Auberginen"
-	},
-	"eggs": {
-		"name": "Ei",
-		"plural_name": "Eier"
-	},
-	"endive": {
-		"name": "Endivie",
-		"plural_name": "Endivien"
-	},
-	"fats": {
-		"name": "Fett"
-	},
-	"fava-beans": {
-		"name": "Ackerbohnen"
-	},
-	"fiddlehead": {
-		"name": "Farnspitzen des Straußenfarns (Fiddleheads)"
-	},
-	"fiddlehead-fern": {
-		"name": "Farnspitze des Straußenfarns (Fiddlehead)",
-		"plural_name": "Farnspitzen des Straußenfarns (Fiddleheads)"
-	},
-	"fish": {
-		"name": "Fisch"
-	},
-	"five-spice-powder": {
-		"name": "Fünf-Gewürze-Pulver"
-	},
-	"flour": {
-		"name": "Mehl"
-	},
-	"frisee": {
-		"name": "Frisée"
-	},
-	"fructose": {
-		"name": "Fruktose"
-	},
-	"fruit": {
-		"name": "Obst"
-	},
-	"fruit-sugar": {
-		"name": "Fruchtzucker"
-	},
-	"ful": {
-		"name": "Bohnen"
-	},
-	"garam-masala": {
-		"name": "Garam Masala"
-	},
-	"garlic": {
-		"name": "Knoblauch",
-		"plural_name": "Knoblauch"
-	},
-	"gem-squash": {
-		"name": "Gem Squash (Gartenkürbis)"
-	},
-	"ghee": {
-		"name": "Ghee"
-	},
-	"giblets": {
-		"name": "Innereien"
-	},
-	"ginger": {
-		"name": "Ingwer"
-	},
-	"grains": {
-		"name": "Getreide"
-	},
-	"granulated-sugar": {
-		"name": "granulierter Zucker"
-	},
-	"grape-seed-oil": {
-		"name": "Traubenkernöl"
-	},
-	"green-onion": {
-		"name": "Frühlingszwiebel",
-		"plural_name": "Frühlingszwiebeln"
-	},
-	"heart-of-palm": {
-		"name": "Palmherz",
-		"plural_name": "Palmherzen"
-	},
-	"hemp": {
-		"name": "Hanf"
-	},
-	"herbs": {
-		"name": "Kräuter"
-	},
-	"honey": {
-		"name": "Honig"
-	},
-	"isomalt": {
-		"name": "Isomalt"
-	},
-	"jackfruit": {
-		"name": "Jackfruit",
-		"plural_name": "Jackfruits"
-	},
-	"jaggery": {
-		"name": "Jaggery"
-	},
-	"jams": {
-		"name": "Marmelade"
-	},
-	"jellies": {
-		"name": "Gelees"
-	},
-	"jerusalem-artichoke": {
-		"name": "Topinambur"
-	},
-	"jicama": {
-		"name": "Yambohnenknolle"
-	},
-	"kale": {
-		"name": "Grünkohl"
-	},
-	"kohlrabi": {
-		"name": "Kohlrabi"
-	},
-	"kumara": {
-		"name": "Süßkartoffel"
-	},
-	"leavening-agents": {
-		"name": "Backtriebmittel"
-	},
-	"leek": {
-		"name": "Lauch",
-		"plural_name": "Lauch"
-	},
-	"legumes": {
-		"name": "Hülsenfrüchte"
-	},
-	"lemongrass": {
-		"name": "Zitronengras"
-	},
-	"lentils": {
-		"name": "Linsen"
-	},
-	"lettuce": {
-		"name": "Salat"
-	},
-	"liver": {
-		"name": "Leber",
-		"plural_name": "Lebern"
-	},
-	"maize": {
-		"name": "Mais"
-	},
-	"maple-syrup": {
-		"name": "Ahornsirup"
-	},
-	"meat": {
-		"name": "Fleisch"
-	},
-	"milk": {
-		"name": "Milch"
-	},
-	"mortadella": {
-		"name": "Mortadella"
-	},
-	"mushroom": {
-		"name": "Pilz",
-		"plural_name": "Pilze"
-	},
-	"mussels": {
-		"name": "Muscheln"
-	},
-	"nanaimo-bar-mix": {
-		"name": "Nanaimo-Riegel Backmischung"
-	},
-	"nori": {
-		"name": "Nori"
-	},
-	"nutmeg": {
-		"name": "Muskatnuss"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "Nahrungsmittelhefeflocken"
-	},
-	"nuts": {
-		"name": "Nüsse"
-	},
-	"octopuses": {
-		"name": "Tintenfisch",
-		"plural_name": "Tintenfische"
-	},
-	"oils": {
-		"name": "Öl"
-	},
-	"okra": {
-		"name": "Okra"
-	},
-	"olive": {
-		"name": "Olive"
-	},
-	"olive-oil": {
-		"name": "Olivenöl"
-	},
-	"onion": {
-		"name": "Zwiebel"
-	},
-	"onion-family": {
-		"name": "Zwiebelgewächse"
-	},
-	"orange-blossom-water": {
-		"name": "Orangenblütenwasser"
-	},
-	"oranges": {
-		"name": "Orange",
-		"plural_name": "Orangen"
-	},
-	"oregano": {
-		"name": "Oregano"
-	},
-	"oysters": {
-		"name": "Austern"
-	},
-	"panch-puran": {
-		"name": "Panch Phoron"
-	},
-	"paprika": {
-		"name": "Paprika"
-	},
-	"parsley": {
-		"name": "Petersilie"
-	},
-	"parsnip": {
-		"name": "Pastinake",
-		"plural_name": "Pastinaken"
-	},
-	"pear": {
-		"name": "Birne",
-		"plural_name": "Birnen"
-	},
-	"peas": {
-		"name": "Erbsen"
-	},
-	"pepper": {
-		"name": "Pfeffer",
-		"plural_name": "Pfeffer"
-	},
-	"pineapple": {
-		"name": "Ananas",
-		"plural_name": "Ananas"
-	},
-	"plantain": {
-		"name": "Wegerich",
-		"plural_name": "Kochbananen"
-	},
-	"poppy-seeds": {
-		"name": "Mohnsamen"
-	},
-	"potato": {
-		"name": "Kartoffel",
-		"plural_name": "Kartoffeln"
-	},
-	"poultry": {
-		"name": "Geflügel"
-	},
-	"powdered-sugar": {
-		"name": "Puderzucker"
-	},
-	"pumpkin": {
-		"name": "Kürbis",
-		"plural_name": "Kürbisse"
-	},
-	"pumpkin-seeds": {
-		"name": "Kürbiskerne"
-	},
-	"radish": {
-		"name": "Radieschen",
-		"plural_name": "Radieschen"
-	},
-	"raw-sugar": {
-		"name": "Rohzucker"
-	},
-	"refined-sugar": {
-		"name": "Zucker"
-	},
-	"rice": {
-		"name": "Reis"
-	},
-	"rice-flour": {
-		"name": "Reismehl"
-	},
-	"rock-sugar": {
-		"name": "Kandis"
-	},
-	"rum": {
-		"name": "Rum"
-	},
-	"salmon": {
-		"name": "Lachs"
-	},
-	"salt": {
-		"name": "Salz"
-	},
-	"salt-cod": {
-		"name": "Stockfisch"
-	},
-	"scallion": {
-		"name": "Frühlingszwiebel",
-		"plural_name": "Frühlingszwiebeln"
-	},
-	"seafood": {
-		"name": "Meeresfrüchte"
-	},
-	"seeds": {
-		"name": "Samen"
-	},
-	"sesame-seeds": {
-		"name": "Sesamsamen"
-	},
-	"shallot": {
-		"name": "Schalotte",
-		"plural_name": "Schalotten"
-	},
-	"skate": {
-		"name": "Rochen"
-	},
-	"soda": {
-		"name": "Natron"
-	},
-	"soda-baking": {
-		"name": "Backnatron"
-	},
-	"soybean": {
-		"name": "Sojabohne"
-	},
-	"spaghetti-squash": {
-		"name": "Spaghettikürbis",
-		"plural_name": "Spaghettikürbisse"
-	},
-	"speck": {
-		"name": "Speck"
-	},
-	"spices": {
-		"name": "Gewürze"
-	},
-	"spinach": {
-		"name": "Spinat"
-	},
-	"spring-onion": {
-		"name": "Frühlingszwiebeln",
-		"plural_name": "Frühlingszwiebeln"
-	},
-	"squash": {
-		"name": "Kürbis",
-		"plural_name": "Kürbisse"
-	},
-	"squash-family": {
-		"name": "Kürbisgewächse"
-	},
-	"stockfish": {
-		"name": "Stockfisch"
-	},
-	"sugar": {
-		"name": "Zucker"
-	},
-	"sunchoke": {
-		"name": "Topinambur",
-		"plural_name": "Topinamburen"
-	},
-	"sunflower-seeds": {
-		"name": "Sonnenblumenkerne"
-	},
-	"superfine-sugar": {
-		"name": "superfeiner Zucker"
-	},
-	"sweet-potato": {
-		"name": "Süßkartoffel",
-		"plural_name": "Süßkartoffeln"
-	},
-	"sweetcorn": {
-		"name": "Zuckermais",
-		"plural_name": "Zuckermais"
-	},
-	"sweeteners": {
-		"name": "Süßstoffe"
-	},
-	"tahini": {
-		"name": "Tahina"
-	},
-	"taro": {
-		"name": "Taro (Wasserbrotwurzel)",
-		"plural_name": "Taros (Wasserbrotwurzeln)"
-	},
-	"teff": {
-		"name": "Zwerghirse"
-	},
-	"tomato": {
-		"name": "Tomate",
-		"plural_name": "Tomaten"
-	},
-	"trout": {
-		"name": "Forelle"
-	},
-	"tubers": {
-		"name": "Knolle",
-		"plural_name": "Knollen"
-	},
-	"tuna": {
-		"name": "Thunfisch"
-	},
-	"turbanado-sugar": {
-		"name": "Turbinado-Zucker"
-	},
-	"turnip": {
-		"name": "Speiserübe",
-		"plural_name": "Speiserüben"
-	},
-	"unrefined-sugar": {
-		"name": "unraffinierter Zucker"
-	},
-	"vanilla": {
-		"name": "Vanille"
-	},
-	"vegetables": {
-		"name": "Gemüse"
-	},
-	"watercress": {
-		"name": "Brunnenkresse"
-	},
-	"watermelon": {
-		"name": "Wassermelone",
-		"plural_name": "Wassermelonen"
-	},
-	"white-mushroom": {
-		"name": "weißer Pilz",
-		"plural_name": "weiße Pilze"
-	},
-	"white-sugar": {
-		"name": "weißer Zucker"
-	},
-	"xanthan-gum": {
-		"name": "Xanthan"
-	},
-	"yam": {
-		"name": "Yamswurzel",
-		"plural_name": "Yamswurzeln"
-	},
-	"yeast": {
-		"name": "Hefe"
-	},
-	"zucchini": {
-		"name": "Zucchini",
-		"plural_name": "Zucchini"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "Eichelkürbis"
+            },
+            "alfalfa-sprouts": {
+                "name": "Alfalfasprossen"
+            },
+            "anchovies": {
+                "name": "Sardellen"
+            },
+            "apples": {
+                "name": "Apfel",
+                "plural_name": "Äpfel"
+            },
+            "artichoke": {
+                "name": "Artischocke"
+            },
+            "arugula": {
+                "name": "Rucola"
+            },
+            "asparagus": {
+                "name": "Spargel"
+            },
+            "avocado": {
+                "name": "Avocado",
+                "plural_name": "Avocados"
+            },
+            "bacon": {
+                "name": "Speck"
+            },
+            "baking-powder": {
+                "name": "Backpulver"
+            },
+            "baking-soda": {
+                "name": "Backnatron"
+            },
+            "baking-sugar": {
+                "name": "Backzucker"
+            },
+            "bar-sugar": {
+                "name": "Rohrzucker"
+            },
+            "basil": {
+                "name": "Basilikum"
+            },
+            "beans": {
+                "name": "Bohnen"
+            },
+            "bell-peppers": {
+                "name": "Paprika",
+                "plural_name": "Paprikas"
+            },
+            "blackberries": {
+                "name": "Brombeeren"
+            },
+            "bok-choy": {
+                "name": "Pak Choi"
+            },
+            "brassicas": {
+                "name": "Kohlarten"
+            },
+            "bread": {
+                "name": "Brot"
+            },
+            "breadfruit": {
+                "name": "Brotfrucht"
+            },
+            "broccoflower": {
+                "name": "Brokkoli"
+            },
+            "broccoli": {
+                "name": "Brokkoli"
+            },
+            "broccoli-rabe": {
+                "name": "Brokkoli"
+            },
+            "broccolini": {
+                "name": "Brokkoli"
+            },
+            "brown-sugar": {
+                "name": "brauner Zucker"
+            },
+            "brussels-sprouts": {
+                "name": "Rosenkohl"
+            },
+            "butter": {
+                "name": "Butter"
+            },
+            "butternut-pumpkin": {
+                "name": "Butternut-Kürbis"
+            },
+            "butternut-squash": {
+                "name": "Butternut-Kürbis"
+            },
+            "cabbage": {
+                "name": "Kohl",
+                "plural_name": "Kohle"
+            },
+            "cactus-edible": {
+                "name": "Kaktus, essbar"
+            },
+            "calabrese": {
+                "name": "Calabrese"
+            },
+            "cane-sugar": {
+                "name": "Rohrzucker"
+            },
+            "cannabis": {
+                "name": "Cannabis"
+            },
+            "capsicum": {
+                "name": "Paprika"
+            },
+            "caraway": {
+                "name": "Kümmel"
+            },
+            "carrot": {
+                "name": "Karotte",
+                "plural_name": "Karotten"
+            },
+            "caster-sugar": {
+                "name": "Backzucker"
+            },
+            "castor-sugar": {
+                "name": "Zucker"
+            },
+            "catfish": {
+                "name": "Wels"
+            },
+            "cauliflower": {
+                "name": "Blumenkohl",
+                "plural_name": "Blumenkohle"
+            },
+            "cayenne-pepper": {
+                "name": "Cayennepfeffer"
+            },
+            "celeriac": {
+                "name": "Sellerieknolle"
+            },
+            "celery": {
+                "name": "Sellerie"
+            },
+            "cereal-grains": {
+                "name": "Getreidekörner"
+            },
+            "chard": {
+                "name": "Mangold"
+            },
+            "cheese": {
+                "name": "Käse"
+            },
+            "chicory": {
+                "name": "Chicorée"
+            },
+            "chilli-peppers": {
+                "name": "Chilischote",
+                "plural_name": "Chilischoten"
+            },
+            "chinese-leaves": {
+                "name": "Chinakohl"
+            },
+            "chives": {
+                "name": "Schnittlauch"
+            },
+            "chocolate": {
+                "name": "Schokolade"
+            },
+            "cilantro": {
+                "name": "Koriander"
+            },
+            "cinnamon": {
+                "name": "Zimt"
+            },
+            "clarified-butter": {
+                "name": "geklärte Butter"
+            },
+            "coconut": {
+                "name": "Kokosnuss",
+                "plural_name": "Kokosnüsse"
+            },
+            "coconut-milk": {
+                "name": "Kokosmilch"
+            },
+            "cod": {
+                "name": "Kabeljau"
+            },
+            "coffee": {
+                "name": "Kaffee"
+            },
+            "collard-greens": {
+                "name": "Kohlblätter"
+            },
+            "confectioners-sugar": {
+                "name": "Konditorzucker"
+            },
+            "coriander": {
+                "name": "Koriander"
+            },
+            "corn": {
+                "name": "Mais",
+                "plural_name": "Mais"
+            },
+            "corn-syrup": {
+                "name": "Maissirup"
+            },
+            "cottonseed-oil": {
+                "name": "Baumwollsaatöl"
+            },
+            "courgette": {
+                "name": "Zucchini"
+            },
+            "cream-of-tartar": {
+                "name": "Weinstein"
+            },
+            "cucumber": {
+                "name": "Gurke",
+                "plural_name": "Gurken"
+            },
+            "cumin": {
+                "name": "Kreuzkümmel"
+            },
+            "daikon": {
+                "name": "Winterrettich",
+                "plural_name": "Winterrettiche"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "Milchprodukte und Milchersatzprodukte"
+            },
+            "dandelion": {
+                "name": "Löwenzahn"
+            },
+            "demerara-sugar": {
+                "name": "Demerara-Zucker"
+            },
+            "dough": {
+                "name": "Teig"
+            },
+            "edible-cactus": {
+                "name": "Speisekaktus"
+            },
+            "eggplant": {
+                "name": "Aubergine",
+                "plural_name": "Auberginen"
+            },
+            "eggs": {
+                "name": "Ei",
+                "plural_name": "Eier"
+            },
+            "endive": {
+                "name": "Endivie",
+                "plural_name": "Endivien"
+            },
+            "fats": {
+                "name": "Fett"
+            },
+            "fava-beans": {
+                "name": "Ackerbohnen"
+            },
+            "fiddlehead": {
+                "name": "Farnspitzen des Straußenfarns (Fiddleheads)"
+            },
+            "fiddlehead-fern": {
+                "name": "Farnspitze des Straußenfarns (Fiddlehead)",
+                "plural_name": "Farnspitzen des Straußenfarns (Fiddleheads)"
+            },
+            "fish": {
+                "name": "Fisch"
+            },
+            "five-spice-powder": {
+                "name": "Fünf-Gewürze-Pulver"
+            },
+            "flour": {
+                "name": "Mehl"
+            },
+            "frisee": {
+                "name": "Frisée"
+            },
+            "fructose": {
+                "name": "Fruktose"
+            },
+            "fruit": {
+                "name": "Obst"
+            },
+            "fruit-sugar": {
+                "name": "Fruchtzucker"
+            },
+            "ful": {
+                "name": "Bohnen"
+            },
+            "garam-masala": {
+                "name": "Garam Masala"
+            },
+            "garlic": {
+                "name": "Knoblauch",
+                "plural_name": "Knoblauch"
+            },
+            "gem-squash": {
+                "name": "Gem Squash (Gartenkürbis)"
+            },
+            "ghee": {
+                "name": "Ghee"
+            },
+            "giblets": {
+                "name": "Innereien"
+            },
+            "ginger": {
+                "name": "Ingwer"
+            },
+            "grains": {
+                "name": "Getreide"
+            },
+            "granulated-sugar": {
+                "name": "granulierter Zucker"
+            },
+            "grape-seed-oil": {
+                "name": "Traubenkernöl"
+            },
+            "green-onion": {
+                "name": "Frühlingszwiebel",
+                "plural_name": "Frühlingszwiebeln"
+            },
+            "heart-of-palm": {
+                "name": "Palmherz",
+                "plural_name": "Palmherzen"
+            },
+            "hemp": {
+                "name": "Hanf"
+            },
+            "herbs": {
+                "name": "Kräuter"
+            },
+            "honey": {
+                "name": "Honig"
+            },
+            "isomalt": {
+                "name": "Isomalt"
+            },
+            "jackfruit": {
+                "name": "Jackfruit",
+                "plural_name": "Jackfruits"
+            },
+            "jaggery": {
+                "name": "Jaggery"
+            },
+            "jams": {
+                "name": "Marmelade"
+            },
+            "jellies": {
+                "name": "Gelees"
+            },
+            "jerusalem-artichoke": {
+                "name": "Topinambur"
+            },
+            "jicama": {
+                "name": "Yambohnenknolle"
+            },
+            "kale": {
+                "name": "Grünkohl"
+            },
+            "kohlrabi": {
+                "name": "Kohlrabi"
+            },
+            "kumara": {
+                "name": "Süßkartoffel"
+            },
+            "leavening-agents": {
+                "name": "Backtriebmittel"
+            },
+            "leek": {
+                "name": "Lauch",
+                "plural_name": "Lauch"
+            },
+            "legumes": {
+                "name": "Hülsenfrüchte"
+            },
+            "lemongrass": {
+                "name": "Zitronengras"
+            },
+            "lentils": {
+                "name": "Linsen"
+            },
+            "lettuce": {
+                "name": "Salat"
+            },
+            "liver": {
+                "name": "Leber",
+                "plural_name": "Lebern"
+            },
+            "maize": {
+                "name": "Mais"
+            },
+            "maple-syrup": {
+                "name": "Ahornsirup"
+            },
+            "meat": {
+                "name": "Fleisch"
+            },
+            "milk": {
+                "name": "Milch"
+            },
+            "mortadella": {
+                "name": "Mortadella"
+            },
+            "mushroom": {
+                "name": "Pilz",
+                "plural_name": "Pilze"
+            },
+            "mussels": {
+                "name": "Muscheln"
+            },
+            "nanaimo-bar-mix": {
+                "name": "Nanaimo-Riegel Backmischung"
+            },
+            "nori": {
+                "name": "Nori"
+            },
+            "nutmeg": {
+                "name": "Muskatnuss"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "Nahrungsmittelhefeflocken"
+            },
+            "nuts": {
+                "name": "Nüsse"
+            },
+            "octopuses": {
+                "name": "Tintenfisch",
+                "plural_name": "Tintenfische"
+            },
+            "oils": {
+                "name": "Öl"
+            },
+            "okra": {
+                "name": "Okra"
+            },
+            "olive": {
+                "name": "Olive"
+            },
+            "olive-oil": {
+                "name": "Olivenöl"
+            },
+            "onion": {
+                "name": "Zwiebel"
+            },
+            "onion-family": {
+                "name": "Zwiebelgewächse"
+            },
+            "orange-blossom-water": {
+                "name": "Orangenblütenwasser"
+            },
+            "oranges": {
+                "name": "Orange",
+                "plural_name": "Orangen"
+            },
+            "oregano": {
+                "name": "Oregano"
+            },
+            "oysters": {
+                "name": "Austern"
+            },
+            "panch-puran": {
+                "name": "Panch Phoron"
+            },
+            "paprika": {
+                "name": "Paprika"
+            },
+            "parsley": {
+                "name": "Petersilie"
+            },
+            "parsnip": {
+                "name": "Pastinake",
+                "plural_name": "Pastinaken"
+            },
+            "pear": {
+                "name": "Birne",
+                "plural_name": "Birnen"
+            },
+            "peas": {
+                "name": "Erbsen"
+            },
+            "pepper": {
+                "name": "Pfeffer",
+                "plural_name": "Pfeffer"
+            },
+            "pineapple": {
+                "name": "Ananas",
+                "plural_name": "Ananas"
+            },
+            "plantain": {
+                "name": "Wegerich",
+                "plural_name": "Kochbananen"
+            },
+            "poppy-seeds": {
+                "name": "Mohnsamen"
+            },
+            "potato": {
+                "name": "Kartoffel",
+                "plural_name": "Kartoffeln"
+            },
+            "poultry": {
+                "name": "Geflügel"
+            },
+            "powdered-sugar": {
+                "name": "Puderzucker"
+            },
+            "pumpkin": {
+                "name": "Kürbis",
+                "plural_name": "Kürbisse"
+            },
+            "pumpkin-seeds": {
+                "name": "Kürbiskerne"
+            },
+            "radish": {
+                "name": "Radieschen",
+                "plural_name": "Radieschen"
+            },
+            "raw-sugar": {
+                "name": "Rohzucker"
+            },
+            "refined-sugar": {
+                "name": "Zucker"
+            },
+            "rice": {
+                "name": "Reis"
+            },
+            "rice-flour": {
+                "name": "Reismehl"
+            },
+            "rock-sugar": {
+                "name": "Kandis"
+            },
+            "rum": {
+                "name": "Rum"
+            },
+            "salmon": {
+                "name": "Lachs"
+            },
+            "salt": {
+                "name": "Salz"
+            },
+            "salt-cod": {
+                "name": "Stockfisch"
+            },
+            "scallion": {
+                "name": "Frühlingszwiebel",
+                "plural_name": "Frühlingszwiebeln"
+            },
+            "seafood": {
+                "name": "Meeresfrüchte"
+            },
+            "seeds": {
+                "name": "Samen"
+            },
+            "sesame-seeds": {
+                "name": "Sesamsamen"
+            },
+            "shallot": {
+                "name": "Schalotte",
+                "plural_name": "Schalotten"
+            },
+            "skate": {
+                "name": "Rochen"
+            },
+            "soda": {
+                "name": "Natron"
+            },
+            "soda-baking": {
+                "name": "Backnatron"
+            },
+            "soybean": {
+                "name": "Sojabohne"
+            },
+            "spaghetti-squash": {
+                "name": "Spaghettikürbis",
+                "plural_name": "Spaghettikürbisse"
+            },
+            "speck": {
+                "name": "Speck"
+            },
+            "spices": {
+                "name": "Gewürze"
+            },
+            "spinach": {
+                "name": "Spinat"
+            },
+            "spring-onion": {
+                "name": "Frühlingszwiebeln",
+                "plural_name": "Frühlingszwiebeln"
+            },
+            "squash": {
+                "name": "Kürbis",
+                "plural_name": "Kürbisse"
+            },
+            "squash-family": {
+                "name": "Kürbisgewächse"
+            },
+            "stockfish": {
+                "name": "Stockfisch"
+            },
+            "sugar": {
+                "name": "Zucker"
+            },
+            "sunchoke": {
+                "name": "Topinambur",
+                "plural_name": "Topinamburen"
+            },
+            "sunflower-seeds": {
+                "name": "Sonnenblumenkerne"
+            },
+            "superfine-sugar": {
+                "name": "superfeiner Zucker"
+            },
+            "sweet-potato": {
+                "name": "Süßkartoffel",
+                "plural_name": "Süßkartoffeln"
+            },
+            "sweetcorn": {
+                "name": "Zuckermais",
+                "plural_name": "Zuckermais"
+            },
+            "sweeteners": {
+                "name": "Süßstoffe"
+            },
+            "tahini": {
+                "name": "Tahina"
+            },
+            "taro": {
+                "name": "Taro (Wasserbrotwurzel)",
+                "plural_name": "Taros (Wasserbrotwurzeln)"
+            },
+            "teff": {
+                "name": "Zwerghirse"
+            },
+            "tomato": {
+                "name": "Tomate",
+                "plural_name": "Tomaten"
+            },
+            "trout": {
+                "name": "Forelle"
+            },
+            "tubers": {
+                "name": "Knolle",
+                "plural_name": "Knollen"
+            },
+            "tuna": {
+                "name": "Thunfisch"
+            },
+            "turbanado-sugar": {
+                "name": "Turbinado-Zucker"
+            },
+            "turnip": {
+                "name": "Speiserübe",
+                "plural_name": "Speiserüben"
+            },
+            "unrefined-sugar": {
+                "name": "unraffinierter Zucker"
+            },
+            "vanilla": {
+                "name": "Vanille"
+            },
+            "vegetables": {
+                "name": "Gemüse"
+            },
+            "watercress": {
+                "name": "Brunnenkresse"
+            },
+            "watermelon": {
+                "name": "Wassermelone",
+                "plural_name": "Wassermelonen"
+            },
+            "white-mushroom": {
+                "name": "weißer Pilz",
+                "plural_name": "weiße Pilze"
+            },
+            "white-sugar": {
+                "name": "weißer Zucker"
+            },
+            "xanthan-gum": {
+                "name": "Xanthan"
+            },
+            "yam": {
+                "name": "Yamswurzel",
+                "plural_name": "Yamswurzeln"
+            },
+            "yeast": {
+                "name": "Hefe"
+            },
+            "zucchini": {
+                "name": "Zucchini",
+                "plural_name": "Zucchini"
+            }
+        }
+    },
+    "Obst & Gemüse": {
+        "foods": {}
+    },
+    "Getreide": {
+        "foods": {}
+    },
+    "Obst": {
+        "foods": {}
+    },
+    "Gemüse": {
+        "foods": {}
+    },
+    "Fleisch": {
+        "foods": {}
+    },
+    "Meeresfrüchte": {
+        "foods": {}
+    },
+    "Getränke": {
+        "foods": {}
+    },
+    "Backwaren": {
+        "foods": {}
+    },
+    "Konserven": {
+        "foods": {}
+    },
+    "Würzmittel": {
+        "foods": {}
+    },
+    "Konditorwaren": {
+        "foods": {}
+    },
+    "Milchprodukte": {
+        "foods": {}
+    },
+    "Tiefkühlware": {
+        "foods": {}
+    },
+    "Bio-Lebensmittel": {
+        "foods": {}
+    },
+    "Haushalt": {
+        "foods": {}
+    },
+    "Fleischprodukte": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Gewürze": {
+        "foods": {}
+    },
+    "Süßwaren": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Sonstiges": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/el-GR.json
+++ b/mealie/repos/seed/resources/foods/locales/el-GR.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "βελανίδι σκουός"
-	},
-	"alfalfa-sprouts": {
-		"name": "φύτρα σπόρων αλφάλφα"
-	},
-	"anchovies": {
-		"name": "αντζούγιες"
-	},
-	"apples": {
-		"name": "μήλα",
-		"plural_name": "μήλα"
-	},
-	"artichoke": {
-		"name": "αγκινάρα"
-	},
-	"arugula": {
-		"name": "ρόκα"
-	},
-	"asparagus": {
-		"name": "σπαράγγι"
-	},
-	"avocado": {
-		"name": "αβοκάντο",
-		"plural_name": "αβοκάντο"
-	},
-	"bacon": {
-		"name": "μπέικον"
-	},
-	"baking-powder": {
-		"name": "μπέικιν πάουντερ"
-	},
-	"baking-soda": {
-		"name": "μαγειρική σόδα"
-	},
-	"baking-sugar": {
-		"name": "μαγειρική ζάχαρη"
-	},
-	"bar-sugar": {
-		"name": "μπάρα ζάχαρης"
-	},
-	"basil": {
-		"name": "βασιλικός"
-	},
-	"beans": {
-		"name": "φασόλια"
-	},
-	"bell-peppers": {
-		"name": "πιπεριές",
-		"plural_name": "πιπεριές"
-	},
-	"blackberries": {
-		"name": "βατόμουρα"
-	},
-	"bok-choy": {
-		"name": "μποκ τσόι"
-	},
-	"brassicas": {
-		"name": "μπράσικες"
-	},
-	"bread": {
-		"name": "ψωμί"
-	},
-	"breadfruit": {
-		"name": "αρτόκαρπος"
-	},
-	"broccoflower": {
-		"name": "ρομανέσκο"
-	},
-	"broccoli": {
-		"name": "μπρόκολο"
-	},
-	"broccoli-rabe": {
-		"name": "ραπίνι"
-	},
-	"broccolini": {
-		"name": "μπροκολίνι"
-	},
-	"brown-sugar": {
-		"name": "καστανή ζάχαρη"
-	},
-	"brussels-sprouts": {
-		"name": "λαχανάκια Βρυξελλών"
-	},
-	"butter": {
-		"name": "βούτυρο"
-	},
-	"butternut-pumpkin": {
-		"name": "κολοκύθα βουτυράτη"
-	},
-	"butternut-squash": {
-		"name": "κολοκύθα βουτυράτη"
-	},
-	"cabbage": {
-		"name": "λάχανο",
-		"plural_name": "λάχανα"
-	},
-	"cactus-edible": {
-		"name": "κάκτος, βρώσιμος"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "ζάχαρη ζαχαροκαλάμου"
-	},
-	"cannabis": {
-		"name": "κάνναβη"
-	},
-	"capsicum": {
-		"name": "καψικόν"
-	},
-	"caraway": {
-		"name": "άγριο κύμινο"
-	},
-	"carrot": {
-		"name": "καρότο",
-		"plural_name": "καρότα"
-	},
-	"caster-sugar": {
-		"name": "άχνη ζάχαρη"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "γατόψαρο"
-	},
-	"cauliflower": {
-		"name": "κουνουπίδι",
-		"plural_name": "κουνουπίδια"
-	},
-	"cayenne-pepper": {
-		"name": "πιπέρι καγιέν"
-	},
-	"celeriac": {
-		"name": "σέλινο"
-	},
-	"celery": {
-		"name": "σέλινο"
-	},
-	"cereal-grains": {
-		"name": "πίτουρο δημητριακών"
-	},
-	"chard": {
-		"name": "σέσκουλο"
-	},
-	"cheese": {
-		"name": "τυρί"
-	},
-	"chicory": {
-		"name": "ραδίκι"
-	},
-	"chilli-peppers": {
-		"name": "πιπεριές τσίλι",
-		"plural_name": "πιπεριές τσίλι"
-	},
-	"chinese-leaves": {
-		"name": "κινέζικα φύλλα"
-	},
-	"chives": {
-		"name": "σχοινόπρασο"
-	},
-	"chocolate": {
-		"name": "σοκολάτα"
-	},
-	"cilantro": {
-		"name": "κόλιανδρος"
-	},
-	"cinnamon": {
-		"name": "κανέλα"
-	},
-	"clarified-butter": {
-		"name": "διαυγές βούτυρο"
-	},
-	"coconut": {
-		"name": "καρύδα",
-		"plural_name": "καρύδες"
-	},
-	"coconut-milk": {
-		"name": "γάλα καρύδας"
-	},
-	"cod": {
-		"name": "μπακαλιάρος"
-	},
-	"coffee": {
-		"name": "καφές"
-	},
-	"collard-greens": {
-		"name": "λαχανίδες"
-	},
-	"confectioners-sugar": {
-		"name": "ζάχαρη άχνη"
-	},
-	"coriander": {
-		"name": "κόλιανδρος"
-	},
-	"corn": {
-		"name": "καλαμπόκι",
-		"plural_name": "καλαμπόκια"
-	},
-	"corn-syrup": {
-		"name": "σιρόπι καλαμποκιού"
-	},
-	"cottonseed-oil": {
-		"name": "βαμβακέλαιο"
-	},
-	"courgette": {
-		"name": "κολοκυθάκι"
-	},
-	"cream-of-tartar": {
-		"name": "κρέμα ταρτάρ"
-	},
-	"cucumber": {
-		"name": "αγγούρι",
-		"plural_name": "αγγούρια"
-	},
-	"cumin": {
-		"name": "κύμινο"
-	},
-	"daikon": {
-		"name": "νταϊκόν",
-		"plural_name": "νταϊκόν"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "γαλακτοκομικά και υποκατάστατα γαλακτοκομικών"
-	},
-	"dandelion": {
-		"name": "πικραλίδα"
-	},
-	"demerara-sugar": {
-		"name": "ζάχαρη demerara"
-	},
-	"dough": {
-		"name": "ζυμάρι"
-	},
-	"edible-cactus": {
-		"name": "κάκτος που τρώγεται"
-	},
-	"eggplant": {
-		"name": "μελιτζάνα",
-		"plural_name": "μελιτζάνες"
-	},
-	"eggs": {
-		"name": "αβγά",
-		"plural_name": "αβγά"
-	},
-	"endive": {
-		"name": "αντίδι",
-		"plural_name": "αντίδια"
-	},
-	"fats": {
-		"name": "λιπαρά"
-	},
-	"fava-beans": {
-		"name": "κουκιά"
-	},
-	"fiddlehead": {
-		"name": "βλαστάρια φτέρης"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "ψάρι"
-	},
-	"five-spice-powder": {
-		"name": "σκόνη πέντε μπαχαρικών"
-	},
-	"flour": {
-		"name": "αλεύρι"
-	},
-	"frisee": {
-		"name": "κατσαρό αντίδι"
-	},
-	"fructose": {
-		"name": "φρουκτόζη"
-	},
-	"fruit": {
-		"name": "φρούτο"
-	},
-	"fruit-sugar": {
-		"name": "ζάχαρη φρούτων"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "γκαράμ μασάλα"
-	},
-	"garlic": {
-		"name": "σκόρδο",
-		"plural_name": "σκόρδα"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "γκι (βούτυρο)"
-	},
-	"giblets": {
-		"name": "εντόσθια πουλερικών"
-	},
-	"ginger": {
-		"name": "τζίντζερ"
-	},
-	"grains": {
-		"name": "σιτηρά"
-	},
-	"granulated-sugar": {
-		"name": "ζάχαρη σε κόκκους"
-	},
-	"grape-seed-oil": {
-		"name": "έλαιο από σταφύλια"
-	},
-	"green-onion": {
-		"name": "πράσινο κρεμμύδι",
-		"plural_name": "πράσινα κρεμμύδια"
-	},
-	"heart-of-palm": {
-		"name": "καρδιά φοίνικα",
-		"plural_name": "καρδιές φοινίκων"
-	},
-	"hemp": {
-		"name": "βιομηχανική κάνναβη"
-	},
-	"herbs": {
-		"name": "βότανα"
-	},
-	"honey": {
-		"name": "μέλι"
-	},
-	"isomalt": {
-		"name": "ισομαλτόζη"
-	},
-	"jackfruit": {
-		"name": "τζάκφρουτ",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "ζάχαρη jaggery"
-	},
-	"jams": {
-		"name": "μαρμελάδα"
-	},
-	"jellies": {
-		"name": "ζελέδες"
-	},
-	"jerusalem-artichoke": {
-		"name": "αγκινάρα της Ιερουσαλήμ"
-	},
-	"jicama": {
-		"name": "χίκαμα"
-	},
-	"kale": {
-		"name": "λαχανίδα"
-	},
-	"kohlrabi": {
-		"name": "λαχανόριζα"
-	},
-	"kumara": {
-		"name": "κούμαρα"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "πράσο",
-		"plural_name": "πράσα"
-	},
-	"legumes": {
-		"name": "όσπρια"
-	},
-	"lemongrass": {
-		"name": "λεμονόχορτο"
-	},
-	"lentils": {
-		"name": "φακές"
-	},
-	"lettuce": {
-		"name": "μαρούλι"
-	},
-	"liver": {
-		"name": "συκώτι",
-		"plural_name": "συκώτια"
-	},
-	"maize": {
-		"name": "καλαμπόκι"
-	},
-	"maple-syrup": {
-		"name": "σιρόπι σφενδάμου"
-	},
-	"meat": {
-		"name": "κρέας"
-	},
-	"milk": {
-		"name": "γάλα"
-	},
-	"mortadella": {
-		"name": "μορταδέλα"
-	},
-	"mushroom": {
-		"name": "μανιτάρι",
-		"plural_name": "μανιτάρια"
-	},
-	"mussels": {
-		"name": "μύδια"
-	},
-	"nanaimo-bar-mix": {
-		"name": "μείγμα μπάρας nanaimo"
-	},
-	"nori": {
-		"name": "νόρι"
-	},
-	"nutmeg": {
-		"name": "μοσχοκάρυδο"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "νιφάδες μαγιάς"
-	},
-	"nuts": {
-		"name": "ξηροί καρποί"
-	},
-	"octopuses": {
-		"name": "χταπόδια",
-		"plural_name": "χταπόδια"
-	},
-	"oils": {
-		"name": "λάδια"
-	},
-	"okra": {
-		"name": "μπάμια"
-	},
-	"olive": {
-		"name": "ελιά"
-	},
-	"olive-oil": {
-		"name": "ελαιόλαδο"
-	},
-	"onion": {
-		"name": "κρεμμύδι"
-	},
-	"onion-family": {
-		"name": "κρεμμυδοειδή"
-	},
-	"orange-blossom-water": {
-		"name": "νερό από άνθη πορτοκαλιάς"
-	},
-	"oranges": {
-		"name": "πορτοκάλι",
-		"plural_name": "πορτοκάλια"
-	},
-	"oregano": {
-		"name": "ρίγανη"
-	},
-	"oysters": {
-		"name": "στρείδια"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "πάπρικα"
-	},
-	"parsley": {
-		"name": "μαϊντανός"
-	},
-	"parsnip": {
-		"name": "παστινάκι",
-		"plural_name": "παστινάκια"
-	},
-	"pear": {
-		"name": "αχλάδι",
-		"plural_name": "αχλάδια"
-	},
-	"peas": {
-		"name": "αρακάς"
-	},
-	"pepper": {
-		"name": "πιπέρι",
-		"plural_name": "πιπεριές"
-	},
-	"pineapple": {
-		"name": "ανανάς",
-		"plural_name": "ανανάδες"
-	},
-	"plantain": {
-		"name": "μπανάνες Αντιλλών",
-		"plural_name": "μπανάνες Αντιλλών"
-	},
-	"poppy-seeds": {
-		"name": "παπαρουνόσπορος"
-	},
-	"potato": {
-		"name": "πατάτα",
-		"plural_name": "πατάτες"
-	},
-	"poultry": {
-		"name": "πουλερικά"
-	},
-	"powdered-sugar": {
-		"name": "ζάχαρη άχνη"
-	},
-	"pumpkin": {
-		"name": "κολοκύθα",
-		"plural_name": "κολοκύθες"
-	},
-	"pumpkin-seeds": {
-		"name": "σπόροι κολοκύθας"
-	},
-	"radish": {
-		"name": "ραπανάκι",
-		"plural_name": "ραπανάκια"
-	},
-	"raw-sugar": {
-		"name": "ακατέργαστη ζάχαρη"
-	},
-	"refined-sugar": {
-		"name": "ραφιναρισμένη ζάχαρη"
-	},
-	"rice": {
-		"name": "ρύζι"
-	},
-	"rice-flour": {
-		"name": "ρυζάλευρο"
-	},
-	"rock-sugar": {
-		"name": "κύβοι ζάχαρης"
-	},
-	"rum": {
-		"name": "ρούμι"
-	},
-	"salmon": {
-		"name": "σολομός"
-	},
-	"salt": {
-		"name": "αλάτι"
-	},
-	"salt-cod": {
-		"name": "αλατισμένος μπακαλιάρος"
-	},
-	"scallion": {
-		"name": "φρέσκο κρεμμυδάκι",
-		"plural_name": "φρέσκα κρεμμυδάκια"
-	},
-	"seafood": {
-		"name": "θαλασσινά"
-	},
-	"seeds": {
-		"name": "σπόροι"
-	},
-	"sesame-seeds": {
-		"name": "σπόροι σουσαμιού"
-	},
-	"shallot": {
-		"name": "ασκαλώνιο",
-		"plural_name": "ασκαλώνια"
-	},
-	"skate": {
-		"name": "σαλάχι"
-	},
-	"soda": {
-		"name": "σόδα"
-	},
-	"soda-baking": {
-		"name": "σόδα, μπέικιν"
-	},
-	"soybean": {
-		"name": "σόγια"
-	},
-	"spaghetti-squash": {
-		"name": "μακαρόνια κολοκύθας",
-		"plural_name": "μακαρόνια κολοκύθας"
-	},
-	"speck": {
-		"name": "σπεκ"
-	},
-	"spices": {
-		"name": "μπαχαρικά"
-	},
-	"spinach": {
-		"name": "σπανάκι"
-	},
-	"spring-onion": {
-		"name": "φρέσκο κρεμμυδάκι",
-		"plural_name": "φρέσκα κρεμμυδάκια"
-	},
-	"squash": {
-		"name": "κολοκύθα",
-		"plural_name": "κολοκύθες"
-	},
-	"squash-family": {
-		"name": "κολοκυθοειδή"
-	},
-	"stockfish": {
-		"name": "ξηρός μπακαλάος"
-	},
-	"sugar": {
-		"name": "ζάχαρη"
-	},
-	"sunchoke": {
-		"name": "τοπιναμπούρ",
-		"plural_name": "τοπιναμπούρ"
-	},
-	"sunflower-seeds": {
-		"name": "σπόροι ηλίανθου"
-	},
-	"superfine-sugar": {
-		"name": "υπερλεπτή ζάχαρη"
-	},
-	"sweet-potato": {
-		"name": "γλυκοπατάτα",
-		"plural_name": "γλυκοπατάτες"
-	},
-	"sweetcorn": {
-		"name": "γλυκο καλαμποκι",
-		"plural_name": "γλυκά καλαμπόκια"
-	},
-	"sweeteners": {
-		"name": "γλυκαντικά"
-	},
-	"tahini": {
-		"name": "ταχίνι"
-	},
-	"taro": {
-		"name": "κολοκασία (εδώδιμος)",
-		"plural_name": "κολοκασίες (εδώδιμες)"
-	},
-	"teff": {
-		"name": "τεφ"
-	},
-	"tomato": {
-		"name": "ντομάτα",
-		"plural_name": "ντομάτες"
-	},
-	"trout": {
-		"name": "πέστροφα"
-	},
-	"tubers": {
-		"name": "κόνδυλοι",
-		"plural_name": "κόνδυλοι"
-	},
-	"tuna": {
-		"name": "τόνος"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "γογγύλι",
-		"plural_name": "γογγύλια"
-	},
-	"unrefined-sugar": {
-		"name": "αραφινάριστη ζάχαρη"
-	},
-	"vanilla": {
-		"name": "βανίλια"
-	},
-	"vegetables": {
-		"name": "λαχανικά"
-	},
-	"watercress": {
-		"name": "νεροκάρδαμο"
-	},
-	"watermelon": {
-		"name": "καρπούζι",
-		"plural_name": "καρπούζια"
-	},
-	"white-mushroom": {
-		"name": "λευκό μανιτάρι",
-		"plural_name": "λευκά μανιτάρια"
-	},
-	"white-sugar": {
-		"name": "λευκή ζάχαρη"
-	},
-	"xanthan-gum": {
-		"name": "ξανθάνη"
-	},
-	"yam": {
-		"name": "γιαμ",
-		"plural_name": "γιαμ"
-	},
-	"yeast": {
-		"name": "μαγιά"
-	},
-	"zucchini": {
-		"name": "κολοκύθι",
-		"plural_name": "κολοκύθια"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "βελανίδι σκουός"
+            },
+            "alfalfa-sprouts": {
+                "name": "φύτρα σπόρων αλφάλφα"
+            },
+            "anchovies": {
+                "name": "αντζούγιες"
+            },
+            "apples": {
+                "name": "μήλα",
+                "plural_name": "μήλα"
+            },
+            "artichoke": {
+                "name": "αγκινάρα"
+            },
+            "arugula": {
+                "name": "ρόκα"
+            },
+            "asparagus": {
+                "name": "σπαράγγι"
+            },
+            "avocado": {
+                "name": "αβοκάντο",
+                "plural_name": "αβοκάντο"
+            },
+            "bacon": {
+                "name": "μπέικον"
+            },
+            "baking-powder": {
+                "name": "μπέικιν πάουντερ"
+            },
+            "baking-soda": {
+                "name": "μαγειρική σόδα"
+            },
+            "baking-sugar": {
+                "name": "μαγειρική ζάχαρη"
+            },
+            "bar-sugar": {
+                "name": "μπάρα ζάχαρης"
+            },
+            "basil": {
+                "name": "βασιλικός"
+            },
+            "beans": {
+                "name": "φασόλια"
+            },
+            "bell-peppers": {
+                "name": "πιπεριές",
+                "plural_name": "πιπεριές"
+            },
+            "blackberries": {
+                "name": "βατόμουρα"
+            },
+            "bok-choy": {
+                "name": "μποκ τσόι"
+            },
+            "brassicas": {
+                "name": "μπράσικες"
+            },
+            "bread": {
+                "name": "ψωμί"
+            },
+            "breadfruit": {
+                "name": "αρτόκαρπος"
+            },
+            "broccoflower": {
+                "name": "ρομανέσκο"
+            },
+            "broccoli": {
+                "name": "μπρόκολο"
+            },
+            "broccoli-rabe": {
+                "name": "ραπίνι"
+            },
+            "broccolini": {
+                "name": "μπροκολίνι"
+            },
+            "brown-sugar": {
+                "name": "καστανή ζάχαρη"
+            },
+            "brussels-sprouts": {
+                "name": "λαχανάκια Βρυξελλών"
+            },
+            "butter": {
+                "name": "βούτυρο"
+            },
+            "butternut-pumpkin": {
+                "name": "κολοκύθα βουτυράτη"
+            },
+            "butternut-squash": {
+                "name": "κολοκύθα βουτυράτη"
+            },
+            "cabbage": {
+                "name": "λάχανο",
+                "plural_name": "λάχανα"
+            },
+            "cactus-edible": {
+                "name": "κάκτος, βρώσιμος"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "ζάχαρη ζαχαροκαλάμου"
+            },
+            "cannabis": {
+                "name": "κάνναβη"
+            },
+            "capsicum": {
+                "name": "καψικόν"
+            },
+            "caraway": {
+                "name": "άγριο κύμινο"
+            },
+            "carrot": {
+                "name": "καρότο",
+                "plural_name": "καρότα"
+            },
+            "caster-sugar": {
+                "name": "άχνη ζάχαρη"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "γατόψαρο"
+            },
+            "cauliflower": {
+                "name": "κουνουπίδι",
+                "plural_name": "κουνουπίδια"
+            },
+            "cayenne-pepper": {
+                "name": "πιπέρι καγιέν"
+            },
+            "celeriac": {
+                "name": "σέλινο"
+            },
+            "celery": {
+                "name": "σέλινο"
+            },
+            "cereal-grains": {
+                "name": "πίτουρο δημητριακών"
+            },
+            "chard": {
+                "name": "σέσκουλο"
+            },
+            "cheese": {
+                "name": "τυρί"
+            },
+            "chicory": {
+                "name": "ραδίκι"
+            },
+            "chilli-peppers": {
+                "name": "πιπεριές τσίλι",
+                "plural_name": "πιπεριές τσίλι"
+            },
+            "chinese-leaves": {
+                "name": "κινέζικα φύλλα"
+            },
+            "chives": {
+                "name": "σχοινόπρασο"
+            },
+            "chocolate": {
+                "name": "σοκολάτα"
+            },
+            "cilantro": {
+                "name": "κόλιανδρος"
+            },
+            "cinnamon": {
+                "name": "κανέλα"
+            },
+            "clarified-butter": {
+                "name": "διαυγές βούτυρο"
+            },
+            "coconut": {
+                "name": "καρύδα",
+                "plural_name": "καρύδες"
+            },
+            "coconut-milk": {
+                "name": "γάλα καρύδας"
+            },
+            "cod": {
+                "name": "μπακαλιάρος"
+            },
+            "coffee": {
+                "name": "καφές"
+            },
+            "collard-greens": {
+                "name": "λαχανίδες"
+            },
+            "confectioners-sugar": {
+                "name": "ζάχαρη άχνη"
+            },
+            "coriander": {
+                "name": "κόλιανδρος"
+            },
+            "corn": {
+                "name": "καλαμπόκι",
+                "plural_name": "καλαμπόκια"
+            },
+            "corn-syrup": {
+                "name": "σιρόπι καλαμποκιού"
+            },
+            "cottonseed-oil": {
+                "name": "βαμβακέλαιο"
+            },
+            "courgette": {
+                "name": "κολοκυθάκι"
+            },
+            "cream-of-tartar": {
+                "name": "κρέμα ταρτάρ"
+            },
+            "cucumber": {
+                "name": "αγγούρι",
+                "plural_name": "αγγούρια"
+            },
+            "cumin": {
+                "name": "κύμινο"
+            },
+            "daikon": {
+                "name": "νταϊκόν",
+                "plural_name": "νταϊκόν"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "γαλακτοκομικά και υποκατάστατα γαλακτοκομικών"
+            },
+            "dandelion": {
+                "name": "πικραλίδα"
+            },
+            "demerara-sugar": {
+                "name": "ζάχαρη demerara"
+            },
+            "dough": {
+                "name": "ζυμάρι"
+            },
+            "edible-cactus": {
+                "name": "κάκτος που τρώγεται"
+            },
+            "eggplant": {
+                "name": "μελιτζάνα",
+                "plural_name": "μελιτζάνες"
+            },
+            "eggs": {
+                "name": "αβγά",
+                "plural_name": "αβγά"
+            },
+            "endive": {
+                "name": "αντίδι",
+                "plural_name": "αντίδια"
+            },
+            "fats": {
+                "name": "λιπαρά"
+            },
+            "fava-beans": {
+                "name": "κουκιά"
+            },
+            "fiddlehead": {
+                "name": "βλαστάρια φτέρης"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "ψάρι"
+            },
+            "five-spice-powder": {
+                "name": "σκόνη πέντε μπαχαρικών"
+            },
+            "flour": {
+                "name": "αλεύρι"
+            },
+            "frisee": {
+                "name": "κατσαρό αντίδι"
+            },
+            "fructose": {
+                "name": "φρουκτόζη"
+            },
+            "fruit": {
+                "name": "φρούτο"
+            },
+            "fruit-sugar": {
+                "name": "ζάχαρη φρούτων"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "γκαράμ μασάλα"
+            },
+            "garlic": {
+                "name": "σκόρδο",
+                "plural_name": "σκόρδα"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "γκι (βούτυρο)"
+            },
+            "giblets": {
+                "name": "εντόσθια πουλερικών"
+            },
+            "ginger": {
+                "name": "τζίντζερ"
+            },
+            "grains": {
+                "name": "σιτηρά"
+            },
+            "granulated-sugar": {
+                "name": "ζάχαρη σε κόκκους"
+            },
+            "grape-seed-oil": {
+                "name": "έλαιο από σταφύλια"
+            },
+            "green-onion": {
+                "name": "πράσινο κρεμμύδι",
+                "plural_name": "πράσινα κρεμμύδια"
+            },
+            "heart-of-palm": {
+                "name": "καρδιά φοίνικα",
+                "plural_name": "καρδιές φοινίκων"
+            },
+            "hemp": {
+                "name": "βιομηχανική κάνναβη"
+            },
+            "herbs": {
+                "name": "βότανα"
+            },
+            "honey": {
+                "name": "μέλι"
+            },
+            "isomalt": {
+                "name": "ισομαλτόζη"
+            },
+            "jackfruit": {
+                "name": "τζάκφρουτ",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "ζάχαρη jaggery"
+            },
+            "jams": {
+                "name": "μαρμελάδα"
+            },
+            "jellies": {
+                "name": "ζελέδες"
+            },
+            "jerusalem-artichoke": {
+                "name": "αγκινάρα της Ιερουσαλήμ"
+            },
+            "jicama": {
+                "name": "χίκαμα"
+            },
+            "kale": {
+                "name": "λαχανίδα"
+            },
+            "kohlrabi": {
+                "name": "λαχανόριζα"
+            },
+            "kumara": {
+                "name": "κούμαρα"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "πράσο",
+                "plural_name": "πράσα"
+            },
+            "legumes": {
+                "name": "όσπρια"
+            },
+            "lemongrass": {
+                "name": "λεμονόχορτο"
+            },
+            "lentils": {
+                "name": "φακές"
+            },
+            "lettuce": {
+                "name": "μαρούλι"
+            },
+            "liver": {
+                "name": "συκώτι",
+                "plural_name": "συκώτια"
+            },
+            "maize": {
+                "name": "καλαμπόκι"
+            },
+            "maple-syrup": {
+                "name": "σιρόπι σφενδάμου"
+            },
+            "meat": {
+                "name": "κρέας"
+            },
+            "milk": {
+                "name": "γάλα"
+            },
+            "mortadella": {
+                "name": "μορταδέλα"
+            },
+            "mushroom": {
+                "name": "μανιτάρι",
+                "plural_name": "μανιτάρια"
+            },
+            "mussels": {
+                "name": "μύδια"
+            },
+            "nanaimo-bar-mix": {
+                "name": "μείγμα μπάρας nanaimo"
+            },
+            "nori": {
+                "name": "νόρι"
+            },
+            "nutmeg": {
+                "name": "μοσχοκάρυδο"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "νιφάδες μαγιάς"
+            },
+            "nuts": {
+                "name": "ξηροί καρποί"
+            },
+            "octopuses": {
+                "name": "χταπόδια",
+                "plural_name": "χταπόδια"
+            },
+            "oils": {
+                "name": "λάδια"
+            },
+            "okra": {
+                "name": "μπάμια"
+            },
+            "olive": {
+                "name": "ελιά"
+            },
+            "olive-oil": {
+                "name": "ελαιόλαδο"
+            },
+            "onion": {
+                "name": "κρεμμύδι"
+            },
+            "onion-family": {
+                "name": "κρεμμυδοειδή"
+            },
+            "orange-blossom-water": {
+                "name": "νερό από άνθη πορτοκαλιάς"
+            },
+            "oranges": {
+                "name": "πορτοκάλι",
+                "plural_name": "πορτοκάλια"
+            },
+            "oregano": {
+                "name": "ρίγανη"
+            },
+            "oysters": {
+                "name": "στρείδια"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "πάπρικα"
+            },
+            "parsley": {
+                "name": "μαϊντανός"
+            },
+            "parsnip": {
+                "name": "παστινάκι",
+                "plural_name": "παστινάκια"
+            },
+            "pear": {
+                "name": "αχλάδι",
+                "plural_name": "αχλάδια"
+            },
+            "peas": {
+                "name": "αρακάς"
+            },
+            "pepper": {
+                "name": "πιπέρι",
+                "plural_name": "πιπεριές"
+            },
+            "pineapple": {
+                "name": "ανανάς",
+                "plural_name": "ανανάδες"
+            },
+            "plantain": {
+                "name": "μπανάνες Αντιλλών",
+                "plural_name": "μπανάνες Αντιλλών"
+            },
+            "poppy-seeds": {
+                "name": "παπαρουνόσπορος"
+            },
+            "potato": {
+                "name": "πατάτα",
+                "plural_name": "πατάτες"
+            },
+            "poultry": {
+                "name": "πουλερικά"
+            },
+            "powdered-sugar": {
+                "name": "ζάχαρη άχνη"
+            },
+            "pumpkin": {
+                "name": "κολοκύθα",
+                "plural_name": "κολοκύθες"
+            },
+            "pumpkin-seeds": {
+                "name": "σπόροι κολοκύθας"
+            },
+            "radish": {
+                "name": "ραπανάκι",
+                "plural_name": "ραπανάκια"
+            },
+            "raw-sugar": {
+                "name": "ακατέργαστη ζάχαρη"
+            },
+            "refined-sugar": {
+                "name": "ραφιναρισμένη ζάχαρη"
+            },
+            "rice": {
+                "name": "ρύζι"
+            },
+            "rice-flour": {
+                "name": "ρυζάλευρο"
+            },
+            "rock-sugar": {
+                "name": "κύβοι ζάχαρης"
+            },
+            "rum": {
+                "name": "ρούμι"
+            },
+            "salmon": {
+                "name": "σολομός"
+            },
+            "salt": {
+                "name": "αλάτι"
+            },
+            "salt-cod": {
+                "name": "αλατισμένος μπακαλιάρος"
+            },
+            "scallion": {
+                "name": "φρέσκο κρεμμυδάκι",
+                "plural_name": "φρέσκα κρεμμυδάκια"
+            },
+            "seafood": {
+                "name": "θαλασσινά"
+            },
+            "seeds": {
+                "name": "σπόροι"
+            },
+            "sesame-seeds": {
+                "name": "σπόροι σουσαμιού"
+            },
+            "shallot": {
+                "name": "ασκαλώνιο",
+                "plural_name": "ασκαλώνια"
+            },
+            "skate": {
+                "name": "σαλάχι"
+            },
+            "soda": {
+                "name": "σόδα"
+            },
+            "soda-baking": {
+                "name": "σόδα, μπέικιν"
+            },
+            "soybean": {
+                "name": "σόγια"
+            },
+            "spaghetti-squash": {
+                "name": "μακαρόνια κολοκύθας",
+                "plural_name": "μακαρόνια κολοκύθας"
+            },
+            "speck": {
+                "name": "σπεκ"
+            },
+            "spices": {
+                "name": "μπαχαρικά"
+            },
+            "spinach": {
+                "name": "σπανάκι"
+            },
+            "spring-onion": {
+                "name": "φρέσκο κρεμμυδάκι",
+                "plural_name": "φρέσκα κρεμμυδάκια"
+            },
+            "squash": {
+                "name": "κολοκύθα",
+                "plural_name": "κολοκύθες"
+            },
+            "squash-family": {
+                "name": "κολοκυθοειδή"
+            },
+            "stockfish": {
+                "name": "ξηρός μπακαλάος"
+            },
+            "sugar": {
+                "name": "ζάχαρη"
+            },
+            "sunchoke": {
+                "name": "τοπιναμπούρ",
+                "plural_name": "τοπιναμπούρ"
+            },
+            "sunflower-seeds": {
+                "name": "σπόροι ηλίανθου"
+            },
+            "superfine-sugar": {
+                "name": "υπερλεπτή ζάχαρη"
+            },
+            "sweet-potato": {
+                "name": "γλυκοπατάτα",
+                "plural_name": "γλυκοπατάτες"
+            },
+            "sweetcorn": {
+                "name": "γλυκο καλαμποκι",
+                "plural_name": "γλυκά καλαμπόκια"
+            },
+            "sweeteners": {
+                "name": "γλυκαντικά"
+            },
+            "tahini": {
+                "name": "ταχίνι"
+            },
+            "taro": {
+                "name": "κολοκασία (εδώδιμος)",
+                "plural_name": "κολοκασίες (εδώδιμες)"
+            },
+            "teff": {
+                "name": "τεφ"
+            },
+            "tomato": {
+                "name": "ντομάτα",
+                "plural_name": "ντομάτες"
+            },
+            "trout": {
+                "name": "πέστροφα"
+            },
+            "tubers": {
+                "name": "κόνδυλοι",
+                "plural_name": "κόνδυλοι"
+            },
+            "tuna": {
+                "name": "τόνος"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "γογγύλι",
+                "plural_name": "γογγύλια"
+            },
+            "unrefined-sugar": {
+                "name": "αραφινάριστη ζάχαρη"
+            },
+            "vanilla": {
+                "name": "βανίλια"
+            },
+            "vegetables": {
+                "name": "λαχανικά"
+            },
+            "watercress": {
+                "name": "νεροκάρδαμο"
+            },
+            "watermelon": {
+                "name": "καρπούζι",
+                "plural_name": "καρπούζια"
+            },
+            "white-mushroom": {
+                "name": "λευκό μανιτάρι",
+                "plural_name": "λευκά μανιτάρια"
+            },
+            "white-sugar": {
+                "name": "λευκή ζάχαρη"
+            },
+            "xanthan-gum": {
+                "name": "ξανθάνη"
+            },
+            "yam": {
+                "name": "γιαμ",
+                "plural_name": "γιαμ"
+            },
+            "yeast": {
+                "name": "μαγιά"
+            },
+            "zucchini": {
+                "name": "κολοκύθι",
+                "plural_name": "κολοκύθια"
+            }
+        }
+    },
+    "Παραγωγής": {
+        "foods": {}
+    },
+    "Σιτηρά": {
+        "foods": {}
+    },
+    "Φρούτα": {
+        "foods": {}
+    },
+    "Λαχανικά": {
+        "foods": {}
+    },
+    "Κρέας": {
+        "foods": {}
+    },
+    "Θαλασσινά": {
+        "foods": {}
+    },
+    "Ποτά": {
+        "foods": {}
+    },
+    "Αρτοσκευάσματα": {
+        "foods": {}
+    },
+    "Κονσερβοποιημένα Αγαθά": {
+        "foods": {}
+    },
+    "Καρυκεύματα": {
+        "foods": {}
+    },
+    "Ζαχαροπλαστική": {
+        "foods": {}
+    },
+    "Γαλακτοκομικά": {
+        "foods": {}
+    },
+    "Κατεψυγμένα Τρόφιμα": {
+        "foods": {}
+    },
+    "Υγιεινά τρόφιμα": {
+        "foods": {}
+    },
+    "Νοικοκυριό": {
+        "foods": {}
+    },
+    "Κρεατικά": {
+        "foods": {}
+    },
+    "Σνακ": {
+        "foods": {}
+    },
+    "Μπαχαρικά": {
+        "foods": {}
+    },
+    "Γλυκά": {
+        "foods": {}
+    },
+    "Αλκοόλ": {
+        "foods": {}
+    },
+    "Άλλα": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/en-GB.json
+++ b/mealie/repos/seed/resources/foods/locales/en-GB.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "rocket"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocados"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "bicarbonate of soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell pepper",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "Tender-stem broccoli"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussel sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "caster sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "diakon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "broad beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grain"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jam"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oyster"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "spring onion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "bicarbonate of soda"
-	},
-	"soybean": {
-		"name": "soya beans"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "rocket"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocados"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "bicarbonate of soda"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell pepper",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "blackberries"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "bread"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "Tender-stem broccoli"
+            },
+            "brown-sugar": {
+                "name": "brown sugar"
+            },
+            "brussels-sprouts": {
+                "name": "brussel sprouts"
+            },
+            "butter": {
+                "name": "butter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "caster sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "cheese"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "diakon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "broad beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grain"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jam"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oyster"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rice"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "spring onion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "bicarbonate of soda"
+            },
+            "soybean": {
+                "name": "soya beans"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Fresh Produce": {
+        "foods": {}
+    },
+    "Grains": {
+        "foods": {}
+    },
+    "Fruits": {
+        "foods": {}
+    },
+    "Vegetables": {
+        "foods": {}
+    },
+    "Meat": {
+        "foods": {}
+    },
+    "Seafood": {
+        "foods": {}
+    },
+    "Beverages": {
+        "foods": {}
+    },
+    "Baked Goods": {
+        "foods": {}
+    },
+    "Canned Goods": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Confectionery": {
+        "foods": {}
+    },
+    "Dairy Products": {
+        "foods": {}
+    },
+    "Frozen Foods": {
+        "foods": {}
+    },
+    "Health Foods": {
+        "foods": {}
+    },
+    "Household": {
+        "foods": {}
+    },
+    "Meat Products": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Spices": {
+        "foods": {}
+    },
+    "Sweets": {
+        "foods": {}
+    },
+    "Alcohol": {
+        "foods": {}
+    },
+    "Other": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/en-US.json
+++ b/mealie/repos/seed/resources/foods/locales/en-US.json
@@ -1,692 +1,16337 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
+	"Vegetables & Greens": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic",
+				"pluralName": "garlics"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion",
+				"pluralName": "onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bell pepper",
+				"pluralName": "bell peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carrot",
+				"pluralName": "carrots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "scallion",
+				"pluralName": "scallions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "zucchini",
+				"pluralName": "zucchinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato",
+				"pluralName": "potatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red onion",
+				"pluralName": "red onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow onion",
+				"pluralName": "yellow onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "celery",
+				"pluralName": "celeries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jalapeno",
+				"pluralName": "jalapenoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "avocado",
+				"pluralName": "avocados"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "zucchini",
+				"pluralName": "zucchinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shallot",
+				"pluralName": "shallots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry tomato",
+				"pluralName": "cherry tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cucumber",
+				"pluralName": "cucumbers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spinach",
+				"pluralName": "spinaches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet corn",
+				"pluralName": "sweet corns"
+			},
+			{
+				"aliases": [
+					"capsicum"
+				],
+				"description": "",
+				"name": "chile pepper",
+				"pluralName": "chile peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet potato",
+				"pluralName": "sweet potatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "broccoli",
+				"pluralName": "broccolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "heart of palm",
+				"pluralName": "heart of palms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baby green",
+				"pluralName": "baby greens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin",
+				"pluralName": "pumpkins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cauliflower",
+				"pluralName": "cauliflowers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cabbage",
+				"pluralName": "cabbages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "asparagu",
+				"pluralName": "asparagus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kale",
+				"pluralName": "kales"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arugula",
+				"pluralName": "arugulas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "leek",
+				"pluralName": "leeks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eggplant",
+				"pluralName": "eggplants"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lettuce",
+				"pluralName": "lettuces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butternut squash",
+				"pluralName": "butternut squashes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "romaine",
+				"pluralName": "romaines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beetroot",
+				"pluralName": "beetroots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brussels sprout",
+				"pluralName": "brussels sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fennel",
+				"pluralName": "fennels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun dried tomato",
+				"pluralName": "sun dried tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "radish",
+				"pluralName": "radishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red cabbage",
+				"pluralName": "red cabbages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "artichoke",
+				"pluralName": "artichokes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "new potato",
+				"pluralName": "new potatoes"
+			},
+			{
+				"aliases": [
+					"courgette",
+					"gem squash"
+				],
+				"description": "",
+				"name": "summer squash",
+				"pluralName": "summer squashes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed green",
+				"pluralName": "mixed greens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "parsnip",
+				"pluralName": "parsnips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baby carrot",
+				"pluralName": "baby carrots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed vegetable",
+				"pluralName": "mixed vegetables"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "poblano pepper",
+				"pluralName": "poblano peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet pepper",
+				"pluralName": "sweet peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "serrano pepper",
+				"pluralName": "serrano peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cayenne pepper",
+				"pluralName": "cayenne peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green tomato",
+				"pluralName": "green tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "watercress",
+				"pluralName": "watercress"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "iceberg",
+				"pluralName": "icebergs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mashed potato",
+				"pluralName": "mashed potatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "horseradish",
+				"pluralName": "horseradishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chard",
+				"pluralName": "chards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pimiento",
+				"pluralName": "pimientoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spaghetti squash",
+				"pluralName": "spaghetti squashes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter lettuce",
+				"pluralName": "butter lettuces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hash brown",
+				"pluralName": "hash browns"
+			},
+			{
+				"aliases": [
+					"chinese  leaves"
+				],
+				"description": "",
+				"name": "napa cabbage",
+				"pluralName": "napa cabbages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "celeriac",
+				"pluralName": "celeriacs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "water chestnut",
+				"pluralName": "water chestnuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turnip",
+				"pluralName": "turnips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai chile pepper",
+				"pluralName": "thai chile peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bok choy",
+				"pluralName": "bok choy"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "okra",
+				"pluralName": "okra"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "acorn squash",
+				"pluralName": "acorn squashes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn cob",
+				"pluralName": "corn cobs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "radicchio",
+				"pluralName": "radicchio"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pearl onion",
+				"pluralName": "pearl onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tenderstem broccoli",
+				"pluralName": "tenderstem broccolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plantain",
+				"pluralName": "plantains"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "leaf lettuce",
+				"pluralName": "leaf lettuces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pepperoncini",
+				"pluralName": "pepperoncinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baby bok choy",
+				"pluralName": "baby bok choys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jicama",
+				"pluralName": "jicamas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "endive",
+				"pluralName": "endives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "habanero pepper",
+				"pluralName": "habanero peppers"
+			},
+			{
+				"aliases": [
+					"maize"
+				],
+				"description": "",
+				"name": "corn husk",
+				"pluralName": "corn husks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "collard green",
+				"pluralName": "collard greens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "french-fried onion",
+				"pluralName": "french-fried onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "daikon",
+				"pluralName": "daikons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baby corn",
+				"pluralName": "baby corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "broccoli rabe",
+				"pluralName": "broccoli rabes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rutabaga",
+				"pluralName": "rutabagas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "belgian endive",
+				"pluralName": "belgian endives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yam",
+				"pluralName": "yams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ancho chile pepper",
+				"pluralName": "ancho chile peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "microgreen",
+				"pluralName": "microgreens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boston lettuce",
+				"pluralName": "boston lettuces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kohlrabi",
+				"pluralName": "kohlrabis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresno chile",
+				"pluralName": "fresno chiles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "delicata squash",
+				"pluralName": "delicata squashes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frisee",
+				"pluralName": "frisees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anaheim pepper",
+				"pluralName": "anaheim peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cres",
+				"pluralName": "cress"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "broccoli slaw",
+				"pluralName": "broccoli slaws"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arbol chile pepper",
+				"pluralName": "arbol chile peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden beet",
+				"pluralName": "golden beets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pea shoot",
+				"pluralName": "pea shoots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "alfalfa",
+				"pluralName": "alfalfas"
+			}
+		]
+	},
+	"Fruits": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "Yes they are a fruit",
+				"name": "tomato",
+				"pluralName": "tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon",
+				"pluralName": "lemons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime",
+				"pluralName": "limes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple",
+				"pluralName": "apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana",
+				"pluralName": "bananas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange",
+				"pluralName": "oranges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raisin",
+				"pluralName": "raisins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pineapple",
+				"pluralName": "pineapples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango",
+				"pluralName": "mangoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach",
+				"pluralName": "peaches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "date",
+				"pluralName": "dates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut",
+				"pluralName": "coconuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "craisin",
+				"pluralName": "craisins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pear",
+				"pluralName": "pears"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grape",
+				"pluralName": "grapes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomegranate",
+				"pluralName": "pomegranates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "watermelon",
+				"pluralName": "watermelons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rhubarb",
+				"pluralName": "rhubarbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried apricot",
+				"pluralName": "dried apricots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kiwi",
+				"pluralName": "kiwis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grapefruit",
+				"pluralName": "grapefruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plum",
+				"pluralName": "plums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fig",
+				"pluralName": "figs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apricot",
+				"pluralName": "apricots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "currant",
+				"pluralName": "currants"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mandarin",
+				"pluralName": "mandarins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prune",
+				"pluralName": "prunes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cantaloupe",
+				"pluralName": "cantaloupes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sultana",
+				"pluralName": "sultanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "passion fruit",
+				"pluralName": "passion fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "papaya",
+				"pluralName": "papayas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind",
+				"pluralName": "tamarinds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nectarine",
+				"pluralName": "nectarines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried fig",
+				"pluralName": "dried figs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chestnut",
+				"pluralName": "chestnuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "meyer lemon",
+				"pluralName": "meyer lemons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honeydew melon",
+				"pluralName": "honeydew melons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried fruit",
+				"pluralName": "dried fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clementine",
+				"pluralName": "clementines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "persimmon",
+				"pluralName": "persimmons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "melon",
+				"pluralName": "melons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tangerine",
+				"pluralName": "tangerines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried mango",
+				"pluralName": "dried mangoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried apple",
+				"pluralName": "dried apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quince",
+				"pluralName": "quinces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guava",
+				"pluralName": "guavas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana chip",
+				"pluralName": "banana chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kumquat",
+				"pluralName": "kumquats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jackfruit",
+				"pluralName": "jackfruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dragon fruit",
+				"pluralName": "dragon fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed fruit",
+				"pluralName": "mixed fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "asian pear",
+				"pluralName": "asian pears"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lychee",
+				"pluralName": "lychees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "young coconut",
+				"pluralName": "young coconuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kaffir lime",
+				"pluralName": "kaffir limes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "star fruit",
+				"pluralName": "star fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green papaya",
+				"pluralName": "green papayas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomelo",
+				"pluralName": "pomeloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chestnut puree",
+				"pluralName": "chestnut purees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prickly pear",
+				"pluralName": "prickly pears"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "calamansi",
+				"pluralName": "calamansis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yuzu",
+				"pluralName": "yuzus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "granadilla",
+				"pluralName": "granadillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple chip",
+				"pluralName": "apple chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed peel",
+				"pluralName": "mixed peels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kokum",
+				"pluralName": "kokums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tangelo",
+				"pluralName": "tangeloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried lime",
+				"pluralName": "dried limes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jujube",
+				"pluralName": "jujubes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet lime",
+				"pluralName": "sweet limes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "custard-apple",
+				"pluralName": "custard-apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried lemon",
+				"pluralName": "dried lemons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "young jackfruit",
+				"pluralName": "young jackfruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "durian",
+				"pluralName": "durians"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried apple",
+				"pluralName": "freeze-dried apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried tamarind",
+				"pluralName": "dried tamarinds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey date",
+				"pluralName": "honey dates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "physali",
+				"pluralName": "physalis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarillo",
+				"pluralName": "tamarilloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ice-apple",
+				"pluralName": "ice-apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "longan",
+				"pluralName": "longans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "finger lime",
+				"pluralName": "finger limes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bitter orange",
+				"pluralName": "bitter oranges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "feijoa",
+				"pluralName": "feijoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried persimmon",
+				"pluralName": "dried persimmons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rambutan",
+				"pluralName": "rambutans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rose apple",
+				"pluralName": "rose apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried orange slice",
+				"pluralName": "dried orange slices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "loquat",
+				"pluralName": "loquats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crabapple",
+				"pluralName": "crabapples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fig leaf",
+				"pluralName": "fig leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried pineapple",
+				"pluralName": "freeze-dried pineapples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pluot",
+				"pluralName": "pluots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soursop",
+				"pluralName": "soursops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hog plum",
+				"pluralName": "hog plums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bergamot orange",
+				"pluralName": "bergamot oranges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "luo han guo",
+				"pluralName": "luo han guos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mamey",
+				"pluralName": "mameys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sapote",
+				"pluralName": "sapotes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green ume plum",
+				"pluralName": "green ume plums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kiwano",
+				"pluralName": "kiwanoes"
+			}
+		]
+	},
+	"Mushrooms": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "button mushroom",
+				"pluralName": "button mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shiitake mushroom",
+				"pluralName": "shiitake mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "portobello mushroom",
+				"pluralName": "portobello mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wild mushroom",
+				"pluralName": "wild mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "porcini",
+				"pluralName": "porcinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed mushroom",
+				"pluralName": "mixed mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oyster mushroom",
+				"pluralName": "oyster mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chestnut mushroom",
+				"pluralName": "chestnut mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "enoki mushroom",
+				"pluralName": "enoki mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black fungu",
+				"pluralName": "black fungus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black truffle",
+				"pluralName": "black truffles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "morel mushroom",
+				"pluralName": "morel mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "field mushroom",
+				"pluralName": "field mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "king oyster mushroom",
+				"pluralName": "king oyster mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shimeji mushroom",
+				"pluralName": "shimeji mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "straw mushroom",
+				"pluralName": "straw mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried chinese mushroom",
+				"pluralName": "dried chinese mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maitake",
+				"pluralName": "maitakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "trumpet mushroom",
+				"pluralName": "trumpet mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white truffle",
+				"pluralName": "white truffles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white fungu",
+				"pluralName": "white fungus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pioppini",
+				"pluralName": "pioppinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "snow fungu",
+				"pluralName": "snow fungus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white beech mushroom",
+				"pluralName": "white beech mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boletu",
+				"pluralName": "boletus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "huitlacoche",
+				"pluralName": "huitlacoches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matsutake",
+				"pluralName": "matsutakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nameko",
+				"pluralName": "namekoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "djon djon mushroom",
+				"pluralName": "djon djon mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed asian mushroom",
+				"pluralName": "mixed asian mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffball",
+				"pluralName": "puffballs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey fungu",
+				"pluralName": "honey fungus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caesar's mushroom",
+				"pluralName": "caesar's mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy cap mushroom",
+				"pluralName": "candy cap mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lion\u2019s mane mushroom",
+				"pluralName": "lion\u2019s mane mushrooms"
+			}
+		]
+	},
+	"Berries": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry",
+				"pluralName": "strawberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blueberry",
+				"pluralName": "blueberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry",
+				"pluralName": "raspberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry",
+				"pluralName": "cranberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry",
+				"pluralName": "cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackberry",
+				"pluralName": "blackberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "berry mix",
+				"pluralName": "berry mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maraschino cherry",
+				"pluralName": "maraschino cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried cherry",
+				"pluralName": "dried cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "juniper berry",
+				"pluralName": "juniper berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sour cherry",
+				"pluralName": "sour cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goji berry",
+				"pluralName": "goji berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried blueberry",
+				"pluralName": "dried blueberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried strawberry",
+				"pluralName": "freeze-dried strawberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gooseberry",
+				"pluralName": "gooseberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried raspberry",
+				"pluralName": "freeze-dried raspberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lingonberry",
+				"pluralName": "lingonberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned sour cherry",
+				"pluralName": "canned sour cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mulberry",
+				"pluralName": "mulberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "acai berry",
+				"pluralName": "acai berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned cherry",
+				"pluralName": "canned cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amla",
+				"pluralName": "amlas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderberry",
+				"pluralName": "elderberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried blueberry",
+				"pluralName": "freeze-dried blueberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "huckleberry",
+				"pluralName": "huckleberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried elderberry",
+				"pluralName": "dried elderberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barberry",
+				"pluralName": "barberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried berry",
+				"pluralName": "dried berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea buckthorn",
+				"pluralName": "sea buckthorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "saskatoon berry",
+				"pluralName": "saskatoon berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rosehip",
+				"pluralName": "rosehips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hawthorn",
+				"pluralName": "hawthorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boysenberry",
+				"pluralName": "boysenberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cloudberry",
+				"pluralName": "cloudberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried berry",
+				"pluralName": "freeze-dried berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aronia berry",
+				"pluralName": "aronia berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chokeberry",
+				"pluralName": "chokeberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "loganberry",
+				"pluralName": "loganberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackcurrant leaf",
+				"pluralName": "blackcurrant leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "haskap berry",
+				"pluralName": "haskap berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dewberry",
+				"pluralName": "dewberries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sloe berry",
+				"pluralName": "sloe berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oregon grape",
+				"pluralName": "oregon grapes"
+			}
+		]
+	},
+	"Nuts & Seeds": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "walnut",
+				"pluralName": "walnuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pecan",
+				"pluralName": "pecans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond",
+				"pluralName": "almonds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sesame seed",
+				"pluralName": "sesame seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cashew",
+				"pluralName": "cashews"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pine nut",
+				"pluralName": "pine nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pistachio",
+				"pluralName": "pistachios"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut",
+				"pluralName": "peanuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chia",
+				"pluralName": "chias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flax",
+				"pluralName": "flaxes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "slivered almond",
+				"pluralName": "slivered almonds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin seed",
+				"pluralName": "pumpkin seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut",
+				"pluralName": "hazelnuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "poppy seed",
+				"pluralName": "poppy seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sunflower seed",
+				"pluralName": "sunflower seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macadamia",
+				"pluralName": "macadamias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted peanut",
+				"pluralName": "roasted peanuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chopped nut",
+				"pluralName": "chopped nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hemp heart",
+				"pluralName": "hemp hearts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nigella seed",
+				"pluralName": "nigella seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed nut",
+				"pluralName": "mixed nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brazil nut",
+				"pluralName": "brazil nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed seed",
+				"pluralName": "mixed seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion seed",
+				"pluralName": "onion seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "watermelon seed",
+				"pluralName": "watermelon seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey-roasted peanut",
+				"pluralName": "honey-roasted peanuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "melon seed",
+				"pluralName": "melon seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lotus seed",
+				"pluralName": "lotus seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white chia",
+				"pluralName": "white chias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "trail mix",
+				"pluralName": "trail mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "basil seed",
+				"pluralName": "basil seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candlenut",
+				"pluralName": "candlenuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut brittle",
+				"pluralName": "peanut brittles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jackfruit seed",
+				"pluralName": "jackfruit seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey-roasted almond",
+				"pluralName": "honey-roasted almonds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "toasted nut",
+				"pluralName": "toasted nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chironji",
+				"pluralName": "chironjis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey-roasted pecan",
+				"pluralName": "honey-roasted pecans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tigernut",
+				"pluralName": "tigernuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sunflower sprout",
+				"pluralName": "sunflower sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apricot kernel",
+				"pluralName": "apricot kernels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "palm seed",
+				"pluralName": "palm seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginkgo nut",
+				"pluralName": "ginkgo nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "keto trail mix",
+				"pluralName": "keto trail mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wattleseed",
+				"pluralName": "wattleseeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bar\u00f9ka",
+				"pluralName": "bar\u00f9kas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "indian almond",
+				"pluralName": "indian almonds"
+			}
+		]
+	},
+	"Cheeses": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "parmesan",
+				"pluralName": "parmesans"
+			},
+			{
+				"aliases": [
+					"cheddars"
+				],
+				"description": "",
+				"name": "cheddar cheese",
+				"pluralName": "cheddar cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream cheese",
+				"pluralName": "cream cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sharp cheddar",
+				"pluralName": "sharp cheddars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese",
+				"pluralName": "cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mozzarella",
+				"pluralName": "mozzarellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "feta",
+				"pluralName": "fetas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ricotta",
+				"pluralName": "ricottas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheddar-jack cheese",
+				"pluralName": "cheddar-jack cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "monterey jack",
+				"pluralName": "monterey jacks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blue cheese",
+				"pluralName": "blue cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goat cheese",
+				"pluralName": "goat cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh mozzarella",
+				"pluralName": "fresh mozzarellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "swiss cheese",
+				"pluralName": "swiss cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pecorino",
+				"pluralName": "pecorinoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gruyere",
+				"pluralName": "gruyeres"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mascarpone",
+				"pluralName": "mascarpones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cottage cheese",
+				"pluralName": "cottage cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "american cheese",
+				"pluralName": "american cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "provolone",
+				"pluralName": "provolones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican cheese blend",
+				"pluralName": "mexican cheese blends"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pepper jack",
+				"pluralName": "pepper jacks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brie",
+				"pluralName": "bries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "paneer",
+				"pluralName": "paneers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fontina",
+				"pluralName": "fontinas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "queso fresco",
+				"pluralName": "queso frescoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quark",
+				"pluralName": "quarks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gouda",
+				"pluralName": "goudas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cotija",
+				"pluralName": "cotijas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "asiago",
+				"pluralName": "asiagoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked cheese",
+				"pluralName": "smoked cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "halloumi",
+				"pluralName": "halloumis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chevre",
+				"pluralName": "chevres"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "manchego",
+				"pluralName": "manchegoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "italian cheese blend",
+				"pluralName": "italian cheese blends"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "neufchatel",
+				"pluralName": "neufchatels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herb cream cheese",
+				"pluralName": "herb cream cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "burrata",
+				"pluralName": "burratas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "havarti",
+				"pluralName": "havartis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "colby",
+				"pluralName": "colbies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grana-padano",
+				"pluralName": "grana-padanoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "muenster",
+				"pluralName": "muensters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "string cheese",
+				"pluralName": "string cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "camembert",
+				"pluralName": "camemberts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soft cheese",
+				"pluralName": "soft cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stilton",
+				"pluralName": "stiltons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raclette",
+				"pluralName": "raclettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "colby-jack cheese",
+				"pluralName": "colby-jack cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "colby-jack cheese",
+				"pluralName": "colby-jack cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jarlsberg cheese",
+				"pluralName": "jarlsberg cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taleggio",
+				"pluralName": "taleggios"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oaxaca",
+				"pluralName": "oaxacas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "labneh",
+				"pluralName": "labnehs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "edam",
+				"pluralName": "edams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creamy cheese wedge",
+				"pluralName": "creamy cheese wedges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese powder",
+				"pluralName": "cheese powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fromage blanc",
+				"pluralName": "fromage blancs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "asadero",
+				"pluralName": "asaderoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marble cheese",
+				"pluralName": "marble cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "leicester",
+				"pluralName": "leicesters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kefalotyri",
+				"pluralName": "kefalotyris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mizithra",
+				"pluralName": "mizithras"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lancashire",
+				"pluralName": "lancashires"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kasseri",
+				"pluralName": "kasseris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "babybel",
+				"pluralName": "babybels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "panela cheese",
+				"pluralName": "panela cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "longhorn",
+				"pluralName": "longhorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seasoned feta cheese",
+				"pluralName": "seasoned feta cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "comt\u00e9",
+				"pluralName": "comt\u00e9s"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "graviera",
+				"pluralName": "gravieras"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wensleydale",
+				"pluralName": "wensleydales"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "scamorza",
+				"pluralName": "scamorzas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cambozola",
+				"pluralName": "cambozolas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheshire cheese",
+				"pluralName": "cheshire cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anthotyro",
+				"pluralName": "anthotyros"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chenna",
+				"pluralName": "chennas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hard goat cheese",
+				"pluralName": "hard goat cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kashkaval",
+				"pluralName": "kashkavals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sheep cheese",
+				"pluralName": "sheep cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amul cheese",
+				"pluralName": "amul cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "reblochon",
+				"pluralName": "reblochons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "robiola",
+				"pluralName": "robiolas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brick cheese",
+				"pluralName": "brick cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quick-melt cheese",
+				"pluralName": "quick-melt cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "farmer's cheese",
+				"pluralName": "farmer's cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "manouri",
+				"pluralName": "manouris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mimolette",
+				"pluralName": "mimolettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "queso quesadilla",
+				"pluralName": "queso quesadillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caciocavallo",
+				"pluralName": "caciocavalloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "requeij\u00e3o",
+				"pluralName": "requeij\u00e3oes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vacherin",
+				"pluralName": "vacherins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown cheese",
+				"pluralName": "brown cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gloucester",
+				"pluralName": "gloucesters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "port salut",
+				"pluralName": "port saluts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "derby cheese",
+				"pluralName": "derby cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fontal",
+				"pluralName": "fontals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salad cheese",
+				"pluralName": "salad cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "truffle cheese",
+				"pluralName": "truffle cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "epoisses cheese",
+				"pluralName": "epoisses cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maasdam",
+				"pluralName": "maasdams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "petit-suisse",
+				"pluralName": "petit-suisses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sbrinz",
+				"pluralName": "sbrinzzes"
+			}
+		]
+	},
+	"Dairy & Eggs": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter",
+				"pluralName": "butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg",
+				"pluralName": "eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "milk",
+				"pluralName": "milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "heavy cream",
+				"pluralName": "heavy creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sour cream",
+				"pluralName": "sour creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buttermilk",
+				"pluralName": "buttermilks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yogurt",
+				"pluralName": "yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "greek yogurt",
+				"pluralName": "greek yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream",
+				"pluralName": "creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whipped cream",
+				"pluralName": "whipped creams"
+			},
+			{
+				"aliases": [
+					"clarified butter"
+				],
+				"description": "",
+				"name": "ghee",
+				"pluralName": "ghees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shortening",
+				"pluralName": "shortenings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "condensed milk",
+				"pluralName": "condensed milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "half and half",
+				"pluralName": "half and halves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweetened condensed milk",
+				"pluralName": "sweetened condensed milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ice cream",
+				"pluralName": "ice creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "margarine",
+				"pluralName": "margarines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creme fraiche",
+				"pluralName": "creme fraiches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frosting",
+				"pluralName": "frostings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "milk powder",
+				"pluralName": "milk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curd",
+				"pluralName": "curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thickened cream",
+				"pluralName": "thickened creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon curd",
+				"pluralName": "lemon curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dulce de leche",
+				"pluralName": "dulce de leche"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "custard",
+				"pluralName": "custards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate frosting",
+				"pluralName": "chocolate frostings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kefir",
+				"pluralName": "kefirs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sherbet",
+				"pluralName": "sherbets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate milk",
+				"pluralName": "chocolate milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid egg substitute",
+				"pluralName": "liquid egg substitutes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whey",
+				"pluralName": "wheys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hung curd",
+				"pluralName": "hung curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quail egg",
+				"pluralName": "quail eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buttermilk powder",
+				"pluralName": "buttermilk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen yogurt",
+				"pluralName": "frozen yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "khoya",
+				"pluralName": "khoyas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "milk cream",
+				"pluralName": "milk creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee creamer",
+				"pluralName": "coffee creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clotted cream",
+				"pluralName": "clotted creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goat milk",
+				"pluralName": "goat milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese curd",
+				"pluralName": "cheese curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sour milk",
+				"pluralName": "sour milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ganache",
+				"pluralName": "ganaches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cajeta",
+				"pluralName": "cajetas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck egg",
+				"pluralName": "duck eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salted egg",
+				"pluralName": "salted eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "skyr",
+				"pluralName": "skyrs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin spice coffee creamer",
+				"pluralName": "pumpkin spice coffee creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw milk",
+				"pluralName": "raw milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime curd",
+				"pluralName": "lime curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "powdered coffee creamer",
+				"pluralName": "powdered coffee creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chantilly",
+				"pluralName": "chantillies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "milkfat",
+				"pluralName": "milkfats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yogurt starter",
+				"pluralName": "yogurt starters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rainbow sherbet",
+				"pluralName": "rainbow sherbets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry frosting",
+				"pluralName": "strawberry frostings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey greek yogurt",
+				"pluralName": "honey greek yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amul butter",
+				"pluralName": "amul butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey butter",
+				"pluralName": "honey butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry cream cheese",
+				"pluralName": "strawberry cream cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goat butter",
+				"pluralName": "goat butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "century egg",
+				"pluralName": "century eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange curd",
+				"pluralName": "orange curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goat yogurt",
+				"pluralName": "goat yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dahi",
+				"pluralName": "dahis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon sugar butter spread",
+				"pluralName": "cinnamon sugar butter spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bulgarian yogurt",
+				"pluralName": "bulgarian yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tvorog",
+				"pluralName": "tvorogs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate milk powder",
+				"pluralName": "chocolate milk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid rennet",
+				"pluralName": "liquid rennets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sheep\u2019s milk yoghurt",
+				"pluralName": "sheep\u2019s milk yoghurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry milk",
+				"pluralName": "strawberry milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ayran",
+				"pluralName": "ayrans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cuajada",
+				"pluralName": "cuajadas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yogurt drink",
+				"pluralName": "yogurt drinks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "passion-fruit curd",
+				"pluralName": "passion-fruit curds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled egg",
+				"pluralName": "pickled eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sheep milk",
+				"pluralName": "sheep milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "starter culture",
+				"pluralName": "starter cultures"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kashk",
+				"pluralName": "kashks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ostrich egg",
+				"pluralName": "ostrich eggs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla milk",
+				"pluralName": "vanilla milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yoplait whip",
+				"pluralName": "yoplait whips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buffalo milk",
+				"pluralName": "buffalo milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goat kefir",
+				"pluralName": "goat kefirs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lebneh",
+				"pluralName": "lebnehs"
+			}
+		]
+	},
+	"Dairy-Free & Meat Substitutes": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut milk",
+				"pluralName": "coconut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond milk",
+				"pluralName": "almond milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond butter",
+				"pluralName": "almond butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tofu",
+				"pluralName": "tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut cream",
+				"pluralName": "coconut creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan butter",
+				"pluralName": "vegan butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "non-dairy milk",
+				"pluralName": "non-dairy milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy milk",
+				"pluralName": "soy milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "extra firm tofu",
+				"pluralName": "extra firm tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "silken tofu",
+				"pluralName": "silken tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kala namak salt",
+				"pluralName": "kala namak salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut butter",
+				"pluralName": "coconut butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg replacer",
+				"pluralName": "egg replacers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan mayonnaise",
+				"pluralName": "vegan mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan cheese",
+				"pluralName": "vegan cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cashew butter",
+				"pluralName": "cashew butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tempeh",
+				"pluralName": "tempehs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan cream cheese",
+				"pluralName": "vegan cream cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut yogurt",
+				"pluralName": "coconut yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "non-dairy yogurt",
+				"pluralName": "non-dairy yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seed butter",
+				"pluralName": "seed butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cashew milk",
+				"pluralName": "cashew milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oat milk",
+				"pluralName": "oat milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nut butter",
+				"pluralName": "nut butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice milk",
+				"pluralName": "rice milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan sour cream",
+				"pluralName": "vegan sour creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "textured vegetable protein",
+				"pluralName": "textured vegetable proteins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan worcestershire",
+				"pluralName": "vegan worcestershires"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy yogurt",
+				"pluralName": "soy yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan mozzarella",
+				"pluralName": "vegan mozzarellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "non-dairy creamer",
+				"pluralName": "non-dairy creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan sausage",
+				"pluralName": "vegan sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut whipped cream",
+				"pluralName": "coconut whipped creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked tofu",
+				"pluralName": "smoked tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut powder",
+				"pluralName": "coconut powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy cream",
+				"pluralName": "soy creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seitan",
+				"pluralName": "seitans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut milk powder",
+				"pluralName": "coconut milk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "non-dairy whipped topping",
+				"pluralName": "non-dairy whipped toppings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nut milk",
+				"pluralName": "nut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "non-dairy cream",
+				"pluralName": "non-dairy creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan burger patty",
+				"pluralName": "vegan burger patties"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "condensed coconut milk",
+				"pluralName": "condensed coconut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan ground beef",
+				"pluralName": "vegan ground beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pulled oat",
+				"pluralName": "pulled oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan bacon",
+				"pluralName": "vegan bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy curl",
+				"pluralName": "soy curls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan pesto",
+				"pluralName": "vegan pestoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marinated tofu",
+				"pluralName": "marinated tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan feta",
+				"pluralName": "vegan fetas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy chorizo",
+				"pluralName": "soy chorizoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hemp milk",
+				"pluralName": "hemp milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan beef",
+				"pluralName": "vegan beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut butter",
+				"pluralName": "hazelnut butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan ranch",
+				"pluralName": "vegan ranches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan chicken",
+				"pluralName": "vegan chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut paste",
+				"pluralName": "coconut pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable suet",
+				"pluralName": "vegetable suets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dairy-free ice-cream",
+				"pluralName": "dairy-free ice-creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond-coconut milk",
+				"pluralName": "almond-coconut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana blossom",
+				"pluralName": "banana blossoms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan fish sauce",
+				"pluralName": "vegan fish sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetarian hot dog",
+				"pluralName": "vegetarian hot dogs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut milk",
+				"pluralName": "hazelnut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maple almond butter",
+				"pluralName": "maple almond butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan meatball",
+				"pluralName": "vegan meatballs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond-milk yogurt",
+				"pluralName": "almond-milk yogurts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond creamer",
+				"pluralName": "almond creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy milk powder",
+				"pluralName": "soy milk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan cream cheese frosting",
+				"pluralName": "vegan cream cheese frostings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut manna",
+				"pluralName": "coconut mannas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "falafel mix",
+				"pluralName": "falafel mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ready-made falafel",
+				"pluralName": "ready-made falafels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan gravy",
+				"pluralName": "vegan gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cashew cheese sauce",
+				"pluralName": "cashew cheese sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut fat",
+				"pluralName": "coconut fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flax milk",
+				"pluralName": "flax milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut creamer",
+				"pluralName": "hazelnut creamers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quorn",
+				"pluralName": "quorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy-free butter",
+				"pluralName": "soy-free butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tofurky",
+				"pluralName": "tofurkies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan nutella",
+				"pluralName": "vegan nutellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan tzatziki",
+				"pluralName": "vegan tzatzikis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cashew cream cheese",
+				"pluralName": "cashew cream cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cricket flour",
+				"pluralName": "cricket flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macadamia butter",
+				"pluralName": "macadamia butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "okara",
+				"pluralName": "okaras"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg tofu",
+				"pluralName": "egg tofus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "protein drink",
+				"pluralName": "protein drinks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macadamia milk",
+				"pluralName": "macadamia milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan taco meat",
+				"pluralName": "vegan taco meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "walnut taco meat",
+				"pluralName": "walnut taco meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan yogurt starter",
+				"pluralName": "vegan yogurt starters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana milk",
+				"pluralName": "banana milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy quark",
+				"pluralName": "soy quarks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan chicken nugget",
+				"pluralName": "vegan chicken nuggets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan starter culture",
+				"pluralName": "vegan starter cultures"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "walnut milk",
+				"pluralName": "walnut milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "latik",
+				"pluralName": "latiks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice cream",
+				"pluralName": "rice creams"
+			}
+		]
+	},
+	"Meats": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bacon",
+				"pluralName": "bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chopped bacon",
+				"pluralName": "chopped bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground beef",
+				"pluralName": "ground beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef steak",
+				"pluralName": "beef steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ham",
+				"pluralName": "hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork chop",
+				"pluralName": "pork chops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet italian sausage",
+				"pluralName": "sweet italian sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork loin",
+				"pluralName": "pork loins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prosciutto",
+				"pluralName": "prosciuttoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sausage",
+				"pluralName": "sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef roast",
+				"pluralName": "beef roasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground pork",
+				"pluralName": "ground porks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef stew meat",
+				"pluralName": "beef stew meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pepperoni",
+				"pluralName": "pepperonis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chorizo",
+				"pluralName": "chorizoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pancetta",
+				"pluralName": "pancettas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork fillet",
+				"pluralName": "pork fillets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork shoulder",
+				"pluralName": "pork shoulders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground lamb",
+				"pluralName": "ground lambs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork rib",
+				"pluralName": "pork ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked sausage",
+				"pluralName": "smoked sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "breakfast sausage",
+				"pluralName": "breakfast sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot dog",
+				"pluralName": "hot dogs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef sirloin",
+				"pluralName": "beef sirloins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salami",
+				"pluralName": "salamis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brisket",
+				"pluralName": "briskets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "deli ham",
+				"pluralName": "deli hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "leg of lamb",
+				"pluralName": "leg of lamb"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef short rib",
+				"pluralName": "beef short ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kielbasa",
+				"pluralName": "kielbasas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork belly",
+				"pluralName": "pork bellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "andouille",
+				"pluralName": "andouilles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boneless lamb",
+				"pluralName": "boneless lambs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground sausage",
+				"pluralName": "ground sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground pork sausage",
+				"pluralName": "ground pork sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roast beef",
+				"pluralName": "roast beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bacon bit",
+				"pluralName": "bacon bits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork roast",
+				"pluralName": "pork roasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot italian sausage",
+				"pluralName": "hot italian sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork spare rib",
+				"pluralName": "pork spare ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb shoulder",
+				"pluralName": "lamb shoulders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef rib",
+				"pluralName": "beef ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal steak",
+				"pluralName": "veal steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb chop",
+				"pluralName": "lamb chops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bone-in ham",
+				"pluralName": "bone-in hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork butt",
+				"pluralName": "pork butts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canadian bacon",
+				"pluralName": "canadian bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef sausage",
+				"pluralName": "beef sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb shank",
+				"pluralName": "lamb shanks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mutton",
+				"pluralName": "muttons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ham steak",
+				"pluralName": "ham steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "venison",
+				"pluralName": "venisons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bratwurst",
+				"pluralName": "bratwursts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pulled pork",
+				"pluralName": "pulled porks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ham hock",
+				"pluralName": "ham hocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen meatball",
+				"pluralName": "frozen meatballs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed ground meat",
+				"pluralName": "mixed ground meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rabbit",
+				"pluralName": "rabbits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork cutlet",
+				"pluralName": "pork cutlets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal cutlet",
+				"pluralName": "veal cutlets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soup bone",
+				"pluralName": "soup bones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb loin",
+				"pluralName": "lamb loins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork steak",
+				"pluralName": "pork steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican chorizo",
+				"pluralName": "mexican chorizoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rack of lamb",
+				"pluralName": "rack of lamb"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork back rib",
+				"pluralName": "pork back ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "country style rib",
+				"pluralName": "country style ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black forest ham",
+				"pluralName": "black forest hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oxtail",
+				"pluralName": "oxtails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked ham hock",
+				"pluralName": "smoked ham hocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "serrano ham",
+				"pluralName": "serrano hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw chorizo",
+				"pluralName": "raw chorizoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef liver",
+				"pluralName": "beef livers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pastrami",
+				"pluralName": "pastramis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cocktail sausage",
+				"pluralName": "cocktail sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hard salami",
+				"pluralName": "hard salamis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "back bacon",
+				"pluralName": "back bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salt pork",
+				"pluralName": "salt porks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal shank",
+				"pluralName": "veal shanks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground venison",
+				"pluralName": "ground venisons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef shank",
+				"pluralName": "beef shanks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lap cheong",
+				"pluralName": "lap cheongs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blood sausage",
+				"pluralName": "blood sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried beef",
+				"pluralName": "dried beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gammon joint",
+				"pluralName": "gammon joints"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boneless beef short rib",
+				"pluralName": "boneless beef short ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "country ham",
+				"pluralName": "country hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boneless ham",
+				"pluralName": "boneless hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mortadella",
+				"pluralName": "mortadellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground bison",
+				"pluralName": "ground bisons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh sausage",
+				"pluralName": "fresh sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bologna",
+				"pluralName": "bolognas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "burger patty",
+				"pluralName": "burger patties"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked pork chop",
+				"pluralName": "smoked pork chops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb neck",
+				"pluralName": "lamb necks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sausage patty",
+				"pluralName": "sausage patties"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef suet",
+				"pluralName": "beef suets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal roast",
+				"pluralName": "veal roasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef shoulder",
+				"pluralName": "beef shoulders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "steak tip",
+				"pluralName": "steak tips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal chop",
+				"pluralName": "veal chops"
+			}
+		]
+	},
+	"Poultry": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken breast",
+				"pluralName": "chicken breasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken thigh",
+				"pluralName": "chicken thighs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cooked chicken",
+				"pluralName": "cooked chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground turkey",
+				"pluralName": "ground turkeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whole chicken",
+				"pluralName": "whole chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whole turkey",
+				"pluralName": "whole turkeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken leg",
+				"pluralName": "chicken legs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken wing",
+				"pluralName": "chicken wings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey breast",
+				"pluralName": "turkey breasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground chicken",
+				"pluralName": "ground chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rotisserie chicken",
+				"pluralName": "rotisserie chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken tender",
+				"pluralName": "chicken tenders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey sausage",
+				"pluralName": "turkey sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken sausage",
+				"pluralName": "chicken sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey bacon",
+				"pluralName": "turkey bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck",
+				"pluralName": "ducks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck breast",
+				"pluralName": "duck breasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boneless chicken",
+				"pluralName": "boneless chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken liver",
+				"pluralName": "chicken livers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornish hen",
+				"pluralName": "cornish hens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "deli turkey",
+				"pluralName": "deli turkeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked turkey",
+				"pluralName": "smoked turkeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey meat",
+				"pluralName": "turkey meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken quarter",
+				"pluralName": "chicken quarters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ground turkey sausage",
+				"pluralName": "ground turkey sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quail",
+				"pluralName": "quails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked turkey sausage",
+				"pluralName": "smoked turkey sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked chicken",
+				"pluralName": "smoked chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey leg",
+				"pluralName": "turkey legs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pheasant",
+				"pluralName": "pheasants"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goose",
+				"pluralName": "geese"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey pepperoni",
+				"pluralName": "turkey pepperonis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey ham",
+				"pluralName": "turkey hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey thigh",
+				"pluralName": "turkey thighs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken bone",
+				"pluralName": "chicken bones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey meatball",
+				"pluralName": "turkey meatballs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "foie gra",
+				"pluralName": "foie gras"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken giblet",
+				"pluralName": "chicken giblets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey wing",
+				"pluralName": "turkey wings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey giblet",
+				"pluralName": "turkey giblets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey neck",
+				"pluralName": "turkey necks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken nugget",
+				"pluralName": "chicken nuggets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey burger",
+				"pluralName": "turkey burgers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken andouille",
+				"pluralName": "chicken andouilles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken gizzard",
+				"pluralName": "chicken gizzards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked turkey leg",
+				"pluralName": "smoked turkey legs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken italian sausage",
+				"pluralName": "chicken italian sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crispy chicken strip",
+				"pluralName": "crispy chicken strips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ostrich",
+				"pluralName": "ostriches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "popcorn chicken",
+				"pluralName": "popcorn chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey kielbasa",
+				"pluralName": "turkey kielbasas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken-apple sausage",
+				"pluralName": "chicken-apple sausages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken foot",
+				"pluralName": "chicken feet"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pulled chicken",
+				"pluralName": "pulled chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "deli chicken",
+				"pluralName": "deli chickens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked duck breast",
+				"pluralName": "smoked duck breasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pigeon",
+				"pluralName": "pigeons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wild game bird",
+				"pluralName": "wild game birds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey liver",
+				"pluralName": "turkey livers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken neck",
+				"pluralName": "chicken necks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck confit",
+				"pluralName": "duck confits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roast duck",
+				"pluralName": "roast ducks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken meatball",
+				"pluralName": "chicken meatballs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck liver",
+				"pluralName": "duck livers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guinea fowl",
+				"pluralName": "guinea fowls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked turkey wing",
+				"pluralName": "smoked turkey wings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken curry-cut",
+				"pluralName": "chicken curry-cuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken schnitzel",
+				"pluralName": "chicken schnitzels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grouse",
+				"pluralName": "grouses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken roast",
+				"pluralName": "chicken roasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goose liver",
+				"pluralName": "goose livers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey bone",
+				"pluralName": "turkey bones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey lunch meat",
+				"pluralName": "turkey lunch meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey roast",
+				"pluralName": "turkey roasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "capon",
+				"pluralName": "capons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked turkey bacon",
+				"pluralName": "smoked turkey bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken bacon",
+				"pluralName": "chicken bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey rissole",
+				"pluralName": "turkey rissoles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken kebab",
+				"pluralName": "chicken kebabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken ham",
+				"pluralName": "chicken hams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck neck",
+				"pluralName": "duck necks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken chorizo",
+				"pluralName": "chicken chorizoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken frame",
+				"pluralName": "chicken frames"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck bacon",
+				"pluralName": "duck bacons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pulled turkey",
+				"pluralName": "pulled turkeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken gyro",
+				"pluralName": "chicken gyros"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken patty",
+				"pluralName": "chicken patties"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken rib",
+				"pluralName": "chicken ribs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey tail",
+				"pluralName": "turkey tails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken milanesa",
+				"pluralName": "chicken milanesas"
+			}
+		]
+	},
+	"Fish": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salmon",
+				"pluralName": "salmon"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked salmon",
+				"pluralName": "smoked salmon"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cod",
+				"pluralName": "cod"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tilapia",
+				"pluralName": "tilapias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tuna steak",
+				"pluralName": "tuna steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whitefish",
+				"pluralName": "whitefish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "halibut",
+				"pluralName": "halibuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red snapper",
+				"pluralName": "red snappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea bas",
+				"pluralName": "sea bass"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish fillet",
+				"pluralName": "fish fillets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "trout",
+				"pluralName": "trout"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "catfish",
+				"pluralName": "catfishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "surimi",
+				"pluralName": "surimis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "swordfish",
+				"pluralName": "swordfish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sardine",
+				"pluralName": "sardines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sole",
+				"pluralName": "soles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mahi mahi",
+				"pluralName": "mahi mahis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mackerel",
+				"pluralName": "mackerel"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked trout",
+				"pluralName": "smoked trout"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caviar",
+				"pluralName": "caviars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "haddock",
+				"pluralName": "haddocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "monkfish",
+				"pluralName": "monkfish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked haddock",
+				"pluralName": "smoked haddocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flounder",
+				"pluralName": "flounder"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "perch",
+				"pluralName": "perches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hake",
+				"pluralName": "hakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pollock",
+				"pluralName": "pollocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salt cod",
+				"pluralName": "salt cod"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked mackerel",
+				"pluralName": "smoked mackerel"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea bream",
+				"pluralName": "sea bream"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rainbow trout",
+				"pluralName": "rainbow trout"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carp",
+				"pluralName": "carp"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cuttlefish",
+				"pluralName": "cuttlefish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grouper",
+				"pluralName": "groupers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herring",
+				"pluralName": "herrings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salmon roe",
+				"pluralName": "salmon roes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "steelhead trout",
+				"pluralName": "steelhead trout"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roe",
+				"pluralName": "roes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barramundi",
+				"pluralName": "barramundis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black cod",
+				"pluralName": "black cod"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kingfish",
+				"pluralName": "kingfish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange roughy",
+				"pluralName": "orange roughies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turbot",
+				"pluralName": "turbots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bangu",
+				"pluralName": "bangus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rockfish",
+				"pluralName": "rockfish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "branzino",
+				"pluralName": "branzinoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomfret",
+				"pluralName": "pomfrets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eel",
+				"pluralName": "eels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried anchovy",
+				"pluralName": "dried anchovies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arctic char",
+				"pluralName": "arctic chars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh anchovy",
+				"pluralName": "fresh anchovies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon sole",
+				"pluralName": "lemon soles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellowtail",
+				"pluralName": "yellowtails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "battered fish",
+				"pluralName": "battered fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pike",
+				"pluralName": "pikes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled herring",
+				"pluralName": "pickled herrings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "john dory",
+				"pluralName": "john dories"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "swai fish",
+				"pluralName": "swai fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "walleye",
+				"pluralName": "walleyes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh mackerel",
+				"pluralName": "fresh mackerel"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salmon trout",
+				"pluralName": "salmon trout"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "basa fish",
+				"pluralName": "basa fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked eel",
+				"pluralName": "smoked eels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish ball",
+				"pluralName": "fish balls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sturgeon",
+				"pluralName": "sturgeons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bluefish",
+				"pluralName": "bluefish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red mullet",
+				"pluralName": "red mullets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gurnard",
+				"pluralName": "gurnards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plaice",
+				"pluralName": "plaices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pompano",
+				"pluralName": "pompanoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked fish",
+				"pluralName": "smoked fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish head",
+				"pluralName": "fish heads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rohu fish",
+				"pluralName": "rohu fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried fish",
+				"pluralName": "dried fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flathead",
+				"pluralName": "flatheads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish cake",
+				"pluralName": "fish cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salt fish",
+				"pluralName": "salt fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked herring",
+				"pluralName": "smoked herrings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whiting",
+				"pluralName": "whiting"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salmon burger meat",
+				"pluralName": "salmon burger meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shark meat",
+				"pluralName": "shark meats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garoupa",
+				"pluralName": "garoupas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gilt-head bream",
+				"pluralName": "gilt-head bream"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pangasiu",
+				"pluralName": "pangasius"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salt herring",
+				"pluralName": "salt herrings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soused herring",
+				"pluralName": "soused herrings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tinapa",
+				"pluralName": "tinapas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "zander",
+				"pluralName": "zanders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amberjack",
+				"pluralName": "amberjacks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "korean fish cake",
+				"pluralName": "korean fish cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mullet",
+				"pluralName": "mullets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "skipjack tuna",
+				"pluralName": "skipjack tuna"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bottarga",
+				"pluralName": "bottargas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried baby sardine",
+				"pluralName": "dried baby sardines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marlin",
+				"pluralName": "marlins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "threadfin",
+				"pluralName": "threadfins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tiny fish",
+				"pluralName": "tiny fish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tuna belly",
+				"pluralName": "tuna bellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beluga caviar",
+				"pluralName": "beluga caviars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bombay duck",
+				"pluralName": "bombay ducks"
+			}
+		]
+	},
+	"Seafood & Seaweed": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shrimp",
+				"pluralName": "shrimps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "octopuse",
+				"pluralName": "octopi"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prawn",
+				"pluralName": "prawns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crab",
+				"pluralName": "crabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "scallop",
+				"pluralName": "scallops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mussel",
+				"pluralName": "mussels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clam",
+				"pluralName": "clams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "squid",
+				"pluralName": "squids"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nori",
+				"pluralName": "noris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lobster",
+				"pluralName": "lobsters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oyster",
+				"pluralName": "oysters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lobster tail",
+				"pluralName": "lobster tails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crawfish",
+				"pluralName": "crawfish"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "octopu",
+				"pluralName": "octopus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kombu",
+				"pluralName": "kombus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried shrimp",
+				"pluralName": "dried shrimps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bay scallop",
+				"pluralName": "bay scallops"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wakame",
+				"pluralName": "wakames"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soft-shell crab",
+				"pluralName": "soft-shell crabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "scampi",
+				"pluralName": "scampis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "king crab",
+				"pluralName": "king crabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed seafood",
+				"pluralName": "mixed seafoods"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baby squid",
+				"pluralName": "baby squids"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "squid ink",
+				"pluralName": "squid inks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried prawn",
+				"pluralName": "dried prawns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dulse seaweed",
+				"pluralName": "dulse seaweeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted seaweed",
+				"pluralName": "roasted seaweeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked oyster",
+				"pluralName": "smoked oysters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kelp",
+				"pluralName": "kelps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kizami nori",
+				"pluralName": "kizami noris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hijiki",
+				"pluralName": "hijikis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salted shrimp",
+				"pluralName": "salted shrimps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yaki-nori",
+				"pluralName": "yaki-noris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "conch",
+				"pluralName": "conches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arame",
+				"pluralName": "arames"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "calamari steak",
+				"pluralName": "calamari steaks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mud crab",
+				"pluralName": "mud crabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea urchin",
+				"pluralName": "sea urchins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "abalone",
+				"pluralName": "abalones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seaweed salad",
+				"pluralName": "seaweed salads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dulse",
+				"pluralName": "dulses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked mussel",
+				"pluralName": "smoked mussels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea snail",
+				"pluralName": "sea snails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aonori",
+				"pluralName": "aonoris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prepared crab cake",
+				"pluralName": "prepared crab cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea lettuce",
+				"pluralName": "sea lettuces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "korean seaweed",
+				"pluralName": "korean seaweeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ogo seaweed",
+				"pluralName": "ogo seaweeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seaweed caviar",
+				"pluralName": "seaweed caviars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "haddock",
+				"pluralName": "haddocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sea mos",
+				"pluralName": "sea moss"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "langoustine",
+				"pluralName": "langoustines"
+			}
+		]
+	},
+	"Herbs & Spices": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon",
+				"pluralName": "cinnamons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "parsley",
+				"pluralName": "parsleys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cilantro",
+				"pluralName": "cilantros"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cumin",
+				"pluralName": "cumins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "basil",
+				"pluralName": "basils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thyme",
+				"pluralName": "thymes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger root",
+				"pluralName": "ginger roots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic powder",
+				"pluralName": "garlic powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oregano",
+				"pluralName": "oreganos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nutmeg",
+				"pluralName": "nutmegs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili flake",
+				"pluralName": "chili flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili powder",
+				"pluralName": "chili powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "paprika",
+				"pluralName": "paprikas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cayenne",
+				"pluralName": "cayennes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rosemary",
+				"pluralName": "rosemaries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bay leaf",
+				"pluralName": "bay leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turmeric",
+				"pluralName": "turmerics"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clove",
+				"pluralName": "cloves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion powder",
+				"pluralName": "onion powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger powder",
+				"pluralName": "ginger powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "panch puran",
+				"pluralName": "panch purans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dill",
+				"pluralName": "dills"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chive",
+				"pluralName": "chives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mint",
+				"pluralName": "mints"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green cardamom",
+				"pluralName": "green cardamoms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked paprika",
+				"pluralName": "smoked paprikas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh mint",
+				"pluralName": "fresh mints"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coriander powder",
+				"pluralName": "coriander powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sage",
+				"pluralName": "sages"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coriander",
+				"pluralName": "corianders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "allspice",
+				"pluralName": "allspices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cracked pepper",
+				"pluralName": "cracked peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppercorn",
+				"pluralName": "peppercorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard seed",
+				"pluralName": "mustard seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white pepper",
+				"pluralName": "white peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curry leaf",
+				"pluralName": "curry leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fennel seed",
+				"pluralName": "fennel seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tarragon",
+				"pluralName": "tarragons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "saffron",
+				"pluralName": "saffrons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "asafoetida",
+				"pluralName": "asafoetidas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "star anise",
+				"pluralName": "star anises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marjoram",
+				"pluralName": "marjorams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemongras",
+				"pluralName": "lemongrass"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caraway",
+				"pluralName": "caraways"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic granule",
+				"pluralName": "garlic granules"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "celery seed",
+				"pluralName": "celery seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chipotle powder",
+				"pluralName": "chipotle powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chipotle",
+				"pluralName": "chipotles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fenugreek",
+				"pluralName": "fenugreeks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion flake",
+				"pluralName": "onion flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matcha powder",
+				"pluralName": "matcha powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ancho chile powder",
+				"pluralName": "ancho chile powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sumac",
+				"pluralName": "sumacs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried parsley flake",
+				"pluralName": "dried parsley flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fenugreek seed",
+				"pluralName": "fenugreek seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kashmiri red chilli",
+				"pluralName": "kashmiri red chillis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai basil",
+				"pluralName": "thai basils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "edible flower",
+				"pluralName": "edible flowers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aniseed",
+				"pluralName": "aniseeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kaffir lime leaf",
+				"pluralName": "kaffir lime leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chervil",
+				"pluralName": "chervils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lavender",
+				"pluralName": "lavenders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carom seed",
+				"pluralName": "carom seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican oregano",
+				"pluralName": "mexican oreganos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mace",
+				"pluralName": "maces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango powder",
+				"pluralName": "mango powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black mustard seed",
+				"pluralName": "black mustard seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried chili",
+				"pluralName": "dried chilies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black cardamom",
+				"pluralName": "black cardamoms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "saffron strand",
+				"pluralName": "saffron strands"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guajillo pepper",
+				"pluralName": "guajillo peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pink peppercorn",
+				"pluralName": "pink peppercorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot paprika",
+				"pluralName": "hot paprikas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon thyme",
+				"pluralName": "lemon thymes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "galangal",
+				"pluralName": "galangals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic flake",
+				"pluralName": "garlic flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried cilantro",
+				"pluralName": "dried cilantros"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon balm",
+				"pluralName": "lemon balms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dill seed",
+				"pluralName": "dill seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green peppercorn",
+				"pluralName": "green peppercorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aleppo pepper",
+				"pluralName": "aleppo peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wasabi powder",
+				"pluralName": "wasabi powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "achiote seed",
+				"pluralName": "achiote seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "savory herb",
+				"pluralName": "savory herbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pandan leaf",
+				"pluralName": "pandan leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sorrel",
+				"pluralName": "sorrels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gochugaru",
+				"pluralName": "gochugarus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "saigon cinnamon",
+				"pluralName": "saigon cinnamons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemongrass paste",
+				"pluralName": "lemongrass pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shiso",
+				"pluralName": "shisoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "celery powder",
+				"pluralName": "celery powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black cumin",
+				"pluralName": "black cumins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anardana",
+				"pluralName": "anardanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vietnamese mint",
+				"pluralName": "vietnamese mints"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried orange peel",
+				"pluralName": "dried orange peels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "espelette pepper",
+				"pluralName": "espelette peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon verbena",
+				"pluralName": "lemon verbenas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw stevia",
+				"pluralName": "raw stevias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "achiote paste",
+				"pluralName": "achiote pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "summer savory",
+				"pluralName": "summer savories"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fennel pollen",
+				"pluralName": "fennel pollens"
+			}
+		]
+	},
+	"Sugar & Sweeteners": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sugar",
+				"pluralName": "sugars"
+			},
+			{
+				"aliases": [
+					"turbinado sugar"
+				],
+				"description": "",
+				"name": "brown sugar",
+				"pluralName": "brown sugars"
+			},
+			{
+				"aliases": [
+					"powdered sugar",
+					"icing sugar"
+				],
+				"description": "",
+				"name": "confectioners sugar",
+				"pluralName": "confectioners sugars"
+			},
+			{
+				"aliases": [
+					"castor sugar"
+				],
+				"description": "",
+				"name": "bar sugar",
+				"pluralName": "bar sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maple syrup",
+				"pluralName": "maple syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn syrup",
+				"pluralName": "corn syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut sugar",
+				"pluralName": "coconut sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "molass",
+				"pluralName": "molasses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stevia",
+				"pluralName": "stevias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "agave nectar",
+				"pluralName": "agave nectars"
+			},
+			{
+				"aliases": [],
+				"description": "sugar free sweetner",
+				"name": "sugar syrup",
+				"pluralName": "sugar syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "isomalt",
+				"pluralName": "isomalts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "erythritol",
+				"pluralName": "erythritols"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla sugar",
+				"pluralName": "vanilla sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "demerara sugar",
+				"pluralName": "demerara sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caramel syrup",
+				"pluralName": "caramel syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate syrup",
+				"pluralName": "chocolate syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jaggery",
+				"pluralName": "jaggeries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw sugar",
+				"pluralName": "raw sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden syrup",
+				"pluralName": "golden syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon sugar",
+				"pluralName": "cinnamon sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid stevia",
+				"pluralName": "liquid stevias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grenadine",
+				"pluralName": "grenadines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coarse sugar",
+				"pluralName": "coarse sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salted caramel syrup",
+				"pluralName": "salted caramel syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sanding sugar",
+				"pluralName": "sanding sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark corn syrup",
+				"pluralName": "dark corn syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sucralose",
+				"pluralName": "sucraloses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "monk fruit sweetener",
+				"pluralName": "monk fruit sweeteners"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maple sugar",
+				"pluralName": "maple sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackstrap molass",
+				"pluralName": "blackstrap molasses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glucose",
+				"pluralName": "glucoses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rock sugar",
+				"pluralName": "rock sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "confectioners' sweetener",
+				"pluralName": "confectioners' sweeteners"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "xylitol",
+				"pluralName": "xylitols"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jam sugar",
+				"pluralName": "jam sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown rice syrup",
+				"pluralName": "brown rice syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown sugar substitute",
+				"pluralName": "brown sugar substitutes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry syrup",
+				"pluralName": "strawberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla syrup",
+				"pluralName": "vanilla syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger syrup",
+				"pluralName": "ginger syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orgeat",
+				"pluralName": "orgeats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice malt syrup",
+				"pluralName": "rice malt syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pancake syrup",
+				"pluralName": "pancake syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry syrup",
+				"pluralName": "raspberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "date syrup",
+				"pluralName": "date syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black treacle",
+				"pluralName": "black treacles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "date paste",
+				"pluralName": "date pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut syrup",
+				"pluralName": "coconut syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mint syrup",
+				"pluralName": "mint syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "treacle",
+				"pluralName": "treacles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice syrup",
+				"pluralName": "rice syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "manuka honey",
+				"pluralName": "manuka honeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maple butter",
+				"pluralName": "maple butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blueberry syrup",
+				"pluralName": "blueberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple syrup",
+				"pluralName": "apple syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "allulose",
+				"pluralName": "alluloses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackberry syrup",
+				"pluralName": "blackberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "piloncillo",
+				"pluralName": "piloncilloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry syrup",
+				"pluralName": "cherry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hibiscus syrup",
+				"pluralName": "hibiscus syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lavender syrup",
+				"pluralName": "lavender syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh sugar cane",
+				"pluralName": "fresh sugar canes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut syrup",
+				"pluralName": "hazelnut syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white chocolate sauce",
+				"pluralName": "white chocolate sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin spice syrup",
+				"pluralName": "pumpkin spice syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glycerine",
+				"pluralName": "glycerines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sorghum syrup",
+				"pluralName": "sorghum syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lucuma powder",
+				"pluralName": "lucuma powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black sugar",
+				"pluralName": "black sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry syrup",
+				"pluralName": "cranberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden sugar",
+				"pluralName": "golden sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cane syrup",
+				"pluralName": "cane syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango syrup",
+				"pluralName": "mango syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "malt syrup",
+				"pluralName": "malt syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot honey",
+				"pluralName": "hot honeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gula melaka",
+				"pluralName": "gula melakas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderberry syrup",
+				"pluralName": "elderberry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rosemary syrup",
+				"pluralName": "rosemary syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark chocolate syrup",
+				"pluralName": "dark chocolate syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "inulin",
+				"pluralName": "inulins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet'n low",
+				"pluralName": "sweet'n lows"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fructose",
+				"pluralName": "fructoses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey powder",
+				"pluralName": "honey powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "berry syrup",
+				"pluralName": "berry syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grape syrup",
+				"pluralName": "grape syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown butter syrup",
+				"pluralName": "brown butter syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "date sugar",
+				"pluralName": "date sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mastic gum",
+				"pluralName": "mastic gums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gum syrup",
+				"pluralName": "gum syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "irish cream syrup",
+				"pluralName": "irish cream syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prickly pear syrup",
+				"pluralName": "prickly pear syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cookie butter syrup",
+				"pluralName": "cookie butter syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creamed honey",
+				"pluralName": "creamed honeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buttermilk syrup",
+				"pluralName": "buttermilk syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate sugar",
+				"pluralName": "chocolate sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flavored syrup",
+				"pluralName": "flavored syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderflower syrup",
+				"pluralName": "elderflower syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "malt sugar",
+				"pluralName": "malt sugars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buckwheat honey",
+				"pluralName": "buckwheat honeys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "truffle honey",
+				"pluralName": "truffle honeys"
+			}
+		]
+	},
+	"Seasonings & Spice Blends": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "italian seasoning",
+				"pluralName": "italian seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ranch dressing packet",
+				"pluralName": "ranch dressing packets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seasoned salt",
+				"pluralName": "seasoned salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curry",
+				"pluralName": "curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garam masala",
+				"pluralName": "garam masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin pie spice",
+				"pluralName": "pumpkin pie spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard powder",
+				"pluralName": "mustard powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taco seasoning",
+				"pluralName": "taco seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cajun seasoning",
+				"pluralName": "cajun seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dry ranch seasoning",
+				"pluralName": "dry ranch seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white miso",
+				"pluralName": "white misoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "himalayan salt",
+				"pluralName": "himalayan salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon & pepper seasoning",
+				"pluralName": "lemon & pepper seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid smoke",
+				"pluralName": "liquid smokes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "poultry seasoning",
+				"pluralName": "poultry seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chinese five spice",
+				"pluralName": "chinese five spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red curry",
+				"pluralName": "red curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "old bay seasoning",
+				"pluralName": "old bay seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herbe de provence",
+				"pluralName": "herbes de provence"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chaat masala",
+				"pluralName": "chaat masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creole seasoning",
+				"pluralName": "creole seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "steak seasoning",
+				"pluralName": "steak seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed spice",
+				"pluralName": "mixed spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fleur de sel",
+				"pluralName": "fleur de sel"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai red curry paste",
+				"pluralName": "thai red curry pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed herb",
+				"pluralName": "mixed herbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green curry",
+				"pluralName": "green curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barbecue seasoning",
+				"pluralName": "barbecue seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple pie spice",
+				"pluralName": "apple pie spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "za'atar",
+				"pluralName": "za'atars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ras el hanout",
+				"pluralName": "ras el hanouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "all-purpose seasoning",
+				"pluralName": "all-purpose seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seafood seasoning",
+				"pluralName": "seafood seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bagel seasoning",
+				"pluralName": "bagel seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fajita seasoning",
+				"pluralName": "fajita seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tandoori spice",
+				"pluralName": "tandoori spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickling spice",
+				"pluralName": "pickling spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caribbean jerk seasoning",
+				"pluralName": "caribbean jerk seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gravy mix",
+				"pluralName": "gravy mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic & herb seasoning",
+				"pluralName": "garlic & herb seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic-pepper seasoning",
+				"pluralName": "garlic-pepper seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickling salt",
+				"pluralName": "pickling salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "greek seasoning",
+				"pluralName": "greek seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "msg",
+				"pluralName": "msgs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "teriyaki marinade",
+				"pluralName": "teriyaki marinades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "adobo seasoning",
+				"pluralName": "adobo seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sambar powder",
+				"pluralName": "sambar powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "smoked salt",
+				"pluralName": "smoked salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dash seasoning",
+				"pluralName": "dash seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red miso",
+				"pluralName": "red misoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot curry",
+				"pluralName": "hot curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salt-free seasoning",
+				"pluralName": "salt-free seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carne asada seasoning",
+				"pluralName": "carne asada seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bouquet garni",
+				"pluralName": "bouquet garnis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow miso",
+				"pluralName": "yellow misoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dukkah",
+				"pluralName": "dukkahs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pav bhaji masala",
+				"pluralName": "pav bhaji masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curing salt",
+				"pluralName": "curing salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican seasoning",
+				"pluralName": "mexican seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tajin seasoning",
+				"pluralName": "tajin seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seasoned pepper",
+				"pluralName": "seasoned peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crab boil seasoning",
+				"pluralName": "crab boil seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shichimi togarashi",
+				"pluralName": "shichimi togarashis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rib rub",
+				"pluralName": "rib rubs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "truffle salt",
+				"pluralName": "truffle salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "biryani masala",
+				"pluralName": "biryani masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "furikake",
+				"pluralName": "furikakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "togarashi",
+				"pluralName": "togarashis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chipotle seasoning",
+				"pluralName": "chipotle seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "meat masala",
+				"pluralName": "meat masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "harissa spice blend",
+				"pluralName": "harissa spice blends"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chana masala",
+				"pluralName": "chana masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken gravy mix",
+				"pluralName": "chicken gravy mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grey sea salt",
+				"pluralName": "grey sea salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken taco seasoning",
+				"pluralName": "chicken taco seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mushroom seasoning",
+				"pluralName": "mushroom seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "au jus mix",
+				"pluralName": "au jus mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gingerbread spice",
+				"pluralName": "gingerbread spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "popcorn seasoning",
+				"pluralName": "popcorn seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "berbere",
+				"pluralName": "berberes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili-lime seasoning",
+				"pluralName": "chili-lime seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown miso",
+				"pluralName": "brown misoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackening seasoning",
+				"pluralName": "blackening seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pizza seasoning",
+				"pluralName": "pizza seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fines herbe",
+				"pluralName": "fines herbes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shawarma seasoning",
+				"pluralName": "shawarma seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chai masala",
+				"pluralName": "chai masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "panang curry",
+				"pluralName": "panang curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kitchen king masala",
+				"pluralName": "kitchen king masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon & herb seasoning",
+				"pluralName": "lemon & herb seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla salt",
+				"pluralName": "vanilla salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai seasoning",
+				"pluralName": "thai seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mulling spice",
+				"pluralName": "mulling spices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sriracha seasoning",
+				"pluralName": "sriracha seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee rub",
+				"pluralName": "coffee rubs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hawaiian salt",
+				"pluralName": "hawaiian salts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mesquite seasoning",
+				"pluralName": "mesquite seasonings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tom yum paste",
+				"pluralName": "tom yum pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish masala",
+				"pluralName": "fish masalas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh mixed herb",
+				"pluralName": "fresh mixed herbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "southwest chipotle seasoning",
+				"pluralName": "southwest chipotle seasonings"
+			}
+		]
+	},
+	"Baking": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flour",
+				"pluralName": "flours"
+			},
+			{
+				"aliases": [
+					"vanilla",
+					"vanillas"
+				],
+				"description": "",
+				"name": "vanilla extract",
+				"pluralName": "vanilla extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baking powder",
+				"pluralName": "baking powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baking soda",
+				"pluralName": "baking sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornstarch",
+				"pluralName": "cornstarches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yeast",
+				"pluralName": "yeasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate chip",
+				"pluralName": "chocolate chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark chocolate chip",
+				"pluralName": "dark chocolate chips"
+			},
+			{
+				"aliases": [
+					"whole wheat flour"
+				],
+				"description": "",
+				"name": "whole-wheat flour",
+				"pluralName": "whole-wheat flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond flour",
+				"pluralName": "almond flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "self-raising flour",
+				"pluralName": "self-raising flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shredded coconut",
+				"pluralName": "shredded coconuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornmeal",
+				"pluralName": "cornmeals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut flake",
+				"pluralName": "coconut flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gelatin",
+				"pluralName": "gelatins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pastry flour",
+				"pluralName": "pastry flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut flour",
+				"pluralName": "coconut flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baking mix",
+				"pluralName": "baking mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cake flour",
+				"pluralName": "cake flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn flour",
+				"pluralName": "corn flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of tartar",
+				"pluralName": "cream of tartar"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread flour",
+				"pluralName": "bread flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond meal",
+				"pluralName": "almond meals"
+			},
+			{
+				"aliases": [
+					"unbleached flour",
+					"all-purpose flour",
+					"all purpose flour"
+				],
+				"description": "",
+				"name": "unbleached all-purpose flour",
+				"pluralName": "unbleached all-purpose flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white baking chip",
+				"pluralName": "white baking chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free flour",
+				"pluralName": "gluten-free flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice flour",
+				"pluralName": "rice flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "desiccated coconut",
+				"pluralName": "desiccated coconuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tapioca starch",
+				"pluralName": "tapioca starches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow cake mix",
+				"pluralName": "yellow cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chickpea flour",
+				"pluralName": "chickpea flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "xanthan gum",
+				"pluralName": "xanthan gums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oat flour",
+				"pluralName": "oat flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whole-wheat pastry flour",
+				"pluralName": "whole-wheat pastry flours"
+			},
+			{
+				"aliases": [
+					"whole wheat",
+					"whole wheats"
+				],
+				"description": "",
+				"name": "whole-wheat",
+				"pluralName": "whole-wheats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy sprinkle",
+				"pluralName": "candy sprinkles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spelt",
+				"pluralName": "spelts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brownie mix",
+				"pluralName": "brownie mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arrowroot flour",
+				"pluralName": "arrowroot flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flaxseed meal",
+				"pluralName": "flaxseed meals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate cake mix",
+				"pluralName": "chocolate cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato starch",
+				"pluralName": "potato starches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jello",
+				"pluralName": "jelloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butterscotch chip",
+				"pluralName": "butterscotch chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut butter chip",
+				"pluralName": "peanut butter chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crystallized ginger",
+				"pluralName": "crystallized gingers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buckwheat flour",
+				"pluralName": "buckwheat flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown rice flour",
+				"pluralName": "brown rice flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pectin",
+				"pluralName": "pectins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rye flour",
+				"pluralName": "rye flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "psyllium husk",
+				"pluralName": "psyllium husks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "semolina flour",
+				"pluralName": "semolina flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glutinous rice flour",
+				"pluralName": "glutinous rice flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pancake mix",
+				"pluralName": "pancake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "refined flour",
+				"pluralName": "refined flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "muffin mix",
+				"pluralName": "muffin mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marzipan",
+				"pluralName": "marzipans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee bean",
+				"pluralName": "coffee beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "toffee bit",
+				"pluralName": "toffee bits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornbread mix",
+				"pluralName": "cornbread mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spice cake mix",
+				"pluralName": "spice cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "devil's food cake mix",
+				"pluralName": "devil's food cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sorghum flour",
+				"pluralName": "sorghum flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato flake",
+				"pluralName": "potato flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "masa harina",
+				"pluralName": "masa harinas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon chip",
+				"pluralName": "cinnamon chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "agar agar",
+				"pluralName": "agar agars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red velvet cake mix",
+				"pluralName": "red velvet cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matzo meal",
+				"pluralName": "matzo meals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sago",
+				"pluralName": "sagos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white baking chocolate",
+				"pluralName": "white baking chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cassava flour",
+				"pluralName": "cassava flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whipped cream stabilizer",
+				"pluralName": "whipped cream stabilizers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sugar cookie mix",
+				"pluralName": "sugar cookie mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vital wheat gluten",
+				"pluralName": "vital wheat glutens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baking chip",
+				"pluralName": "baking chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "meringue powder",
+				"pluralName": "meringue powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut flour",
+				"pluralName": "hazelnut flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "citric acid",
+				"pluralName": "citric acids"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut chip",
+				"pluralName": "coconut chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quinoa flour",
+				"pluralName": "quinoa flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "finger millet flour",
+				"pluralName": "finger millet flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fondant",
+				"pluralName": "fondants"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mint baking chip",
+				"pluralName": "mint baking chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "angel food cake mix",
+				"pluralName": "angel food cake mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white cornmeal",
+				"pluralName": "white cornmeals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "millet flour",
+				"pluralName": "millet flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mincemeat",
+				"pluralName": "mincemeats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free baking flour",
+				"pluralName": "gluten-free baking flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "einkorn flour",
+				"pluralName": "einkorn flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "self-rising cornmeal",
+				"pluralName": "self-rising cornmeals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free self-raising flour",
+				"pluralName": "gluten-free self-raising flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut flour",
+				"pluralName": "peanut flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet bean paste",
+				"pluralName": "sweet bean pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carob powder",
+				"pluralName": "carob powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tapioca pearl",
+				"pluralName": "tapioca pearls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "teff flour",
+				"pluralName": "teff flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guar gum",
+				"pluralName": "guar gums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato flour",
+				"pluralName": "potato flours"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ready-made icing",
+				"pluralName": "ready-made icings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fruit salt",
+				"pluralName": "fruit salts"
+			}
+		]
+	},
+	"Pre-Made Doughs & Wrappers": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pie crust",
+				"pluralName": "pie crusts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puff pastry",
+				"pluralName": "puff pastries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pizza crust",
+				"pluralName": "pizza crusts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pizza dough",
+				"pluralName": "pizza doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "phyllo",
+				"pluralName": "phylloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "refrigerated crescent roll",
+				"pluralName": "refrigerated crescent rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "biscuit dough",
+				"pluralName": "biscuit doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dumpling wrapper",
+				"pluralName": "dumpling wrappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice paper",
+				"pluralName": "rice papers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sourdough starter",
+				"pluralName": "sourdough starters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cookie dough",
+				"pluralName": "cookie doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg roll wrapper",
+				"pluralName": "egg roll wrappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread dough",
+				"pluralName": "bread doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter puff pastry",
+				"pluralName": "butter puff pastries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen dinner roll",
+				"pluralName": "frozen dinner rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon roll dough",
+				"pluralName": "cinnamon roll doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dosa batter",
+				"pluralName": "dosa batters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puff pastry shell",
+				"pluralName": "puff pastry shells"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wonton",
+				"pluralName": "wontons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gyoza wrapper",
+				"pluralName": "gyoza wrappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wonton strip",
+				"pluralName": "wonton strips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free pizza crust",
+				"pluralName": "gluten-free pizza crusts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fresh pasta dough",
+				"pluralName": "fresh pasta doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "idli batter",
+				"pluralName": "idli batters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potsticker wrapper",
+				"pluralName": "potsticker wrappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate pie crust",
+				"pluralName": "chocolate pie crusts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "croissant dough",
+				"pluralName": "croissant doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tofu skin",
+				"pluralName": "tofu skins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brisee",
+				"pluralName": "brisees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sausage roll",
+				"pluralName": "sausage rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kataifi",
+				"pluralName": "kataifis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "korean rice cake",
+				"pluralName": "korean rice cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn dog",
+				"pluralName": "corn dogs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tortilla dough",
+				"pluralName": "tortilla doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "empanada wrapper",
+				"pluralName": "empanada wrappers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rough-puff pastry",
+				"pluralName": "rough-puff pastries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gingerbread cookie dough",
+				"pluralName": "gingerbread cookie doughs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yufka",
+				"pluralName": "yufkas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cob loaf",
+				"pluralName": "cob loaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg wrap",
+				"pluralName": "egg wraps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "samosa sheet",
+				"pluralName": "samosa sheets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen pizza roll",
+				"pluralName": "frozen pizza rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brick pastry",
+				"pluralName": "brick pastries"
+			}
+		]
+	},
+	"Grains & Cereals": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rolled oat",
+				"pluralName": "rolled oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice",
+				"pluralName": "rices"
+			},
+			{
+				"aliases": [
+					"Rice Krispie"
+				],
+				"description": "",
+				"name": "Rice Krispie Cereal",
+				"pluralName": "Rice Krispie Cereal"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quinoa",
+				"pluralName": "quinoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "basmati rice",
+				"pluralName": "basmati rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown rice",
+				"pluralName": "brown rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quick-cooking oat",
+				"pluralName": "quick-cooking oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "breakfast cereal",
+				"pluralName": "breakfast cereals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "risotto rice",
+				"pluralName": "risotto rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "couscou",
+				"pluralName": "couscous"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice cereal",
+				"pluralName": "rice cereals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wild rice",
+				"pluralName": "wild rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "semolina",
+				"pluralName": "semolinas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jasmine rice",
+				"pluralName": "jasmine rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "polenta",
+				"pluralName": "polentas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "granola cereal",
+				"pluralName": "granola cereals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bulgur",
+				"pluralName": "bulgurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pearl barley",
+				"pluralName": "pearl barleys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "farro",
+				"pluralName": "farroes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barley",
+				"pluralName": "barleys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wheat germ",
+				"pluralName": "wheat germs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grit",
+				"pluralName": "grits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "steel cut oat",
+				"pluralName": "steel cut oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "millet",
+				"pluralName": "millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oat bran",
+				"pluralName": "oat brans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sushi rice",
+				"pluralName": "sushi rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glutinous rice",
+				"pluralName": "glutinous rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "instant rice",
+				"pluralName": "instant rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hominy",
+				"pluralName": "hominies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red quinoa",
+				"pluralName": "red quinoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw buckwheat",
+				"pluralName": "raw buckwheats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wheat bran",
+				"pluralName": "wheat brans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "instant oat",
+				"pluralName": "instant oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "instant oat",
+				"pluralName": "instant oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wheat berry",
+				"pluralName": "wheat berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "poha",
+				"pluralName": "pohas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black rice",
+				"pluralName": "black rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow rice",
+				"pluralName": "yellow rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fine semolina",
+				"pluralName": "fine semolinas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "muesli",
+				"pluralName": "mueslis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amaranth",
+				"pluralName": "amaranths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kasha",
+				"pluralName": "kashas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quinoa flake",
+				"pluralName": "quinoa flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffed rice",
+				"pluralName": "puffed rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pearled farro",
+				"pluralName": "pearled farroes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cracked wheat",
+				"pluralName": "cracked wheats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freekeh",
+				"pluralName": "freekehs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "paella rice",
+				"pluralName": "paella rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sorghum",
+				"pluralName": "sorghums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red rice",
+				"pluralName": "red rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican rice",
+				"pluralName": "mexican rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "idli rice",
+				"pluralName": "idli rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown jasmine rice",
+				"pluralName": "brown jasmine rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of wheat",
+				"pluralName": "cream of wheat"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice pilaf",
+				"pluralName": "rice pilafs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barnyard millet",
+				"pluralName": "barnyard millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "weetabix",
+				"pluralName": "weetabixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jambalaya rice mix",
+				"pluralName": "jambalaya rice mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black glutinous rice",
+				"pluralName": "black glutinous rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whole-grain oat",
+				"pluralName": "whole-grain oats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffed quinoa",
+				"pluralName": "puffed quinoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cilantro lime rice",
+				"pluralName": "cilantro lime rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dirty rice mix",
+				"pluralName": "dirty rice mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffed wheat",
+				"pluralName": "puffed wheats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hulled barley",
+				"pluralName": "hulled barleys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown long grain rice",
+				"pluralName": "brown long grain rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "finger millet",
+				"pluralName": "finger millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "foxtail millet",
+				"pluralName": "foxtail millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matta rice",
+				"pluralName": "matta rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rye berry",
+				"pluralName": "rye berries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spelt flake",
+				"pluralName": "spelt flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kodo millet",
+				"pluralName": "kodo millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oat groat",
+				"pluralName": "oat groats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "teff",
+				"pluralName": "teffs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rye flake",
+				"pluralName": "rye flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "little millet",
+				"pluralName": "little millets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free breakfast cereal",
+				"pluralName": "gluten-free breakfast cereals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffed amaranth",
+				"pluralName": "puffed amaranths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut rice",
+				"pluralName": "coconut rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amaranth flake",
+				"pluralName": "amaranth flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "puffed kamut",
+				"pluralName": "puffed kamuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bamboo rice",
+				"pluralName": "bamboo rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pearled sorghum",
+				"pluralName": "pearled sorghums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shirataki rice",
+				"pluralName": "shirataki rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable fried rice",
+				"pluralName": "vegetable fried rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gr\u00fcnkern",
+				"pluralName": "gr\u00fcnkerns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jeera rice",
+				"pluralName": "jeera rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fonio",
+				"pluralName": "fonios"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kamut flake",
+				"pluralName": "kamut flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "texmati rice",
+				"pluralName": "texmati rices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of rice",
+				"pluralName": "cream of rice"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ka\u00f1iwa",
+				"pluralName": "ka\u00f1iwas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "proso millet",
+				"pluralName": "proso millets"
+			}
+		]
+	},
+	"Legumes": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pea",
+				"pluralName": "peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green bean",
+				"pluralName": "green beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chickpea",
+				"pluralName": "chickpeas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black bean",
+				"pluralName": "black beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kidney bean",
+				"pluralName": "kidney beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white bean",
+				"pluralName": "white beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lentil",
+				"pluralName": "lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pinto bean",
+				"pluralName": "pinto beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "snow pea",
+				"pluralName": "snow peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "snap pea",
+				"pluralName": "snap peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red lentil",
+				"pluralName": "red lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cannellini bean",
+				"pluralName": "cannellini beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean sprout",
+				"pluralName": "bean sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "edamame",
+				"pluralName": "edamames"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green lentil",
+				"pluralName": "green lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "urad dal",
+				"pluralName": "urad dals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lima bean",
+				"pluralName": "lima beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chana dal",
+				"pluralName": "chana dals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fava bean",
+				"pluralName": "fava beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black-eyed pea",
+				"pluralName": "black-eyed peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moong dal",
+				"pluralName": "moong dals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "split pea",
+				"pluralName": "split peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pigeon pea",
+				"pluralName": "pigeon peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red bean",
+				"pluralName": "red beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mung bean sprout",
+				"pluralName": "mung bean sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soybean",
+				"pluralName": "soybeans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mung bean",
+				"pluralName": "mung beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "string bean",
+				"pluralName": "string beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow split pea",
+				"pluralName": "yellow split peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black lentil",
+				"pluralName": "black lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "borlotti bean",
+				"pluralName": "borlotti beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aquafaba",
+				"pluralName": "aquafabas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chana",
+				"pluralName": "chanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "snake bean",
+				"pluralName": "snake beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yellow lentil",
+				"pluralName": "yellow lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mixed bean",
+				"pluralName": "mixed beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kala chana",
+				"pluralName": "kala chanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fermented black bean",
+				"pluralName": "fermented black beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black gram",
+				"pluralName": "black grams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wax bean",
+				"pluralName": "wax beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dried pea",
+				"pluralName": "dried peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pink bean",
+				"pluralName": "pink beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lentil sprout",
+				"pluralName": "lentil sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white pea",
+				"pluralName": "white peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black soybean",
+				"pluralName": "black soybeans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "field pea",
+				"pluralName": "field peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gigante",
+				"pluralName": "gigantes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flageolet",
+				"pluralName": "flageolets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "horse gram",
+				"pluralName": "horse grams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy sprout",
+				"pluralName": "soy sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey bean",
+				"pluralName": "honey beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cluster bean",
+				"pluralName": "cluster beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown bean",
+				"pluralName": "brown beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mayocoba bean",
+				"pluralName": "mayocoba beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "winged bean",
+				"pluralName": "winged beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "castelluccio lentil",
+				"pluralName": "castelluccio lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden wax bean",
+				"pluralName": "golden wax beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moth bean",
+				"pluralName": "moth beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chickpea sprout",
+				"pluralName": "chickpea sprouts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hara chana",
+				"pluralName": "hara chanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lupini bean",
+				"pluralName": "lupini beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "natto",
+				"pluralName": "nattoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hyacinth bean",
+				"pluralName": "hyacinth beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "petai",
+				"pluralName": "petais"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "scarlet runner bean",
+				"pluralName": "scarlet runner beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy flake",
+				"pluralName": "soy flakes"
+			}
+		]
+	},
+	"Pasta": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "short-cut pasta",
+				"pluralName": "short-cut pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spaghetti",
+				"pluralName": "spaghettis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macaroni",
+				"pluralName": "macaronis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg noodle",
+				"pluralName": "egg noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spiral pasta",
+				"pluralName": "spiral pastas"
+			},
+			{
+				"aliases": [
+					"lasagnas"
+				],
+				"description": "",
+				"name": "lasagna noodle",
+				"pluralName": "lasagna noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "linguine",
+				"pluralName": "linguines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fettuccine",
+				"pluralName": "fettuccines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orzo",
+				"pluralName": "orzoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pasta shell",
+				"pluralName": "pasta shells"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bow-tie pasta",
+				"pluralName": "bow-tie pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "noodle",
+				"pluralName": "noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tortellini",
+				"pluralName": "tortellinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese tortellini",
+				"pluralName": "cheese tortellinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice noodle",
+				"pluralName": "rice noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rigatoni",
+				"pluralName": "rigatonis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gnocchi",
+				"pluralName": "gnocchis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "angel hair pasta",
+				"pluralName": "angel hair pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ramen noodle",
+				"pluralName": "ramen noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vermicelli",
+				"pluralName": "vermicellis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tagliatelle",
+				"pluralName": "tagliatelles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soba noodle",
+				"pluralName": "soba noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ravioli",
+				"pluralName": "raviolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ziti",
+				"pluralName": "zitis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orecchiette",
+				"pluralName": "orecchiettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "israeli couscou",
+				"pluralName": "israeli couscous"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "zoodle",
+				"pluralName": "zoodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "udon noodle",
+				"pluralName": "udon noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ditalini",
+				"pluralName": "ditalinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice vermicelli",
+				"pluralName": "rice vermicellis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pappardelle",
+				"pluralName": "pappardelles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glass noodle",
+				"pluralName": "glass noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free pasta",
+				"pluralName": "gluten-free pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mac 'n cheese",
+				"pluralName": "mac 'n cheeses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "penne rigate",
+				"pluralName": "penne rigates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "manicotti",
+				"pluralName": "manicottis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bucatini",
+				"pluralName": "bucatinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cannelloni",
+				"pluralName": "cannellonis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai rice noodle",
+				"pluralName": "thai rice noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown rice pasta",
+				"pluralName": "brown rice pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rotelle",
+				"pluralName": "rotelles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shirataki noodle",
+				"pluralName": "shirataki noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken raman",
+				"pluralName": "chicken ramen"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pierogi",
+				"pluralName": "pierogis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soup pasta",
+				"pluralName": "soup pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet potato noodle",
+				"pluralName": "sweet potato noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "acini di pepe",
+				"pluralName": "acini di pepes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cavatelli",
+				"pluralName": "cavatellis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "instant noodle",
+				"pluralName": "instant noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "somen noodle",
+				"pluralName": "somen noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yakisoba noodle",
+				"pluralName": "yakisoba noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef ravioli",
+				"pluralName": "beef raviolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hakka noodle",
+				"pluralName": "hakka noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kelp noodle",
+				"pluralName": "kelp noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fideo pasta",
+				"pluralName": "fideo pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spaetzle",
+				"pluralName": "spaetzles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "radiatore",
+				"pluralName": "radiatores"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "paccheri",
+				"pluralName": "paccheris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kluski noodle",
+				"pluralName": "kluski noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yolk-free noodle",
+				"pluralName": "yolk-free noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black bean pasta",
+				"pluralName": "black bean pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matzo farfel",
+				"pluralName": "matzo farfels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spinach fettuccine",
+				"pluralName": "spinach fettuccines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice-a-roni",
+				"pluralName": "rice-a-ronis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen dumpling",
+				"pluralName": "frozen dumplings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fregola",
+				"pluralName": "fregolas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef tortellini",
+				"pluralName": "beef tortellinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banh pho",
+				"pluralName": "banh phoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butternut squash noodle",
+				"pluralName": "butternut squash noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mie noodle",
+				"pluralName": "mie noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "trahana",
+				"pluralName": "trahanas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "busiate",
+				"pluralName": "busiates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lobster ravioli",
+				"pluralName": "lobster raviolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mafalde",
+				"pluralName": "mafaldes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "misua",
+				"pluralName": "misuas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "palmini",
+				"pluralName": "palminis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "trottole",
+				"pluralName": "trottoles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mandu",
+				"pluralName": "mandus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pasta salad mix",
+				"pluralName": "pasta salad mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pot pie noodle",
+				"pluralName": "pot pie noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "casarecce",
+				"pluralName": "casarecces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "quinoa pasta",
+				"pluralName": "quinoa pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean pasta",
+				"pluralName": "bean pastas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean sheet",
+				"pluralName": "bean sheets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hilopite",
+				"pluralName": "hilopites"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jjolmyeon",
+				"pluralName": "jjolmyeons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "naengmyeon noodle",
+				"pluralName": "naengmyeon noodles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yuba noodle",
+				"pluralName": "yuba noodles"
+			}
+		]
+	},
+	"Bread & Salty Snackssta": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread",
+				"pluralName": "breads"
+			}
+		]
+	},
+	"Bread & Salty Snacks": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread crumb",
+				"pluralName": "bread crumbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "panko",
+				"pluralName": "pankoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flour tortilla",
+				"pluralName": "flour tortillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond flour tortilla",
+				"pluralName": "almond flour tortillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn tortilla",
+				"pluralName": "corn tortillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cracker",
+				"pluralName": "crackers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baguette",
+				"pluralName": "baguettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tortilla chip",
+				"pluralName": "tortilla chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pita",
+				"pluralName": "pitas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pretzel",
+				"pluralName": "pretzels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sourdough bread",
+				"pluralName": "sourdough breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rustic italian bread",
+				"pluralName": "rustic italian breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "popcorn",
+				"pluralName": "popcorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crouton",
+				"pluralName": "croutons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whole-wheat tortilla",
+				"pluralName": "whole-wheat tortillas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "english muffin",
+				"pluralName": "english muffins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brioche",
+				"pluralName": "brioches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "italian bread crumb",
+				"pluralName": "italian bread crumbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rye bread",
+				"pluralName": "rye breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flatbread",
+				"pluralName": "flatbreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dry-roasted peanut",
+				"pluralName": "dry-roasted peanuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato chip",
+				"pluralName": "potato chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "naan",
+				"pluralName": "naans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stuffing mix",
+				"pluralName": "stuffing mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornbread",
+				"pluralName": "cornbreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taco shell",
+				"pluralName": "taco shells"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tater tot",
+				"pluralName": "tater tots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bagel",
+				"pluralName": "bagels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn chip",
+				"pluralName": "corn chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "unpopped popcorn",
+				"pluralName": "unpopped popcorns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "croissant",
+				"pluralName": "croissants"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork rind",
+				"pluralName": "pork rinds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpernickel",
+				"pluralName": "pumpernickels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet bread",
+				"pluralName": "sweet breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hawaiian roll",
+				"pluralName": "hawaiian rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pita chip",
+				"pluralName": "pita chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten free bread",
+				"pluralName": "gluten free breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato bread",
+				"pluralName": "potato breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "muffin",
+				"pluralName": "muffins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "breadstick",
+				"pluralName": "breadsticks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "focaccia",
+				"pluralName": "focaccias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten-free bread crumb",
+				"pluralName": "gluten-free bread crumbs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tostada shell",
+				"pluralName": "tostada shells"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crispy fried onion",
+				"pluralName": "crispy fried onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "matzo",
+				"pluralName": "matzoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic bread",
+				"pluralName": "garlic breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yeast extract spread",
+				"pluralName": "yeast extract spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "challah",
+				"pluralName": "challahs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted gram",
+				"pluralName": "roasted grams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crostini",
+				"pluralName": "crostinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice cake",
+				"pluralName": "rice cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "panettone",
+				"pluralName": "panettones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet potato fry",
+				"pluralName": "sweet potato fries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sev",
+				"pluralName": "sevs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable chip",
+				"pluralName": "vegetable chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "papad",
+				"pluralName": "papads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spinach wrap",
+				"pluralName": "spinach wraps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plantain chip",
+				"pluralName": "plantain chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted chickpea",
+				"pluralName": "roasted chickpeas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheeto",
+				"pluralName": "cheetos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chapati",
+				"pluralName": "chapatis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crumpet",
+				"pluralName": "crumpets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seed bread",
+				"pluralName": "seed breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "keto bread",
+				"pluralName": "keto breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread bowl",
+				"pluralName": "bread bowls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sprouted grain bread",
+				"pluralName": "sprouted grain breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cornbread stuffing mix",
+				"pluralName": "cornbread stuffing mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "low-carb wrap",
+				"pluralName": "low-carb wraps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frozen onion ring",
+				"pluralName": "frozen onion rings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn muffin",
+				"pluralName": "corn muffins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pav bun",
+				"pluralName": "pav buns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn nut",
+				"pluralName": "corn nuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice cracker",
+				"pluralName": "rice crackers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rusk",
+				"pluralName": "rusks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fruit bread",
+				"pluralName": "fruit breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sprouted bread",
+				"pluralName": "sprouted breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pretzel bun",
+				"pluralName": "pretzel buns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roti bread",
+				"pluralName": "roti breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crispbread",
+				"pluralName": "crispbreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate muffin",
+				"pluralName": "chocolate muffins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "milk bread",
+				"pluralName": "milk breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "popcorn shrimp",
+				"pluralName": "popcorn shrimps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prawn cracker",
+				"pluralName": "prawn crackers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bao bun",
+				"pluralName": "bao buns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ezekiel bread",
+				"pluralName": "ezekiel breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wasabi pea",
+				"pluralName": "wasabi peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": null,
+				"pluralName": "achiote seeds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "arabic bread",
+				"pluralName": "arabic breads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "boboli",
+				"pluralName": "bobolis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "zwieback",
+				"pluralName": "zwiebacks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oven chip",
+				"pluralName": "oven chips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taco kit",
+				"pluralName": "taco kits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gluten free pita",
+				"pluralName": "gluten free pitas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ready-made arepa",
+				"pluralName": "ready-made arepas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ready-made pancake",
+				"pluralName": "ready-made pancakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "breading mix",
+				"pluralName": "breading mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "japanese peanut",
+				"pluralName": "japanese peanuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "khari boondi",
+				"pluralName": "khari boondis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato waffle",
+				"pluralName": "potato waffles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tartlet shell",
+				"pluralName": "tartlet shells"
+			}
+		]
+	},
+	"Oils & Fats": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "olive oil",
+				"pluralName": "olive oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable oil",
+				"pluralName": "vegetable oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "extra virgin olive oil",
+				"pluralName": "extra virgin olive oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canola oil",
+				"pluralName": "canola oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut oil",
+				"pluralName": "coconut oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cooking spray",
+				"pluralName": "cooking sprays"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sesame oil",
+				"pluralName": "sesame oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "frying oil",
+				"pluralName": "frying oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sunflower oil",
+				"pluralName": "sunflower oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "avocado oil",
+				"pluralName": "avocado oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "toasted sesame oil",
+				"pluralName": "toasted sesame oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut oil",
+				"pluralName": "peanut oils"
+			},
+			{
+				"aliases": [
+					"grape seed oil"
+				],
+				"description": "",
+				"name": "grapeseed oil",
+				"pluralName": "grapeseed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lard",
+				"pluralName": "lards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn oil",
+				"pluralName": "corn oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "virgin coconut oil",
+				"pluralName": "virgin coconut oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili oil",
+				"pluralName": "chili oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard oil",
+				"pluralName": "mustard oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "walnut oil",
+				"pluralName": "walnut oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic oil",
+				"pluralName": "garlic oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "truffle oil",
+				"pluralName": "truffle oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bacon grease",
+				"pluralName": "bacon greases"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "safflower oil",
+				"pluralName": "safflower oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cacao butter",
+				"pluralName": "cacao butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salad oil",
+				"pluralName": "salad oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck fat",
+				"pluralName": "duck fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice bran oil",
+				"pluralName": "rice bran oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soybean oil",
+				"pluralName": "soybean oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter-flavored cooking spray",
+				"pluralName": "butter-flavored cooking sprays"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "medium-chain triglyceride",
+				"pluralName": "medium-chain triglycerides"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "flaxseed oil",
+				"pluralName": "flaxseed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white truffle oil",
+				"pluralName": "white truffle oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin seed oil",
+				"pluralName": "pumpkin seed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut oil",
+				"pluralName": "hazelnut oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut oil spray",
+				"pluralName": "coconut oil sprays"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond oil",
+				"pluralName": "almond oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon oil",
+				"pluralName": "lemon oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macadamia oil",
+				"pluralName": "macadamia oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goose fat",
+				"pluralName": "goose fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "palm oil",
+				"pluralName": "palm oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "basil oil",
+				"pluralName": "basil oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork fat",
+				"pluralName": "pork fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef dripping",
+				"pluralName": "beef drippings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "schmaltz",
+				"pluralName": "schmaltzzes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tallow",
+				"pluralName": "tallows"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sushi vinegar",
+				"pluralName": "sushi vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pistachio oil",
+				"pluralName": "pistachio oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herb-infused olive oil",
+				"pluralName": "herb-infused olive oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted peanut oil",
+				"pluralName": "roasted peanut oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "argan oil",
+				"pluralName": "argan oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef fat",
+				"pluralName": "beef fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pecan oil",
+				"pluralName": "pecan oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crisco oil",
+				"pluralName": "crisco oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red palm oil",
+				"pluralName": "red palm oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shea butter",
+				"pluralName": "shea butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb fat",
+				"pluralName": "lamb fats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "castor oil",
+				"pluralName": "castor oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken dripping",
+				"pluralName": "chicken drippings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shallot oil",
+				"pluralName": "shallot oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "achiote oil",
+				"pluralName": "achiote oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jojoba oil",
+				"pluralName": "jojoba oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oregano oil",
+				"pluralName": "oregano oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hemp seed oil",
+				"pluralName": "hemp seed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wheat germ oil",
+				"pluralName": "wheat germ oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger oil",
+				"pluralName": "ginger oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cottonseed oil",
+				"pluralName": "cottonseed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork dripping",
+				"pluralName": "pork drippings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rosehip seed oil",
+				"pluralName": "rosehip seed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "camelina oil",
+				"pluralName": "camelina oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marula oil",
+				"pluralName": "marula oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moringa seed oil",
+				"pluralName": "moringa seed oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white cacao butter",
+				"pluralName": "white cacao butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black seed oil",
+				"pluralName": "black seed oils"
+			}
+		]
+	},
+	"Dressings & Vinegars": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mayonnaise",
+				"pluralName": "mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple cider vinegar",
+				"pluralName": "apple cider vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "balsamic vinegar",
+				"pluralName": "balsamic vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vinegar",
+				"pluralName": "vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red wine vinegar",
+				"pluralName": "red wine vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice wine vinegar",
+				"pluralName": "rice wine vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white wine vinegar",
+				"pluralName": "white wine vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ranch dressing",
+				"pluralName": "ranch dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "italian dressing",
+				"pluralName": "italian dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sherry vinegar",
+				"pluralName": "sherry vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "distilled white vinegar",
+				"pluralName": "distilled white vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet chilli sauce",
+				"pluralName": "sweet chilli sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white balsamic vinegar",
+				"pluralName": "white balsamic vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "champagne vinegar",
+				"pluralName": "champagne vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vinaigrette dressing",
+				"pluralName": "vinaigrette dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "balsamic vinaigrette",
+				"pluralName": "balsamic vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blue cheese dressing",
+				"pluralName": "blue cheese dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caesar dressing",
+				"pluralName": "caesar dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thousand island",
+				"pluralName": "thousand islands"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "malt vinegar",
+				"pluralName": "malt vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black vinegar",
+				"pluralName": "black vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canola mayonnaise",
+				"pluralName": "canola mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry vinegar",
+				"pluralName": "raspberry vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "japanese mayonnaise",
+				"pluralName": "japanese mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tarragon vinegar",
+				"pluralName": "tarragon vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "greek vinaigrette",
+				"pluralName": "greek vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sesame dressing",
+				"pluralName": "sesame dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey mustard dressing",
+				"pluralName": "honey mustard dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aioli sauce",
+				"pluralName": "aioli sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "french dressing",
+				"pluralName": "french dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spicy mayo",
+				"pluralName": "spicy mayoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "poppyseed dressing",
+				"pluralName": "poppyseed dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "catalina dressing",
+				"pluralName": "catalina dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "verjuice",
+				"pluralName": "verjuices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cane vinegar",
+				"pluralName": "cane vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry vinaigrette",
+				"pluralName": "raspberry vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red wine vinaigrette",
+				"pluralName": "red wine vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "russian dressing",
+				"pluralName": "russian dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "avocado oil mayonnaise",
+				"pluralName": "avocado oil mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creamy balsamic dressing",
+				"pluralName": "creamy balsamic dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "champagne vinaigrette",
+				"pluralName": "champagne vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun-dried tomato vinaigrette",
+				"pluralName": "sun-dried tomato vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic mayonnaise",
+				"pluralName": "garlic mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown rice vinegar",
+				"pluralName": "brown rice vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut vinegar",
+				"pluralName": "coconut vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ume plum vinegar",
+				"pluralName": "ume plum vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "buttermilk ranch dressing",
+				"pluralName": "buttermilk ranch dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cilantro dressing",
+				"pluralName": "cilantro dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spicy ranch dressing",
+				"pluralName": "spicy ranch dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fig balsamic",
+				"pluralName": "fig balsamics"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green goddess dressing",
+				"pluralName": "green goddess dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creamy dressing",
+				"pluralName": "creamy dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion salad dressing",
+				"pluralName": "onion salad dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "miso dressing",
+				"pluralName": "miso dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white balsamic vinaigrette",
+				"pluralName": "white balsamic vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chardonnay vinegar",
+				"pluralName": "chardonnay vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prepared coleslaw dressing",
+				"pluralName": "prepared coleslaw dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey vinegar",
+				"pluralName": "honey vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tandoori mayonnaise",
+				"pluralName": "tandoori mayonnaises"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili vinegar",
+				"pluralName": "chili vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili-lime dressing",
+				"pluralName": "chili-lime dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moscatel vinegar",
+				"pluralName": "moscatel vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vinegar powder",
+				"pluralName": "vinegar powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caramelised onion dressing",
+				"pluralName": "caramelised onion dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango vinaigrette",
+				"pluralName": "mango vinaigrettes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sugarcane vinegar",
+				"pluralName": "sugarcane vinegars"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "avocado-lime dressing",
+				"pluralName": "avocado-lime dressings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spicy vinegar",
+				"pluralName": "spicy vinegars"
+			}
+		]
+	},
+	"Condiments": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy sauce",
+				"pluralName": "soy sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dijon mustard",
+				"pluralName": "dijon mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "worcestershire",
+				"pluralName": "worcestershires"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot sauce",
+				"pluralName": "hot sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "worcestershire sauce",
+				"pluralName": "worcestershire sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ketchup",
+				"pluralName": "ketchups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard",
+				"pluralName": "mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish sauce",
+				"pluralName": "fish sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bbq sauce",
+				"pluralName": "bbq sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sriracha",
+				"pluralName": "srirachas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wholegrain mustard",
+				"pluralName": "wholegrain mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamari",
+				"pluralName": "tamaris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oyster sauce",
+				"pluralName": "oyster sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili sauce",
+				"pluralName": "chili sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger-garlic paste",
+				"pluralName": "ginger-garlic pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brown mustard",
+				"pluralName": "brown mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wing sauce",
+				"pluralName": "wing sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "teriyaki sauce",
+				"pluralName": "teriyaki sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prepared horseradish",
+				"pluralName": "prepared horseradishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger paste",
+				"pluralName": "ginger pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark soy sauce",
+				"pluralName": "dark soy sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut amino",
+				"pluralName": "coconut aminos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili paste",
+				"pluralName": "chili pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry sauce",
+				"pluralName": "cranberry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "harissa",
+				"pluralName": "harissas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili-garlic sauce",
+				"pluralName": "chili-garlic sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind paste",
+				"pluralName": "tamarind pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomegranate molass",
+				"pluralName": "pomegranate molasses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gochujang",
+				"pluralName": "gochujangs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wasabi",
+				"pluralName": "wasabis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey mustard",
+				"pluralName": "honey mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango chutney",
+				"pluralName": "mango chutneys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "english mustard",
+				"pluralName": "english mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sambal oelek",
+				"pluralName": "sambal oeleks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "preserved lemon",
+				"pluralName": "preserved lemons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kecap mani",
+				"pluralName": "kecap manis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chutney",
+				"pluralName": "chutneys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shrimp paste",
+				"pluralName": "shrimp pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "picante sauce",
+				"pluralName": "picante sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai sweet chili sauce",
+				"pluralName": "thai sweet chili sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet and sour sauce",
+				"pluralName": "sweet and sour sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid amino",
+				"pluralName": "liquid aminos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tartar sauce",
+				"pluralName": "tartar sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot pepper jelly",
+				"pluralName": "hot pepper jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili-garlic paste",
+				"pluralName": "chili-garlic pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bonito flake",
+				"pluralName": "bonito flakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green chutney",
+				"pluralName": "green chutneys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican hot sauce",
+				"pluralName": "mexican hot sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ponzu",
+				"pluralName": "ponzus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green chilli sauce",
+				"pluralName": "green chilli sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sambal",
+				"pluralName": "sambals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crispy onion",
+				"pluralName": "crispy onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red pepper jelly",
+				"pluralName": "red pepper jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai chili paste",
+				"pluralName": "thai chili pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peri peri",
+				"pluralName": "peri peris"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green chilli paste",
+				"pluralName": "green chilli pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mint jelly",
+				"pluralName": "mint jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "horseradish mustard",
+				"pluralName": "horseradish mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard paste",
+				"pluralName": "mustard pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aji amarillo",
+				"pluralName": "aji amarilloes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pepper paste",
+				"pluralName": "pepper pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yuzu juice",
+				"pluralName": "yuzu juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tonkatsu sauce",
+				"pluralName": "tonkatsu sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chermoula",
+				"pluralName": "chermoulas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind chutney",
+				"pluralName": "tamarind chutneys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hp sauce",
+				"pluralName": "hp sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck sauce",
+				"pluralName": "duck sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger chili paste",
+				"pluralName": "ginger chili pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion marmalade",
+				"pluralName": "onion marmalades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "giardiniera",
+				"pluralName": "giardinieras"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black soy sauce",
+				"pluralName": "black soy sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "doubanjiang",
+				"pluralName": "doubanjiangs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "korean bbq sauce",
+				"pluralName": "korean bbq sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maggi sauce",
+				"pluralName": "maggi sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chinese mustard",
+				"pluralName": "chinese mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chamoy",
+				"pluralName": "chamoys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime pickle",
+				"pluralName": "lime pickles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "doenjang",
+				"pluralName": "doenjangs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili crisp",
+				"pluralName": "chili crisps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "karashi",
+				"pluralName": "karashis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mushroom soy sauce",
+				"pluralName": "mushroom soy sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yuzu kosho",
+				"pluralName": "yuzu koshoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "german mustard",
+				"pluralName": "german mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taucheo",
+				"pluralName": "taucheos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eel sauce",
+				"pluralName": "eel sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hot bean paste",
+				"pluralName": "hot bean pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pati",
+				"pluralName": "patis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "remoulade",
+				"pluralName": "remoulades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white bbq sauce",
+				"pluralName": "white bbq sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickapeppa sauce",
+				"pluralName": "pickapeppa sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salsa lizano",
+				"pluralName": "salsa lizanoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shrimp sauce",
+				"pluralName": "shrimp sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet soybean paste",
+				"pluralName": "sweet soybean pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grape must",
+				"pluralName": "grape musts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shrimp powder",
+				"pluralName": "shrimp powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana ketchup",
+				"pluralName": "banana ketchups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili puree",
+				"pluralName": "chili purees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green harissa",
+				"pluralName": "green harissas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "crab paste",
+				"pluralName": "crab pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beer mustard",
+				"pluralName": "beer mustards"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guk ganjang",
+				"pluralName": "guk ganjangs"
+			}
+		]
+	},
+	"Canned Food": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned tomato",
+				"pluralName": "canned tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caper",
+				"pluralName": "capers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green olive",
+				"pluralName": "green olives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned chickpea",
+				"pluralName": "canned chickpeas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black olive",
+				"pluralName": "black olives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned black bean",
+				"pluralName": "canned black beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pumpkin",
+				"pluralName": "canned pumpkins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kalamata olive",
+				"pluralName": "kalamata olives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned tuna",
+				"pluralName": "canned tuna"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickle",
+				"pluralName": "pickles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pineapple",
+				"pluralName": "canned pineapples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chipotle in adobo",
+				"pluralName": "chipotle in adobo"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned anchovy",
+				"pluralName": "canned anchovies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted red pepper",
+				"pluralName": "roasted red peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato with green chiles",
+				"pluralName": "tomatoes with green chiles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned artichoke",
+				"pluralName": "canned artichokes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned corn",
+				"pluralName": "canned corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned kidney bean",
+				"pluralName": "canned kidney beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pie filling",
+				"pluralName": "canned pie fillings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned cannellini bean",
+				"pluralName": "canned cannellini beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "refried bean",
+				"pluralName": "refried beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned whole tomato",
+				"pluralName": "canned whole tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sweet pickle relish",
+				"pluralName": "sweet pickle relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sauerkraut",
+				"pluralName": "sauerkrauts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creamed corn",
+				"pluralName": "creamed corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corned beef",
+				"pluralName": "corned beefs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned bean",
+				"pluralName": "canned beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled jalapeno",
+				"pluralName": "pickled jalapenos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "diced green chile",
+				"pluralName": "diced green chiles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun-dried tomato in oil",
+				"pluralName": "sun-dried tomatoes in oil"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kimchi",
+				"pluralName": "kimchis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned mandarin orange",
+				"pluralName": "canned mandarin oranges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili bean",
+				"pluralName": "chili beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned crab",
+				"pluralName": "canned crabs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bamboo shoot",
+				"pluralName": "bamboo shoots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned mushroom",
+				"pluralName": "canned mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baked bean",
+				"pluralName": "baked beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned salmon",
+				"pluralName": "canned salmon"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickling juice",
+				"pluralName": "pickling juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dill pickle relish",
+				"pluralName": "dill pickle relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned peach",
+				"pluralName": "canned peaches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned black-eyed pea",
+				"pluralName": "canned black-eyed peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled ginger",
+				"pluralName": "pickled gingers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned apple",
+				"pluralName": "canned apples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned green bean",
+				"pluralName": "canned green beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spam",
+				"pluralName": "spams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned clam",
+				"pluralName": "canned clams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili with beans",
+				"pluralName": "chili with beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled onion",
+				"pluralName": "pickled onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fruit cocktail",
+				"pluralName": "fruit cocktails"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned lentil",
+				"pluralName": "canned lentils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pea",
+				"pluralName": "canned peas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled red onion",
+				"pluralName": "pickled red onions"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pimiento-stuffed green olive",
+				"pluralName": "pimiento-stuffed green olives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pork",
+				"pluralName": "canned porks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled beet",
+				"pluralName": "pickled beets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned cherry tomato",
+				"pluralName": "canned cherry tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bread & butter pickle",
+				"pluralName": "bread & butter pickles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned apricot",
+				"pluralName": "canned apricots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned sweet potato",
+				"pluralName": "canned sweet potatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pear",
+				"pluralName": "canned pears"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppadew pepper",
+				"pluralName": "peppadew peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled vegetable",
+				"pluralName": "pickled vegetables"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion paste",
+				"pluralName": "onion pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned baby corn",
+				"pluralName": "canned baby corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican-style corn",
+				"pluralName": "mexican-style corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili without bean",
+				"pluralName": "chili without beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork and bean",
+				"pluralName": "pork and beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ranch-style bean",
+				"pluralName": "ranch-style beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned chicken breast",
+				"pluralName": "canned chicken breasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned carrot",
+				"pluralName": "canned carrots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana pepper ring",
+				"pluralName": "banana pepper rings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned lychee",
+				"pluralName": "canned lychees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin pie filling",
+				"pluralName": "pumpkin pie fillings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned sardine",
+				"pluralName": "canned sardines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled pepper",
+				"pluralName": "pickled peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato relish",
+				"pluralName": "tomato relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned jackfruit",
+				"pluralName": "canned jackfruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taggiasca olive",
+				"pluralName": "taggiasca olives"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry relish",
+				"pluralName": "cranberry relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red pepper relish",
+				"pluralName": "red pepper relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned asparagu",
+				"pluralName": "canned asparagus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fire-roasted green chile",
+				"pluralName": "fire-roasted green chiles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled hot pepper",
+				"pluralName": "pickled hot peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned peas and carrot",
+				"pluralName": "canned peas and carrots"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn relish",
+				"pluralName": "corn relishes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden hominy",
+				"pluralName": "golden hominies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned mackerel",
+				"pluralName": "canned mackerel"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled cherry pepper",
+				"pluralName": "pickled cherry peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied jalapeno",
+				"pluralName": "candied jalapenos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "umeboshi",
+				"pluralName": "umeboshis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned pimento",
+				"pluralName": "canned pimentos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned potato",
+				"pluralName": "canned potatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "okra pickle",
+				"pluralName": "okra pickles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato confit",
+				"pluralName": "tomato confits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brandied cherry",
+				"pluralName": "brandied cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "macapuno",
+				"pluralName": "macapunoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "canned four-bean mix",
+				"pluralName": "canned four-bean mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "half-sour pickle",
+				"pluralName": "half-sour pickles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pickled green bean",
+				"pluralName": "pickled green beans"
+			}
+		]
+	},
+	"Sauces, Spreads & Dips": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut butter",
+				"pluralName": "peanut butters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato paste",
+				"pluralName": "tomato pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato sauce",
+				"pluralName": "tomato sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salsa",
+				"pluralName": "salsas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tahini",
+				"pluralName": "tahinis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pesto",
+				"pluralName": "pestoes"
+			},
+			{
+				"aliases": [
+					"marinara sauce - jarred"
+				],
+				"description": "",
+				"name": "marinara sauce",
+				"pluralName": "marinara sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pasta sauce",
+				"pluralName": "pasta sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hoisin sauce",
+				"pluralName": "hoisin sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pico de gallo",
+				"pluralName": "pico de gallo"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stewed tomato",
+				"pluralName": "stewed tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guacamole",
+				"pluralName": "guacamoles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hummu",
+				"pluralName": "hummus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "enchilada sauce",
+				"pluralName": "enchilada sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fire-roasted tomato",
+				"pluralName": "fire-roasted tomatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "salsa verde",
+				"pluralName": "salsa verdes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "alfredo sauce",
+				"pluralName": "alfredo sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "balsamic glaze",
+				"pluralName": "balsamic glazes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anchovy paste",
+				"pluralName": "anchovy pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red enchilada sauce",
+				"pluralName": "red enchilada sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "steak sauce",
+				"pluralName": "steak sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chunky peanut butter",
+				"pluralName": "chunky peanut butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tzatziki",
+				"pluralName": "tzatzikis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "taco sauce",
+				"pluralName": "taco sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef gravy",
+				"pluralName": "beef gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun-dried tomato pesto",
+				"pluralName": "sun-dried tomato pestoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "b\u00e9chamel sauce",
+				"pluralName": "b\u00e9chamel sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "horseradish sauce",
+				"pluralName": "horseradish sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plum sauce",
+				"pluralName": "plum sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic butter",
+				"pluralName": "garlic butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hollandaise sauce",
+				"pluralName": "hollandaise sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cocktail sauce",
+				"pluralName": "cocktail sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese dip",
+				"pluralName": "cheese dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black bean sauce",
+				"pluralName": "black bean sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tapenade",
+				"pluralName": "tapenades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey gravy",
+				"pluralName": "turkey gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stir-fry sauce",
+				"pluralName": "stir-fry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai peanut sauce",
+				"pluralName": "thai peanut sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken gravy",
+				"pluralName": "chicken gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sloppy joe sauce",
+				"pluralName": "sloppy joe sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pimento cheese spread",
+				"pluralName": "pimento cheese spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sofrito",
+				"pluralName": "sofritoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mustard sauce",
+				"pluralName": "mustard sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun-dried tomato paste",
+				"pluralName": "sun-dried tomato pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato paste",
+				"pluralName": "tomato pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "queso dip",
+				"pluralName": "queso dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "demi-glace",
+				"pluralName": "demi-glaces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chimichurri sauce",
+				"pluralName": "chimichurri sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "french onion dip",
+				"pluralName": "french onion dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herb butter",
+				"pluralName": "herb butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bolognese sauce",
+				"pluralName": "bolognese sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curry sauce",
+				"pluralName": "curry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liver spread",
+				"pluralName": "liver spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "browning sauce",
+				"pluralName": "browning sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "schezwan sauce",
+				"pluralName": "schezwan sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mushroom gravy",
+				"pluralName": "mushroom gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork gravy",
+				"pluralName": "pork gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "country gravy",
+				"pluralName": "country gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange sauce",
+				"pluralName": "orange sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pineapple salsa",
+				"pluralName": "pineapple salsas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "artichoke dip",
+				"pluralName": "artichoke dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "japanese curry",
+				"pluralName": "japanese curries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango salsa",
+				"pluralName": "mango salsas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "olive paste",
+				"pluralName": "olive pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spinach dip",
+				"pluralName": "spinach dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black truffle butter",
+				"pluralName": "black truffle butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "roasted red pepper hummu",
+				"pluralName": "roasted red pepper hummus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bacon jam",
+				"pluralName": "bacon jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tikka masala sauce",
+				"pluralName": "tikka masala sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vodka sauce",
+				"pluralName": "vodka sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whipped cream cheese spread",
+				"pluralName": "whipped cream cheese spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kung pao sauce",
+				"pluralName": "kung pao sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mole paste",
+				"pluralName": "mole pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion gravy",
+				"pluralName": "onion gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sesame sauce",
+				"pluralName": "sesame sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese spread",
+				"pluralName": "cheese spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn salsa",
+				"pluralName": "corn salsas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pad thai sauce",
+				"pluralName": "pad thai sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sausage gravy",
+				"pluralName": "sausage gravies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "deviled ham spread",
+				"pluralName": "deviled ham spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter chicken sauce",
+				"pluralName": "butter chicken sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic spread",
+				"pluralName": "garlic spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black pepper sauce",
+				"pluralName": "black pepper sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "char siu sauce",
+				"pluralName": "char siu sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "garlic pasta sauce",
+				"pluralName": "garlic pasta sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green olive tapenade",
+				"pluralName": "green olive tapenades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "schezwan chutney",
+				"pluralName": "schezwan chutneys"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mentsuyu",
+				"pluralName": "mentsuyus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai red curry sauce",
+				"pluralName": "thai red curry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tarama",
+				"pluralName": "taramas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ssamjang",
+				"pluralName": "ssamjangs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white pizza sauce",
+				"pluralName": "white pizza sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato tapenade",
+				"pluralName": "tomato tapenades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "yum yum sauce",
+				"pluralName": "yum yum sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "honey garlic sauce",
+				"pluralName": "honey garlic sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mole sauce",
+				"pluralName": "mole sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nuoc cham",
+				"pluralName": "nuoc chams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white clam sauce",
+				"pluralName": "white clam sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean dip",
+				"pluralName": "bean dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eggplant dip",
+				"pluralName": "eggplant dips"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomegranate sauce",
+				"pluralName": "pomegranate sauces"
+			}
+		]
+	},
+	"Soups, Stews & Stocks": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken broth",
+				"pluralName": "chicken broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable broth",
+				"pluralName": "vegetable broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken stock",
+				"pluralName": "chicken stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef broth",
+				"pluralName": "beef broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef stock",
+				"pluralName": "beef stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of mushroom",
+				"pluralName": "cream of mushroom"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bouillon cube",
+				"pluralName": "bouillon cubes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of chicken",
+				"pluralName": "cream of chicken"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion soup mix",
+				"pluralName": "onion soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato soup",
+				"pluralName": "tomato soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish stock",
+				"pluralName": "fish stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of celery",
+				"pluralName": "cream of celery"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "better than bouillon",
+				"pluralName": "better than bouillons"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clam juice",
+				"pluralName": "clam juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheese soup",
+				"pluralName": "cheese soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bone broth",
+				"pluralName": "bone broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dashi",
+				"pluralName": "dashis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "onion soup",
+				"pluralName": "onion soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken soup",
+				"pluralName": "chicken soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal stock",
+				"pluralName": "veal stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken bone broth",
+				"pluralName": "chicken bone broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey stock",
+				"pluralName": "turkey stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb stock",
+				"pluralName": "lamb stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey broth",
+				"pluralName": "turkey broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef consomm\u00e9",
+				"pluralName": "beef consomm\u00e9s"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "stock paste",
+				"pluralName": "stock pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of potato",
+				"pluralName": "cream of potato"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "golden mushroom soup",
+				"pluralName": "golden mushroom soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "seafood stock",
+				"pluralName": "seafood stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mushroom broth",
+				"pluralName": "mushroom broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable soup",
+				"pluralName": "vegetable soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken noodle soup",
+				"pluralName": "chicken noodle soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable soup mix",
+				"pluralName": "vegetable soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken consomm\u00e9",
+				"pluralName": "chicken consomm\u00e9s"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shrimp stock",
+				"pluralName": "shrimp stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nacho cheese soup",
+				"pluralName": "nacho cheese soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ramen noodle soup",
+				"pluralName": "ramen noodle soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of broccoli",
+				"pluralName": "cream of broccoli"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lobster stock",
+				"pluralName": "lobster stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork stock",
+				"pluralName": "pork stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken rice soup",
+				"pluralName": "chicken rice soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beefy onion soup mix",
+				"pluralName": "beefy onion soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butternut squash soup",
+				"pluralName": "butternut squash soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken stock paste",
+				"pluralName": "chicken stock pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "miso soup",
+				"pluralName": "miso soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "broccoli-cheese soup",
+				"pluralName": "broccoli-cheese soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "duck stock",
+				"pluralName": "duck stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clam broth",
+				"pluralName": "clam broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan chicken broth",
+				"pluralName": "vegan chicken broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of asparagus",
+				"pluralName": "cream of asparagus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork broth",
+				"pluralName": "pork broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beefy mushroom soup",
+				"pluralName": "beefy mushroom soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "new england clam chowder",
+				"pluralName": "new england clam chowders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean soup mix",
+				"pluralName": "bean soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "black bean soup",
+				"pluralName": "black bean soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ham stock",
+				"pluralName": "ham stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lentil soup",
+				"pluralName": "lentil soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of shrimp soup",
+				"pluralName": "cream of shrimp soup"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "veal broth",
+				"pluralName": "veal broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegetable beef soup",
+				"pluralName": "vegetable beef soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken soup mix",
+				"pluralName": "chicken soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of bacon",
+				"pluralName": "cream of bacon"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lobster bisque",
+				"pluralName": "lobster bisques"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bean with bacon soup",
+				"pluralName": "bean with bacon soup"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clam chowder",
+				"pluralName": "clam chowders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "condensed chicken gumbo soup",
+				"pluralName": "condensed chicken gumbo soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tortilla soup base",
+				"pluralName": "tortilla soup bases"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "turkey bone broth",
+				"pluralName": "turkey bone broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anchovy stock",
+				"pluralName": "anchovy stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of chicken soup mix:",
+				"pluralName": "cream of chicken soup mix:"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "noodle soup mix",
+				"pluralName": "noodle soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lamb broth",
+				"pluralName": "lamb broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "minestrone",
+				"pluralName": "minestrones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai chicken broth",
+				"pluralName": "thai chicken broths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato bisque",
+				"pluralName": "tomato bisques"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "venison stock",
+				"pluralName": "venison stocks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beef stock paste",
+				"pluralName": "beef stock pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bovril",
+				"pluralName": "bovrils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken corn chowder",
+				"pluralName": "chicken corn chowders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pork & bean",
+				"pluralName": "pork & beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sun-dried tomato bisque mix",
+				"pluralName": "sun-dried tomato bisque mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ham-flavored concentrate",
+				"pluralName": "ham-flavored concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oxtail soup",
+				"pluralName": "oxtail soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "potato soup mix",
+				"pluralName": "potato soup mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "callaloo",
+				"pluralName": "callaloos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "split pea soup",
+				"pluralName": "split pea soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken and mushroom soup",
+				"pluralName": "chicken and mushroom soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chili beef soup",
+				"pluralName": "chili beef soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn chowder",
+				"pluralName": "corn chowders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of cauliflower",
+				"pluralName": "cream of cauliflower"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dashida",
+				"pluralName": "dashidas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green pea soup",
+				"pluralName": "green pea soups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pho broth",
+				"pluralName": "pho broths"
+			}
+		]
+	},
+	"Desserts & Sweet Snacks": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cocoa",
+				"pluralName": "cocoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark chocolate",
+				"pluralName": "dark chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark cocoa",
+				"pluralName": "dark cocoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate",
+				"pluralName": "chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "graham cracker",
+				"pluralName": "graham crackers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "baking chocolate",
+				"pluralName": "baking chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marshmallow",
+				"pluralName": "marshmallows"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mini arshmallow",
+				"pluralName": "mini marshmallows"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "applesauce",
+				"pluralName": "applesauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white chocolate",
+				"pluralName": "white chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "oreo",
+				"pluralName": "oreos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate hazelnut spread",
+				"pluralName": "chocolate hazelnut spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "instant pudding",
+				"pluralName": "instant puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate candy",
+				"pluralName": "chocolate candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate cream-filled chocolate sandwich cookie",
+				"pluralName": "chocolate cream-filled chocolate sandwich cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dutch-process cocoa",
+				"pluralName": "dutch-process cocoas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry jam",
+				"pluralName": "raspberry jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apricot jam",
+				"pluralName": "apricot jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caramel sauce",
+				"pluralName": "caramel sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy coating",
+				"pluralName": "candy coatings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raw cacao powder",
+				"pluralName": "raw cacao powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry jam",
+				"pluralName": "strawberry jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "biscuit",
+				"pluralName": "biscuits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marshmallow creme",
+				"pluralName": "marshmallow cremes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy",
+				"pluralName": "candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jam",
+				"pluralName": "jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange marmalade",
+				"pluralName": "orange marmalades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wafer",
+				"pluralName": "wafers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cookie",
+				"pluralName": "cookies"
+			},
+			{
+				"aliases": [
+					"Reeses PB cup",
+					"Reeses Peanut Buttercup"
+				],
+				"description": "",
+				"name": "peanut butter cup",
+				"pluralName": "peanut butter cups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate pudding",
+				"pluralName": "chocolate puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy cane",
+				"pluralName": "candy canes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger snap",
+				"pluralName": "ginger snaps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cacao nib",
+				"pluralName": "cacao nibs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lady finger",
+				"pluralName": "lady fingers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate chip cookie",
+				"pluralName": "chocolate chip cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fudge sauce",
+				"pluralName": "fudge sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate cookie",
+				"pluralName": "chocolate cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "digestive biscuit",
+				"pluralName": "digestive biscuits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple butter",
+				"pluralName": "apple butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppermint candy",
+				"pluralName": "peppermint candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon roll",
+				"pluralName": "cinnamon rolls"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter cookie",
+				"pluralName": "butter cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied cherry",
+				"pluralName": "candied cherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caramel candy",
+				"pluralName": "caramel candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla pudding",
+				"pluralName": "vanilla puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "currant jelly",
+				"pluralName": "currant jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied ginger",
+				"pluralName": "candied gingers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "angel food cake",
+				"pluralName": "angel food cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach preserve",
+				"pluralName": "peach preserves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate wafer",
+				"pluralName": "chocolate wafers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied peel",
+				"pluralName": "candied peels"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nutella",
+				"pluralName": "nutellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry jam",
+				"pluralName": "cherry jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dark couverture chocolate",
+				"pluralName": "dark couverture chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "couverture chocolate",
+				"pluralName": "couverture chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grape jelly",
+				"pluralName": "grape jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "waffle",
+				"pluralName": "waffles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tartlet shell",
+				"pluralName": "tartlet shells"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cookie butter",
+				"pluralName": "cookie butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fig jam",
+				"pluralName": "fig jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butterscotch",
+				"pluralName": "butterscotches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blueberry jam",
+				"pluralName": "blueberry jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied fruit",
+				"pluralName": "candied fruits"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond cookie",
+				"pluralName": "almond cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gummy",
+				"pluralName": "gummies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple jelly",
+				"pluralName": "apple jellies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackberry preserve",
+				"pluralName": "blackberry preserves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candy corn",
+				"pluralName": "candy corns"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ice-cream cone",
+				"pluralName": "ice-cream cones"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sugar cookie",
+				"pluralName": "sugar cookies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marmalade",
+				"pluralName": "marmalades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg candy",
+				"pluralName": "egg candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry puree",
+				"pluralName": "strawberry purees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate powder",
+				"pluralName": "chocolate powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sponge cake",
+				"pluralName": "sponge cakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate-covered espresso bean",
+				"pluralName": "chocolate-covered espresso beans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pineapple jam",
+				"pluralName": "pineapple jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "licorice",
+				"pluralName": "licorices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plum jam",
+				"pluralName": "plum jams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mexican chocolate",
+				"pluralName": "mexican chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana pudding",
+				"pluralName": "banana puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white couverture",
+				"pluralName": "white couvertures"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sorbet",
+				"pluralName": "sorbets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate peanut butter",
+				"pluralName": "chocolate peanut butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon candy",
+				"pluralName": "cinnamon candies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin butter",
+				"pluralName": "pumpkin butter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guava paste",
+				"pluralName": "guava pastes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fudge",
+				"pluralName": "fudges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry sauce",
+				"pluralName": "strawberry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butterscotch pudding mix",
+				"pluralName": "butterscotch pudding mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate spread",
+				"pluralName": "chocolate spreads"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "doughnut",
+				"pluralName": "doughnuts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "biscotti",
+				"pluralName": "biscottis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cheesecake instant pudding",
+				"pluralName": "cheesecake instant puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppermint patty",
+				"pluralName": "peppermint patties"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pistachio pudding",
+				"pluralName": "pistachio puddings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate fudge",
+				"pluralName": "chocolate fudges"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry sauce",
+				"pluralName": "raspberry sauces"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry sorbet",
+				"pluralName": "raspberry sorbets"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "candied pineapple",
+				"pluralName": "candied pineapples"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hershey kiss",
+				"pluralName": "hershey kisses"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pistachio instant pudding",
+				"pluralName": "pistachio instant puddings"
+			}
+		]
+	},
+	"Wine, Beer & Spirits": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white wine",
+				"pluralName": "white wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red wine",
+				"pluralName": "red wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "whisky",
+				"pluralName": "whiskies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rum",
+				"pluralName": "rums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vodka",
+				"pluralName": "vodkas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beer",
+				"pluralName": "beers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange liqueur",
+				"pluralName": "orange liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cider",
+				"pluralName": "ciders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tequila",
+				"pluralName": "tequilas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sherry",
+				"pluralName": "sherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gin",
+				"pluralName": "gins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brandy",
+				"pluralName": "brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bitter",
+				"pluralName": "bitters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mirin",
+				"pluralName": "mirins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white rum",
+				"pluralName": "white rums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee liqueur",
+				"pluralName": "coffee liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "champagne",
+				"pluralName": "champagnes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "irish cream",
+				"pluralName": "irish creams"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vermouth",
+				"pluralName": "vermouths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "amaretto",
+				"pluralName": "amarettoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "marsala wine",
+				"pluralName": "marsala wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cognac",
+				"pluralName": "cognacs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sparkling wine",
+				"pluralName": "sparkling wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sake",
+				"pluralName": "sakes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice wine",
+				"pluralName": "rice wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "shaoxing wine",
+				"pluralName": "shaoxing wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dry vermouth",
+				"pluralName": "dry vermouths"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liqueur",
+				"pluralName": "liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut rum",
+				"pluralName": "coconut rums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dessert wine",
+				"pluralName": "dessert wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "curacao",
+				"pluralName": "curacaos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "port wine",
+				"pluralName": "port wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kirsch",
+				"pluralName": "kirsches"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach schnapp",
+				"pluralName": "peach schnapps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple brandy",
+				"pluralName": "apple brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ros\u00e9 wine",
+				"pluralName": "ros\u00e9 wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anise liqueur",
+				"pluralName": "anise liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herbal liqueur",
+				"pluralName": "herbal liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "limoncello",
+				"pluralName": "limoncellos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderflower liqueur",
+				"pluralName": "elderflower liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cooking wine",
+				"pluralName": "cooking wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut liqueur",
+				"pluralName": "hazelnut liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach liqueur",
+				"pluralName": "peach liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "melon liqueur",
+				"pluralName": "melon liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry liqueur",
+				"pluralName": "raspberry liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creme de cacao",
+				"pluralName": "creme de cacao"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "schnapp",
+				"pluralName": "schnapps"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana liqueur",
+				"pluralName": "banana liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "madeira wine",
+				"pluralName": "madeira wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "absinthe",
+				"pluralName": "absinthes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white cooking wine",
+				"pluralName": "white cooking wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aperol",
+				"pluralName": "aperols"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla vodka",
+				"pluralName": "vanilla vodkas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon alcohol",
+				"pluralName": "cinnamon alcohols"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creme de menthe",
+				"pluralName": "creme de menthe"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apricot brandy",
+				"pluralName": "apricot brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cacha\u00e7a",
+				"pluralName": "cacha\u00e7as"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderflower cordial",
+				"pluralName": "elderflower cordials"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate liqueur",
+				"pluralName": "chocolate liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger liqueur",
+				"pluralName": "ginger liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sloe gin",
+				"pluralName": "sloe gins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maraschino",
+				"pluralName": "maraschinoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creme de cassis",
+				"pluralName": "creme de cassis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bloody mary mix",
+				"pluralName": "bloody mary mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream sherry",
+				"pluralName": "cream sherries"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "gold rum",
+				"pluralName": "gold rums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "red cooking wine",
+				"pluralName": "red cooking wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sparkling ros\u00e9",
+				"pluralName": "sparkling ros\u00e9s"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grappa",
+				"pluralName": "grappas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime cordial",
+				"pluralName": "lime cordials"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mezcal",
+				"pluralName": "mezcals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry liqueur",
+				"pluralName": "strawberry liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "drambuie",
+				"pluralName": "drambuies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger wine",
+				"pluralName": "ginger wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin ale",
+				"pluralName": "pumpkin ales"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white port",
+				"pluralName": "white ports"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppermint liqueur",
+				"pluralName": "peppermint liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "advocaat",
+				"pluralName": "advocaats"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pi\u00f1a colada mix",
+				"pluralName": "pi\u00f1a colada mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "b\u00e9n\u00e9dictine",
+				"pluralName": "b\u00e9n\u00e9dictines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rumchata liqueur",
+				"pluralName": "rumchata liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut liqueur",
+				"pluralName": "coconut liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "daiquiri mix",
+				"pluralName": "daiquiri mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "galliano",
+				"pluralName": "gallianoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackberry brandy",
+				"pluralName": "blackberry brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "plum wine",
+				"pluralName": "plum wines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pisco",
+				"pluralName": "piscoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate bitter",
+				"pluralName": "chocolate bitters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vanilla liqueur",
+				"pluralName": "vanilla liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sangria",
+				"pluralName": "sangrias"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grapefruit bitter",
+				"pluralName": "grapefruit bitters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach brandy",
+				"pluralName": "peach brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white chocolate liqueur",
+				"pluralName": "white chocolate liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple liqueur",
+				"pluralName": "apple liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pear brandy",
+				"pluralName": "pear brandies"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moonshine",
+				"pluralName": "moonshines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rhum agricole",
+				"pluralName": "rhum agricoles"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "armagnac",
+				"pluralName": "armagnacs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bergamot liqueur",
+				"pluralName": "bergamot liqueurs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry vodka",
+				"pluralName": "cherry vodkas"
+			}
+		]
+	},
+	"Beverages": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange juice",
+				"pluralName": "orange juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee",
+				"pluralName": "coffees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "club soda",
+				"pluralName": "club sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "espresso",
+				"pluralName": "espressos"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pineapple juice",
+				"pluralName": "pineapple juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apple juice",
+				"pluralName": "apple juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tea",
+				"pluralName": "teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry juice",
+				"pluralName": "cranberry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tomato juice",
+				"pluralName": "tomato juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut water",
+				"pluralName": "coconut waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pomegranate juice",
+				"pluralName": "pomegranate juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grapefruit juice",
+				"pluralName": "grapefruit juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemonade",
+				"pluralName": "lemonades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coke",
+				"pluralName": "cokes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eggnog",
+				"pluralName": "eggnogs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger ale",
+				"pluralName": "ginger ales"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ginger beer",
+				"pluralName": "ginger beers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange juice concentrate",
+				"pluralName": "orange juice concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon lime soda",
+				"pluralName": "lemon lime sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream of coconut",
+				"pluralName": "cream of coconut"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sprite",
+				"pluralName": "sprites"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green tea",
+				"pluralName": "green teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemonade concentrate",
+				"pluralName": "lemonade concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chai tea",
+				"pluralName": "chai teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "root beer",
+				"pluralName": "root beers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "drinking chocolate",
+				"pluralName": "drinking chocolates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tonic water",
+				"pluralName": "tonic waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "malted milk powder",
+				"pluralName": "malted milk powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango juice",
+				"pluralName": "mango juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sour mix",
+				"pluralName": "sour mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hibiscu",
+				"pluralName": "hibiscus"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tea leaf",
+				"pluralName": "tea leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grape juice",
+				"pluralName": "grape juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry juice",
+				"pluralName": "cherry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "carrot juice",
+				"pluralName": "carrot juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "limeade concentrate",
+				"pluralName": "limeade concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "dr pepper",
+				"pluralName": "dr peppers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white grape juice",
+				"pluralName": "white grape juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "watermelon juice",
+				"pluralName": "watermelon juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tangerine juice",
+				"pluralName": "tangerine juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fruit juice",
+				"pluralName": "fruit juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "passion-fruit juice",
+				"pluralName": "passion-fruit juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "iced tea",
+				"pluralName": "iced teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kombucha",
+				"pluralName": "kombuchas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "apricot juice",
+				"pluralName": "apricot juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beet juice",
+				"pluralName": "beet juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peach juice",
+				"pluralName": "peach juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange soda",
+				"pluralName": "orange sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "margarita mix",
+				"pluralName": "margarita mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kool aid",
+				"pluralName": "kool aids"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "energy drink",
+				"pluralName": "energy drinks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chamomile tea",
+				"pluralName": "chamomile teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pear juice",
+				"pluralName": "pear juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind juice",
+				"pluralName": "tamarind juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cream soda",
+				"pluralName": "cream sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind water",
+				"pluralName": "tamarind waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mountain dew",
+				"pluralName": "mountain dews"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "grapefruit soda",
+				"pluralName": "grapefruit sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rooibos tea",
+				"pluralName": "rooibos teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime soda",
+				"pluralName": "lime sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry juice",
+				"pluralName": "raspberry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "guava juice",
+				"pluralName": "guava juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "jasmine tea",
+				"pluralName": "jasmine teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clamato",
+				"pluralName": "clamatoes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry juice",
+				"pluralName": "strawberry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "iced coffee concentrate",
+				"pluralName": "iced coffee concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "green tea leaf",
+				"pluralName": "green tea leaves"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "beetroot juice",
+				"pluralName": "beetroot juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blueberry juice",
+				"pluralName": "blueberry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemonade mix",
+				"pluralName": "lemonade mixes"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rose syrup",
+				"pluralName": "rose syrups"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "v8 juice",
+				"pluralName": "v8 juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thai tea",
+				"pluralName": "thai teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "aloe vera juice",
+				"pluralName": "aloe vera juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "white tea",
+				"pluralName": "white teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "juice blend",
+				"pluralName": "juice blends"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "prune juice",
+				"pluralName": "prune juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sparkling cider",
+				"pluralName": null
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "berry juice",
+				"pluralName": "berry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butterfly pea flower",
+				"pluralName": "butterfly pea flowers"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "passion tea",
+				"pluralName": "passion teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry soda",
+				"pluralName": "strawberry sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lapsang souchong",
+				"pluralName": "lapsang souchongs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blackcurrant juice",
+				"pluralName": "blackcurrant juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "herbal tea",
+				"pluralName": "herbal teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana juice",
+				"pluralName": "banana juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lychee juice",
+				"pluralName": "lychee juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sugar cane juice",
+				"pluralName": "sugar cane juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry-raspberry juice",
+				"pluralName": "cranberry-raspberry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "decaf coffee",
+				"pluralName": "decaf coffees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pumpkin spice coffee",
+				"pluralName": "pumpkin spice coffees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pepsi",
+				"pluralName": "pepsis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry soda",
+				"pluralName": "cherry sodas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppermint tea",
+				"pluralName": "peppermint teas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sports drink",
+				"pluralName": "sports drinks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "acai berry juice",
+				"pluralName": "acai berry juices"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon crystal",
+				"pluralName": "lemon crystals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry lemonade",
+				"pluralName": "raspberry lemonades"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicory coffee",
+				"pluralName": "chicory coffees"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "elderberry juice",
+				"pluralName": "elderberry juices"
+			}
+		]
+	},
+	"Supplements & Extracts": {
+		"foods": [
+			{
+				"aliases": [],
+				"description": "",
+				"name": "almond extract",
+				"pluralName": "almond extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "food coloring",
+				"pluralName": "food colorings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "nutritional yeast",
+				"pluralName": "nutritional yeasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peppermint extract",
+				"pluralName": "peppermint extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "protein powder",
+				"pluralName": "protein powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon extract",
+				"pluralName": "lemon extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coconut extract",
+				"pluralName": "coconut extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rose water",
+				"pluralName": "rose waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange extract",
+				"pluralName": "orange extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rum extract",
+				"pluralName": "rum extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maple extract",
+				"pluralName": "maple extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "collagen",
+				"pluralName": "collagens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate protein powder",
+				"pluralName": "chocolate protein powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "orange blossom water",
+				"pluralName": "orange blossom waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "liquid egg white",
+				"pluralName": "liquid egg whites"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "peanut butter powder",
+				"pluralName": "peanut butter powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vegan protein powder",
+				"pluralName": "vegan protein powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "essence",
+				"pluralName": "essences"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maca powder",
+				"pluralName": "maca powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "spirulina",
+				"pluralName": "spirulinas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "coffee extract",
+				"pluralName": "coffee extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "brewer's yeast",
+				"pluralName": "brewer's yeasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "strawberry extract",
+				"pluralName": "strawberry extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butter extract",
+				"pluralName": "butter extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate extract",
+				"pluralName": "chocolate extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry extract",
+				"pluralName": "raspberry extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "anise extract",
+				"pluralName": "anise extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "bee pollen",
+				"pluralName": "bee pollens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cannabi",
+				"pluralName": "cannabis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana extract",
+				"pluralName": "banana extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lavender oil",
+				"pluralName": "lavender oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "essential oil",
+				"pluralName": "essential oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chicken essence",
+				"pluralName": "chicken essences"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "caramel extract",
+				"pluralName": "caramel extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg white powder",
+				"pluralName": "egg white powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cannabutter",
+				"pluralName": "cannabutter"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "root beer extract",
+				"pluralName": "root beer extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vitamin c",
+				"pluralName": "vitamin cs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "acai powder",
+				"pluralName": "acai powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hemp protein",
+				"pluralName": "hemp proteins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ube flavoring",
+				"pluralName": "ube flavorings"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "glucomannan",
+				"pluralName": "glucomannans"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "hazelnut extract",
+				"pluralName": "hazelnut extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "freeze-dried strawberry powder",
+				"pluralName": "freeze-dried strawberry powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tamarind extract",
+				"pluralName": "tamarind extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cherry extract",
+				"pluralName": "cherry extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "butterscotch flavor",
+				"pluralName": "butterscotch flavors"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kewra water",
+				"pluralName": "kewra waters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pineapple extract",
+				"pluralName": "pineapple extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lemon juice concentrate",
+				"pluralName": "lemon juice concentrates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chocolate collagen",
+				"pluralName": "chocolate collagens"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cinnamon extract",
+				"pluralName": "cinnamon extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cannabis milk",
+				"pluralName": "cannabis milks"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "malt extract",
+				"pluralName": "malt extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "kombucha starter",
+				"pluralName": "kombucha starters"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pandan extract",
+				"pluralName": "pandan extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "camu powder",
+				"pluralName": "camu powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "soy lecithin",
+				"pluralName": "soy lecithins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wheatgrass powder",
+				"pluralName": "wheatgrass powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "ashwagandha",
+				"pluralName": "ashwagandhas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "casein",
+				"pluralName": "caseins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cbd oil",
+				"pluralName": "cbd oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chlorella",
+				"pluralName": "chlorellas"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "fish oil",
+				"pluralName": "fish oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "lime essential oil",
+				"pluralName": "lime essential oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "probiotic",
+				"pluralName": "probiotics"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "activated charcoal",
+				"pluralName": "activated charcoals"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "egg powder",
+				"pluralName": "egg powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "reishi mushroom",
+				"pluralName": "reishi mushrooms"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vitamin e",
+				"pluralName": "vitamin es"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "wine yeast",
+				"pluralName": "wine yeasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "barley gras",
+				"pluralName": "barley grass"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "greens powder",
+				"pluralName": "greens powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rice protein powder",
+				"pluralName": "rice protein powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "tea-tree oil",
+				"pluralName": "tea-tree oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "vitamin d",
+				"pluralName": "vitamin ds"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "calcium lactate",
+				"pluralName": "calcium lactates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "mango extract",
+				"pluralName": "mango extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "raspberry powder",
+				"pluralName": "raspberry powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "blueberry extract",
+				"pluralName": "blueberry extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "corn extract",
+				"pluralName": "corn extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "magnesium",
+				"pluralName": "magnesiums"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "creatine",
+				"pluralName": "creatines"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "daily vitamin",
+				"pluralName": "daily vitamins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "moringa powder",
+				"pluralName": "moringa powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "pure lime extract",
+				"pluralName": "pure lime extracts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sodium alginate",
+				"pluralName": "sodium alginates"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "sunflower lecithin",
+				"pluralName": "sunflower lecithins"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "thc",
+				"pluralName": "thcs"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "berry powder",
+				"pluralName": "berry powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "champagne yeast",
+				"pluralName": "champagne yeasts"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maqui",
+				"pluralName": "maquis"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "rose oil",
+				"pluralName": "rose oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "banana powder",
+				"pluralName": "banana powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "chaga mushroom powder",
+				"pluralName": "chaga mushroom powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "clove oil",
+				"pluralName": "clove oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "cranberry powder",
+				"pluralName": "cranberry powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "eucalyptus oil",
+				"pluralName": "eucalyptus oils"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "goji berry powder",
+				"pluralName": "goji berry powders"
+			},
+			{
+				"aliases": [],
+				"description": "",
+				"name": "maltodextrin",
+				"pluralName": "maltodextrins"
+			}
+		]
 	}
 }

--- a/mealie/repos/seed/resources/foods/locales/en-US.json
+++ b/mealie/repos/seed/resources/foods/locales/en-US.json
@@ -1,16331 +1,16307 @@
 {
-	"Vegetables & Greens": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic",
-				"pluralName": "garlics"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion",
-				"pluralName": "onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bell pepper",
-				"pluralName": "bell peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carrot",
-				"pluralName": "carrots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "scallion",
-				"pluralName": "scallions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "zucchini",
-				"pluralName": "zucchinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato",
-				"pluralName": "potatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red onion",
-				"pluralName": "red onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow onion",
-				"pluralName": "yellow onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "celery",
-				"pluralName": "celeries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jalapeno",
-				"pluralName": "jalapenoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "avocado",
-				"pluralName": "avocados"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "zucchini",
-				"pluralName": "zucchinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shallot",
-				"pluralName": "shallots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry tomato",
-				"pluralName": "cherry tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cucumber",
-				"pluralName": "cucumbers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spinach",
-				"pluralName": "spinaches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet corn",
-				"pluralName": "sweet corns"
-			},
-			{
-				"aliases": [
-					"capsicum"
-				],
-				"description": "",
-				"name": "chile pepper",
-				"pluralName": "chile peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet potato",
-				"pluralName": "sweet potatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "broccoli",
-				"pluralName": "broccolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "heart of palm",
-				"pluralName": "heart of palms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baby green",
-				"pluralName": "baby greens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin",
-				"pluralName": "pumpkins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cauliflower",
-				"pluralName": "cauliflowers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cabbage",
-				"pluralName": "cabbages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "asparagu",
-				"pluralName": "asparagus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kale",
-				"pluralName": "kales"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arugula",
-				"pluralName": "arugulas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "leek",
-				"pluralName": "leeks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eggplant",
-				"pluralName": "eggplants"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lettuce",
-				"pluralName": "lettuces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butternut squash",
-				"pluralName": "butternut squashes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "romaine",
-				"pluralName": "romaines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beetroot",
-				"pluralName": "beetroots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brussels sprout",
-				"pluralName": "brussels sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fennel",
-				"pluralName": "fennels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun dried tomato",
-				"pluralName": "sun dried tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "radish",
-				"pluralName": "radishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red cabbage",
-				"pluralName": "red cabbages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "artichoke",
-				"pluralName": "artichokes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "new potato",
-				"pluralName": "new potatoes"
-			},
-			{
-				"aliases": [
-					"courgette",
-					"gem squash"
-				],
-				"description": "",
-				"name": "summer squash",
-				"pluralName": "summer squashes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed green",
-				"pluralName": "mixed greens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "parsnip",
-				"pluralName": "parsnips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baby carrot",
-				"pluralName": "baby carrots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed vegetable",
-				"pluralName": "mixed vegetables"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "poblano pepper",
-				"pluralName": "poblano peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet pepper",
-				"pluralName": "sweet peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "serrano pepper",
-				"pluralName": "serrano peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cayenne pepper",
-				"pluralName": "cayenne peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green tomato",
-				"pluralName": "green tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "watercress",
-				"pluralName": "watercress"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "iceberg",
-				"pluralName": "icebergs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mashed potato",
-				"pluralName": "mashed potatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "horseradish",
-				"pluralName": "horseradishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chard",
-				"pluralName": "chards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pimiento",
-				"pluralName": "pimientoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spaghetti squash",
-				"pluralName": "spaghetti squashes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter lettuce",
-				"pluralName": "butter lettuces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hash brown",
-				"pluralName": "hash browns"
-			},
-			{
-				"aliases": [
-					"chinese  leaves"
-				],
-				"description": "",
-				"name": "napa cabbage",
-				"pluralName": "napa cabbages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "celeriac",
-				"pluralName": "celeriacs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "water chestnut",
-				"pluralName": "water chestnuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turnip",
-				"pluralName": "turnips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai chile pepper",
-				"pluralName": "thai chile peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bok choy",
-				"pluralName": "bok choy"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "okra",
-				"pluralName": "okra"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "acorn squash",
-				"pluralName": "acorn squashes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn cob",
-				"pluralName": "corn cobs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "radicchio",
-				"pluralName": "radicchio"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pearl onion",
-				"pluralName": "pearl onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tenderstem broccoli",
-				"pluralName": "tenderstem broccolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plantain",
-				"pluralName": "plantains"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "leaf lettuce",
-				"pluralName": "leaf lettuces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pepperoncini",
-				"pluralName": "pepperoncinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baby bok choy",
-				"pluralName": "baby bok choys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jicama",
-				"pluralName": "jicamas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "endive",
-				"pluralName": "endives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "habanero pepper",
-				"pluralName": "habanero peppers"
-			},
-			{
-				"aliases": [
-					"maize"
-				],
-				"description": "",
-				"name": "corn husk",
-				"pluralName": "corn husks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "collard green",
-				"pluralName": "collard greens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "french-fried onion",
-				"pluralName": "french-fried onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "daikon",
-				"pluralName": "daikons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baby corn",
-				"pluralName": "baby corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "broccoli rabe",
-				"pluralName": "broccoli rabes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rutabaga",
-				"pluralName": "rutabagas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "belgian endive",
-				"pluralName": "belgian endives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yam",
-				"pluralName": "yams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ancho chile pepper",
-				"pluralName": "ancho chile peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "microgreen",
-				"pluralName": "microgreens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boston lettuce",
-				"pluralName": "boston lettuces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kohlrabi",
-				"pluralName": "kohlrabis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresno chile",
-				"pluralName": "fresno chiles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "delicata squash",
-				"pluralName": "delicata squashes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frisee",
-				"pluralName": "frisees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anaheim pepper",
-				"pluralName": "anaheim peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cres",
-				"pluralName": "cress"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "broccoli slaw",
-				"pluralName": "broccoli slaws"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arbol chile pepper",
-				"pluralName": "arbol chile peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden beet",
-				"pluralName": "golden beets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pea shoot",
-				"pluralName": "pea shoots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "alfalfa",
-				"pluralName": "alfalfas"
-			}
-		]
-	},
-	"Fruits": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "Yes they are a fruit",
-				"name": "tomato",
-				"pluralName": "tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon",
-				"pluralName": "lemons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime",
-				"pluralName": "limes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple",
-				"pluralName": "apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana",
-				"pluralName": "bananas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange",
-				"pluralName": "oranges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raisin",
-				"pluralName": "raisins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pineapple",
-				"pluralName": "pineapples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango",
-				"pluralName": "mangoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach",
-				"pluralName": "peaches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "date",
-				"pluralName": "dates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut",
-				"pluralName": "coconuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "craisin",
-				"pluralName": "craisins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pear",
-				"pluralName": "pears"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grape",
-				"pluralName": "grapes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomegranate",
-				"pluralName": "pomegranates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "watermelon",
-				"pluralName": "watermelons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rhubarb",
-				"pluralName": "rhubarbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried apricot",
-				"pluralName": "dried apricots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kiwi",
-				"pluralName": "kiwis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grapefruit",
-				"pluralName": "grapefruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plum",
-				"pluralName": "plums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fig",
-				"pluralName": "figs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apricot",
-				"pluralName": "apricots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "currant",
-				"pluralName": "currants"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mandarin",
-				"pluralName": "mandarins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prune",
-				"pluralName": "prunes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cantaloupe",
-				"pluralName": "cantaloupes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sultana",
-				"pluralName": "sultanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "passion fruit",
-				"pluralName": "passion fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "papaya",
-				"pluralName": "papayas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind",
-				"pluralName": "tamarinds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nectarine",
-				"pluralName": "nectarines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried fig",
-				"pluralName": "dried figs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chestnut",
-				"pluralName": "chestnuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "meyer lemon",
-				"pluralName": "meyer lemons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honeydew melon",
-				"pluralName": "honeydew melons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried fruit",
-				"pluralName": "dried fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clementine",
-				"pluralName": "clementines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "persimmon",
-				"pluralName": "persimmons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "melon",
-				"pluralName": "melons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tangerine",
-				"pluralName": "tangerines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried mango",
-				"pluralName": "dried mangoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried apple",
-				"pluralName": "dried apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quince",
-				"pluralName": "quinces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guava",
-				"pluralName": "guavas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana chip",
-				"pluralName": "banana chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kumquat",
-				"pluralName": "kumquats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jackfruit",
-				"pluralName": "jackfruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dragon fruit",
-				"pluralName": "dragon fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed fruit",
-				"pluralName": "mixed fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "asian pear",
-				"pluralName": "asian pears"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lychee",
-				"pluralName": "lychees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "young coconut",
-				"pluralName": "young coconuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kaffir lime",
-				"pluralName": "kaffir limes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "star fruit",
-				"pluralName": "star fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green papaya",
-				"pluralName": "green papayas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomelo",
-				"pluralName": "pomeloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chestnut puree",
-				"pluralName": "chestnut purees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prickly pear",
-				"pluralName": "prickly pears"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "calamansi",
-				"pluralName": "calamansis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yuzu",
-				"pluralName": "yuzus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "granadilla",
-				"pluralName": "granadillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple chip",
-				"pluralName": "apple chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed peel",
-				"pluralName": "mixed peels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kokum",
-				"pluralName": "kokums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tangelo",
-				"pluralName": "tangeloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried lime",
-				"pluralName": "dried limes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jujube",
-				"pluralName": "jujubes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet lime",
-				"pluralName": "sweet limes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "custard-apple",
-				"pluralName": "custard-apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried lemon",
-				"pluralName": "dried lemons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "young jackfruit",
-				"pluralName": "young jackfruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "durian",
-				"pluralName": "durians"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried apple",
-				"pluralName": "freeze-dried apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried tamarind",
-				"pluralName": "dried tamarinds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey date",
-				"pluralName": "honey dates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "physali",
-				"pluralName": "physalis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarillo",
-				"pluralName": "tamarilloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ice-apple",
-				"pluralName": "ice-apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "longan",
-				"pluralName": "longans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "finger lime",
-				"pluralName": "finger limes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bitter orange",
-				"pluralName": "bitter oranges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "feijoa",
-				"pluralName": "feijoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried persimmon",
-				"pluralName": "dried persimmons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rambutan",
-				"pluralName": "rambutans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rose apple",
-				"pluralName": "rose apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried orange slice",
-				"pluralName": "dried orange slices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "loquat",
-				"pluralName": "loquats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crabapple",
-				"pluralName": "crabapples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fig leaf",
-				"pluralName": "fig leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried pineapple",
-				"pluralName": "freeze-dried pineapples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pluot",
-				"pluralName": "pluots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soursop",
-				"pluralName": "soursops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hog plum",
-				"pluralName": "hog plums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bergamot orange",
-				"pluralName": "bergamot oranges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "luo han guo",
-				"pluralName": "luo han guos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mamey",
-				"pluralName": "mameys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sapote",
-				"pluralName": "sapotes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green ume plum",
-				"pluralName": "green ume plums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kiwano",
-				"pluralName": "kiwanoes"
-			}
-		]
-	},
-	"Mushrooms": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "button mushroom",
-				"pluralName": "button mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shiitake mushroom",
-				"pluralName": "shiitake mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "portobello mushroom",
-				"pluralName": "portobello mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wild mushroom",
-				"pluralName": "wild mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "porcini",
-				"pluralName": "porcinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed mushroom",
-				"pluralName": "mixed mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oyster mushroom",
-				"pluralName": "oyster mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chestnut mushroom",
-				"pluralName": "chestnut mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "enoki mushroom",
-				"pluralName": "enoki mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black fungu",
-				"pluralName": "black fungus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black truffle",
-				"pluralName": "black truffles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "morel mushroom",
-				"pluralName": "morel mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "field mushroom",
-				"pluralName": "field mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "king oyster mushroom",
-				"pluralName": "king oyster mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shimeji mushroom",
-				"pluralName": "shimeji mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "straw mushroom",
-				"pluralName": "straw mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried chinese mushroom",
-				"pluralName": "dried chinese mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maitake",
-				"pluralName": "maitakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "trumpet mushroom",
-				"pluralName": "trumpet mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white truffle",
-				"pluralName": "white truffles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white fungu",
-				"pluralName": "white fungus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pioppini",
-				"pluralName": "pioppinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "snow fungu",
-				"pluralName": "snow fungus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white beech mushroom",
-				"pluralName": "white beech mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boletu",
-				"pluralName": "boletus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "huitlacoche",
-				"pluralName": "huitlacoches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matsutake",
-				"pluralName": "matsutakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nameko",
-				"pluralName": "namekoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "djon djon mushroom",
-				"pluralName": "djon djon mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed asian mushroom",
-				"pluralName": "mixed asian mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffball",
-				"pluralName": "puffballs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey fungu",
-				"pluralName": "honey fungus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caesar's mushroom",
-				"pluralName": "caesar's mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy cap mushroom",
-				"pluralName": "candy cap mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lion\u2019s mane mushroom",
-				"pluralName": "lion\u2019s mane mushrooms"
-			}
-		]
-	},
-	"Berries": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry",
-				"pluralName": "strawberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blueberry",
-				"pluralName": "blueberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry",
-				"pluralName": "raspberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry",
-				"pluralName": "cranberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry",
-				"pluralName": "cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackberry",
-				"pluralName": "blackberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "berry mix",
-				"pluralName": "berry mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maraschino cherry",
-				"pluralName": "maraschino cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried cherry",
-				"pluralName": "dried cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "juniper berry",
-				"pluralName": "juniper berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sour cherry",
-				"pluralName": "sour cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goji berry",
-				"pluralName": "goji berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried blueberry",
-				"pluralName": "dried blueberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried strawberry",
-				"pluralName": "freeze-dried strawberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gooseberry",
-				"pluralName": "gooseberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried raspberry",
-				"pluralName": "freeze-dried raspberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lingonberry",
-				"pluralName": "lingonberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned sour cherry",
-				"pluralName": "canned sour cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mulberry",
-				"pluralName": "mulberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "acai berry",
-				"pluralName": "acai berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned cherry",
-				"pluralName": "canned cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amla",
-				"pluralName": "amlas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderberry",
-				"pluralName": "elderberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried blueberry",
-				"pluralName": "freeze-dried blueberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "huckleberry",
-				"pluralName": "huckleberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried elderberry",
-				"pluralName": "dried elderberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barberry",
-				"pluralName": "barberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried berry",
-				"pluralName": "dried berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea buckthorn",
-				"pluralName": "sea buckthorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "saskatoon berry",
-				"pluralName": "saskatoon berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rosehip",
-				"pluralName": "rosehips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hawthorn",
-				"pluralName": "hawthorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boysenberry",
-				"pluralName": "boysenberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cloudberry",
-				"pluralName": "cloudberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried berry",
-				"pluralName": "freeze-dried berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aronia berry",
-				"pluralName": "aronia berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chokeberry",
-				"pluralName": "chokeberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "loganberry",
-				"pluralName": "loganberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackcurrant leaf",
-				"pluralName": "blackcurrant leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "haskap berry",
-				"pluralName": "haskap berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dewberry",
-				"pluralName": "dewberries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sloe berry",
-				"pluralName": "sloe berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oregon grape",
-				"pluralName": "oregon grapes"
-			}
-		]
-	},
-	"Nuts & Seeds": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "walnut",
-				"pluralName": "walnuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pecan",
-				"pluralName": "pecans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond",
-				"pluralName": "almonds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sesame seed",
-				"pluralName": "sesame seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cashew",
-				"pluralName": "cashews"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pine nut",
-				"pluralName": "pine nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pistachio",
-				"pluralName": "pistachios"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut",
-				"pluralName": "peanuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chia",
-				"pluralName": "chias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flax",
-				"pluralName": "flaxes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "slivered almond",
-				"pluralName": "slivered almonds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin seed",
-				"pluralName": "pumpkin seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut",
-				"pluralName": "hazelnuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "poppy seed",
-				"pluralName": "poppy seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sunflower seed",
-				"pluralName": "sunflower seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macadamia",
-				"pluralName": "macadamias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted peanut",
-				"pluralName": "roasted peanuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chopped nut",
-				"pluralName": "chopped nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hemp heart",
-				"pluralName": "hemp hearts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nigella seed",
-				"pluralName": "nigella seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed nut",
-				"pluralName": "mixed nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brazil nut",
-				"pluralName": "brazil nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed seed",
-				"pluralName": "mixed seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion seed",
-				"pluralName": "onion seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "watermelon seed",
-				"pluralName": "watermelon seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey-roasted peanut",
-				"pluralName": "honey-roasted peanuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "melon seed",
-				"pluralName": "melon seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lotus seed",
-				"pluralName": "lotus seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white chia",
-				"pluralName": "white chias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "trail mix",
-				"pluralName": "trail mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "basil seed",
-				"pluralName": "basil seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candlenut",
-				"pluralName": "candlenuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut brittle",
-				"pluralName": "peanut brittles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jackfruit seed",
-				"pluralName": "jackfruit seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey-roasted almond",
-				"pluralName": "honey-roasted almonds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "toasted nut",
-				"pluralName": "toasted nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chironji",
-				"pluralName": "chironjis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey-roasted pecan",
-				"pluralName": "honey-roasted pecans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tigernut",
-				"pluralName": "tigernuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sunflower sprout",
-				"pluralName": "sunflower sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apricot kernel",
-				"pluralName": "apricot kernels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "palm seed",
-				"pluralName": "palm seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginkgo nut",
-				"pluralName": "ginkgo nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "keto trail mix",
-				"pluralName": "keto trail mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wattleseed",
-				"pluralName": "wattleseeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bar\u00f9ka",
-				"pluralName": "bar\u00f9kas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "indian almond",
-				"pluralName": "indian almonds"
-			}
-		]
-	},
-	"Cheeses": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "parmesan",
-				"pluralName": "parmesans"
-			},
-			{
-				"aliases": [
-					"cheddars"
-				],
-				"description": "",
-				"name": "cheddar cheese",
-				"pluralName": "cheddar cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream cheese",
-				"pluralName": "cream cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sharp cheddar",
-				"pluralName": "sharp cheddars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese",
-				"pluralName": "cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mozzarella",
-				"pluralName": "mozzarellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "feta",
-				"pluralName": "fetas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ricotta",
-				"pluralName": "ricottas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheddar-jack cheese",
-				"pluralName": "cheddar-jack cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "monterey jack",
-				"pluralName": "monterey jacks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blue cheese",
-				"pluralName": "blue cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goat cheese",
-				"pluralName": "goat cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh mozzarella",
-				"pluralName": "fresh mozzarellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "swiss cheese",
-				"pluralName": "swiss cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pecorino",
-				"pluralName": "pecorinoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gruyere",
-				"pluralName": "gruyeres"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mascarpone",
-				"pluralName": "mascarpones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cottage cheese",
-				"pluralName": "cottage cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "american cheese",
-				"pluralName": "american cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "provolone",
-				"pluralName": "provolones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican cheese blend",
-				"pluralName": "mexican cheese blends"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pepper jack",
-				"pluralName": "pepper jacks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brie",
-				"pluralName": "bries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "paneer",
-				"pluralName": "paneers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fontina",
-				"pluralName": "fontinas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "queso fresco",
-				"pluralName": "queso frescoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quark",
-				"pluralName": "quarks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gouda",
-				"pluralName": "goudas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cotija",
-				"pluralName": "cotijas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "asiago",
-				"pluralName": "asiagoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked cheese",
-				"pluralName": "smoked cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "halloumi",
-				"pluralName": "halloumis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chevre",
-				"pluralName": "chevres"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "manchego",
-				"pluralName": "manchegoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "italian cheese blend",
-				"pluralName": "italian cheese blends"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "neufchatel",
-				"pluralName": "neufchatels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herb cream cheese",
-				"pluralName": "herb cream cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "burrata",
-				"pluralName": "burratas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "havarti",
-				"pluralName": "havartis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "colby",
-				"pluralName": "colbies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grana-padano",
-				"pluralName": "grana-padanoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "muenster",
-				"pluralName": "muensters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "string cheese",
-				"pluralName": "string cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "camembert",
-				"pluralName": "camemberts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soft cheese",
-				"pluralName": "soft cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stilton",
-				"pluralName": "stiltons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raclette",
-				"pluralName": "raclettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "colby-jack cheese",
-				"pluralName": "colby-jack cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "colby-jack cheese",
-				"pluralName": "colby-jack cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jarlsberg cheese",
-				"pluralName": "jarlsberg cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taleggio",
-				"pluralName": "taleggios"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oaxaca",
-				"pluralName": "oaxacas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "labneh",
-				"pluralName": "labnehs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "edam",
-				"pluralName": "edams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creamy cheese wedge",
-				"pluralName": "creamy cheese wedges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese powder",
-				"pluralName": "cheese powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fromage blanc",
-				"pluralName": "fromage blancs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "asadero",
-				"pluralName": "asaderoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marble cheese",
-				"pluralName": "marble cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "leicester",
-				"pluralName": "leicesters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kefalotyri",
-				"pluralName": "kefalotyris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mizithra",
-				"pluralName": "mizithras"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lancashire",
-				"pluralName": "lancashires"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kasseri",
-				"pluralName": "kasseris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "babybel",
-				"pluralName": "babybels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "panela cheese",
-				"pluralName": "panela cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "longhorn",
-				"pluralName": "longhorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seasoned feta cheese",
-				"pluralName": "seasoned feta cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "comt\u00e9",
-				"pluralName": "comt\u00e9s"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "graviera",
-				"pluralName": "gravieras"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wensleydale",
-				"pluralName": "wensleydales"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "scamorza",
-				"pluralName": "scamorzas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cambozola",
-				"pluralName": "cambozolas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheshire cheese",
-				"pluralName": "cheshire cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anthotyro",
-				"pluralName": "anthotyros"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chenna",
-				"pluralName": "chennas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hard goat cheese",
-				"pluralName": "hard goat cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kashkaval",
-				"pluralName": "kashkavals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sheep cheese",
-				"pluralName": "sheep cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amul cheese",
-				"pluralName": "amul cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "reblochon",
-				"pluralName": "reblochons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "robiola",
-				"pluralName": "robiolas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brick cheese",
-				"pluralName": "brick cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quick-melt cheese",
-				"pluralName": "quick-melt cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "farmer's cheese",
-				"pluralName": "farmer's cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "manouri",
-				"pluralName": "manouris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mimolette",
-				"pluralName": "mimolettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "queso quesadilla",
-				"pluralName": "queso quesadillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caciocavallo",
-				"pluralName": "caciocavalloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "requeij\u00e3o",
-				"pluralName": "requeij\u00e3oes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vacherin",
-				"pluralName": "vacherins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown cheese",
-				"pluralName": "brown cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gloucester",
-				"pluralName": "gloucesters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "port salut",
-				"pluralName": "port saluts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "derby cheese",
-				"pluralName": "derby cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fontal",
-				"pluralName": "fontals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salad cheese",
-				"pluralName": "salad cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "truffle cheese",
-				"pluralName": "truffle cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "epoisses cheese",
-				"pluralName": "epoisses cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maasdam",
-				"pluralName": "maasdams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "petit-suisse",
-				"pluralName": "petit-suisses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sbrinz",
-				"pluralName": "sbrinzzes"
-			}
-		]
-	},
-	"Dairy & Eggs": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter",
-				"pluralName": "butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg",
-				"pluralName": "eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "milk",
-				"pluralName": "milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "heavy cream",
-				"pluralName": "heavy creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sour cream",
-				"pluralName": "sour creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buttermilk",
-				"pluralName": "buttermilks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yogurt",
-				"pluralName": "yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "greek yogurt",
-				"pluralName": "greek yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream",
-				"pluralName": "creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whipped cream",
-				"pluralName": "whipped creams"
-			},
-			{
-				"aliases": [
-					"clarified butter"
-				],
-				"description": "",
-				"name": "ghee",
-				"pluralName": "ghees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shortening",
-				"pluralName": "shortenings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "condensed milk",
-				"pluralName": "condensed milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "half and half",
-				"pluralName": "half and halves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweetened condensed milk",
-				"pluralName": "sweetened condensed milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ice cream",
-				"pluralName": "ice creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "margarine",
-				"pluralName": "margarines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creme fraiche",
-				"pluralName": "creme fraiches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frosting",
-				"pluralName": "frostings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "milk powder",
-				"pluralName": "milk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curd",
-				"pluralName": "curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thickened cream",
-				"pluralName": "thickened creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon curd",
-				"pluralName": "lemon curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dulce de leche",
-				"pluralName": "dulce de leche"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "custard",
-				"pluralName": "custards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate frosting",
-				"pluralName": "chocolate frostings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kefir",
-				"pluralName": "kefirs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sherbet",
-				"pluralName": "sherbets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate milk",
-				"pluralName": "chocolate milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid egg substitute",
-				"pluralName": "liquid egg substitutes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whey",
-				"pluralName": "wheys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hung curd",
-				"pluralName": "hung curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quail egg",
-				"pluralName": "quail eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buttermilk powder",
-				"pluralName": "buttermilk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen yogurt",
-				"pluralName": "frozen yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "khoya",
-				"pluralName": "khoyas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "milk cream",
-				"pluralName": "milk creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee creamer",
-				"pluralName": "coffee creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clotted cream",
-				"pluralName": "clotted creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goat milk",
-				"pluralName": "goat milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese curd",
-				"pluralName": "cheese curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sour milk",
-				"pluralName": "sour milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ganache",
-				"pluralName": "ganaches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cajeta",
-				"pluralName": "cajetas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck egg",
-				"pluralName": "duck eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salted egg",
-				"pluralName": "salted eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "skyr",
-				"pluralName": "skyrs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin spice coffee creamer",
-				"pluralName": "pumpkin spice coffee creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw milk",
-				"pluralName": "raw milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime curd",
-				"pluralName": "lime curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "powdered coffee creamer",
-				"pluralName": "powdered coffee creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chantilly",
-				"pluralName": "chantillies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "milkfat",
-				"pluralName": "milkfats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yogurt starter",
-				"pluralName": "yogurt starters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rainbow sherbet",
-				"pluralName": "rainbow sherbets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry frosting",
-				"pluralName": "strawberry frostings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey greek yogurt",
-				"pluralName": "honey greek yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amul butter",
-				"pluralName": "amul butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey butter",
-				"pluralName": "honey butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry cream cheese",
-				"pluralName": "strawberry cream cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goat butter",
-				"pluralName": "goat butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "century egg",
-				"pluralName": "century eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange curd",
-				"pluralName": "orange curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goat yogurt",
-				"pluralName": "goat yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dahi",
-				"pluralName": "dahis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon sugar butter spread",
-				"pluralName": "cinnamon sugar butter spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bulgarian yogurt",
-				"pluralName": "bulgarian yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tvorog",
-				"pluralName": "tvorogs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate milk powder",
-				"pluralName": "chocolate milk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid rennet",
-				"pluralName": "liquid rennets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sheep\u2019s milk yoghurt",
-				"pluralName": "sheep\u2019s milk yoghurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry milk",
-				"pluralName": "strawberry milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ayran",
-				"pluralName": "ayrans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cuajada",
-				"pluralName": "cuajadas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yogurt drink",
-				"pluralName": "yogurt drinks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "passion-fruit curd",
-				"pluralName": "passion-fruit curds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled egg",
-				"pluralName": "pickled eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sheep milk",
-				"pluralName": "sheep milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "starter culture",
-				"pluralName": "starter cultures"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kashk",
-				"pluralName": "kashks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ostrich egg",
-				"pluralName": "ostrich eggs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla milk",
-				"pluralName": "vanilla milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yoplait whip",
-				"pluralName": "yoplait whips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buffalo milk",
-				"pluralName": "buffalo milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goat kefir",
-				"pluralName": "goat kefirs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lebneh",
-				"pluralName": "lebnehs"
-			}
-		]
-	},
-	"Dairy-Free & Meat Substitutes": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut milk",
-				"pluralName": "coconut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond milk",
-				"pluralName": "almond milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond butter",
-				"pluralName": "almond butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tofu",
-				"pluralName": "tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut cream",
-				"pluralName": "coconut creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan butter",
-				"pluralName": "vegan butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "non-dairy milk",
-				"pluralName": "non-dairy milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy milk",
-				"pluralName": "soy milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "extra firm tofu",
-				"pluralName": "extra firm tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "silken tofu",
-				"pluralName": "silken tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kala namak salt",
-				"pluralName": "kala namak salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut butter",
-				"pluralName": "coconut butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg replacer",
-				"pluralName": "egg replacers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan mayonnaise",
-				"pluralName": "vegan mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan cheese",
-				"pluralName": "vegan cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cashew butter",
-				"pluralName": "cashew butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tempeh",
-				"pluralName": "tempehs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan cream cheese",
-				"pluralName": "vegan cream cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut yogurt",
-				"pluralName": "coconut yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "non-dairy yogurt",
-				"pluralName": "non-dairy yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seed butter",
-				"pluralName": "seed butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cashew milk",
-				"pluralName": "cashew milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oat milk",
-				"pluralName": "oat milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nut butter",
-				"pluralName": "nut butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice milk",
-				"pluralName": "rice milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan sour cream",
-				"pluralName": "vegan sour creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "textured vegetable protein",
-				"pluralName": "textured vegetable proteins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan worcestershire",
-				"pluralName": "vegan worcestershires"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy yogurt",
-				"pluralName": "soy yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan mozzarella",
-				"pluralName": "vegan mozzarellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "non-dairy creamer",
-				"pluralName": "non-dairy creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan sausage",
-				"pluralName": "vegan sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut whipped cream",
-				"pluralName": "coconut whipped creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked tofu",
-				"pluralName": "smoked tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut powder",
-				"pluralName": "coconut powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy cream",
-				"pluralName": "soy creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seitan",
-				"pluralName": "seitans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut milk powder",
-				"pluralName": "coconut milk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "non-dairy whipped topping",
-				"pluralName": "non-dairy whipped toppings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nut milk",
-				"pluralName": "nut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "non-dairy cream",
-				"pluralName": "non-dairy creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan burger patty",
-				"pluralName": "vegan burger patties"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "condensed coconut milk",
-				"pluralName": "condensed coconut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan ground beef",
-				"pluralName": "vegan ground beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pulled oat",
-				"pluralName": "pulled oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan bacon",
-				"pluralName": "vegan bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy curl",
-				"pluralName": "soy curls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan pesto",
-				"pluralName": "vegan pestoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marinated tofu",
-				"pluralName": "marinated tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan feta",
-				"pluralName": "vegan fetas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy chorizo",
-				"pluralName": "soy chorizoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hemp milk",
-				"pluralName": "hemp milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan beef",
-				"pluralName": "vegan beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut butter",
-				"pluralName": "hazelnut butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan ranch",
-				"pluralName": "vegan ranches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan chicken",
-				"pluralName": "vegan chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut paste",
-				"pluralName": "coconut pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable suet",
-				"pluralName": "vegetable suets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dairy-free ice-cream",
-				"pluralName": "dairy-free ice-creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond-coconut milk",
-				"pluralName": "almond-coconut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana blossom",
-				"pluralName": "banana blossoms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan fish sauce",
-				"pluralName": "vegan fish sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetarian hot dog",
-				"pluralName": "vegetarian hot dogs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut milk",
-				"pluralName": "hazelnut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maple almond butter",
-				"pluralName": "maple almond butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan meatball",
-				"pluralName": "vegan meatballs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond-milk yogurt",
-				"pluralName": "almond-milk yogurts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond creamer",
-				"pluralName": "almond creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy milk powder",
-				"pluralName": "soy milk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan cream cheese frosting",
-				"pluralName": "vegan cream cheese frostings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut manna",
-				"pluralName": "coconut mannas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "falafel mix",
-				"pluralName": "falafel mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ready-made falafel",
-				"pluralName": "ready-made falafels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan gravy",
-				"pluralName": "vegan gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cashew cheese sauce",
-				"pluralName": "cashew cheese sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut fat",
-				"pluralName": "coconut fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flax milk",
-				"pluralName": "flax milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut creamer",
-				"pluralName": "hazelnut creamers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quorn",
-				"pluralName": "quorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy-free butter",
-				"pluralName": "soy-free butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tofurky",
-				"pluralName": "tofurkies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan nutella",
-				"pluralName": "vegan nutellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan tzatziki",
-				"pluralName": "vegan tzatzikis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cashew cream cheese",
-				"pluralName": "cashew cream cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cricket flour",
-				"pluralName": "cricket flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macadamia butter",
-				"pluralName": "macadamia butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "okara",
-				"pluralName": "okaras"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg tofu",
-				"pluralName": "egg tofus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "protein drink",
-				"pluralName": "protein drinks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macadamia milk",
-				"pluralName": "macadamia milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan taco meat",
-				"pluralName": "vegan taco meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "walnut taco meat",
-				"pluralName": "walnut taco meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan yogurt starter",
-				"pluralName": "vegan yogurt starters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana milk",
-				"pluralName": "banana milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy quark",
-				"pluralName": "soy quarks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan chicken nugget",
-				"pluralName": "vegan chicken nuggets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan starter culture",
-				"pluralName": "vegan starter cultures"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "walnut milk",
-				"pluralName": "walnut milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "latik",
-				"pluralName": "latiks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice cream",
-				"pluralName": "rice creams"
-			}
-		]
-	},
-	"Meats": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bacon",
-				"pluralName": "bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chopped bacon",
-				"pluralName": "chopped bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground beef",
-				"pluralName": "ground beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef steak",
-				"pluralName": "beef steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ham",
-				"pluralName": "hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork chop",
-				"pluralName": "pork chops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet italian sausage",
-				"pluralName": "sweet italian sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork loin",
-				"pluralName": "pork loins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prosciutto",
-				"pluralName": "prosciuttoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sausage",
-				"pluralName": "sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef roast",
-				"pluralName": "beef roasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground pork",
-				"pluralName": "ground porks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef stew meat",
-				"pluralName": "beef stew meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pepperoni",
-				"pluralName": "pepperonis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chorizo",
-				"pluralName": "chorizoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pancetta",
-				"pluralName": "pancettas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork fillet",
-				"pluralName": "pork fillets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork shoulder",
-				"pluralName": "pork shoulders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground lamb",
-				"pluralName": "ground lambs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork rib",
-				"pluralName": "pork ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked sausage",
-				"pluralName": "smoked sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "breakfast sausage",
-				"pluralName": "breakfast sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot dog",
-				"pluralName": "hot dogs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef sirloin",
-				"pluralName": "beef sirloins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salami",
-				"pluralName": "salamis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brisket",
-				"pluralName": "briskets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "deli ham",
-				"pluralName": "deli hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "leg of lamb",
-				"pluralName": "leg of lamb"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef short rib",
-				"pluralName": "beef short ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kielbasa",
-				"pluralName": "kielbasas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork belly",
-				"pluralName": "pork bellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "andouille",
-				"pluralName": "andouilles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boneless lamb",
-				"pluralName": "boneless lambs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground sausage",
-				"pluralName": "ground sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground pork sausage",
-				"pluralName": "ground pork sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roast beef",
-				"pluralName": "roast beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bacon bit",
-				"pluralName": "bacon bits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork roast",
-				"pluralName": "pork roasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot italian sausage",
-				"pluralName": "hot italian sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork spare rib",
-				"pluralName": "pork spare ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb shoulder",
-				"pluralName": "lamb shoulders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef rib",
-				"pluralName": "beef ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal steak",
-				"pluralName": "veal steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb chop",
-				"pluralName": "lamb chops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bone-in ham",
-				"pluralName": "bone-in hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork butt",
-				"pluralName": "pork butts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canadian bacon",
-				"pluralName": "canadian bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef sausage",
-				"pluralName": "beef sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb shank",
-				"pluralName": "lamb shanks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mutton",
-				"pluralName": "muttons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ham steak",
-				"pluralName": "ham steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "venison",
-				"pluralName": "venisons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bratwurst",
-				"pluralName": "bratwursts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pulled pork",
-				"pluralName": "pulled porks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ham hock",
-				"pluralName": "ham hocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen meatball",
-				"pluralName": "frozen meatballs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed ground meat",
-				"pluralName": "mixed ground meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rabbit",
-				"pluralName": "rabbits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork cutlet",
-				"pluralName": "pork cutlets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal cutlet",
-				"pluralName": "veal cutlets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soup bone",
-				"pluralName": "soup bones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb loin",
-				"pluralName": "lamb loins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork steak",
-				"pluralName": "pork steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican chorizo",
-				"pluralName": "mexican chorizoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rack of lamb",
-				"pluralName": "rack of lamb"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork back rib",
-				"pluralName": "pork back ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "country style rib",
-				"pluralName": "country style ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black forest ham",
-				"pluralName": "black forest hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oxtail",
-				"pluralName": "oxtails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked ham hock",
-				"pluralName": "smoked ham hocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "serrano ham",
-				"pluralName": "serrano hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw chorizo",
-				"pluralName": "raw chorizoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef liver",
-				"pluralName": "beef livers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pastrami",
-				"pluralName": "pastramis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cocktail sausage",
-				"pluralName": "cocktail sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hard salami",
-				"pluralName": "hard salamis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "back bacon",
-				"pluralName": "back bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salt pork",
-				"pluralName": "salt porks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal shank",
-				"pluralName": "veal shanks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground venison",
-				"pluralName": "ground venisons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef shank",
-				"pluralName": "beef shanks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lap cheong",
-				"pluralName": "lap cheongs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blood sausage",
-				"pluralName": "blood sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried beef",
-				"pluralName": "dried beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gammon joint",
-				"pluralName": "gammon joints"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boneless beef short rib",
-				"pluralName": "boneless beef short ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "country ham",
-				"pluralName": "country hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boneless ham",
-				"pluralName": "boneless hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mortadella",
-				"pluralName": "mortadellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground bison",
-				"pluralName": "ground bisons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh sausage",
-				"pluralName": "fresh sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bologna",
-				"pluralName": "bolognas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "burger patty",
-				"pluralName": "burger patties"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked pork chop",
-				"pluralName": "smoked pork chops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb neck",
-				"pluralName": "lamb necks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sausage patty",
-				"pluralName": "sausage patties"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef suet",
-				"pluralName": "beef suets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal roast",
-				"pluralName": "veal roasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef shoulder",
-				"pluralName": "beef shoulders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "steak tip",
-				"pluralName": "steak tips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal chop",
-				"pluralName": "veal chops"
-			}
-		]
-	},
-	"Poultry": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken breast",
-				"pluralName": "chicken breasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken thigh",
-				"pluralName": "chicken thighs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cooked chicken",
-				"pluralName": "cooked chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground turkey",
-				"pluralName": "ground turkeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whole chicken",
-				"pluralName": "whole chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whole turkey",
-				"pluralName": "whole turkeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken leg",
-				"pluralName": "chicken legs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken wing",
-				"pluralName": "chicken wings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey breast",
-				"pluralName": "turkey breasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground chicken",
-				"pluralName": "ground chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rotisserie chicken",
-				"pluralName": "rotisserie chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken tender",
-				"pluralName": "chicken tenders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey sausage",
-				"pluralName": "turkey sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken sausage",
-				"pluralName": "chicken sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey bacon",
-				"pluralName": "turkey bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck",
-				"pluralName": "ducks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck breast",
-				"pluralName": "duck breasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boneless chicken",
-				"pluralName": "boneless chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken liver",
-				"pluralName": "chicken livers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornish hen",
-				"pluralName": "cornish hens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "deli turkey",
-				"pluralName": "deli turkeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked turkey",
-				"pluralName": "smoked turkeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey meat",
-				"pluralName": "turkey meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken quarter",
-				"pluralName": "chicken quarters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ground turkey sausage",
-				"pluralName": "ground turkey sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quail",
-				"pluralName": "quails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked turkey sausage",
-				"pluralName": "smoked turkey sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked chicken",
-				"pluralName": "smoked chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey leg",
-				"pluralName": "turkey legs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pheasant",
-				"pluralName": "pheasants"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goose",
-				"pluralName": "geese"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey pepperoni",
-				"pluralName": "turkey pepperonis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey ham",
-				"pluralName": "turkey hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey thigh",
-				"pluralName": "turkey thighs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken bone",
-				"pluralName": "chicken bones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey meatball",
-				"pluralName": "turkey meatballs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "foie gra",
-				"pluralName": "foie gras"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken giblet",
-				"pluralName": "chicken giblets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey wing",
-				"pluralName": "turkey wings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey giblet",
-				"pluralName": "turkey giblets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey neck",
-				"pluralName": "turkey necks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken nugget",
-				"pluralName": "chicken nuggets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey burger",
-				"pluralName": "turkey burgers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken andouille",
-				"pluralName": "chicken andouilles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken gizzard",
-				"pluralName": "chicken gizzards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked turkey leg",
-				"pluralName": "smoked turkey legs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken italian sausage",
-				"pluralName": "chicken italian sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crispy chicken strip",
-				"pluralName": "crispy chicken strips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ostrich",
-				"pluralName": "ostriches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "popcorn chicken",
-				"pluralName": "popcorn chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey kielbasa",
-				"pluralName": "turkey kielbasas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken-apple sausage",
-				"pluralName": "chicken-apple sausages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken foot",
-				"pluralName": "chicken feet"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pulled chicken",
-				"pluralName": "pulled chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "deli chicken",
-				"pluralName": "deli chickens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked duck breast",
-				"pluralName": "smoked duck breasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pigeon",
-				"pluralName": "pigeons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wild game bird",
-				"pluralName": "wild game birds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey liver",
-				"pluralName": "turkey livers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken neck",
-				"pluralName": "chicken necks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck confit",
-				"pluralName": "duck confits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roast duck",
-				"pluralName": "roast ducks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken meatball",
-				"pluralName": "chicken meatballs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck liver",
-				"pluralName": "duck livers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guinea fowl",
-				"pluralName": "guinea fowls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked turkey wing",
-				"pluralName": "smoked turkey wings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken curry-cut",
-				"pluralName": "chicken curry-cuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken schnitzel",
-				"pluralName": "chicken schnitzels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grouse",
-				"pluralName": "grouses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken roast",
-				"pluralName": "chicken roasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goose liver",
-				"pluralName": "goose livers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey bone",
-				"pluralName": "turkey bones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey lunch meat",
-				"pluralName": "turkey lunch meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey roast",
-				"pluralName": "turkey roasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "capon",
-				"pluralName": "capons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked turkey bacon",
-				"pluralName": "smoked turkey bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken bacon",
-				"pluralName": "chicken bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey rissole",
-				"pluralName": "turkey rissoles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken kebab",
-				"pluralName": "chicken kebabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken ham",
-				"pluralName": "chicken hams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck neck",
-				"pluralName": "duck necks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken chorizo",
-				"pluralName": "chicken chorizoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken frame",
-				"pluralName": "chicken frames"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck bacon",
-				"pluralName": "duck bacons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pulled turkey",
-				"pluralName": "pulled turkeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken gyro",
-				"pluralName": "chicken gyros"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken patty",
-				"pluralName": "chicken patties"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken rib",
-				"pluralName": "chicken ribs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey tail",
-				"pluralName": "turkey tails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken milanesa",
-				"pluralName": "chicken milanesas"
-			}
-		]
-	},
-	"Fish": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salmon",
-				"pluralName": "salmon"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked salmon",
-				"pluralName": "smoked salmon"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cod",
-				"pluralName": "cod"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tilapia",
-				"pluralName": "tilapias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tuna steak",
-				"pluralName": "tuna steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whitefish",
-				"pluralName": "whitefish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "halibut",
-				"pluralName": "halibuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red snapper",
-				"pluralName": "red snappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea bas",
-				"pluralName": "sea bass"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish fillet",
-				"pluralName": "fish fillets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "trout",
-				"pluralName": "trout"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "catfish",
-				"pluralName": "catfishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "surimi",
-				"pluralName": "surimis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "swordfish",
-				"pluralName": "swordfish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sardine",
-				"pluralName": "sardines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sole",
-				"pluralName": "soles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mahi mahi",
-				"pluralName": "mahi mahis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mackerel",
-				"pluralName": "mackerel"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked trout",
-				"pluralName": "smoked trout"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caviar",
-				"pluralName": "caviars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "haddock",
-				"pluralName": "haddocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "monkfish",
-				"pluralName": "monkfish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked haddock",
-				"pluralName": "smoked haddocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flounder",
-				"pluralName": "flounder"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "perch",
-				"pluralName": "perches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hake",
-				"pluralName": "hakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pollock",
-				"pluralName": "pollocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salt cod",
-				"pluralName": "salt cod"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked mackerel",
-				"pluralName": "smoked mackerel"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea bream",
-				"pluralName": "sea bream"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rainbow trout",
-				"pluralName": "rainbow trout"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carp",
-				"pluralName": "carp"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cuttlefish",
-				"pluralName": "cuttlefish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grouper",
-				"pluralName": "groupers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herring",
-				"pluralName": "herrings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salmon roe",
-				"pluralName": "salmon roes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "steelhead trout",
-				"pluralName": "steelhead trout"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roe",
-				"pluralName": "roes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barramundi",
-				"pluralName": "barramundis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black cod",
-				"pluralName": "black cod"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kingfish",
-				"pluralName": "kingfish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange roughy",
-				"pluralName": "orange roughies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turbot",
-				"pluralName": "turbots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bangu",
-				"pluralName": "bangus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rockfish",
-				"pluralName": "rockfish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "branzino",
-				"pluralName": "branzinoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomfret",
-				"pluralName": "pomfrets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eel",
-				"pluralName": "eels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried anchovy",
-				"pluralName": "dried anchovies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arctic char",
-				"pluralName": "arctic chars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh anchovy",
-				"pluralName": "fresh anchovies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon sole",
-				"pluralName": "lemon soles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellowtail",
-				"pluralName": "yellowtails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "battered fish",
-				"pluralName": "battered fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pike",
-				"pluralName": "pikes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled herring",
-				"pluralName": "pickled herrings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "john dory",
-				"pluralName": "john dories"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "swai fish",
-				"pluralName": "swai fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "walleye",
-				"pluralName": "walleyes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh mackerel",
-				"pluralName": "fresh mackerel"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salmon trout",
-				"pluralName": "salmon trout"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "basa fish",
-				"pluralName": "basa fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked eel",
-				"pluralName": "smoked eels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish ball",
-				"pluralName": "fish balls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sturgeon",
-				"pluralName": "sturgeons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bluefish",
-				"pluralName": "bluefish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red mullet",
-				"pluralName": "red mullets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gurnard",
-				"pluralName": "gurnards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plaice",
-				"pluralName": "plaices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pompano",
-				"pluralName": "pompanoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked fish",
-				"pluralName": "smoked fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish head",
-				"pluralName": "fish heads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rohu fish",
-				"pluralName": "rohu fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried fish",
-				"pluralName": "dried fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flathead",
-				"pluralName": "flatheads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish cake",
-				"pluralName": "fish cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salt fish",
-				"pluralName": "salt fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked herring",
-				"pluralName": "smoked herrings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whiting",
-				"pluralName": "whiting"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salmon burger meat",
-				"pluralName": "salmon burger meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shark meat",
-				"pluralName": "shark meats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garoupa",
-				"pluralName": "garoupas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gilt-head bream",
-				"pluralName": "gilt-head bream"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pangasiu",
-				"pluralName": "pangasius"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salt herring",
-				"pluralName": "salt herrings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soused herring",
-				"pluralName": "soused herrings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tinapa",
-				"pluralName": "tinapas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "zander",
-				"pluralName": "zanders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amberjack",
-				"pluralName": "amberjacks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "korean fish cake",
-				"pluralName": "korean fish cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mullet",
-				"pluralName": "mullets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "skipjack tuna",
-				"pluralName": "skipjack tuna"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bottarga",
-				"pluralName": "bottargas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried baby sardine",
-				"pluralName": "dried baby sardines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marlin",
-				"pluralName": "marlins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "threadfin",
-				"pluralName": "threadfins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tiny fish",
-				"pluralName": "tiny fish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tuna belly",
-				"pluralName": "tuna bellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beluga caviar",
-				"pluralName": "beluga caviars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bombay duck",
-				"pluralName": "bombay ducks"
-			}
-		]
-	},
-	"Seafood & Seaweed": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shrimp",
-				"pluralName": "shrimps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "octopuse",
-				"pluralName": "octopi"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prawn",
-				"pluralName": "prawns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crab",
-				"pluralName": "crabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "scallop",
-				"pluralName": "scallops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mussel",
-				"pluralName": "mussels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clam",
-				"pluralName": "clams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "squid",
-				"pluralName": "squids"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nori",
-				"pluralName": "noris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lobster",
-				"pluralName": "lobsters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oyster",
-				"pluralName": "oysters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lobster tail",
-				"pluralName": "lobster tails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crawfish",
-				"pluralName": "crawfish"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "octopu",
-				"pluralName": "octopus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kombu",
-				"pluralName": "kombus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried shrimp",
-				"pluralName": "dried shrimps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bay scallop",
-				"pluralName": "bay scallops"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wakame",
-				"pluralName": "wakames"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soft-shell crab",
-				"pluralName": "soft-shell crabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "scampi",
-				"pluralName": "scampis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "king crab",
-				"pluralName": "king crabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed seafood",
-				"pluralName": "mixed seafoods"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baby squid",
-				"pluralName": "baby squids"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "squid ink",
-				"pluralName": "squid inks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried prawn",
-				"pluralName": "dried prawns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dulse seaweed",
-				"pluralName": "dulse seaweeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted seaweed",
-				"pluralName": "roasted seaweeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked oyster",
-				"pluralName": "smoked oysters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kelp",
-				"pluralName": "kelps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kizami nori",
-				"pluralName": "kizami noris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hijiki",
-				"pluralName": "hijikis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salted shrimp",
-				"pluralName": "salted shrimps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yaki-nori",
-				"pluralName": "yaki-noris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "conch",
-				"pluralName": "conches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arame",
-				"pluralName": "arames"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "calamari steak",
-				"pluralName": "calamari steaks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mud crab",
-				"pluralName": "mud crabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea urchin",
-				"pluralName": "sea urchins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "abalone",
-				"pluralName": "abalones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seaweed salad",
-				"pluralName": "seaweed salads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dulse",
-				"pluralName": "dulses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked mussel",
-				"pluralName": "smoked mussels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea snail",
-				"pluralName": "sea snails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aonori",
-				"pluralName": "aonoris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prepared crab cake",
-				"pluralName": "prepared crab cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea lettuce",
-				"pluralName": "sea lettuces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "korean seaweed",
-				"pluralName": "korean seaweeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ogo seaweed",
-				"pluralName": "ogo seaweeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seaweed caviar",
-				"pluralName": "seaweed caviars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "haddock",
-				"pluralName": "haddocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sea mos",
-				"pluralName": "sea moss"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "langoustine",
-				"pluralName": "langoustines"
-			}
-		]
-	},
-	"Herbs & Spices": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon",
-				"pluralName": "cinnamons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "parsley",
-				"pluralName": "parsleys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cilantro",
-				"pluralName": "cilantros"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cumin",
-				"pluralName": "cumins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "basil",
-				"pluralName": "basils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thyme",
-				"pluralName": "thymes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger root",
-				"pluralName": "ginger roots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic powder",
-				"pluralName": "garlic powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oregano",
-				"pluralName": "oreganos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nutmeg",
-				"pluralName": "nutmegs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili flake",
-				"pluralName": "chili flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili powder",
-				"pluralName": "chili powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "paprika",
-				"pluralName": "paprikas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cayenne",
-				"pluralName": "cayennes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rosemary",
-				"pluralName": "rosemaries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bay leaf",
-				"pluralName": "bay leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turmeric",
-				"pluralName": "turmerics"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clove",
-				"pluralName": "cloves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion powder",
-				"pluralName": "onion powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger powder",
-				"pluralName": "ginger powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "panch puran",
-				"pluralName": "panch purans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dill",
-				"pluralName": "dills"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chive",
-				"pluralName": "chives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mint",
-				"pluralName": "mints"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green cardamom",
-				"pluralName": "green cardamoms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked paprika",
-				"pluralName": "smoked paprikas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh mint",
-				"pluralName": "fresh mints"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coriander powder",
-				"pluralName": "coriander powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sage",
-				"pluralName": "sages"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coriander",
-				"pluralName": "corianders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "allspice",
-				"pluralName": "allspices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cracked pepper",
-				"pluralName": "cracked peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppercorn",
-				"pluralName": "peppercorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard seed",
-				"pluralName": "mustard seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white pepper",
-				"pluralName": "white peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curry leaf",
-				"pluralName": "curry leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fennel seed",
-				"pluralName": "fennel seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tarragon",
-				"pluralName": "tarragons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "saffron",
-				"pluralName": "saffrons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "asafoetida",
-				"pluralName": "asafoetidas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "star anise",
-				"pluralName": "star anises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marjoram",
-				"pluralName": "marjorams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemongras",
-				"pluralName": "lemongrass"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caraway",
-				"pluralName": "caraways"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic granule",
-				"pluralName": "garlic granules"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "celery seed",
-				"pluralName": "celery seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chipotle powder",
-				"pluralName": "chipotle powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chipotle",
-				"pluralName": "chipotles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fenugreek",
-				"pluralName": "fenugreeks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion flake",
-				"pluralName": "onion flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matcha powder",
-				"pluralName": "matcha powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ancho chile powder",
-				"pluralName": "ancho chile powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sumac",
-				"pluralName": "sumacs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried parsley flake",
-				"pluralName": "dried parsley flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fenugreek seed",
-				"pluralName": "fenugreek seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kashmiri red chilli",
-				"pluralName": "kashmiri red chillis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai basil",
-				"pluralName": "thai basils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "edible flower",
-				"pluralName": "edible flowers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aniseed",
-				"pluralName": "aniseeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kaffir lime leaf",
-				"pluralName": "kaffir lime leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chervil",
-				"pluralName": "chervils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lavender",
-				"pluralName": "lavenders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carom seed",
-				"pluralName": "carom seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican oregano",
-				"pluralName": "mexican oreganos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mace",
-				"pluralName": "maces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango powder",
-				"pluralName": "mango powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black mustard seed",
-				"pluralName": "black mustard seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried chili",
-				"pluralName": "dried chilies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black cardamom",
-				"pluralName": "black cardamoms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "saffron strand",
-				"pluralName": "saffron strands"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guajillo pepper",
-				"pluralName": "guajillo peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pink peppercorn",
-				"pluralName": "pink peppercorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot paprika",
-				"pluralName": "hot paprikas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon thyme",
-				"pluralName": "lemon thymes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "galangal",
-				"pluralName": "galangals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic flake",
-				"pluralName": "garlic flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried cilantro",
-				"pluralName": "dried cilantros"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon balm",
-				"pluralName": "lemon balms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dill seed",
-				"pluralName": "dill seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green peppercorn",
-				"pluralName": "green peppercorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aleppo pepper",
-				"pluralName": "aleppo peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wasabi powder",
-				"pluralName": "wasabi powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "achiote seed",
-				"pluralName": "achiote seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "savory herb",
-				"pluralName": "savory herbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pandan leaf",
-				"pluralName": "pandan leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sorrel",
-				"pluralName": "sorrels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gochugaru",
-				"pluralName": "gochugarus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "saigon cinnamon",
-				"pluralName": "saigon cinnamons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemongrass paste",
-				"pluralName": "lemongrass pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shiso",
-				"pluralName": "shisoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "celery powder",
-				"pluralName": "celery powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black cumin",
-				"pluralName": "black cumins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anardana",
-				"pluralName": "anardanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vietnamese mint",
-				"pluralName": "vietnamese mints"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried orange peel",
-				"pluralName": "dried orange peels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "espelette pepper",
-				"pluralName": "espelette peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon verbena",
-				"pluralName": "lemon verbenas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw stevia",
-				"pluralName": "raw stevias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "achiote paste",
-				"pluralName": "achiote pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "summer savory",
-				"pluralName": "summer savories"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fennel pollen",
-				"pluralName": "fennel pollens"
-			}
-		]
-	},
-	"Sugar & Sweeteners": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sugar",
-				"pluralName": "sugars"
-			},
-			{
-				"aliases": [
-					"turbinado sugar"
-				],
-				"description": "",
-				"name": "brown sugar",
-				"pluralName": "brown sugars"
-			},
-			{
-				"aliases": [
-					"powdered sugar",
-					"icing sugar"
-				],
-				"description": "",
-				"name": "confectioners sugar",
-				"pluralName": "confectioners sugars"
-			},
-			{
-				"aliases": [
-					"castor sugar"
-				],
-				"description": "",
-				"name": "bar sugar",
-				"pluralName": "bar sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maple syrup",
-				"pluralName": "maple syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn syrup",
-				"pluralName": "corn syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut sugar",
-				"pluralName": "coconut sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "molass",
-				"pluralName": "molasses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stevia",
-				"pluralName": "stevias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "agave nectar",
-				"pluralName": "agave nectars"
-			},
-			{
-				"aliases": [],
-				"description": "sugar free sweetner",
-				"name": "sugar syrup",
-				"pluralName": "sugar syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "isomalt",
-				"pluralName": "isomalts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "erythritol",
-				"pluralName": "erythritols"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla sugar",
-				"pluralName": "vanilla sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "demerara sugar",
-				"pluralName": "demerara sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caramel syrup",
-				"pluralName": "caramel syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate syrup",
-				"pluralName": "chocolate syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jaggery",
-				"pluralName": "jaggeries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw sugar",
-				"pluralName": "raw sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden syrup",
-				"pluralName": "golden syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon sugar",
-				"pluralName": "cinnamon sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid stevia",
-				"pluralName": "liquid stevias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grenadine",
-				"pluralName": "grenadines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coarse sugar",
-				"pluralName": "coarse sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salted caramel syrup",
-				"pluralName": "salted caramel syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sanding sugar",
-				"pluralName": "sanding sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark corn syrup",
-				"pluralName": "dark corn syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sucralose",
-				"pluralName": "sucraloses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "monk fruit sweetener",
-				"pluralName": "monk fruit sweeteners"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maple sugar",
-				"pluralName": "maple sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackstrap molass",
-				"pluralName": "blackstrap molasses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glucose",
-				"pluralName": "glucoses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rock sugar",
-				"pluralName": "rock sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "confectioners' sweetener",
-				"pluralName": "confectioners' sweeteners"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "xylitol",
-				"pluralName": "xylitols"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jam sugar",
-				"pluralName": "jam sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown rice syrup",
-				"pluralName": "brown rice syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown sugar substitute",
-				"pluralName": "brown sugar substitutes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry syrup",
-				"pluralName": "strawberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla syrup",
-				"pluralName": "vanilla syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger syrup",
-				"pluralName": "ginger syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orgeat",
-				"pluralName": "orgeats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice malt syrup",
-				"pluralName": "rice malt syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pancake syrup",
-				"pluralName": "pancake syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry syrup",
-				"pluralName": "raspberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "date syrup",
-				"pluralName": "date syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black treacle",
-				"pluralName": "black treacles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "date paste",
-				"pluralName": "date pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut syrup",
-				"pluralName": "coconut syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mint syrup",
-				"pluralName": "mint syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "treacle",
-				"pluralName": "treacles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice syrup",
-				"pluralName": "rice syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "manuka honey",
-				"pluralName": "manuka honeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maple butter",
-				"pluralName": "maple butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blueberry syrup",
-				"pluralName": "blueberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple syrup",
-				"pluralName": "apple syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "allulose",
-				"pluralName": "alluloses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackberry syrup",
-				"pluralName": "blackberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "piloncillo",
-				"pluralName": "piloncilloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry syrup",
-				"pluralName": "cherry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hibiscus syrup",
-				"pluralName": "hibiscus syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lavender syrup",
-				"pluralName": "lavender syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh sugar cane",
-				"pluralName": "fresh sugar canes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut syrup",
-				"pluralName": "hazelnut syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white chocolate sauce",
-				"pluralName": "white chocolate sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin spice syrup",
-				"pluralName": "pumpkin spice syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glycerine",
-				"pluralName": "glycerines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sorghum syrup",
-				"pluralName": "sorghum syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lucuma powder",
-				"pluralName": "lucuma powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black sugar",
-				"pluralName": "black sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry syrup",
-				"pluralName": "cranberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden sugar",
-				"pluralName": "golden sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cane syrup",
-				"pluralName": "cane syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango syrup",
-				"pluralName": "mango syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "malt syrup",
-				"pluralName": "malt syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot honey",
-				"pluralName": "hot honeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gula melaka",
-				"pluralName": "gula melakas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderberry syrup",
-				"pluralName": "elderberry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rosemary syrup",
-				"pluralName": "rosemary syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark chocolate syrup",
-				"pluralName": "dark chocolate syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "inulin",
-				"pluralName": "inulins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet'n low",
-				"pluralName": "sweet'n lows"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fructose",
-				"pluralName": "fructoses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey powder",
-				"pluralName": "honey powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "berry syrup",
-				"pluralName": "berry syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grape syrup",
-				"pluralName": "grape syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown butter syrup",
-				"pluralName": "brown butter syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "date sugar",
-				"pluralName": "date sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mastic gum",
-				"pluralName": "mastic gums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gum syrup",
-				"pluralName": "gum syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "irish cream syrup",
-				"pluralName": "irish cream syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prickly pear syrup",
-				"pluralName": "prickly pear syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cookie butter syrup",
-				"pluralName": "cookie butter syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creamed honey",
-				"pluralName": "creamed honeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buttermilk syrup",
-				"pluralName": "buttermilk syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate sugar",
-				"pluralName": "chocolate sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flavored syrup",
-				"pluralName": "flavored syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderflower syrup",
-				"pluralName": "elderflower syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "malt sugar",
-				"pluralName": "malt sugars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buckwheat honey",
-				"pluralName": "buckwheat honeys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "truffle honey",
-				"pluralName": "truffle honeys"
-			}
-		]
-	},
-	"Seasonings & Spice Blends": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "italian seasoning",
-				"pluralName": "italian seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ranch dressing packet",
-				"pluralName": "ranch dressing packets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seasoned salt",
-				"pluralName": "seasoned salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curry",
-				"pluralName": "curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garam masala",
-				"pluralName": "garam masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin pie spice",
-				"pluralName": "pumpkin pie spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard powder",
-				"pluralName": "mustard powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taco seasoning",
-				"pluralName": "taco seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cajun seasoning",
-				"pluralName": "cajun seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dry ranch seasoning",
-				"pluralName": "dry ranch seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white miso",
-				"pluralName": "white misoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "himalayan salt",
-				"pluralName": "himalayan salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon & pepper seasoning",
-				"pluralName": "lemon & pepper seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid smoke",
-				"pluralName": "liquid smokes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "poultry seasoning",
-				"pluralName": "poultry seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chinese five spice",
-				"pluralName": "chinese five spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red curry",
-				"pluralName": "red curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "old bay seasoning",
-				"pluralName": "old bay seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herbe de provence",
-				"pluralName": "herbes de provence"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chaat masala",
-				"pluralName": "chaat masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creole seasoning",
-				"pluralName": "creole seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "steak seasoning",
-				"pluralName": "steak seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed spice",
-				"pluralName": "mixed spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fleur de sel",
-				"pluralName": "fleur de sel"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai red curry paste",
-				"pluralName": "thai red curry pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed herb",
-				"pluralName": "mixed herbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green curry",
-				"pluralName": "green curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barbecue seasoning",
-				"pluralName": "barbecue seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple pie spice",
-				"pluralName": "apple pie spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "za'atar",
-				"pluralName": "za'atars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ras el hanout",
-				"pluralName": "ras el hanouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "all-purpose seasoning",
-				"pluralName": "all-purpose seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seafood seasoning",
-				"pluralName": "seafood seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bagel seasoning",
-				"pluralName": "bagel seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fajita seasoning",
-				"pluralName": "fajita seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tandoori spice",
-				"pluralName": "tandoori spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickling spice",
-				"pluralName": "pickling spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caribbean jerk seasoning",
-				"pluralName": "caribbean jerk seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gravy mix",
-				"pluralName": "gravy mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic & herb seasoning",
-				"pluralName": "garlic & herb seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic-pepper seasoning",
-				"pluralName": "garlic-pepper seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickling salt",
-				"pluralName": "pickling salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "greek seasoning",
-				"pluralName": "greek seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "msg",
-				"pluralName": "msgs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "teriyaki marinade",
-				"pluralName": "teriyaki marinades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "adobo seasoning",
-				"pluralName": "adobo seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sambar powder",
-				"pluralName": "sambar powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "smoked salt",
-				"pluralName": "smoked salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dash seasoning",
-				"pluralName": "dash seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red miso",
-				"pluralName": "red misoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot curry",
-				"pluralName": "hot curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salt-free seasoning",
-				"pluralName": "salt-free seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carne asada seasoning",
-				"pluralName": "carne asada seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bouquet garni",
-				"pluralName": "bouquet garnis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow miso",
-				"pluralName": "yellow misoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dukkah",
-				"pluralName": "dukkahs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pav bhaji masala",
-				"pluralName": "pav bhaji masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curing salt",
-				"pluralName": "curing salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican seasoning",
-				"pluralName": "mexican seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tajin seasoning",
-				"pluralName": "tajin seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seasoned pepper",
-				"pluralName": "seasoned peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crab boil seasoning",
-				"pluralName": "crab boil seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shichimi togarashi",
-				"pluralName": "shichimi togarashis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rib rub",
-				"pluralName": "rib rubs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "truffle salt",
-				"pluralName": "truffle salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "biryani masala",
-				"pluralName": "biryani masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "furikake",
-				"pluralName": "furikakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "togarashi",
-				"pluralName": "togarashis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chipotle seasoning",
-				"pluralName": "chipotle seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "meat masala",
-				"pluralName": "meat masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "harissa spice blend",
-				"pluralName": "harissa spice blends"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chana masala",
-				"pluralName": "chana masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken gravy mix",
-				"pluralName": "chicken gravy mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grey sea salt",
-				"pluralName": "grey sea salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken taco seasoning",
-				"pluralName": "chicken taco seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mushroom seasoning",
-				"pluralName": "mushroom seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "au jus mix",
-				"pluralName": "au jus mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gingerbread spice",
-				"pluralName": "gingerbread spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "popcorn seasoning",
-				"pluralName": "popcorn seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "berbere",
-				"pluralName": "berberes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili-lime seasoning",
-				"pluralName": "chili-lime seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown miso",
-				"pluralName": "brown misoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackening seasoning",
-				"pluralName": "blackening seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pizza seasoning",
-				"pluralName": "pizza seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fines herbe",
-				"pluralName": "fines herbes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shawarma seasoning",
-				"pluralName": "shawarma seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chai masala",
-				"pluralName": "chai masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "panang curry",
-				"pluralName": "panang curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kitchen king masala",
-				"pluralName": "kitchen king masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon & herb seasoning",
-				"pluralName": "lemon & herb seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla salt",
-				"pluralName": "vanilla salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai seasoning",
-				"pluralName": "thai seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mulling spice",
-				"pluralName": "mulling spices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sriracha seasoning",
-				"pluralName": "sriracha seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee rub",
-				"pluralName": "coffee rubs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hawaiian salt",
-				"pluralName": "hawaiian salts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mesquite seasoning",
-				"pluralName": "mesquite seasonings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tom yum paste",
-				"pluralName": "tom yum pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish masala",
-				"pluralName": "fish masalas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh mixed herb",
-				"pluralName": "fresh mixed herbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "southwest chipotle seasoning",
-				"pluralName": "southwest chipotle seasonings"
-			}
-		]
-	},
-	"Baking": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flour",
-				"pluralName": "flours"
-			},
-			{
-				"aliases": [
-					"vanilla",
-					"vanillas"
-				],
-				"description": "",
-				"name": "vanilla extract",
-				"pluralName": "vanilla extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baking powder",
-				"pluralName": "baking powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baking soda",
-				"pluralName": "baking sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornstarch",
-				"pluralName": "cornstarches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yeast",
-				"pluralName": "yeasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate chip",
-				"pluralName": "chocolate chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark chocolate chip",
-				"pluralName": "dark chocolate chips"
-			},
-			{
-				"aliases": [
-					"whole wheat flour"
-				],
-				"description": "",
-				"name": "whole-wheat flour",
-				"pluralName": "whole-wheat flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond flour",
-				"pluralName": "almond flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "self-raising flour",
-				"pluralName": "self-raising flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shredded coconut",
-				"pluralName": "shredded coconuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornmeal",
-				"pluralName": "cornmeals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut flake",
-				"pluralName": "coconut flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gelatin",
-				"pluralName": "gelatins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pastry flour",
-				"pluralName": "pastry flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut flour",
-				"pluralName": "coconut flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baking mix",
-				"pluralName": "baking mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cake flour",
-				"pluralName": "cake flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn flour",
-				"pluralName": "corn flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of tartar",
-				"pluralName": "cream of tartar"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread flour",
-				"pluralName": "bread flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond meal",
-				"pluralName": "almond meals"
-			},
-			{
-				"aliases": [
-					"unbleached flour",
-					"all-purpose flour",
-					"all purpose flour"
-				],
-				"description": "",
-				"name": "unbleached all-purpose flour",
-				"pluralName": "unbleached all-purpose flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white baking chip",
-				"pluralName": "white baking chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free flour",
-				"pluralName": "gluten-free flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice flour",
-				"pluralName": "rice flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "desiccated coconut",
-				"pluralName": "desiccated coconuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tapioca starch",
-				"pluralName": "tapioca starches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow cake mix",
-				"pluralName": "yellow cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chickpea flour",
-				"pluralName": "chickpea flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "xanthan gum",
-				"pluralName": "xanthan gums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oat flour",
-				"pluralName": "oat flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whole-wheat pastry flour",
-				"pluralName": "whole-wheat pastry flours"
-			},
-			{
-				"aliases": [
-					"whole wheat",
-					"whole wheats"
-				],
-				"description": "",
-				"name": "whole-wheat",
-				"pluralName": "whole-wheats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy sprinkle",
-				"pluralName": "candy sprinkles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spelt",
-				"pluralName": "spelts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brownie mix",
-				"pluralName": "brownie mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arrowroot flour",
-				"pluralName": "arrowroot flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flaxseed meal",
-				"pluralName": "flaxseed meals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate cake mix",
-				"pluralName": "chocolate cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato starch",
-				"pluralName": "potato starches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jello",
-				"pluralName": "jelloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butterscotch chip",
-				"pluralName": "butterscotch chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut butter chip",
-				"pluralName": "peanut butter chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crystallized ginger",
-				"pluralName": "crystallized gingers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buckwheat flour",
-				"pluralName": "buckwheat flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown rice flour",
-				"pluralName": "brown rice flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pectin",
-				"pluralName": "pectins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rye flour",
-				"pluralName": "rye flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "psyllium husk",
-				"pluralName": "psyllium husks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "semolina flour",
-				"pluralName": "semolina flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glutinous rice flour",
-				"pluralName": "glutinous rice flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pancake mix",
-				"pluralName": "pancake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "refined flour",
-				"pluralName": "refined flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "muffin mix",
-				"pluralName": "muffin mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marzipan",
-				"pluralName": "marzipans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee bean",
-				"pluralName": "coffee beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "toffee bit",
-				"pluralName": "toffee bits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornbread mix",
-				"pluralName": "cornbread mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spice cake mix",
-				"pluralName": "spice cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "devil's food cake mix",
-				"pluralName": "devil's food cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sorghum flour",
-				"pluralName": "sorghum flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato flake",
-				"pluralName": "potato flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "masa harina",
-				"pluralName": "masa harinas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon chip",
-				"pluralName": "cinnamon chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "agar agar",
-				"pluralName": "agar agars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red velvet cake mix",
-				"pluralName": "red velvet cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matzo meal",
-				"pluralName": "matzo meals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sago",
-				"pluralName": "sagos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white baking chocolate",
-				"pluralName": "white baking chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cassava flour",
-				"pluralName": "cassava flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whipped cream stabilizer",
-				"pluralName": "whipped cream stabilizers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sugar cookie mix",
-				"pluralName": "sugar cookie mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vital wheat gluten",
-				"pluralName": "vital wheat glutens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baking chip",
-				"pluralName": "baking chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "meringue powder",
-				"pluralName": "meringue powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut flour",
-				"pluralName": "hazelnut flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "citric acid",
-				"pluralName": "citric acids"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut chip",
-				"pluralName": "coconut chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quinoa flour",
-				"pluralName": "quinoa flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "finger millet flour",
-				"pluralName": "finger millet flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fondant",
-				"pluralName": "fondants"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mint baking chip",
-				"pluralName": "mint baking chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "angel food cake mix",
-				"pluralName": "angel food cake mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white cornmeal",
-				"pluralName": "white cornmeals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "millet flour",
-				"pluralName": "millet flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mincemeat",
-				"pluralName": "mincemeats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free baking flour",
-				"pluralName": "gluten-free baking flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "einkorn flour",
-				"pluralName": "einkorn flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "self-rising cornmeal",
-				"pluralName": "self-rising cornmeals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free self-raising flour",
-				"pluralName": "gluten-free self-raising flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut flour",
-				"pluralName": "peanut flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet bean paste",
-				"pluralName": "sweet bean pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carob powder",
-				"pluralName": "carob powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tapioca pearl",
-				"pluralName": "tapioca pearls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "teff flour",
-				"pluralName": "teff flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guar gum",
-				"pluralName": "guar gums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato flour",
-				"pluralName": "potato flours"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ready-made icing",
-				"pluralName": "ready-made icings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fruit salt",
-				"pluralName": "fruit salts"
-			}
-		]
-	},
-	"Pre-Made Doughs & Wrappers": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pie crust",
-				"pluralName": "pie crusts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puff pastry",
-				"pluralName": "puff pastries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pizza crust",
-				"pluralName": "pizza crusts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pizza dough",
-				"pluralName": "pizza doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "phyllo",
-				"pluralName": "phylloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "refrigerated crescent roll",
-				"pluralName": "refrigerated crescent rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "biscuit dough",
-				"pluralName": "biscuit doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dumpling wrapper",
-				"pluralName": "dumpling wrappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice paper",
-				"pluralName": "rice papers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sourdough starter",
-				"pluralName": "sourdough starters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cookie dough",
-				"pluralName": "cookie doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg roll wrapper",
-				"pluralName": "egg roll wrappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread dough",
-				"pluralName": "bread doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter puff pastry",
-				"pluralName": "butter puff pastries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen dinner roll",
-				"pluralName": "frozen dinner rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon roll dough",
-				"pluralName": "cinnamon roll doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dosa batter",
-				"pluralName": "dosa batters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puff pastry shell",
-				"pluralName": "puff pastry shells"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wonton",
-				"pluralName": "wontons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gyoza wrapper",
-				"pluralName": "gyoza wrappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wonton strip",
-				"pluralName": "wonton strips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free pizza crust",
-				"pluralName": "gluten-free pizza crusts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fresh pasta dough",
-				"pluralName": "fresh pasta doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "idli batter",
-				"pluralName": "idli batters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potsticker wrapper",
-				"pluralName": "potsticker wrappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate pie crust",
-				"pluralName": "chocolate pie crusts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "croissant dough",
-				"pluralName": "croissant doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tofu skin",
-				"pluralName": "tofu skins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brisee",
-				"pluralName": "brisees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sausage roll",
-				"pluralName": "sausage rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kataifi",
-				"pluralName": "kataifis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "korean rice cake",
-				"pluralName": "korean rice cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn dog",
-				"pluralName": "corn dogs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tortilla dough",
-				"pluralName": "tortilla doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "empanada wrapper",
-				"pluralName": "empanada wrappers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rough-puff pastry",
-				"pluralName": "rough-puff pastries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gingerbread cookie dough",
-				"pluralName": "gingerbread cookie doughs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yufka",
-				"pluralName": "yufkas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cob loaf",
-				"pluralName": "cob loaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg wrap",
-				"pluralName": "egg wraps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "samosa sheet",
-				"pluralName": "samosa sheets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen pizza roll",
-				"pluralName": "frozen pizza rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brick pastry",
-				"pluralName": "brick pastries"
-			}
-		]
-	},
-	"Grains & Cereals": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rolled oat",
-				"pluralName": "rolled oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice",
-				"pluralName": "rices"
-			},
-			{
-				"aliases": [
-					"Rice Krispie"
-				],
-				"description": "",
-				"name": "Rice Krispie Cereal",
-				"pluralName": "Rice Krispie Cereal"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quinoa",
-				"pluralName": "quinoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "basmati rice",
-				"pluralName": "basmati rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown rice",
-				"pluralName": "brown rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quick-cooking oat",
-				"pluralName": "quick-cooking oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "breakfast cereal",
-				"pluralName": "breakfast cereals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "risotto rice",
-				"pluralName": "risotto rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "couscou",
-				"pluralName": "couscous"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice cereal",
-				"pluralName": "rice cereals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wild rice",
-				"pluralName": "wild rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "semolina",
-				"pluralName": "semolinas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jasmine rice",
-				"pluralName": "jasmine rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "polenta",
-				"pluralName": "polentas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "granola cereal",
-				"pluralName": "granola cereals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bulgur",
-				"pluralName": "bulgurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pearl barley",
-				"pluralName": "pearl barleys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "farro",
-				"pluralName": "farroes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barley",
-				"pluralName": "barleys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wheat germ",
-				"pluralName": "wheat germs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grit",
-				"pluralName": "grits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "steel cut oat",
-				"pluralName": "steel cut oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "millet",
-				"pluralName": "millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oat bran",
-				"pluralName": "oat brans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sushi rice",
-				"pluralName": "sushi rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glutinous rice",
-				"pluralName": "glutinous rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "instant rice",
-				"pluralName": "instant rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hominy",
-				"pluralName": "hominies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red quinoa",
-				"pluralName": "red quinoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw buckwheat",
-				"pluralName": "raw buckwheats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wheat bran",
-				"pluralName": "wheat brans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "instant oat",
-				"pluralName": "instant oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "instant oat",
-				"pluralName": "instant oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wheat berry",
-				"pluralName": "wheat berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "poha",
-				"pluralName": "pohas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black rice",
-				"pluralName": "black rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow rice",
-				"pluralName": "yellow rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fine semolina",
-				"pluralName": "fine semolinas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "muesli",
-				"pluralName": "mueslis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amaranth",
-				"pluralName": "amaranths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kasha",
-				"pluralName": "kashas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quinoa flake",
-				"pluralName": "quinoa flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffed rice",
-				"pluralName": "puffed rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pearled farro",
-				"pluralName": "pearled farroes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cracked wheat",
-				"pluralName": "cracked wheats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freekeh",
-				"pluralName": "freekehs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "paella rice",
-				"pluralName": "paella rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sorghum",
-				"pluralName": "sorghums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red rice",
-				"pluralName": "red rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican rice",
-				"pluralName": "mexican rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "idli rice",
-				"pluralName": "idli rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown jasmine rice",
-				"pluralName": "brown jasmine rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of wheat",
-				"pluralName": "cream of wheat"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice pilaf",
-				"pluralName": "rice pilafs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barnyard millet",
-				"pluralName": "barnyard millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "weetabix",
-				"pluralName": "weetabixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jambalaya rice mix",
-				"pluralName": "jambalaya rice mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black glutinous rice",
-				"pluralName": "black glutinous rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whole-grain oat",
-				"pluralName": "whole-grain oats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffed quinoa",
-				"pluralName": "puffed quinoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cilantro lime rice",
-				"pluralName": "cilantro lime rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dirty rice mix",
-				"pluralName": "dirty rice mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffed wheat",
-				"pluralName": "puffed wheats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hulled barley",
-				"pluralName": "hulled barleys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown long grain rice",
-				"pluralName": "brown long grain rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "finger millet",
-				"pluralName": "finger millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "foxtail millet",
-				"pluralName": "foxtail millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matta rice",
-				"pluralName": "matta rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rye berry",
-				"pluralName": "rye berries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spelt flake",
-				"pluralName": "spelt flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kodo millet",
-				"pluralName": "kodo millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oat groat",
-				"pluralName": "oat groats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "teff",
-				"pluralName": "teffs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rye flake",
-				"pluralName": "rye flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "little millet",
-				"pluralName": "little millets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free breakfast cereal",
-				"pluralName": "gluten-free breakfast cereals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffed amaranth",
-				"pluralName": "puffed amaranths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut rice",
-				"pluralName": "coconut rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amaranth flake",
-				"pluralName": "amaranth flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "puffed kamut",
-				"pluralName": "puffed kamuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bamboo rice",
-				"pluralName": "bamboo rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pearled sorghum",
-				"pluralName": "pearled sorghums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shirataki rice",
-				"pluralName": "shirataki rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable fried rice",
-				"pluralName": "vegetable fried rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gr\u00fcnkern",
-				"pluralName": "gr\u00fcnkerns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jeera rice",
-				"pluralName": "jeera rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fonio",
-				"pluralName": "fonios"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kamut flake",
-				"pluralName": "kamut flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "texmati rice",
-				"pluralName": "texmati rices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of rice",
-				"pluralName": "cream of rice"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ka\u00f1iwa",
-				"pluralName": "ka\u00f1iwas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "proso millet",
-				"pluralName": "proso millets"
-			}
-		]
-	},
-	"Legumes": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pea",
-				"pluralName": "peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green bean",
-				"pluralName": "green beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chickpea",
-				"pluralName": "chickpeas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black bean",
-				"pluralName": "black beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kidney bean",
-				"pluralName": "kidney beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white bean",
-				"pluralName": "white beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lentil",
-				"pluralName": "lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pinto bean",
-				"pluralName": "pinto beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "snow pea",
-				"pluralName": "snow peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "snap pea",
-				"pluralName": "snap peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red lentil",
-				"pluralName": "red lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cannellini bean",
-				"pluralName": "cannellini beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean sprout",
-				"pluralName": "bean sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "edamame",
-				"pluralName": "edamames"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green lentil",
-				"pluralName": "green lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "urad dal",
-				"pluralName": "urad dals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lima bean",
-				"pluralName": "lima beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chana dal",
-				"pluralName": "chana dals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fava bean",
-				"pluralName": "fava beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black-eyed pea",
-				"pluralName": "black-eyed peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moong dal",
-				"pluralName": "moong dals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "split pea",
-				"pluralName": "split peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pigeon pea",
-				"pluralName": "pigeon peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red bean",
-				"pluralName": "red beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mung bean sprout",
-				"pluralName": "mung bean sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soybean",
-				"pluralName": "soybeans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mung bean",
-				"pluralName": "mung beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "string bean",
-				"pluralName": "string beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow split pea",
-				"pluralName": "yellow split peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black lentil",
-				"pluralName": "black lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "borlotti bean",
-				"pluralName": "borlotti beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aquafaba",
-				"pluralName": "aquafabas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chana",
-				"pluralName": "chanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "snake bean",
-				"pluralName": "snake beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yellow lentil",
-				"pluralName": "yellow lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mixed bean",
-				"pluralName": "mixed beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kala chana",
-				"pluralName": "kala chanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fermented black bean",
-				"pluralName": "fermented black beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black gram",
-				"pluralName": "black grams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wax bean",
-				"pluralName": "wax beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dried pea",
-				"pluralName": "dried peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pink bean",
-				"pluralName": "pink beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lentil sprout",
-				"pluralName": "lentil sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white pea",
-				"pluralName": "white peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black soybean",
-				"pluralName": "black soybeans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "field pea",
-				"pluralName": "field peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gigante",
-				"pluralName": "gigantes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flageolet",
-				"pluralName": "flageolets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "horse gram",
-				"pluralName": "horse grams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy sprout",
-				"pluralName": "soy sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey bean",
-				"pluralName": "honey beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cluster bean",
-				"pluralName": "cluster beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown bean",
-				"pluralName": "brown beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mayocoba bean",
-				"pluralName": "mayocoba beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "winged bean",
-				"pluralName": "winged beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "castelluccio lentil",
-				"pluralName": "castelluccio lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden wax bean",
-				"pluralName": "golden wax beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moth bean",
-				"pluralName": "moth beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chickpea sprout",
-				"pluralName": "chickpea sprouts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hara chana",
-				"pluralName": "hara chanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lupini bean",
-				"pluralName": "lupini beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "natto",
-				"pluralName": "nattoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hyacinth bean",
-				"pluralName": "hyacinth beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "petai",
-				"pluralName": "petais"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "scarlet runner bean",
-				"pluralName": "scarlet runner beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy flake",
-				"pluralName": "soy flakes"
-			}
-		]
-	},
-	"Pasta": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "short-cut pasta",
-				"pluralName": "short-cut pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spaghetti",
-				"pluralName": "spaghettis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macaroni",
-				"pluralName": "macaronis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg noodle",
-				"pluralName": "egg noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spiral pasta",
-				"pluralName": "spiral pastas"
-			},
-			{
-				"aliases": [
-					"lasagnas"
-				],
-				"description": "",
-				"name": "lasagna noodle",
-				"pluralName": "lasagna noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "linguine",
-				"pluralName": "linguines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fettuccine",
-				"pluralName": "fettuccines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orzo",
-				"pluralName": "orzoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pasta shell",
-				"pluralName": "pasta shells"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bow-tie pasta",
-				"pluralName": "bow-tie pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "noodle",
-				"pluralName": "noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tortellini",
-				"pluralName": "tortellinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese tortellini",
-				"pluralName": "cheese tortellinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice noodle",
-				"pluralName": "rice noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rigatoni",
-				"pluralName": "rigatonis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gnocchi",
-				"pluralName": "gnocchis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "angel hair pasta",
-				"pluralName": "angel hair pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ramen noodle",
-				"pluralName": "ramen noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vermicelli",
-				"pluralName": "vermicellis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tagliatelle",
-				"pluralName": "tagliatelles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soba noodle",
-				"pluralName": "soba noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ravioli",
-				"pluralName": "raviolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ziti",
-				"pluralName": "zitis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orecchiette",
-				"pluralName": "orecchiettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "israeli couscou",
-				"pluralName": "israeli couscous"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "zoodle",
-				"pluralName": "zoodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "udon noodle",
-				"pluralName": "udon noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ditalini",
-				"pluralName": "ditalinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice vermicelli",
-				"pluralName": "rice vermicellis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pappardelle",
-				"pluralName": "pappardelles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glass noodle",
-				"pluralName": "glass noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free pasta",
-				"pluralName": "gluten-free pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mac 'n cheese",
-				"pluralName": "mac 'n cheeses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "penne rigate",
-				"pluralName": "penne rigates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "manicotti",
-				"pluralName": "manicottis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bucatini",
-				"pluralName": "bucatinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cannelloni",
-				"pluralName": "cannellonis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai rice noodle",
-				"pluralName": "thai rice noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown rice pasta",
-				"pluralName": "brown rice pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rotelle",
-				"pluralName": "rotelles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shirataki noodle",
-				"pluralName": "shirataki noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken raman",
-				"pluralName": "chicken ramen"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pierogi",
-				"pluralName": "pierogis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soup pasta",
-				"pluralName": "soup pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet potato noodle",
-				"pluralName": "sweet potato noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "acini di pepe",
-				"pluralName": "acini di pepes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cavatelli",
-				"pluralName": "cavatellis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "instant noodle",
-				"pluralName": "instant noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "somen noodle",
-				"pluralName": "somen noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yakisoba noodle",
-				"pluralName": "yakisoba noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef ravioli",
-				"pluralName": "beef raviolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hakka noodle",
-				"pluralName": "hakka noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kelp noodle",
-				"pluralName": "kelp noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fideo pasta",
-				"pluralName": "fideo pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spaetzle",
-				"pluralName": "spaetzles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "radiatore",
-				"pluralName": "radiatores"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "paccheri",
-				"pluralName": "paccheris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kluski noodle",
-				"pluralName": "kluski noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yolk-free noodle",
-				"pluralName": "yolk-free noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black bean pasta",
-				"pluralName": "black bean pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matzo farfel",
-				"pluralName": "matzo farfels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spinach fettuccine",
-				"pluralName": "spinach fettuccines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice-a-roni",
-				"pluralName": "rice-a-ronis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen dumpling",
-				"pluralName": "frozen dumplings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fregola",
-				"pluralName": "fregolas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef tortellini",
-				"pluralName": "beef tortellinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banh pho",
-				"pluralName": "banh phoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butternut squash noodle",
-				"pluralName": "butternut squash noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mie noodle",
-				"pluralName": "mie noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "trahana",
-				"pluralName": "trahanas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "busiate",
-				"pluralName": "busiates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lobster ravioli",
-				"pluralName": "lobster raviolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mafalde",
-				"pluralName": "mafaldes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "misua",
-				"pluralName": "misuas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "palmini",
-				"pluralName": "palminis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "trottole",
-				"pluralName": "trottoles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mandu",
-				"pluralName": "mandus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pasta salad mix",
-				"pluralName": "pasta salad mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pot pie noodle",
-				"pluralName": "pot pie noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "casarecce",
-				"pluralName": "casarecces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "quinoa pasta",
-				"pluralName": "quinoa pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean pasta",
-				"pluralName": "bean pastas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean sheet",
-				"pluralName": "bean sheets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hilopite",
-				"pluralName": "hilopites"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jjolmyeon",
-				"pluralName": "jjolmyeons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "naengmyeon noodle",
-				"pluralName": "naengmyeon noodles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yuba noodle",
-				"pluralName": "yuba noodles"
-			}
-		]
-	},
-	"Bread & Salty Snackssta": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread",
-				"pluralName": "breads"
-			}
-		]
-	},
-	"Bread & Salty Snacks": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread crumb",
-				"pluralName": "bread crumbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "panko",
-				"pluralName": "pankoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flour tortilla",
-				"pluralName": "flour tortillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond flour tortilla",
-				"pluralName": "almond flour tortillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn tortilla",
-				"pluralName": "corn tortillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cracker",
-				"pluralName": "crackers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baguette",
-				"pluralName": "baguettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tortilla chip",
-				"pluralName": "tortilla chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pita",
-				"pluralName": "pitas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pretzel",
-				"pluralName": "pretzels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sourdough bread",
-				"pluralName": "sourdough breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rustic italian bread",
-				"pluralName": "rustic italian breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "popcorn",
-				"pluralName": "popcorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crouton",
-				"pluralName": "croutons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whole-wheat tortilla",
-				"pluralName": "whole-wheat tortillas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "english muffin",
-				"pluralName": "english muffins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brioche",
-				"pluralName": "brioches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "italian bread crumb",
-				"pluralName": "italian bread crumbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rye bread",
-				"pluralName": "rye breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flatbread",
-				"pluralName": "flatbreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dry-roasted peanut",
-				"pluralName": "dry-roasted peanuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato chip",
-				"pluralName": "potato chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "naan",
-				"pluralName": "naans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stuffing mix",
-				"pluralName": "stuffing mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornbread",
-				"pluralName": "cornbreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taco shell",
-				"pluralName": "taco shells"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tater tot",
-				"pluralName": "tater tots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bagel",
-				"pluralName": "bagels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn chip",
-				"pluralName": "corn chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "unpopped popcorn",
-				"pluralName": "unpopped popcorns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "croissant",
-				"pluralName": "croissants"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork rind",
-				"pluralName": "pork rinds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpernickel",
-				"pluralName": "pumpernickels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet bread",
-				"pluralName": "sweet breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hawaiian roll",
-				"pluralName": "hawaiian rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pita chip",
-				"pluralName": "pita chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten free bread",
-				"pluralName": "gluten free breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato bread",
-				"pluralName": "potato breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "muffin",
-				"pluralName": "muffins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "breadstick",
-				"pluralName": "breadsticks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "focaccia",
-				"pluralName": "focaccias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten-free bread crumb",
-				"pluralName": "gluten-free bread crumbs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tostada shell",
-				"pluralName": "tostada shells"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crispy fried onion",
-				"pluralName": "crispy fried onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "matzo",
-				"pluralName": "matzoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic bread",
-				"pluralName": "garlic breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yeast extract spread",
-				"pluralName": "yeast extract spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "challah",
-				"pluralName": "challahs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted gram",
-				"pluralName": "roasted grams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crostini",
-				"pluralName": "crostinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice cake",
-				"pluralName": "rice cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "panettone",
-				"pluralName": "panettones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet potato fry",
-				"pluralName": "sweet potato fries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sev",
-				"pluralName": "sevs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable chip",
-				"pluralName": "vegetable chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "papad",
-				"pluralName": "papads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spinach wrap",
-				"pluralName": "spinach wraps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plantain chip",
-				"pluralName": "plantain chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted chickpea",
-				"pluralName": "roasted chickpeas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheeto",
-				"pluralName": "cheetos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chapati",
-				"pluralName": "chapatis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crumpet",
-				"pluralName": "crumpets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seed bread",
-				"pluralName": "seed breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "keto bread",
-				"pluralName": "keto breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread bowl",
-				"pluralName": "bread bowls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sprouted grain bread",
-				"pluralName": "sprouted grain breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cornbread stuffing mix",
-				"pluralName": "cornbread stuffing mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "low-carb wrap",
-				"pluralName": "low-carb wraps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frozen onion ring",
-				"pluralName": "frozen onion rings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn muffin",
-				"pluralName": "corn muffins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pav bun",
-				"pluralName": "pav buns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn nut",
-				"pluralName": "corn nuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice cracker",
-				"pluralName": "rice crackers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rusk",
-				"pluralName": "rusks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fruit bread",
-				"pluralName": "fruit breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sprouted bread",
-				"pluralName": "sprouted breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pretzel bun",
-				"pluralName": "pretzel buns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roti bread",
-				"pluralName": "roti breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crispbread",
-				"pluralName": "crispbreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate muffin",
-				"pluralName": "chocolate muffins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "milk bread",
-				"pluralName": "milk breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "popcorn shrimp",
-				"pluralName": "popcorn shrimps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prawn cracker",
-				"pluralName": "prawn crackers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bao bun",
-				"pluralName": "bao buns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ezekiel bread",
-				"pluralName": "ezekiel breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wasabi pea",
-				"pluralName": "wasabi peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "arabic bread",
-				"pluralName": "arabic breads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "boboli",
-				"pluralName": "bobolis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "zwieback",
-				"pluralName": "zwiebacks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oven chip",
-				"pluralName": "oven chips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taco kit",
-				"pluralName": "taco kits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gluten free pita",
-				"pluralName": "gluten free pitas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ready-made arepa",
-				"pluralName": "ready-made arepas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ready-made pancake",
-				"pluralName": "ready-made pancakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "breading mix",
-				"pluralName": "breading mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "japanese peanut",
-				"pluralName": "japanese peanuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "khari boondi",
-				"pluralName": "khari boondis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato waffle",
-				"pluralName": "potato waffles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tartlet shell",
-				"pluralName": "tartlet shells"
-			}
-		]
-	},
-	"Oils & Fats": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "olive oil",
-				"pluralName": "olive oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable oil",
-				"pluralName": "vegetable oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "extra virgin olive oil",
-				"pluralName": "extra virgin olive oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canola oil",
-				"pluralName": "canola oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut oil",
-				"pluralName": "coconut oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cooking spray",
-				"pluralName": "cooking sprays"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sesame oil",
-				"pluralName": "sesame oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "frying oil",
-				"pluralName": "frying oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sunflower oil",
-				"pluralName": "sunflower oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "avocado oil",
-				"pluralName": "avocado oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "toasted sesame oil",
-				"pluralName": "toasted sesame oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut oil",
-				"pluralName": "peanut oils"
-			},
-			{
-				"aliases": [
-					"grape seed oil"
-				],
-				"description": "",
-				"name": "grapeseed oil",
-				"pluralName": "grapeseed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lard",
-				"pluralName": "lards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn oil",
-				"pluralName": "corn oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "virgin coconut oil",
-				"pluralName": "virgin coconut oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili oil",
-				"pluralName": "chili oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard oil",
-				"pluralName": "mustard oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "walnut oil",
-				"pluralName": "walnut oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic oil",
-				"pluralName": "garlic oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "truffle oil",
-				"pluralName": "truffle oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bacon grease",
-				"pluralName": "bacon greases"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "safflower oil",
-				"pluralName": "safflower oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cacao butter",
-				"pluralName": "cacao butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salad oil",
-				"pluralName": "salad oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck fat",
-				"pluralName": "duck fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice bran oil",
-				"pluralName": "rice bran oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soybean oil",
-				"pluralName": "soybean oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter-flavored cooking spray",
-				"pluralName": "butter-flavored cooking sprays"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "medium-chain triglyceride",
-				"pluralName": "medium-chain triglycerides"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "flaxseed oil",
-				"pluralName": "flaxseed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white truffle oil",
-				"pluralName": "white truffle oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin seed oil",
-				"pluralName": "pumpkin seed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut oil",
-				"pluralName": "hazelnut oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut oil spray",
-				"pluralName": "coconut oil sprays"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond oil",
-				"pluralName": "almond oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon oil",
-				"pluralName": "lemon oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macadamia oil",
-				"pluralName": "macadamia oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goose fat",
-				"pluralName": "goose fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "palm oil",
-				"pluralName": "palm oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "basil oil",
-				"pluralName": "basil oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork fat",
-				"pluralName": "pork fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef dripping",
-				"pluralName": "beef drippings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "schmaltz",
-				"pluralName": "schmaltzzes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tallow",
-				"pluralName": "tallows"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sushi vinegar",
-				"pluralName": "sushi vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pistachio oil",
-				"pluralName": "pistachio oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herb-infused olive oil",
-				"pluralName": "herb-infused olive oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted peanut oil",
-				"pluralName": "roasted peanut oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "argan oil",
-				"pluralName": "argan oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef fat",
-				"pluralName": "beef fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pecan oil",
-				"pluralName": "pecan oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crisco oil",
-				"pluralName": "crisco oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red palm oil",
-				"pluralName": "red palm oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shea butter",
-				"pluralName": "shea butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb fat",
-				"pluralName": "lamb fats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "castor oil",
-				"pluralName": "castor oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken dripping",
-				"pluralName": "chicken drippings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shallot oil",
-				"pluralName": "shallot oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "achiote oil",
-				"pluralName": "achiote oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jojoba oil",
-				"pluralName": "jojoba oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oregano oil",
-				"pluralName": "oregano oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hemp seed oil",
-				"pluralName": "hemp seed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wheat germ oil",
-				"pluralName": "wheat germ oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger oil",
-				"pluralName": "ginger oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cottonseed oil",
-				"pluralName": "cottonseed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork dripping",
-				"pluralName": "pork drippings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rosehip seed oil",
-				"pluralName": "rosehip seed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "camelina oil",
-				"pluralName": "camelina oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marula oil",
-				"pluralName": "marula oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moringa seed oil",
-				"pluralName": "moringa seed oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white cacao butter",
-				"pluralName": "white cacao butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black seed oil",
-				"pluralName": "black seed oils"
-			}
-		]
-	},
-	"Dressings & Vinegars": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mayonnaise",
-				"pluralName": "mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple cider vinegar",
-				"pluralName": "apple cider vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "balsamic vinegar",
-				"pluralName": "balsamic vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vinegar",
-				"pluralName": "vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red wine vinegar",
-				"pluralName": "red wine vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice wine vinegar",
-				"pluralName": "rice wine vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white wine vinegar",
-				"pluralName": "white wine vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ranch dressing",
-				"pluralName": "ranch dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "italian dressing",
-				"pluralName": "italian dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sherry vinegar",
-				"pluralName": "sherry vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "distilled white vinegar",
-				"pluralName": "distilled white vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet chilli sauce",
-				"pluralName": "sweet chilli sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white balsamic vinegar",
-				"pluralName": "white balsamic vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "champagne vinegar",
-				"pluralName": "champagne vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vinaigrette dressing",
-				"pluralName": "vinaigrette dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "balsamic vinaigrette",
-				"pluralName": "balsamic vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blue cheese dressing",
-				"pluralName": "blue cheese dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caesar dressing",
-				"pluralName": "caesar dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thousand island",
-				"pluralName": "thousand islands"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "malt vinegar",
-				"pluralName": "malt vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black vinegar",
-				"pluralName": "black vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canola mayonnaise",
-				"pluralName": "canola mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry vinegar",
-				"pluralName": "raspberry vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "japanese mayonnaise",
-				"pluralName": "japanese mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tarragon vinegar",
-				"pluralName": "tarragon vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "greek vinaigrette",
-				"pluralName": "greek vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sesame dressing",
-				"pluralName": "sesame dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey mustard dressing",
-				"pluralName": "honey mustard dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aioli sauce",
-				"pluralName": "aioli sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "french dressing",
-				"pluralName": "french dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spicy mayo",
-				"pluralName": "spicy mayoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "poppyseed dressing",
-				"pluralName": "poppyseed dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "catalina dressing",
-				"pluralName": "catalina dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "verjuice",
-				"pluralName": "verjuices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cane vinegar",
-				"pluralName": "cane vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry vinaigrette",
-				"pluralName": "raspberry vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red wine vinaigrette",
-				"pluralName": "red wine vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "russian dressing",
-				"pluralName": "russian dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "avocado oil mayonnaise",
-				"pluralName": "avocado oil mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creamy balsamic dressing",
-				"pluralName": "creamy balsamic dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "champagne vinaigrette",
-				"pluralName": "champagne vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun-dried tomato vinaigrette",
-				"pluralName": "sun-dried tomato vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic mayonnaise",
-				"pluralName": "garlic mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown rice vinegar",
-				"pluralName": "brown rice vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut vinegar",
-				"pluralName": "coconut vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ume plum vinegar",
-				"pluralName": "ume plum vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "buttermilk ranch dressing",
-				"pluralName": "buttermilk ranch dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cilantro dressing",
-				"pluralName": "cilantro dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spicy ranch dressing",
-				"pluralName": "spicy ranch dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fig balsamic",
-				"pluralName": "fig balsamics"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green goddess dressing",
-				"pluralName": "green goddess dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creamy dressing",
-				"pluralName": "creamy dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion salad dressing",
-				"pluralName": "onion salad dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "miso dressing",
-				"pluralName": "miso dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white balsamic vinaigrette",
-				"pluralName": "white balsamic vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chardonnay vinegar",
-				"pluralName": "chardonnay vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prepared coleslaw dressing",
-				"pluralName": "prepared coleslaw dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey vinegar",
-				"pluralName": "honey vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tandoori mayonnaise",
-				"pluralName": "tandoori mayonnaises"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili vinegar",
-				"pluralName": "chili vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili-lime dressing",
-				"pluralName": "chili-lime dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moscatel vinegar",
-				"pluralName": "moscatel vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vinegar powder",
-				"pluralName": "vinegar powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caramelised onion dressing",
-				"pluralName": "caramelised onion dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango vinaigrette",
-				"pluralName": "mango vinaigrettes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sugarcane vinegar",
-				"pluralName": "sugarcane vinegars"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "avocado-lime dressing",
-				"pluralName": "avocado-lime dressings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spicy vinegar",
-				"pluralName": "spicy vinegars"
-			}
-		]
-	},
-	"Condiments": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy sauce",
-				"pluralName": "soy sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dijon mustard",
-				"pluralName": "dijon mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "worcestershire",
-				"pluralName": "worcestershires"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot sauce",
-				"pluralName": "hot sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "worcestershire sauce",
-				"pluralName": "worcestershire sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ketchup",
-				"pluralName": "ketchups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard",
-				"pluralName": "mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish sauce",
-				"pluralName": "fish sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bbq sauce",
-				"pluralName": "bbq sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sriracha",
-				"pluralName": "srirachas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wholegrain mustard",
-				"pluralName": "wholegrain mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamari",
-				"pluralName": "tamaris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oyster sauce",
-				"pluralName": "oyster sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili sauce",
-				"pluralName": "chili sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger-garlic paste",
-				"pluralName": "ginger-garlic pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brown mustard",
-				"pluralName": "brown mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wing sauce",
-				"pluralName": "wing sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "teriyaki sauce",
-				"pluralName": "teriyaki sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prepared horseradish",
-				"pluralName": "prepared horseradishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger paste",
-				"pluralName": "ginger pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark soy sauce",
-				"pluralName": "dark soy sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut amino",
-				"pluralName": "coconut aminos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili paste",
-				"pluralName": "chili pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry sauce",
-				"pluralName": "cranberry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "harissa",
-				"pluralName": "harissas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili-garlic sauce",
-				"pluralName": "chili-garlic sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind paste",
-				"pluralName": "tamarind pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomegranate molass",
-				"pluralName": "pomegranate molasses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gochujang",
-				"pluralName": "gochujangs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wasabi",
-				"pluralName": "wasabis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey mustard",
-				"pluralName": "honey mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango chutney",
-				"pluralName": "mango chutneys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "english mustard",
-				"pluralName": "english mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sambal oelek",
-				"pluralName": "sambal oeleks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "preserved lemon",
-				"pluralName": "preserved lemons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kecap mani",
-				"pluralName": "kecap manis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chutney",
-				"pluralName": "chutneys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shrimp paste",
-				"pluralName": "shrimp pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "picante sauce",
-				"pluralName": "picante sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai sweet chili sauce",
-				"pluralName": "thai sweet chili sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet and sour sauce",
-				"pluralName": "sweet and sour sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid amino",
-				"pluralName": "liquid aminos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tartar sauce",
-				"pluralName": "tartar sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot pepper jelly",
-				"pluralName": "hot pepper jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili-garlic paste",
-				"pluralName": "chili-garlic pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bonito flake",
-				"pluralName": "bonito flakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green chutney",
-				"pluralName": "green chutneys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican hot sauce",
-				"pluralName": "mexican hot sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ponzu",
-				"pluralName": "ponzus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green chilli sauce",
-				"pluralName": "green chilli sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sambal",
-				"pluralName": "sambals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crispy onion",
-				"pluralName": "crispy onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red pepper jelly",
-				"pluralName": "red pepper jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai chili paste",
-				"pluralName": "thai chili pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peri peri",
-				"pluralName": "peri peris"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green chilli paste",
-				"pluralName": "green chilli pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mint jelly",
-				"pluralName": "mint jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "horseradish mustard",
-				"pluralName": "horseradish mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard paste",
-				"pluralName": "mustard pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aji amarillo",
-				"pluralName": "aji amarilloes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pepper paste",
-				"pluralName": "pepper pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yuzu juice",
-				"pluralName": "yuzu juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tonkatsu sauce",
-				"pluralName": "tonkatsu sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chermoula",
-				"pluralName": "chermoulas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind chutney",
-				"pluralName": "tamarind chutneys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hp sauce",
-				"pluralName": "hp sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck sauce",
-				"pluralName": "duck sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger chili paste",
-				"pluralName": "ginger chili pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion marmalade",
-				"pluralName": "onion marmalades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "giardiniera",
-				"pluralName": "giardinieras"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black soy sauce",
-				"pluralName": "black soy sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "doubanjiang",
-				"pluralName": "doubanjiangs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "korean bbq sauce",
-				"pluralName": "korean bbq sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maggi sauce",
-				"pluralName": "maggi sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chinese mustard",
-				"pluralName": "chinese mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chamoy",
-				"pluralName": "chamoys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime pickle",
-				"pluralName": "lime pickles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "doenjang",
-				"pluralName": "doenjangs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili crisp",
-				"pluralName": "chili crisps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "karashi",
-				"pluralName": "karashis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mushroom soy sauce",
-				"pluralName": "mushroom soy sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yuzu kosho",
-				"pluralName": "yuzu koshoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "german mustard",
-				"pluralName": "german mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taucheo",
-				"pluralName": "taucheos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eel sauce",
-				"pluralName": "eel sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hot bean paste",
-				"pluralName": "hot bean pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pati",
-				"pluralName": "patis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "remoulade",
-				"pluralName": "remoulades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white bbq sauce",
-				"pluralName": "white bbq sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickapeppa sauce",
-				"pluralName": "pickapeppa sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salsa lizano",
-				"pluralName": "salsa lizanoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shrimp sauce",
-				"pluralName": "shrimp sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet soybean paste",
-				"pluralName": "sweet soybean pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grape must",
-				"pluralName": "grape musts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shrimp powder",
-				"pluralName": "shrimp powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana ketchup",
-				"pluralName": "banana ketchups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili puree",
-				"pluralName": "chili purees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green harissa",
-				"pluralName": "green harissas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "crab paste",
-				"pluralName": "crab pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beer mustard",
-				"pluralName": "beer mustards"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guk ganjang",
-				"pluralName": "guk ganjangs"
-			}
-		]
-	},
-	"Canned Food": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned tomato",
-				"pluralName": "canned tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caper",
-				"pluralName": "capers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green olive",
-				"pluralName": "green olives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned chickpea",
-				"pluralName": "canned chickpeas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black olive",
-				"pluralName": "black olives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned black bean",
-				"pluralName": "canned black beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pumpkin",
-				"pluralName": "canned pumpkins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kalamata olive",
-				"pluralName": "kalamata olives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned tuna",
-				"pluralName": "canned tuna"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickle",
-				"pluralName": "pickles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pineapple",
-				"pluralName": "canned pineapples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chipotle in adobo",
-				"pluralName": "chipotle in adobo"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned anchovy",
-				"pluralName": "canned anchovies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted red pepper",
-				"pluralName": "roasted red peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato with green chiles",
-				"pluralName": "tomatoes with green chiles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned artichoke",
-				"pluralName": "canned artichokes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned corn",
-				"pluralName": "canned corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned kidney bean",
-				"pluralName": "canned kidney beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pie filling",
-				"pluralName": "canned pie fillings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned cannellini bean",
-				"pluralName": "canned cannellini beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "refried bean",
-				"pluralName": "refried beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned whole tomato",
-				"pluralName": "canned whole tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sweet pickle relish",
-				"pluralName": "sweet pickle relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sauerkraut",
-				"pluralName": "sauerkrauts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creamed corn",
-				"pluralName": "creamed corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corned beef",
-				"pluralName": "corned beefs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned bean",
-				"pluralName": "canned beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled jalapeno",
-				"pluralName": "pickled jalapenos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "diced green chile",
-				"pluralName": "diced green chiles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun-dried tomato in oil",
-				"pluralName": "sun-dried tomatoes in oil"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kimchi",
-				"pluralName": "kimchis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned mandarin orange",
-				"pluralName": "canned mandarin oranges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili bean",
-				"pluralName": "chili beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned crab",
-				"pluralName": "canned crabs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bamboo shoot",
-				"pluralName": "bamboo shoots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned mushroom",
-				"pluralName": "canned mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baked bean",
-				"pluralName": "baked beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned salmon",
-				"pluralName": "canned salmon"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickling juice",
-				"pluralName": "pickling juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dill pickle relish",
-				"pluralName": "dill pickle relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned peach",
-				"pluralName": "canned peaches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned black-eyed pea",
-				"pluralName": "canned black-eyed peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled ginger",
-				"pluralName": "pickled gingers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned apple",
-				"pluralName": "canned apples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned green bean",
-				"pluralName": "canned green beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spam",
-				"pluralName": "spams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned clam",
-				"pluralName": "canned clams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili with beans",
-				"pluralName": "chili with beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled onion",
-				"pluralName": "pickled onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fruit cocktail",
-				"pluralName": "fruit cocktails"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned lentil",
-				"pluralName": "canned lentils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pea",
-				"pluralName": "canned peas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled red onion",
-				"pluralName": "pickled red onions"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pimiento-stuffed green olive",
-				"pluralName": "pimiento-stuffed green olives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pork",
-				"pluralName": "canned porks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled beet",
-				"pluralName": "pickled beets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned cherry tomato",
-				"pluralName": "canned cherry tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bread & butter pickle",
-				"pluralName": "bread & butter pickles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned apricot",
-				"pluralName": "canned apricots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned sweet potato",
-				"pluralName": "canned sweet potatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pear",
-				"pluralName": "canned pears"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppadew pepper",
-				"pluralName": "peppadew peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled vegetable",
-				"pluralName": "pickled vegetables"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion paste",
-				"pluralName": "onion pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned baby corn",
-				"pluralName": "canned baby corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican-style corn",
-				"pluralName": "mexican-style corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili without bean",
-				"pluralName": "chili without beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork and bean",
-				"pluralName": "pork and beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ranch-style bean",
-				"pluralName": "ranch-style beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned chicken breast",
-				"pluralName": "canned chicken breasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned carrot",
-				"pluralName": "canned carrots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana pepper ring",
-				"pluralName": "banana pepper rings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned lychee",
-				"pluralName": "canned lychees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin pie filling",
-				"pluralName": "pumpkin pie fillings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned sardine",
-				"pluralName": "canned sardines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled pepper",
-				"pluralName": "pickled peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato relish",
-				"pluralName": "tomato relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned jackfruit",
-				"pluralName": "canned jackfruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taggiasca olive",
-				"pluralName": "taggiasca olives"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry relish",
-				"pluralName": "cranberry relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red pepper relish",
-				"pluralName": "red pepper relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned asparagu",
-				"pluralName": "canned asparagus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fire-roasted green chile",
-				"pluralName": "fire-roasted green chiles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled hot pepper",
-				"pluralName": "pickled hot peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned peas and carrot",
-				"pluralName": "canned peas and carrots"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn relish",
-				"pluralName": "corn relishes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden hominy",
-				"pluralName": "golden hominies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned mackerel",
-				"pluralName": "canned mackerel"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled cherry pepper",
-				"pluralName": "pickled cherry peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied jalapeno",
-				"pluralName": "candied jalapenos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "umeboshi",
-				"pluralName": "umeboshis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned pimento",
-				"pluralName": "canned pimentos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned potato",
-				"pluralName": "canned potatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "okra pickle",
-				"pluralName": "okra pickles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato confit",
-				"pluralName": "tomato confits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brandied cherry",
-				"pluralName": "brandied cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "macapuno",
-				"pluralName": "macapunoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "canned four-bean mix",
-				"pluralName": "canned four-bean mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "half-sour pickle",
-				"pluralName": "half-sour pickles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pickled green bean",
-				"pluralName": "pickled green beans"
-			}
-		]
-	},
-	"Sauces, Spreads & Dips": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut butter",
-				"pluralName": "peanut butters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato paste",
-				"pluralName": "tomato pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato sauce",
-				"pluralName": "tomato sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salsa",
-				"pluralName": "salsas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tahini",
-				"pluralName": "tahinis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pesto",
-				"pluralName": "pestoes"
-			},
-			{
-				"aliases": [
-					"marinara sauce - jarred"
-				],
-				"description": "",
-				"name": "marinara sauce",
-				"pluralName": "marinara sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pasta sauce",
-				"pluralName": "pasta sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hoisin sauce",
-				"pluralName": "hoisin sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pico de gallo",
-				"pluralName": "pico de gallo"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stewed tomato",
-				"pluralName": "stewed tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guacamole",
-				"pluralName": "guacamoles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hummu",
-				"pluralName": "hummus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "enchilada sauce",
-				"pluralName": "enchilada sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fire-roasted tomato",
-				"pluralName": "fire-roasted tomatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "salsa verde",
-				"pluralName": "salsa verdes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "alfredo sauce",
-				"pluralName": "alfredo sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "balsamic glaze",
-				"pluralName": "balsamic glazes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anchovy paste",
-				"pluralName": "anchovy pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red enchilada sauce",
-				"pluralName": "red enchilada sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "steak sauce",
-				"pluralName": "steak sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chunky peanut butter",
-				"pluralName": "chunky peanut butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tzatziki",
-				"pluralName": "tzatzikis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "taco sauce",
-				"pluralName": "taco sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef gravy",
-				"pluralName": "beef gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun-dried tomato pesto",
-				"pluralName": "sun-dried tomato pestoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "b\u00e9chamel sauce",
-				"pluralName": "b\u00e9chamel sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "horseradish sauce",
-				"pluralName": "horseradish sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plum sauce",
-				"pluralName": "plum sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic butter",
-				"pluralName": "garlic butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hollandaise sauce",
-				"pluralName": "hollandaise sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cocktail sauce",
-				"pluralName": "cocktail sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese dip",
-				"pluralName": "cheese dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black bean sauce",
-				"pluralName": "black bean sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tapenade",
-				"pluralName": "tapenades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey gravy",
-				"pluralName": "turkey gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stir-fry sauce",
-				"pluralName": "stir-fry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai peanut sauce",
-				"pluralName": "thai peanut sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken gravy",
-				"pluralName": "chicken gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sloppy joe sauce",
-				"pluralName": "sloppy joe sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pimento cheese spread",
-				"pluralName": "pimento cheese spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sofrito",
-				"pluralName": "sofritoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mustard sauce",
-				"pluralName": "mustard sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun-dried tomato paste",
-				"pluralName": "sun-dried tomato pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato paste",
-				"pluralName": "tomato pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "queso dip",
-				"pluralName": "queso dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "demi-glace",
-				"pluralName": "demi-glaces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chimichurri sauce",
-				"pluralName": "chimichurri sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "french onion dip",
-				"pluralName": "french onion dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herb butter",
-				"pluralName": "herb butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bolognese sauce",
-				"pluralName": "bolognese sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curry sauce",
-				"pluralName": "curry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liver spread",
-				"pluralName": "liver spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "browning sauce",
-				"pluralName": "browning sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "schezwan sauce",
-				"pluralName": "schezwan sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mushroom gravy",
-				"pluralName": "mushroom gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork gravy",
-				"pluralName": "pork gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "country gravy",
-				"pluralName": "country gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange sauce",
-				"pluralName": "orange sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pineapple salsa",
-				"pluralName": "pineapple salsas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "artichoke dip",
-				"pluralName": "artichoke dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "japanese curry",
-				"pluralName": "japanese curries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango salsa",
-				"pluralName": "mango salsas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "olive paste",
-				"pluralName": "olive pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spinach dip",
-				"pluralName": "spinach dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black truffle butter",
-				"pluralName": "black truffle butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "roasted red pepper hummu",
-				"pluralName": "roasted red pepper hummus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bacon jam",
-				"pluralName": "bacon jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tikka masala sauce",
-				"pluralName": "tikka masala sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vodka sauce",
-				"pluralName": "vodka sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whipped cream cheese spread",
-				"pluralName": "whipped cream cheese spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kung pao sauce",
-				"pluralName": "kung pao sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mole paste",
-				"pluralName": "mole pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion gravy",
-				"pluralName": "onion gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sesame sauce",
-				"pluralName": "sesame sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese spread",
-				"pluralName": "cheese spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn salsa",
-				"pluralName": "corn salsas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pad thai sauce",
-				"pluralName": "pad thai sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sausage gravy",
-				"pluralName": "sausage gravies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "deviled ham spread",
-				"pluralName": "deviled ham spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter chicken sauce",
-				"pluralName": "butter chicken sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic spread",
-				"pluralName": "garlic spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black pepper sauce",
-				"pluralName": "black pepper sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "char siu sauce",
-				"pluralName": "char siu sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "garlic pasta sauce",
-				"pluralName": "garlic pasta sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green olive tapenade",
-				"pluralName": "green olive tapenades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "schezwan chutney",
-				"pluralName": "schezwan chutneys"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mentsuyu",
-				"pluralName": "mentsuyus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai red curry sauce",
-				"pluralName": "thai red curry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tarama",
-				"pluralName": "taramas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ssamjang",
-				"pluralName": "ssamjangs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white pizza sauce",
-				"pluralName": "white pizza sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato tapenade",
-				"pluralName": "tomato tapenades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "yum yum sauce",
-				"pluralName": "yum yum sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "honey garlic sauce",
-				"pluralName": "honey garlic sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mole sauce",
-				"pluralName": "mole sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nuoc cham",
-				"pluralName": "nuoc chams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white clam sauce",
-				"pluralName": "white clam sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean dip",
-				"pluralName": "bean dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eggplant dip",
-				"pluralName": "eggplant dips"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomegranate sauce",
-				"pluralName": "pomegranate sauces"
-			}
-		]
-	},
-	"Soups, Stews & Stocks": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken broth",
-				"pluralName": "chicken broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable broth",
-				"pluralName": "vegetable broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken stock",
-				"pluralName": "chicken stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef broth",
-				"pluralName": "beef broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef stock",
-				"pluralName": "beef stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of mushroom",
-				"pluralName": "cream of mushroom"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bouillon cube",
-				"pluralName": "bouillon cubes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of chicken",
-				"pluralName": "cream of chicken"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion soup mix",
-				"pluralName": "onion soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato soup",
-				"pluralName": "tomato soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish stock",
-				"pluralName": "fish stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of celery",
-				"pluralName": "cream of celery"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "better than bouillon",
-				"pluralName": "better than bouillons"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clam juice",
-				"pluralName": "clam juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheese soup",
-				"pluralName": "cheese soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bone broth",
-				"pluralName": "bone broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dashi",
-				"pluralName": "dashis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "onion soup",
-				"pluralName": "onion soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken soup",
-				"pluralName": "chicken soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal stock",
-				"pluralName": "veal stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken bone broth",
-				"pluralName": "chicken bone broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey stock",
-				"pluralName": "turkey stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb stock",
-				"pluralName": "lamb stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey broth",
-				"pluralName": "turkey broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef consomm\u00e9",
-				"pluralName": "beef consomm\u00e9s"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "stock paste",
-				"pluralName": "stock pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of potato",
-				"pluralName": "cream of potato"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "golden mushroom soup",
-				"pluralName": "golden mushroom soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "seafood stock",
-				"pluralName": "seafood stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mushroom broth",
-				"pluralName": "mushroom broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable soup",
-				"pluralName": "vegetable soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken noodle soup",
-				"pluralName": "chicken noodle soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable soup mix",
-				"pluralName": "vegetable soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken consomm\u00e9",
-				"pluralName": "chicken consomm\u00e9s"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shrimp stock",
-				"pluralName": "shrimp stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nacho cheese soup",
-				"pluralName": "nacho cheese soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ramen noodle soup",
-				"pluralName": "ramen noodle soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of broccoli",
-				"pluralName": "cream of broccoli"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lobster stock",
-				"pluralName": "lobster stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork stock",
-				"pluralName": "pork stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken rice soup",
-				"pluralName": "chicken rice soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beefy onion soup mix",
-				"pluralName": "beefy onion soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butternut squash soup",
-				"pluralName": "butternut squash soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken stock paste",
-				"pluralName": "chicken stock pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "miso soup",
-				"pluralName": "miso soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "broccoli-cheese soup",
-				"pluralName": "broccoli-cheese soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "duck stock",
-				"pluralName": "duck stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clam broth",
-				"pluralName": "clam broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan chicken broth",
-				"pluralName": "vegan chicken broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of asparagus",
-				"pluralName": "cream of asparagus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork broth",
-				"pluralName": "pork broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beefy mushroom soup",
-				"pluralName": "beefy mushroom soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "new england clam chowder",
-				"pluralName": "new england clam chowders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean soup mix",
-				"pluralName": "bean soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "black bean soup",
-				"pluralName": "black bean soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ham stock",
-				"pluralName": "ham stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lentil soup",
-				"pluralName": "lentil soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of shrimp soup",
-				"pluralName": "cream of shrimp soup"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "veal broth",
-				"pluralName": "veal broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegetable beef soup",
-				"pluralName": "vegetable beef soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken soup mix",
-				"pluralName": "chicken soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of bacon",
-				"pluralName": "cream of bacon"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lobster bisque",
-				"pluralName": "lobster bisques"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bean with bacon soup",
-				"pluralName": "bean with bacon soup"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clam chowder",
-				"pluralName": "clam chowders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "condensed chicken gumbo soup",
-				"pluralName": "condensed chicken gumbo soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tortilla soup base",
-				"pluralName": "tortilla soup bases"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "turkey bone broth",
-				"pluralName": "turkey bone broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anchovy stock",
-				"pluralName": "anchovy stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of chicken soup mix:",
-				"pluralName": "cream of chicken soup mix:"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "noodle soup mix",
-				"pluralName": "noodle soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lamb broth",
-				"pluralName": "lamb broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "minestrone",
-				"pluralName": "minestrones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai chicken broth",
-				"pluralName": "thai chicken broths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato bisque",
-				"pluralName": "tomato bisques"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "venison stock",
-				"pluralName": "venison stocks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beef stock paste",
-				"pluralName": "beef stock pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bovril",
-				"pluralName": "bovrils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken corn chowder",
-				"pluralName": "chicken corn chowders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pork & bean",
-				"pluralName": "pork & beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sun-dried tomato bisque mix",
-				"pluralName": "sun-dried tomato bisque mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ham-flavored concentrate",
-				"pluralName": "ham-flavored concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oxtail soup",
-				"pluralName": "oxtail soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "potato soup mix",
-				"pluralName": "potato soup mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "callaloo",
-				"pluralName": "callaloos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "split pea soup",
-				"pluralName": "split pea soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken and mushroom soup",
-				"pluralName": "chicken and mushroom soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chili beef soup",
-				"pluralName": "chili beef soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn chowder",
-				"pluralName": "corn chowders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of cauliflower",
-				"pluralName": "cream of cauliflower"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dashida",
-				"pluralName": "dashidas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green pea soup",
-				"pluralName": "green pea soups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pho broth",
-				"pluralName": "pho broths"
-			}
-		]
-	},
-	"Desserts & Sweet Snacks": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cocoa",
-				"pluralName": "cocoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark chocolate",
-				"pluralName": "dark chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark cocoa",
-				"pluralName": "dark cocoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate",
-				"pluralName": "chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "graham cracker",
-				"pluralName": "graham crackers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "baking chocolate",
-				"pluralName": "baking chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marshmallow",
-				"pluralName": "marshmallows"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mini arshmallow",
-				"pluralName": "mini marshmallows"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "applesauce",
-				"pluralName": "applesauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white chocolate",
-				"pluralName": "white chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "oreo",
-				"pluralName": "oreos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate hazelnut spread",
-				"pluralName": "chocolate hazelnut spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "instant pudding",
-				"pluralName": "instant puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate candy",
-				"pluralName": "chocolate candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate cream-filled chocolate sandwich cookie",
-				"pluralName": "chocolate cream-filled chocolate sandwich cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dutch-process cocoa",
-				"pluralName": "dutch-process cocoas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry jam",
-				"pluralName": "raspberry jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apricot jam",
-				"pluralName": "apricot jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caramel sauce",
-				"pluralName": "caramel sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy coating",
-				"pluralName": "candy coatings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raw cacao powder",
-				"pluralName": "raw cacao powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry jam",
-				"pluralName": "strawberry jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "biscuit",
-				"pluralName": "biscuits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marshmallow creme",
-				"pluralName": "marshmallow cremes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy",
-				"pluralName": "candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jam",
-				"pluralName": "jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange marmalade",
-				"pluralName": "orange marmalades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wafer",
-				"pluralName": "wafers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cookie",
-				"pluralName": "cookies"
-			},
-			{
-				"aliases": [
-					"Reeses PB cup",
-					"Reeses Peanut Buttercup"
-				],
-				"description": "",
-				"name": "peanut butter cup",
-				"pluralName": "peanut butter cups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate pudding",
-				"pluralName": "chocolate puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy cane",
-				"pluralName": "candy canes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger snap",
-				"pluralName": "ginger snaps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cacao nib",
-				"pluralName": "cacao nibs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lady finger",
-				"pluralName": "lady fingers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate chip cookie",
-				"pluralName": "chocolate chip cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fudge sauce",
-				"pluralName": "fudge sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate cookie",
-				"pluralName": "chocolate cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "digestive biscuit",
-				"pluralName": "digestive biscuits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple butter",
-				"pluralName": "apple butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppermint candy",
-				"pluralName": "peppermint candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon roll",
-				"pluralName": "cinnamon rolls"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter cookie",
-				"pluralName": "butter cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied cherry",
-				"pluralName": "candied cherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caramel candy",
-				"pluralName": "caramel candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla pudding",
-				"pluralName": "vanilla puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "currant jelly",
-				"pluralName": "currant jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied ginger",
-				"pluralName": "candied gingers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "angel food cake",
-				"pluralName": "angel food cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach preserve",
-				"pluralName": "peach preserves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate wafer",
-				"pluralName": "chocolate wafers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied peel",
-				"pluralName": "candied peels"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nutella",
-				"pluralName": "nutellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry jam",
-				"pluralName": "cherry jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dark couverture chocolate",
-				"pluralName": "dark couverture chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "couverture chocolate",
-				"pluralName": "couverture chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grape jelly",
-				"pluralName": "grape jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "waffle",
-				"pluralName": "waffles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tartlet shell",
-				"pluralName": "tartlet shells"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cookie butter",
-				"pluralName": "cookie butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fig jam",
-				"pluralName": "fig jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butterscotch",
-				"pluralName": "butterscotches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blueberry jam",
-				"pluralName": "blueberry jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied fruit",
-				"pluralName": "candied fruits"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond cookie",
-				"pluralName": "almond cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gummy",
-				"pluralName": "gummies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple jelly",
-				"pluralName": "apple jellies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackberry preserve",
-				"pluralName": "blackberry preserves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candy corn",
-				"pluralName": "candy corns"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ice-cream cone",
-				"pluralName": "ice-cream cones"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sugar cookie",
-				"pluralName": "sugar cookies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marmalade",
-				"pluralName": "marmalades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg candy",
-				"pluralName": "egg candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry puree",
-				"pluralName": "strawberry purees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate powder",
-				"pluralName": "chocolate powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sponge cake",
-				"pluralName": "sponge cakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate-covered espresso bean",
-				"pluralName": "chocolate-covered espresso beans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pineapple jam",
-				"pluralName": "pineapple jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "licorice",
-				"pluralName": "licorices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plum jam",
-				"pluralName": "plum jams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mexican chocolate",
-				"pluralName": "mexican chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana pudding",
-				"pluralName": "banana puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white couverture",
-				"pluralName": "white couvertures"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sorbet",
-				"pluralName": "sorbets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate peanut butter",
-				"pluralName": "chocolate peanut butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon candy",
-				"pluralName": "cinnamon candies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin butter",
-				"pluralName": "pumpkin butter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guava paste",
-				"pluralName": "guava pastes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fudge",
-				"pluralName": "fudges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry sauce",
-				"pluralName": "strawberry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butterscotch pudding mix",
-				"pluralName": "butterscotch pudding mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate spread",
-				"pluralName": "chocolate spreads"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "doughnut",
-				"pluralName": "doughnuts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "biscotti",
-				"pluralName": "biscottis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cheesecake instant pudding",
-				"pluralName": "cheesecake instant puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppermint patty",
-				"pluralName": "peppermint patties"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pistachio pudding",
-				"pluralName": "pistachio puddings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate fudge",
-				"pluralName": "chocolate fudges"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry sauce",
-				"pluralName": "raspberry sauces"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry sorbet",
-				"pluralName": "raspberry sorbets"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "candied pineapple",
-				"pluralName": "candied pineapples"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hershey kiss",
-				"pluralName": "hershey kisses"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pistachio instant pudding",
-				"pluralName": "pistachio instant puddings"
-			}
-		]
-	},
-	"Wine, Beer & Spirits": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white wine",
-				"pluralName": "white wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red wine",
-				"pluralName": "red wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "whisky",
-				"pluralName": "whiskies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rum",
-				"pluralName": "rums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vodka",
-				"pluralName": "vodkas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beer",
-				"pluralName": "beers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange liqueur",
-				"pluralName": "orange liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cider",
-				"pluralName": "ciders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tequila",
-				"pluralName": "tequilas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sherry",
-				"pluralName": "sherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gin",
-				"pluralName": "gins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brandy",
-				"pluralName": "brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bitter",
-				"pluralName": "bitters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mirin",
-				"pluralName": "mirins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white rum",
-				"pluralName": "white rums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee liqueur",
-				"pluralName": "coffee liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "champagne",
-				"pluralName": "champagnes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "irish cream",
-				"pluralName": "irish creams"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vermouth",
-				"pluralName": "vermouths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "amaretto",
-				"pluralName": "amarettoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "marsala wine",
-				"pluralName": "marsala wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cognac",
-				"pluralName": "cognacs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sparkling wine",
-				"pluralName": "sparkling wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sake",
-				"pluralName": "sakes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice wine",
-				"pluralName": "rice wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "shaoxing wine",
-				"pluralName": "shaoxing wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dry vermouth",
-				"pluralName": "dry vermouths"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liqueur",
-				"pluralName": "liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut rum",
-				"pluralName": "coconut rums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dessert wine",
-				"pluralName": "dessert wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "curacao",
-				"pluralName": "curacaos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "port wine",
-				"pluralName": "port wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kirsch",
-				"pluralName": "kirsches"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach schnapp",
-				"pluralName": "peach schnapps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple brandy",
-				"pluralName": "apple brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ros\u00e9 wine",
-				"pluralName": "ros\u00e9 wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anise liqueur",
-				"pluralName": "anise liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herbal liqueur",
-				"pluralName": "herbal liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "limoncello",
-				"pluralName": "limoncellos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderflower liqueur",
-				"pluralName": "elderflower liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cooking wine",
-				"pluralName": "cooking wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut liqueur",
-				"pluralName": "hazelnut liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach liqueur",
-				"pluralName": "peach liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "melon liqueur",
-				"pluralName": "melon liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry liqueur",
-				"pluralName": "raspberry liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creme de cacao",
-				"pluralName": "creme de cacao"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "schnapp",
-				"pluralName": "schnapps"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana liqueur",
-				"pluralName": "banana liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "madeira wine",
-				"pluralName": "madeira wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "absinthe",
-				"pluralName": "absinthes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white cooking wine",
-				"pluralName": "white cooking wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aperol",
-				"pluralName": "aperols"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla vodka",
-				"pluralName": "vanilla vodkas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon alcohol",
-				"pluralName": "cinnamon alcohols"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creme de menthe",
-				"pluralName": "creme de menthe"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apricot brandy",
-				"pluralName": "apricot brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cacha\u00e7a",
-				"pluralName": "cacha\u00e7as"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderflower cordial",
-				"pluralName": "elderflower cordials"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate liqueur",
-				"pluralName": "chocolate liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger liqueur",
-				"pluralName": "ginger liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sloe gin",
-				"pluralName": "sloe gins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maraschino",
-				"pluralName": "maraschinoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creme de cassis",
-				"pluralName": "creme de cassis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bloody mary mix",
-				"pluralName": "bloody mary mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream sherry",
-				"pluralName": "cream sherries"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "gold rum",
-				"pluralName": "gold rums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "red cooking wine",
-				"pluralName": "red cooking wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sparkling ros\u00e9",
-				"pluralName": "sparkling ros\u00e9s"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grappa",
-				"pluralName": "grappas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime cordial",
-				"pluralName": "lime cordials"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mezcal",
-				"pluralName": "mezcals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry liqueur",
-				"pluralName": "strawberry liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "drambuie",
-				"pluralName": "drambuies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger wine",
-				"pluralName": "ginger wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin ale",
-				"pluralName": "pumpkin ales"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white port",
-				"pluralName": "white ports"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppermint liqueur",
-				"pluralName": "peppermint liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "advocaat",
-				"pluralName": "advocaats"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pi\u00f1a colada mix",
-				"pluralName": "pi\u00f1a colada mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "b\u00e9n\u00e9dictine",
-				"pluralName": "b\u00e9n\u00e9dictines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rumchata liqueur",
-				"pluralName": "rumchata liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut liqueur",
-				"pluralName": "coconut liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "daiquiri mix",
-				"pluralName": "daiquiri mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "galliano",
-				"pluralName": "gallianoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackberry brandy",
-				"pluralName": "blackberry brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "plum wine",
-				"pluralName": "plum wines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pisco",
-				"pluralName": "piscoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate bitter",
-				"pluralName": "chocolate bitters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vanilla liqueur",
-				"pluralName": "vanilla liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sangria",
-				"pluralName": "sangrias"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grapefruit bitter",
-				"pluralName": "grapefruit bitters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach brandy",
-				"pluralName": "peach brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white chocolate liqueur",
-				"pluralName": "white chocolate liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple liqueur",
-				"pluralName": "apple liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pear brandy",
-				"pluralName": "pear brandies"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moonshine",
-				"pluralName": "moonshines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rhum agricole",
-				"pluralName": "rhum agricoles"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "armagnac",
-				"pluralName": "armagnacs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bergamot liqueur",
-				"pluralName": "bergamot liqueurs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry vodka",
-				"pluralName": "cherry vodkas"
-			}
-		]
-	},
-	"Beverages": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange juice",
-				"pluralName": "orange juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee",
-				"pluralName": "coffees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "club soda",
-				"pluralName": "club sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "espresso",
-				"pluralName": "espressos"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pineapple juice",
-				"pluralName": "pineapple juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apple juice",
-				"pluralName": "apple juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tea",
-				"pluralName": "teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry juice",
-				"pluralName": "cranberry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tomato juice",
-				"pluralName": "tomato juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut water",
-				"pluralName": "coconut waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pomegranate juice",
-				"pluralName": "pomegranate juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grapefruit juice",
-				"pluralName": "grapefruit juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemonade",
-				"pluralName": "lemonades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coke",
-				"pluralName": "cokes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eggnog",
-				"pluralName": "eggnogs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger ale",
-				"pluralName": "ginger ales"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ginger beer",
-				"pluralName": "ginger beers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange juice concentrate",
-				"pluralName": "orange juice concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon lime soda",
-				"pluralName": "lemon lime sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream of coconut",
-				"pluralName": "cream of coconut"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sprite",
-				"pluralName": "sprites"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green tea",
-				"pluralName": "green teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemonade concentrate",
-				"pluralName": "lemonade concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chai tea",
-				"pluralName": "chai teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "root beer",
-				"pluralName": "root beers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "drinking chocolate",
-				"pluralName": "drinking chocolates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tonic water",
-				"pluralName": "tonic waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "malted milk powder",
-				"pluralName": "malted milk powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango juice",
-				"pluralName": "mango juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sour mix",
-				"pluralName": "sour mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hibiscu",
-				"pluralName": "hibiscus"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tea leaf",
-				"pluralName": "tea leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grape juice",
-				"pluralName": "grape juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry juice",
-				"pluralName": "cherry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "carrot juice",
-				"pluralName": "carrot juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "limeade concentrate",
-				"pluralName": "limeade concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "dr pepper",
-				"pluralName": "dr peppers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white grape juice",
-				"pluralName": "white grape juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "watermelon juice",
-				"pluralName": "watermelon juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tangerine juice",
-				"pluralName": "tangerine juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fruit juice",
-				"pluralName": "fruit juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "passion-fruit juice",
-				"pluralName": "passion-fruit juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "iced tea",
-				"pluralName": "iced teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kombucha",
-				"pluralName": "kombuchas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "apricot juice",
-				"pluralName": "apricot juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beet juice",
-				"pluralName": "beet juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peach juice",
-				"pluralName": "peach juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange soda",
-				"pluralName": "orange sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "margarita mix",
-				"pluralName": "margarita mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kool aid",
-				"pluralName": "kool aids"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "energy drink",
-				"pluralName": "energy drinks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chamomile tea",
-				"pluralName": "chamomile teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pear juice",
-				"pluralName": "pear juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind juice",
-				"pluralName": "tamarind juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cream soda",
-				"pluralName": "cream sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind water",
-				"pluralName": "tamarind waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mountain dew",
-				"pluralName": "mountain dews"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "grapefruit soda",
-				"pluralName": "grapefruit sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rooibos tea",
-				"pluralName": "rooibos teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime soda",
-				"pluralName": "lime sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry juice",
-				"pluralName": "raspberry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "guava juice",
-				"pluralName": "guava juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "jasmine tea",
-				"pluralName": "jasmine teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clamato",
-				"pluralName": "clamatoes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry juice",
-				"pluralName": "strawberry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "iced coffee concentrate",
-				"pluralName": "iced coffee concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "green tea leaf",
-				"pluralName": "green tea leaves"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "beetroot juice",
-				"pluralName": "beetroot juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blueberry juice",
-				"pluralName": "blueberry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemonade mix",
-				"pluralName": "lemonade mixes"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rose syrup",
-				"pluralName": "rose syrups"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "v8 juice",
-				"pluralName": "v8 juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thai tea",
-				"pluralName": "thai teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "aloe vera juice",
-				"pluralName": "aloe vera juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "white tea",
-				"pluralName": "white teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "juice blend",
-				"pluralName": "juice blends"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "prune juice",
-				"pluralName": "prune juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sparkling cider",
-				"pluralName": null
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "berry juice",
-				"pluralName": "berry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butterfly pea flower",
-				"pluralName": "butterfly pea flowers"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "passion tea",
-				"pluralName": "passion teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry soda",
-				"pluralName": "strawberry sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lapsang souchong",
-				"pluralName": "lapsang souchongs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blackcurrant juice",
-				"pluralName": "blackcurrant juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "herbal tea",
-				"pluralName": "herbal teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana juice",
-				"pluralName": "banana juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lychee juice",
-				"pluralName": "lychee juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sugar cane juice",
-				"pluralName": "sugar cane juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry-raspberry juice",
-				"pluralName": "cranberry-raspberry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "decaf coffee",
-				"pluralName": "decaf coffees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pumpkin spice coffee",
-				"pluralName": "pumpkin spice coffees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pepsi",
-				"pluralName": "pepsis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry soda",
-				"pluralName": "cherry sodas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppermint tea",
-				"pluralName": "peppermint teas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sports drink",
-				"pluralName": "sports drinks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "acai berry juice",
-				"pluralName": "acai berry juices"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon crystal",
-				"pluralName": "lemon crystals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry lemonade",
-				"pluralName": "raspberry lemonades"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicory coffee",
-				"pluralName": "chicory coffees"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "elderberry juice",
-				"pluralName": "elderberry juices"
-			}
-		]
-	},
-	"Supplements & Extracts": {
-		"foods": [
-			{
-				"aliases": [],
-				"description": "",
-				"name": "almond extract",
-				"pluralName": "almond extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "food coloring",
-				"pluralName": "food colorings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "nutritional yeast",
-				"pluralName": "nutritional yeasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peppermint extract",
-				"pluralName": "peppermint extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "protein powder",
-				"pluralName": "protein powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon extract",
-				"pluralName": "lemon extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coconut extract",
-				"pluralName": "coconut extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rose water",
-				"pluralName": "rose waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange extract",
-				"pluralName": "orange extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rum extract",
-				"pluralName": "rum extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maple extract",
-				"pluralName": "maple extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "collagen",
-				"pluralName": "collagens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate protein powder",
-				"pluralName": "chocolate protein powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "orange blossom water",
-				"pluralName": "orange blossom waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "liquid egg white",
-				"pluralName": "liquid egg whites"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "peanut butter powder",
-				"pluralName": "peanut butter powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vegan protein powder",
-				"pluralName": "vegan protein powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "essence",
-				"pluralName": "essences"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maca powder",
-				"pluralName": "maca powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "spirulina",
-				"pluralName": "spirulinas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "coffee extract",
-				"pluralName": "coffee extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "brewer's yeast",
-				"pluralName": "brewer's yeasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "strawberry extract",
-				"pluralName": "strawberry extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butter extract",
-				"pluralName": "butter extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate extract",
-				"pluralName": "chocolate extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry extract",
-				"pluralName": "raspberry extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "anise extract",
-				"pluralName": "anise extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "bee pollen",
-				"pluralName": "bee pollens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cannabi",
-				"pluralName": "cannabis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana extract",
-				"pluralName": "banana extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lavender oil",
-				"pluralName": "lavender oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "essential oil",
-				"pluralName": "essential oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chicken essence",
-				"pluralName": "chicken essences"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "caramel extract",
-				"pluralName": "caramel extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg white powder",
-				"pluralName": "egg white powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cannabutter",
-				"pluralName": "cannabutter"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "root beer extract",
-				"pluralName": "root beer extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vitamin c",
-				"pluralName": "vitamin cs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "acai powder",
-				"pluralName": "acai powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hemp protein",
-				"pluralName": "hemp proteins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ube flavoring",
-				"pluralName": "ube flavorings"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "glucomannan",
-				"pluralName": "glucomannans"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "hazelnut extract",
-				"pluralName": "hazelnut extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "freeze-dried strawberry powder",
-				"pluralName": "freeze-dried strawberry powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tamarind extract",
-				"pluralName": "tamarind extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cherry extract",
-				"pluralName": "cherry extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "butterscotch flavor",
-				"pluralName": "butterscotch flavors"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kewra water",
-				"pluralName": "kewra waters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pineapple extract",
-				"pluralName": "pineapple extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lemon juice concentrate",
-				"pluralName": "lemon juice concentrates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chocolate collagen",
-				"pluralName": "chocolate collagens"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cinnamon extract",
-				"pluralName": "cinnamon extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cannabis milk",
-				"pluralName": "cannabis milks"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "malt extract",
-				"pluralName": "malt extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "kombucha starter",
-				"pluralName": "kombucha starters"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pandan extract",
-				"pluralName": "pandan extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "camu powder",
-				"pluralName": "camu powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "soy lecithin",
-				"pluralName": "soy lecithins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wheatgrass powder",
-				"pluralName": "wheatgrass powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "ashwagandha",
-				"pluralName": "ashwagandhas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "casein",
-				"pluralName": "caseins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cbd oil",
-				"pluralName": "cbd oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chlorella",
-				"pluralName": "chlorellas"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "fish oil",
-				"pluralName": "fish oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "lime essential oil",
-				"pluralName": "lime essential oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "probiotic",
-				"pluralName": "probiotics"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "activated charcoal",
-				"pluralName": "activated charcoals"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "egg powder",
-				"pluralName": "egg powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "reishi mushroom",
-				"pluralName": "reishi mushrooms"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vitamin e",
-				"pluralName": "vitamin es"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "wine yeast",
-				"pluralName": "wine yeasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "barley gras",
-				"pluralName": "barley grass"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "greens powder",
-				"pluralName": "greens powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rice protein powder",
-				"pluralName": "rice protein powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "tea-tree oil",
-				"pluralName": "tea-tree oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "vitamin d",
-				"pluralName": "vitamin ds"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "calcium lactate",
-				"pluralName": "calcium lactates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "mango extract",
-				"pluralName": "mango extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "raspberry powder",
-				"pluralName": "raspberry powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "blueberry extract",
-				"pluralName": "blueberry extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "corn extract",
-				"pluralName": "corn extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "magnesium",
-				"pluralName": "magnesiums"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "creatine",
-				"pluralName": "creatines"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "daily vitamin",
-				"pluralName": "daily vitamins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "moringa powder",
-				"pluralName": "moringa powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "pure lime extract",
-				"pluralName": "pure lime extracts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sodium alginate",
-				"pluralName": "sodium alginates"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "sunflower lecithin",
-				"pluralName": "sunflower lecithins"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "thc",
-				"pluralName": "thcs"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "berry powder",
-				"pluralName": "berry powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "champagne yeast",
-				"pluralName": "champagne yeasts"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maqui",
-				"pluralName": "maquis"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "rose oil",
-				"pluralName": "rose oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "banana powder",
-				"pluralName": "banana powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "chaga mushroom powder",
-				"pluralName": "chaga mushroom powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "clove oil",
-				"pluralName": "clove oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "cranberry powder",
-				"pluralName": "cranberry powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "eucalyptus oil",
-				"pluralName": "eucalyptus oils"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "goji berry powder",
-				"pluralName": "goji berry powders"
-			},
-			{
-				"aliases": [],
-				"description": "",
-				"name": "maltodextrin",
-				"pluralName": "maltodextrins"
-			}
-		]
-	}
+    "Vegetables & Greens": {
+        "foods": {
+            "garlic": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "onion": {
+                "aliases": [],
+                "description": "",
+                "name": "onion",
+                "plural_name": "onions"
+            },
+            "bell pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "bell pepper",
+                "plural_name": "bell peppers"
+            },
+            "carrot": {
+                "aliases": [],
+                "description": "",
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "scallion": {
+                "aliases": [],
+                "description": "",
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "zucchini": {
+                "aliases": [],
+                "description": "",
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            },
+            "potato": {
+                "aliases": [],
+                "description": "",
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "red onion": {
+                "aliases": [],
+                "description": "",
+                "name": "red onion",
+                "plural_name": "red onions"
+            },
+            "yellow onion": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow onion",
+                "plural_name": "yellow onions"
+            },
+            "celery": {
+                "aliases": [],
+                "description": "",
+                "name": "celery",
+                "plural_name": "celeries"
+            },
+            "jalapeno": {
+                "aliases": [],
+                "description": "",
+                "name": "jalapeno",
+                "plural_name": "jalapenoes"
+            },
+            "avocado": {
+                "aliases": [],
+                "description": "",
+                "name": "avocado",
+                "plural_name": "avocados"
+            },
+            "shallot": {
+                "aliases": [],
+                "description": "",
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "cherry tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry tomato",
+                "plural_name": "cherry tomatoes"
+            },
+            "cucumber": {
+                "aliases": [],
+                "description": "",
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "spinach": {
+                "aliases": [],
+                "description": "",
+                "name": "spinach",
+                "plural_name": "spinaches"
+            },
+            "sweet corn": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet corn",
+                "plural_name": "sweet corns"
+            },
+            "chile pepper": {
+                "aliases": [
+                    "capsicum"
+                ],
+                "description": "",
+                "name": "chile pepper",
+                "plural_name": "chile peppers"
+            },
+            "sweet potato": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "broccoli": {
+                "aliases": [],
+                "description": "",
+                "name": "broccoli",
+                "plural_name": "broccolis"
+            },
+            "heart of palm": {
+                "aliases": [],
+                "description": "",
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "baby green": {
+                "aliases": [],
+                "description": "",
+                "name": "baby green",
+                "plural_name": "baby greens"
+            },
+            "pumpkin": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "cauliflower": {
+                "aliases": [],
+                "description": "",
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cabbage": {
+                "aliases": [],
+                "description": "",
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "asparagu": {
+                "aliases": [],
+                "description": "",
+                "name": "asparagu",
+                "plural_name": "asparagus"
+            },
+            "kale": {
+                "aliases": [],
+                "description": "",
+                "name": "kale",
+                "plural_name": "kales"
+            },
+            "arugula": {
+                "aliases": [],
+                "description": "",
+                "name": "arugula",
+                "plural_name": "arugulas"
+            },
+            "leek": {
+                "aliases": [],
+                "description": "",
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "eggplant": {
+                "aliases": [],
+                "description": "",
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "lettuce": {
+                "aliases": [],
+                "description": "",
+                "name": "lettuce",
+                "plural_name": "lettuces"
+            },
+            "butternut squash": {
+                "aliases": [],
+                "description": "",
+                "name": "butternut squash",
+                "plural_name": "butternut squashes"
+            },
+            "romaine": {
+                "aliases": [],
+                "description": "",
+                "name": "romaine",
+                "plural_name": "romaines"
+            },
+            "beetroot": {
+                "aliases": [],
+                "description": "",
+                "name": "beetroot",
+                "plural_name": "beetroots"
+            },
+            "brussels sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "brussels sprout",
+                "plural_name": "brussels sprouts"
+            },
+            "fennel": {
+                "aliases": [],
+                "description": "",
+                "name": "fennel",
+                "plural_name": "fennels"
+            },
+            "sun dried tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "sun dried tomato",
+                "plural_name": "sun dried tomatoes"
+            },
+            "radish": {
+                "aliases": [],
+                "description": "",
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "red cabbage": {
+                "aliases": [],
+                "description": "",
+                "name": "red cabbage",
+                "plural_name": "red cabbages"
+            },
+            "artichoke": {
+                "aliases": [],
+                "description": "",
+                "name": "artichoke",
+                "plural_name": "artichokes"
+            },
+            "new potato": {
+                "aliases": [],
+                "description": "",
+                "name": "new potato",
+                "plural_name": "new potatoes"
+            },
+            "summer squash": {
+                "aliases": [
+                    "courgette",
+                    "gem squash"
+                ],
+                "description": "",
+                "name": "summer squash",
+                "plural_name": "summer squashes"
+            },
+            "mixed green": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed green",
+                "plural_name": "mixed greens"
+            },
+            "parsnip": {
+                "aliases": [],
+                "description": "",
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "baby carrot": {
+                "aliases": [],
+                "description": "",
+                "name": "baby carrot",
+                "plural_name": "baby carrots"
+            },
+            "mixed vegetable": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed vegetable",
+                "plural_name": "mixed vegetables"
+            },
+            "poblano pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "poblano pepper",
+                "plural_name": "poblano peppers"
+            },
+            "sweet pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet pepper",
+                "plural_name": "sweet peppers"
+            },
+            "serrano pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "serrano pepper",
+                "plural_name": "serrano peppers"
+            },
+            "cayenne pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "cayenne pepper",
+                "plural_name": "cayenne peppers"
+            },
+            "green tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "green tomato",
+                "plural_name": "green tomatoes"
+            },
+            "watercress": {
+                "aliases": [],
+                "description": "",
+                "name": "watercress",
+                "plural_name": "watercress"
+            },
+            "iceberg": {
+                "aliases": [],
+                "description": "",
+                "name": "iceberg",
+                "plural_name": "icebergs"
+            },
+            "mashed potato": {
+                "aliases": [],
+                "description": "",
+                "name": "mashed potato",
+                "plural_name": "mashed potatoes"
+            },
+            "horseradish": {
+                "aliases": [],
+                "description": "",
+                "name": "horseradish",
+                "plural_name": "horseradishes"
+            },
+            "chard": {
+                "aliases": [],
+                "description": "",
+                "name": "chard",
+                "plural_name": "chards"
+            },
+            "pimiento": {
+                "aliases": [],
+                "description": "",
+                "name": "pimiento",
+                "plural_name": "pimientoes"
+            },
+            "spaghetti squash": {
+                "aliases": [],
+                "description": "",
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "butter lettuce": {
+                "aliases": [],
+                "description": "",
+                "name": "butter lettuce",
+                "plural_name": "butter lettuces"
+            },
+            "hash brown": {
+                "aliases": [],
+                "description": "",
+                "name": "hash brown",
+                "plural_name": "hash browns"
+            },
+            "napa cabbage": {
+                "aliases": [
+                    "chinese  leaves"
+                ],
+                "description": "",
+                "name": "napa cabbage",
+                "plural_name": "napa cabbages"
+            },
+            "celeriac": {
+                "aliases": [],
+                "description": "",
+                "name": "celeriac",
+                "plural_name": "celeriacs"
+            },
+            "water chestnut": {
+                "aliases": [],
+                "description": "",
+                "name": "water chestnut",
+                "plural_name": "water chestnuts"
+            },
+            "turnip": {
+                "aliases": [],
+                "description": "",
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "thai chile pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "thai chile pepper",
+                "plural_name": "thai chile peppers"
+            },
+            "bok choy": {
+                "aliases": [],
+                "description": "",
+                "name": "bok choy",
+                "plural_name": "bok choy"
+            },
+            "okra": {
+                "aliases": [],
+                "description": "",
+                "name": "okra",
+                "plural_name": "okra"
+            },
+            "acorn squash": {
+                "aliases": [],
+                "description": "",
+                "name": "acorn squash",
+                "plural_name": "acorn squashes"
+            },
+            "corn cob": {
+                "aliases": [],
+                "description": "",
+                "name": "corn cob",
+                "plural_name": "corn cobs"
+            },
+            "radicchio": {
+                "aliases": [],
+                "description": "",
+                "name": "radicchio",
+                "plural_name": "radicchio"
+            },
+            "pearl onion": {
+                "aliases": [],
+                "description": "",
+                "name": "pearl onion",
+                "plural_name": "pearl onions"
+            },
+            "tenderstem broccoli": {
+                "aliases": [],
+                "description": "",
+                "name": "tenderstem broccoli",
+                "plural_name": "tenderstem broccolis"
+            },
+            "plantain": {
+                "aliases": [],
+                "description": "",
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "leaf lettuce": {
+                "aliases": [],
+                "description": "",
+                "name": "leaf lettuce",
+                "plural_name": "leaf lettuces"
+            },
+            "pepperoncini": {
+                "aliases": [],
+                "description": "",
+                "name": "pepperoncini",
+                "plural_name": "pepperoncinis"
+            },
+            "baby bok choy": {
+                "aliases": [],
+                "description": "",
+                "name": "baby bok choy",
+                "plural_name": "baby bok choys"
+            },
+            "jicama": {
+                "aliases": [],
+                "description": "",
+                "name": "jicama",
+                "plural_name": "jicamas"
+            },
+            "endive": {
+                "aliases": [],
+                "description": "",
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "habanero pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "habanero pepper",
+                "plural_name": "habanero peppers"
+            },
+            "corn husk": {
+                "aliases": [
+                    "maize"
+                ],
+                "description": "",
+                "name": "corn husk",
+                "plural_name": "corn husks"
+            },
+            "collard green": {
+                "aliases": [],
+                "description": "",
+                "name": "collard green",
+                "plural_name": "collard greens"
+            },
+            "french-fried onion": {
+                "aliases": [],
+                "description": "",
+                "name": "french-fried onion",
+                "plural_name": "french-fried onions"
+            },
+            "daikon": {
+                "aliases": [],
+                "description": "",
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "baby corn": {
+                "aliases": [],
+                "description": "",
+                "name": "baby corn",
+                "plural_name": "baby corns"
+            },
+            "broccoli rabe": {
+                "aliases": [],
+                "description": "",
+                "name": "broccoli rabe",
+                "plural_name": "broccoli rabes"
+            },
+            "rutabaga": {
+                "aliases": [],
+                "description": "",
+                "name": "rutabaga",
+                "plural_name": "rutabagas"
+            },
+            "belgian endive": {
+                "aliases": [],
+                "description": "",
+                "name": "belgian endive",
+                "plural_name": "belgian endives"
+            },
+            "yam": {
+                "aliases": [],
+                "description": "",
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "ancho chile pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "ancho chile pepper",
+                "plural_name": "ancho chile peppers"
+            },
+            "microgreen": {
+                "aliases": [],
+                "description": "",
+                "name": "microgreen",
+                "plural_name": "microgreens"
+            },
+            "boston lettuce": {
+                "aliases": [],
+                "description": "",
+                "name": "boston lettuce",
+                "plural_name": "boston lettuces"
+            },
+            "kohlrabi": {
+                "aliases": [],
+                "description": "",
+                "name": "kohlrabi",
+                "plural_name": "kohlrabis"
+            },
+            "fresno chile": {
+                "aliases": [],
+                "description": "",
+                "name": "fresno chile",
+                "plural_name": "fresno chiles"
+            },
+            "delicata squash": {
+                "aliases": [],
+                "description": "",
+                "name": "delicata squash",
+                "plural_name": "delicata squashes"
+            },
+            "frisee": {
+                "aliases": [],
+                "description": "",
+                "name": "frisee",
+                "plural_name": "frisees"
+            },
+            "anaheim pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "anaheim pepper",
+                "plural_name": "anaheim peppers"
+            },
+            "cres": {
+                "aliases": [],
+                "description": "",
+                "name": "cres",
+                "plural_name": "cress"
+            },
+            "broccoli slaw": {
+                "aliases": [],
+                "description": "",
+                "name": "broccoli slaw",
+                "plural_name": "broccoli slaws"
+            },
+            "arbol chile pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "arbol chile pepper",
+                "plural_name": "arbol chile peppers"
+            },
+            "golden beet": {
+                "aliases": [],
+                "description": "",
+                "name": "golden beet",
+                "plural_name": "golden beets"
+            },
+            "pea shoot": {
+                "aliases": [],
+                "description": "",
+                "name": "pea shoot",
+                "plural_name": "pea shoots"
+            },
+            "alfalfa": {
+                "aliases": [],
+                "description": "",
+                "name": "alfalfa",
+                "plural_name": "alfalfas"
+            }
+        }
+    },
+    "Fruits": {
+        "foods": {
+            "tomato": {
+                "aliases": [],
+                "description": "Yes they are a fruit",
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "lemon": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon",
+                "plural_name": "lemons"
+            },
+            "lime": {
+                "aliases": [],
+                "description": "",
+                "name": "lime",
+                "plural_name": "limes"
+            },
+            "apple": {
+                "aliases": [],
+                "description": "",
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "banana": {
+                "aliases": [],
+                "description": "",
+                "name": "banana",
+                "plural_name": "bananas"
+            },
+            "orange": {
+                "aliases": [],
+                "description": "",
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "raisin": {
+                "aliases": [],
+                "description": "",
+                "name": "raisin",
+                "plural_name": "raisins"
+            },
+            "pineapple": {
+                "aliases": [],
+                "description": "",
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "mango": {
+                "aliases": [],
+                "description": "",
+                "name": "mango",
+                "plural_name": "mangoes"
+            },
+            "peach": {
+                "aliases": [],
+                "description": "",
+                "name": "peach",
+                "plural_name": "peaches"
+            },
+            "date": {
+                "aliases": [],
+                "description": "",
+                "name": "date",
+                "plural_name": "dates"
+            },
+            "coconut": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "craisin": {
+                "aliases": [],
+                "description": "",
+                "name": "craisin",
+                "plural_name": "craisins"
+            },
+            "pear": {
+                "aliases": [],
+                "description": "",
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "grape": {
+                "aliases": [],
+                "description": "",
+                "name": "grape",
+                "plural_name": "grapes"
+            },
+            "pomegranate": {
+                "aliases": [],
+                "description": "",
+                "name": "pomegranate",
+                "plural_name": "pomegranates"
+            },
+            "watermelon": {
+                "aliases": [],
+                "description": "",
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "rhubarb": {
+                "aliases": [],
+                "description": "",
+                "name": "rhubarb",
+                "plural_name": "rhubarbs"
+            },
+            "dried apricot": {
+                "aliases": [],
+                "description": "",
+                "name": "dried apricot",
+                "plural_name": "dried apricots"
+            },
+            "kiwi": {
+                "aliases": [],
+                "description": "",
+                "name": "kiwi",
+                "plural_name": "kiwis"
+            },
+            "grapefruit": {
+                "aliases": [],
+                "description": "",
+                "name": "grapefruit",
+                "plural_name": "grapefruits"
+            },
+            "plum": {
+                "aliases": [],
+                "description": "",
+                "name": "plum",
+                "plural_name": "plums"
+            },
+            "fig": {
+                "aliases": [],
+                "description": "",
+                "name": "fig",
+                "plural_name": "figs"
+            },
+            "apricot": {
+                "aliases": [],
+                "description": "",
+                "name": "apricot",
+                "plural_name": "apricots"
+            },
+            "currant": {
+                "aliases": [],
+                "description": "",
+                "name": "currant",
+                "plural_name": "currants"
+            },
+            "mandarin": {
+                "aliases": [],
+                "description": "",
+                "name": "mandarin",
+                "plural_name": "mandarins"
+            },
+            "prune": {
+                "aliases": [],
+                "description": "",
+                "name": "prune",
+                "plural_name": "prunes"
+            },
+            "cantaloupe": {
+                "aliases": [],
+                "description": "",
+                "name": "cantaloupe",
+                "plural_name": "cantaloupes"
+            },
+            "sultana": {
+                "aliases": [],
+                "description": "",
+                "name": "sultana",
+                "plural_name": "sultanas"
+            },
+            "passion fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "passion fruit",
+                "plural_name": "passion fruits"
+            },
+            "papaya": {
+                "aliases": [],
+                "description": "",
+                "name": "papaya",
+                "plural_name": "papayas"
+            },
+            "tamarind": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind",
+                "plural_name": "tamarinds"
+            },
+            "nectarine": {
+                "aliases": [],
+                "description": "",
+                "name": "nectarine",
+                "plural_name": "nectarines"
+            },
+            "dried fig": {
+                "aliases": [],
+                "description": "",
+                "name": "dried fig",
+                "plural_name": "dried figs"
+            },
+            "chestnut": {
+                "aliases": [],
+                "description": "",
+                "name": "chestnut",
+                "plural_name": "chestnuts"
+            },
+            "meyer lemon": {
+                "aliases": [],
+                "description": "",
+                "name": "meyer lemon",
+                "plural_name": "meyer lemons"
+            },
+            "honeydew melon": {
+                "aliases": [],
+                "description": "",
+                "name": "honeydew melon",
+                "plural_name": "honeydew melons"
+            },
+            "dried fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "dried fruit",
+                "plural_name": "dried fruits"
+            },
+            "clementine": {
+                "aliases": [],
+                "description": "",
+                "name": "clementine",
+                "plural_name": "clementines"
+            },
+            "persimmon": {
+                "aliases": [],
+                "description": "",
+                "name": "persimmon",
+                "plural_name": "persimmons"
+            },
+            "melon": {
+                "aliases": [],
+                "description": "",
+                "name": "melon",
+                "plural_name": "melons"
+            },
+            "tangerine": {
+                "aliases": [],
+                "description": "",
+                "name": "tangerine",
+                "plural_name": "tangerines"
+            },
+            "dried mango": {
+                "aliases": [],
+                "description": "",
+                "name": "dried mango",
+                "plural_name": "dried mangoes"
+            },
+            "dried apple": {
+                "aliases": [],
+                "description": "",
+                "name": "dried apple",
+                "plural_name": "dried apples"
+            },
+            "quince": {
+                "aliases": [],
+                "description": "",
+                "name": "quince",
+                "plural_name": "quinces"
+            },
+            "guava": {
+                "aliases": [],
+                "description": "",
+                "name": "guava",
+                "plural_name": "guavas"
+            },
+            "banana chip": {
+                "aliases": [],
+                "description": "",
+                "name": "banana chip",
+                "plural_name": "banana chips"
+            },
+            "kumquat": {
+                "aliases": [],
+                "description": "",
+                "name": "kumquat",
+                "plural_name": "kumquats"
+            },
+            "jackfruit": {
+                "aliases": [],
+                "description": "",
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "dragon fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "dragon fruit",
+                "plural_name": "dragon fruits"
+            },
+            "mixed fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed fruit",
+                "plural_name": "mixed fruits"
+            },
+            "asian pear": {
+                "aliases": [],
+                "description": "",
+                "name": "asian pear",
+                "plural_name": "asian pears"
+            },
+            "lychee": {
+                "aliases": [],
+                "description": "",
+                "name": "lychee",
+                "plural_name": "lychees"
+            },
+            "young coconut": {
+                "aliases": [],
+                "description": "",
+                "name": "young coconut",
+                "plural_name": "young coconuts"
+            },
+            "kaffir lime": {
+                "aliases": [],
+                "description": "",
+                "name": "kaffir lime",
+                "plural_name": "kaffir limes"
+            },
+            "star fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "star fruit",
+                "plural_name": "star fruits"
+            },
+            "green papaya": {
+                "aliases": [],
+                "description": "",
+                "name": "green papaya",
+                "plural_name": "green papayas"
+            },
+            "pomelo": {
+                "aliases": [],
+                "description": "",
+                "name": "pomelo",
+                "plural_name": "pomeloes"
+            },
+            "chestnut puree": {
+                "aliases": [],
+                "description": "",
+                "name": "chestnut puree",
+                "plural_name": "chestnut purees"
+            },
+            "prickly pear": {
+                "aliases": [],
+                "description": "",
+                "name": "prickly pear",
+                "plural_name": "prickly pears"
+            },
+            "calamansi": {
+                "aliases": [],
+                "description": "",
+                "name": "calamansi",
+                "plural_name": "calamansis"
+            },
+            "yuzu": {
+                "aliases": [],
+                "description": "",
+                "name": "yuzu",
+                "plural_name": "yuzus"
+            },
+            "granadilla": {
+                "aliases": [],
+                "description": "",
+                "name": "granadilla",
+                "plural_name": "granadillas"
+            },
+            "apple chip": {
+                "aliases": [],
+                "description": "",
+                "name": "apple chip",
+                "plural_name": "apple chips"
+            },
+            "mixed peel": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed peel",
+                "plural_name": "mixed peels"
+            },
+            "kokum": {
+                "aliases": [],
+                "description": "",
+                "name": "kokum",
+                "plural_name": "kokums"
+            },
+            "tangelo": {
+                "aliases": [],
+                "description": "",
+                "name": "tangelo",
+                "plural_name": "tangeloes"
+            },
+            "dried lime": {
+                "aliases": [],
+                "description": "",
+                "name": "dried lime",
+                "plural_name": "dried limes"
+            },
+            "jujube": {
+                "aliases": [],
+                "description": "",
+                "name": "jujube",
+                "plural_name": "jujubes"
+            },
+            "sweet lime": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet lime",
+                "plural_name": "sweet limes"
+            },
+            "custard-apple": {
+                "aliases": [],
+                "description": "",
+                "name": "custard-apple",
+                "plural_name": "custard-apples"
+            },
+            "dried lemon": {
+                "aliases": [],
+                "description": "",
+                "name": "dried lemon",
+                "plural_name": "dried lemons"
+            },
+            "young jackfruit": {
+                "aliases": [],
+                "description": "",
+                "name": "young jackfruit",
+                "plural_name": "young jackfruits"
+            },
+            "durian": {
+                "aliases": [],
+                "description": "",
+                "name": "durian",
+                "plural_name": "durians"
+            },
+            "freeze-dried apple": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried apple",
+                "plural_name": "freeze-dried apples"
+            },
+            "dried tamarind": {
+                "aliases": [],
+                "description": "",
+                "name": "dried tamarind",
+                "plural_name": "dried tamarinds"
+            },
+            "honey date": {
+                "aliases": [],
+                "description": "",
+                "name": "honey date",
+                "plural_name": "honey dates"
+            },
+            "physali": {
+                "aliases": [],
+                "description": "",
+                "name": "physali",
+                "plural_name": "physalis"
+            },
+            "tamarillo": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarillo",
+                "plural_name": "tamarilloes"
+            },
+            "ice-apple": {
+                "aliases": [],
+                "description": "",
+                "name": "ice-apple",
+                "plural_name": "ice-apples"
+            },
+            "longan": {
+                "aliases": [],
+                "description": "",
+                "name": "longan",
+                "plural_name": "longans"
+            },
+            "finger lime": {
+                "aliases": [],
+                "description": "",
+                "name": "finger lime",
+                "plural_name": "finger limes"
+            },
+            "bitter orange": {
+                "aliases": [],
+                "description": "",
+                "name": "bitter orange",
+                "plural_name": "bitter oranges"
+            },
+            "feijoa": {
+                "aliases": [],
+                "description": "",
+                "name": "feijoa",
+                "plural_name": "feijoas"
+            },
+            "dried persimmon": {
+                "aliases": [],
+                "description": "",
+                "name": "dried persimmon",
+                "plural_name": "dried persimmons"
+            },
+            "rambutan": {
+                "aliases": [],
+                "description": "",
+                "name": "rambutan",
+                "plural_name": "rambutans"
+            },
+            "rose apple": {
+                "aliases": [],
+                "description": "",
+                "name": "rose apple",
+                "plural_name": "rose apples"
+            },
+            "dried orange slice": {
+                "aliases": [],
+                "description": "",
+                "name": "dried orange slice",
+                "plural_name": "dried orange slices"
+            },
+            "loquat": {
+                "aliases": [],
+                "description": "",
+                "name": "loquat",
+                "plural_name": "loquats"
+            },
+            "crabapple": {
+                "aliases": [],
+                "description": "",
+                "name": "crabapple",
+                "plural_name": "crabapples"
+            },
+            "fig leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "fig leaf",
+                "plural_name": "fig leaves"
+            },
+            "freeze-dried pineapple": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried pineapple",
+                "plural_name": "freeze-dried pineapples"
+            },
+            "pluot": {
+                "aliases": [],
+                "description": "",
+                "name": "pluot",
+                "plural_name": "pluots"
+            },
+            "soursop": {
+                "aliases": [],
+                "description": "",
+                "name": "soursop",
+                "plural_name": "soursops"
+            },
+            "hog plum": {
+                "aliases": [],
+                "description": "",
+                "name": "hog plum",
+                "plural_name": "hog plums"
+            },
+            "bergamot orange": {
+                "aliases": [],
+                "description": "",
+                "name": "bergamot orange",
+                "plural_name": "bergamot oranges"
+            },
+            "luo han guo": {
+                "aliases": [],
+                "description": "",
+                "name": "luo han guo",
+                "plural_name": "luo han guos"
+            },
+            "mamey": {
+                "aliases": [],
+                "description": "",
+                "name": "mamey",
+                "plural_name": "mameys"
+            },
+            "sapote": {
+                "aliases": [],
+                "description": "",
+                "name": "sapote",
+                "plural_name": "sapotes"
+            },
+            "green ume plum": {
+                "aliases": [],
+                "description": "",
+                "name": "green ume plum",
+                "plural_name": "green ume plums"
+            },
+            "kiwano": {
+                "aliases": [],
+                "description": "",
+                "name": "kiwano",
+                "plural_name": "kiwanoes"
+            }
+        }
+    },
+    "Mushrooms": {
+        "foods": {
+            "button mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "button mushroom",
+                "plural_name": "button mushrooms"
+            },
+            "shiitake mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "shiitake mushroom",
+                "plural_name": "shiitake mushrooms"
+            },
+            "portobello mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "portobello mushroom",
+                "plural_name": "portobello mushrooms"
+            },
+            "wild mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "wild mushroom",
+                "plural_name": "wild mushrooms"
+            },
+            "porcini": {
+                "aliases": [],
+                "description": "",
+                "name": "porcini",
+                "plural_name": "porcinis"
+            },
+            "mixed mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed mushroom",
+                "plural_name": "mixed mushrooms"
+            },
+            "oyster mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "oyster mushroom",
+                "plural_name": "oyster mushrooms"
+            },
+            "chestnut mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "chestnut mushroom",
+                "plural_name": "chestnut mushrooms"
+            },
+            "enoki mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "enoki mushroom",
+                "plural_name": "enoki mushrooms"
+            },
+            "black fungu": {
+                "aliases": [],
+                "description": "",
+                "name": "black fungu",
+                "plural_name": "black fungus"
+            },
+            "black truffle": {
+                "aliases": [],
+                "description": "",
+                "name": "black truffle",
+                "plural_name": "black truffles"
+            },
+            "morel mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "morel mushroom",
+                "plural_name": "morel mushrooms"
+            },
+            "field mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "field mushroom",
+                "plural_name": "field mushrooms"
+            },
+            "king oyster mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "king oyster mushroom",
+                "plural_name": "king oyster mushrooms"
+            },
+            "shimeji mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "shimeji mushroom",
+                "plural_name": "shimeji mushrooms"
+            },
+            "straw mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "straw mushroom",
+                "plural_name": "straw mushrooms"
+            },
+            "dried chinese mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "dried chinese mushroom",
+                "plural_name": "dried chinese mushrooms"
+            },
+            "maitake": {
+                "aliases": [],
+                "description": "",
+                "name": "maitake",
+                "plural_name": "maitakes"
+            },
+            "trumpet mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "trumpet mushroom",
+                "plural_name": "trumpet mushrooms"
+            },
+            "white truffle": {
+                "aliases": [],
+                "description": "",
+                "name": "white truffle",
+                "plural_name": "white truffles"
+            },
+            "white fungu": {
+                "aliases": [],
+                "description": "",
+                "name": "white fungu",
+                "plural_name": "white fungus"
+            },
+            "pioppini": {
+                "aliases": [],
+                "description": "",
+                "name": "pioppini",
+                "plural_name": "pioppinis"
+            },
+            "snow fungu": {
+                "aliases": [],
+                "description": "",
+                "name": "snow fungu",
+                "plural_name": "snow fungus"
+            },
+            "white beech mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "white beech mushroom",
+                "plural_name": "white beech mushrooms"
+            },
+            "boletu": {
+                "aliases": [],
+                "description": "",
+                "name": "boletu",
+                "plural_name": "boletus"
+            },
+            "huitlacoche": {
+                "aliases": [],
+                "description": "",
+                "name": "huitlacoche",
+                "plural_name": "huitlacoches"
+            },
+            "matsutake": {
+                "aliases": [],
+                "description": "",
+                "name": "matsutake",
+                "plural_name": "matsutakes"
+            },
+            "nameko": {
+                "aliases": [],
+                "description": "",
+                "name": "nameko",
+                "plural_name": "namekoes"
+            },
+            "djon djon mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "djon djon mushroom",
+                "plural_name": "djon djon mushrooms"
+            },
+            "mixed asian mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed asian mushroom",
+                "plural_name": "mixed asian mushrooms"
+            },
+            "puffball": {
+                "aliases": [],
+                "description": "",
+                "name": "puffball",
+                "plural_name": "puffballs"
+            },
+            "honey fungu": {
+                "aliases": [],
+                "description": "",
+                "name": "honey fungu",
+                "plural_name": "honey fungus"
+            },
+            "caesar's mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "caesar's mushroom",
+                "plural_name": "caesar's mushrooms"
+            },
+            "candy cap mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "candy cap mushroom",
+                "plural_name": "candy cap mushrooms"
+            },
+            "lion\u2019s mane mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "lion\u2019s mane mushroom",
+                "plural_name": "lion\u2019s mane mushrooms"
+            }
+        }
+    },
+    "Berries": {
+        "foods": {
+            "strawberry": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry",
+                "plural_name": "strawberries"
+            },
+            "blueberry": {
+                "aliases": [],
+                "description": "",
+                "name": "blueberry",
+                "plural_name": "blueberries"
+            },
+            "raspberry": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry",
+                "plural_name": "raspberries"
+            },
+            "cranberry": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry",
+                "plural_name": "cranberries"
+            },
+            "cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry",
+                "plural_name": "cherries"
+            },
+            "blackberry": {
+                "aliases": [],
+                "description": "",
+                "name": "blackberry",
+                "plural_name": "blackberries"
+            },
+            "berry mix": {
+                "aliases": [],
+                "description": "",
+                "name": "berry mix",
+                "plural_name": "berry mixes"
+            },
+            "maraschino cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "maraschino cherry",
+                "plural_name": "maraschino cherries"
+            },
+            "dried cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "dried cherry",
+                "plural_name": "dried cherries"
+            },
+            "juniper berry": {
+                "aliases": [],
+                "description": "",
+                "name": "juniper berry",
+                "plural_name": "juniper berries"
+            },
+            "sour cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "sour cherry",
+                "plural_name": "sour cherries"
+            },
+            "goji berry": {
+                "aliases": [],
+                "description": "",
+                "name": "goji berry",
+                "plural_name": "goji berries"
+            },
+            "dried blueberry": {
+                "aliases": [],
+                "description": "",
+                "name": "dried blueberry",
+                "plural_name": "dried blueberries"
+            },
+            "freeze-dried strawberry": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried strawberry",
+                "plural_name": "freeze-dried strawberries"
+            },
+            "gooseberry": {
+                "aliases": [],
+                "description": "",
+                "name": "gooseberry",
+                "plural_name": "gooseberries"
+            },
+            "freeze-dried raspberry": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried raspberry",
+                "plural_name": "freeze-dried raspberries"
+            },
+            "lingonberry": {
+                "aliases": [],
+                "description": "",
+                "name": "lingonberry",
+                "plural_name": "lingonberries"
+            },
+            "canned sour cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "canned sour cherry",
+                "plural_name": "canned sour cherries"
+            },
+            "mulberry": {
+                "aliases": [],
+                "description": "",
+                "name": "mulberry",
+                "plural_name": "mulberries"
+            },
+            "acai berry": {
+                "aliases": [],
+                "description": "",
+                "name": "acai berry",
+                "plural_name": "acai berries"
+            },
+            "canned cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "canned cherry",
+                "plural_name": "canned cherries"
+            },
+            "amla": {
+                "aliases": [],
+                "description": "",
+                "name": "amla",
+                "plural_name": "amlas"
+            },
+            "elderberry": {
+                "aliases": [],
+                "description": "",
+                "name": "elderberry",
+                "plural_name": "elderberries"
+            },
+            "freeze-dried blueberry": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried blueberry",
+                "plural_name": "freeze-dried blueberries"
+            },
+            "huckleberry": {
+                "aliases": [],
+                "description": "",
+                "name": "huckleberry",
+                "plural_name": "huckleberries"
+            },
+            "dried elderberry": {
+                "aliases": [],
+                "description": "",
+                "name": "dried elderberry",
+                "plural_name": "dried elderberries"
+            },
+            "barberry": {
+                "aliases": [],
+                "description": "",
+                "name": "barberry",
+                "plural_name": "barberries"
+            },
+            "dried berry": {
+                "aliases": [],
+                "description": "",
+                "name": "dried berry",
+                "plural_name": "dried berries"
+            },
+            "sea buckthorn": {
+                "aliases": [],
+                "description": "",
+                "name": "sea buckthorn",
+                "plural_name": "sea buckthorns"
+            },
+            "saskatoon berry": {
+                "aliases": [],
+                "description": "",
+                "name": "saskatoon berry",
+                "plural_name": "saskatoon berries"
+            },
+            "rosehip": {
+                "aliases": [],
+                "description": "",
+                "name": "rosehip",
+                "plural_name": "rosehips"
+            },
+            "hawthorn": {
+                "aliases": [],
+                "description": "",
+                "name": "hawthorn",
+                "plural_name": "hawthorns"
+            },
+            "boysenberry": {
+                "aliases": [],
+                "description": "",
+                "name": "boysenberry",
+                "plural_name": "boysenberries"
+            },
+            "cloudberry": {
+                "aliases": [],
+                "description": "",
+                "name": "cloudberry",
+                "plural_name": "cloudberries"
+            },
+            "freeze-dried berry": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried berry",
+                "plural_name": "freeze-dried berries"
+            },
+            "aronia berry": {
+                "aliases": [],
+                "description": "",
+                "name": "aronia berry",
+                "plural_name": "aronia berries"
+            },
+            "chokeberry": {
+                "aliases": [],
+                "description": "",
+                "name": "chokeberry",
+                "plural_name": "chokeberries"
+            },
+            "loganberry": {
+                "aliases": [],
+                "description": "",
+                "name": "loganberry",
+                "plural_name": "loganberries"
+            },
+            "blackcurrant leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "blackcurrant leaf",
+                "plural_name": "blackcurrant leaves"
+            },
+            "haskap berry": {
+                "aliases": [],
+                "description": "",
+                "name": "haskap berry",
+                "plural_name": "haskap berries"
+            },
+            "dewberry": {
+                "aliases": [],
+                "description": "",
+                "name": "dewberry",
+                "plural_name": "dewberries"
+            },
+            "sloe berry": {
+                "aliases": [],
+                "description": "",
+                "name": "sloe berry",
+                "plural_name": "sloe berries"
+            },
+            "oregon grape": {
+                "aliases": [],
+                "description": "",
+                "name": "oregon grape",
+                "plural_name": "oregon grapes"
+            }
+        }
+    },
+    "Nuts & Seeds": {
+        "foods": {
+            "walnut": {
+                "aliases": [],
+                "description": "",
+                "name": "walnut",
+                "plural_name": "walnuts"
+            },
+            "pecan": {
+                "aliases": [],
+                "description": "",
+                "name": "pecan",
+                "plural_name": "pecans"
+            },
+            "almond": {
+                "aliases": [],
+                "description": "",
+                "name": "almond",
+                "plural_name": "almonds"
+            },
+            "sesame seed": {
+                "aliases": [],
+                "description": "",
+                "name": "sesame seed",
+                "plural_name": "sesame seeds"
+            },
+            "cashew": {
+                "aliases": [],
+                "description": "",
+                "name": "cashew",
+                "plural_name": "cashews"
+            },
+            "pine nut": {
+                "aliases": [],
+                "description": "",
+                "name": "pine nut",
+                "plural_name": "pine nuts"
+            },
+            "pistachio": {
+                "aliases": [],
+                "description": "",
+                "name": "pistachio",
+                "plural_name": "pistachios"
+            },
+            "peanut": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut",
+                "plural_name": "peanuts"
+            },
+            "chia": {
+                "aliases": [],
+                "description": "",
+                "name": "chia",
+                "plural_name": "chias"
+            },
+            "flax": {
+                "aliases": [],
+                "description": "",
+                "name": "flax",
+                "plural_name": "flaxes"
+            },
+            "slivered almond": {
+                "aliases": [],
+                "description": "",
+                "name": "slivered almond",
+                "plural_name": "slivered almonds"
+            },
+            "pumpkin seed": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin seed",
+                "plural_name": "pumpkin seeds"
+            },
+            "hazelnut": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut",
+                "plural_name": "hazelnuts"
+            },
+            "poppy seed": {
+                "aliases": [],
+                "description": "",
+                "name": "poppy seed",
+                "plural_name": "poppy seeds"
+            },
+            "sunflower seed": {
+                "aliases": [],
+                "description": "",
+                "name": "sunflower seed",
+                "plural_name": "sunflower seeds"
+            },
+            "macadamia": {
+                "aliases": [],
+                "description": "",
+                "name": "macadamia",
+                "plural_name": "macadamias"
+            },
+            "roasted peanut": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted peanut",
+                "plural_name": "roasted peanuts"
+            },
+            "chopped nut": {
+                "aliases": [],
+                "description": "",
+                "name": "chopped nut",
+                "plural_name": "chopped nuts"
+            },
+            "hemp heart": {
+                "aliases": [],
+                "description": "",
+                "name": "hemp heart",
+                "plural_name": "hemp hearts"
+            },
+            "nigella seed": {
+                "aliases": [],
+                "description": "",
+                "name": "nigella seed",
+                "plural_name": "nigella seeds"
+            },
+            "mixed nut": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed nut",
+                "plural_name": "mixed nuts"
+            },
+            "brazil nut": {
+                "aliases": [],
+                "description": "",
+                "name": "brazil nut",
+                "plural_name": "brazil nuts"
+            },
+            "mixed seed": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed seed",
+                "plural_name": "mixed seeds"
+            },
+            "onion seed": {
+                "aliases": [],
+                "description": "",
+                "name": "onion seed",
+                "plural_name": "onion seeds"
+            },
+            "watermelon seed": {
+                "aliases": [],
+                "description": "",
+                "name": "watermelon seed",
+                "plural_name": "watermelon seeds"
+            },
+            "honey-roasted peanut": {
+                "aliases": [],
+                "description": "",
+                "name": "honey-roasted peanut",
+                "plural_name": "honey-roasted peanuts"
+            },
+            "melon seed": {
+                "aliases": [],
+                "description": "",
+                "name": "melon seed",
+                "plural_name": "melon seeds"
+            },
+            "lotus seed": {
+                "aliases": [],
+                "description": "",
+                "name": "lotus seed",
+                "plural_name": "lotus seeds"
+            },
+            "white chia": {
+                "aliases": [],
+                "description": "",
+                "name": "white chia",
+                "plural_name": "white chias"
+            },
+            "trail mix": {
+                "aliases": [],
+                "description": "",
+                "name": "trail mix",
+                "plural_name": "trail mixes"
+            },
+            "basil seed": {
+                "aliases": [],
+                "description": "",
+                "name": "basil seed",
+                "plural_name": "basil seeds"
+            },
+            "candlenut": {
+                "aliases": [],
+                "description": "",
+                "name": "candlenut",
+                "plural_name": "candlenuts"
+            },
+            "peanut brittle": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut brittle",
+                "plural_name": "peanut brittles"
+            },
+            "jackfruit seed": {
+                "aliases": [],
+                "description": "",
+                "name": "jackfruit seed",
+                "plural_name": "jackfruit seeds"
+            },
+            "honey-roasted almond": {
+                "aliases": [],
+                "description": "",
+                "name": "honey-roasted almond",
+                "plural_name": "honey-roasted almonds"
+            },
+            "toasted nut": {
+                "aliases": [],
+                "description": "",
+                "name": "toasted nut",
+                "plural_name": "toasted nuts"
+            },
+            "chironji": {
+                "aliases": [],
+                "description": "",
+                "name": "chironji",
+                "plural_name": "chironjis"
+            },
+            "honey-roasted pecan": {
+                "aliases": [],
+                "description": "",
+                "name": "honey-roasted pecan",
+                "plural_name": "honey-roasted pecans"
+            },
+            "tigernut": {
+                "aliases": [],
+                "description": "",
+                "name": "tigernut",
+                "plural_name": "tigernuts"
+            },
+            "sunflower sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "sunflower sprout",
+                "plural_name": "sunflower sprouts"
+            },
+            "apricot kernel": {
+                "aliases": [],
+                "description": "",
+                "name": "apricot kernel",
+                "plural_name": "apricot kernels"
+            },
+            "palm seed": {
+                "aliases": [],
+                "description": "",
+                "name": "palm seed",
+                "plural_name": "palm seeds"
+            },
+            "ginkgo nut": {
+                "aliases": [],
+                "description": "",
+                "name": "ginkgo nut",
+                "plural_name": "ginkgo nuts"
+            },
+            "keto trail mix": {
+                "aliases": [],
+                "description": "",
+                "name": "keto trail mix",
+                "plural_name": "keto trail mixes"
+            },
+            "wattleseed": {
+                "aliases": [],
+                "description": "",
+                "name": "wattleseed",
+                "plural_name": "wattleseeds"
+            },
+            "bar\u00f9ka": {
+                "aliases": [],
+                "description": "",
+                "name": "bar\u00f9ka",
+                "plural_name": "bar\u00f9kas"
+            },
+            "indian almond": {
+                "aliases": [],
+                "description": "",
+                "name": "indian almond",
+                "plural_name": "indian almonds"
+            }
+        }
+    },
+    "Cheeses": {
+        "foods": {
+            "parmesan": {
+                "aliases": [],
+                "description": "",
+                "name": "parmesan",
+                "plural_name": "parmesans"
+            },
+            "cheddar cheese": {
+                "aliases": [
+                    "cheddars"
+                ],
+                "description": "",
+                "name": "cheddar cheese",
+                "plural_name": "cheddar cheeses"
+            },
+            "cream cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cream cheese",
+                "plural_name": "cream cheeses"
+            },
+            "sharp cheddar": {
+                "aliases": [],
+                "description": "",
+                "name": "sharp cheddar",
+                "plural_name": "sharp cheddars"
+            },
+            "cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese",
+                "plural_name": "cheeses"
+            },
+            "mozzarella": {
+                "aliases": [],
+                "description": "",
+                "name": "mozzarella",
+                "plural_name": "mozzarellas"
+            },
+            "feta": {
+                "aliases": [],
+                "description": "",
+                "name": "feta",
+                "plural_name": "fetas"
+            },
+            "ricotta": {
+                "aliases": [],
+                "description": "",
+                "name": "ricotta",
+                "plural_name": "ricottas"
+            },
+            "cheddar-jack cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cheddar-jack cheese",
+                "plural_name": "cheddar-jack cheeses"
+            },
+            "monterey jack": {
+                "aliases": [],
+                "description": "",
+                "name": "monterey jack",
+                "plural_name": "monterey jacks"
+            },
+            "blue cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "blue cheese",
+                "plural_name": "blue cheeses"
+            },
+            "goat cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "goat cheese",
+                "plural_name": "goat cheeses"
+            },
+            "fresh mozzarella": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh mozzarella",
+                "plural_name": "fresh mozzarellas"
+            },
+            "swiss cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "swiss cheese",
+                "plural_name": "swiss cheeses"
+            },
+            "pecorino": {
+                "aliases": [],
+                "description": "",
+                "name": "pecorino",
+                "plural_name": "pecorinoes"
+            },
+            "gruyere": {
+                "aliases": [],
+                "description": "",
+                "name": "gruyere",
+                "plural_name": "gruyeres"
+            },
+            "mascarpone": {
+                "aliases": [],
+                "description": "",
+                "name": "mascarpone",
+                "plural_name": "mascarpones"
+            },
+            "cottage cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cottage cheese",
+                "plural_name": "cottage cheeses"
+            },
+            "american cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "american cheese",
+                "plural_name": "american cheeses"
+            },
+            "provolone": {
+                "aliases": [],
+                "description": "",
+                "name": "provolone",
+                "plural_name": "provolones"
+            },
+            "mexican cheese blend": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican cheese blend",
+                "plural_name": "mexican cheese blends"
+            },
+            "pepper jack": {
+                "aliases": [],
+                "description": "",
+                "name": "pepper jack",
+                "plural_name": "pepper jacks"
+            },
+            "brie": {
+                "aliases": [],
+                "description": "",
+                "name": "brie",
+                "plural_name": "bries"
+            },
+            "paneer": {
+                "aliases": [],
+                "description": "",
+                "name": "paneer",
+                "plural_name": "paneers"
+            },
+            "fontina": {
+                "aliases": [],
+                "description": "",
+                "name": "fontina",
+                "plural_name": "fontinas"
+            },
+            "queso fresco": {
+                "aliases": [],
+                "description": "",
+                "name": "queso fresco",
+                "plural_name": "queso frescoes"
+            },
+            "quark": {
+                "aliases": [],
+                "description": "",
+                "name": "quark",
+                "plural_name": "quarks"
+            },
+            "gouda": {
+                "aliases": [],
+                "description": "",
+                "name": "gouda",
+                "plural_name": "goudas"
+            },
+            "cotija": {
+                "aliases": [],
+                "description": "",
+                "name": "cotija",
+                "plural_name": "cotijas"
+            },
+            "asiago": {
+                "aliases": [],
+                "description": "",
+                "name": "asiago",
+                "plural_name": "asiagoes"
+            },
+            "smoked cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked cheese",
+                "plural_name": "smoked cheeses"
+            },
+            "halloumi": {
+                "aliases": [],
+                "description": "",
+                "name": "halloumi",
+                "plural_name": "halloumis"
+            },
+            "chevre": {
+                "aliases": [],
+                "description": "",
+                "name": "chevre",
+                "plural_name": "chevres"
+            },
+            "manchego": {
+                "aliases": [],
+                "description": "",
+                "name": "manchego",
+                "plural_name": "manchegoes"
+            },
+            "italian cheese blend": {
+                "aliases": [],
+                "description": "",
+                "name": "italian cheese blend",
+                "plural_name": "italian cheese blends"
+            },
+            "neufchatel": {
+                "aliases": [],
+                "description": "",
+                "name": "neufchatel",
+                "plural_name": "neufchatels"
+            },
+            "herb cream cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "herb cream cheese",
+                "plural_name": "herb cream cheeses"
+            },
+            "burrata": {
+                "aliases": [],
+                "description": "",
+                "name": "burrata",
+                "plural_name": "burratas"
+            },
+            "havarti": {
+                "aliases": [],
+                "description": "",
+                "name": "havarti",
+                "plural_name": "havartis"
+            },
+            "colby": {
+                "aliases": [],
+                "description": "",
+                "name": "colby",
+                "plural_name": "colbies"
+            },
+            "grana-padano": {
+                "aliases": [],
+                "description": "",
+                "name": "grana-padano",
+                "plural_name": "grana-padanoes"
+            },
+            "muenster": {
+                "aliases": [],
+                "description": "",
+                "name": "muenster",
+                "plural_name": "muensters"
+            },
+            "string cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "string cheese",
+                "plural_name": "string cheeses"
+            },
+            "camembert": {
+                "aliases": [],
+                "description": "",
+                "name": "camembert",
+                "plural_name": "camemberts"
+            },
+            "soft cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "soft cheese",
+                "plural_name": "soft cheeses"
+            },
+            "stilton": {
+                "aliases": [],
+                "description": "",
+                "name": "stilton",
+                "plural_name": "stiltons"
+            },
+            "raclette": {
+                "aliases": [],
+                "description": "",
+                "name": "raclette",
+                "plural_name": "raclettes"
+            },
+            "colby-jack cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "colby-jack cheese",
+                "plural_name": "colby-jack cheeses"
+            },
+            "jarlsberg cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "jarlsberg cheese",
+                "plural_name": "jarlsberg cheeses"
+            },
+            "taleggio": {
+                "aliases": [],
+                "description": "",
+                "name": "taleggio",
+                "plural_name": "taleggios"
+            },
+            "oaxaca": {
+                "aliases": [],
+                "description": "",
+                "name": "oaxaca",
+                "plural_name": "oaxacas"
+            },
+            "labneh": {
+                "aliases": [],
+                "description": "",
+                "name": "labneh",
+                "plural_name": "labnehs"
+            },
+            "edam": {
+                "aliases": [],
+                "description": "",
+                "name": "edam",
+                "plural_name": "edams"
+            },
+            "creamy cheese wedge": {
+                "aliases": [],
+                "description": "",
+                "name": "creamy cheese wedge",
+                "plural_name": "creamy cheese wedges"
+            },
+            "cheese powder": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese powder",
+                "plural_name": "cheese powders"
+            },
+            "fromage blanc": {
+                "aliases": [],
+                "description": "",
+                "name": "fromage blanc",
+                "plural_name": "fromage blancs"
+            },
+            "asadero": {
+                "aliases": [],
+                "description": "",
+                "name": "asadero",
+                "plural_name": "asaderoes"
+            },
+            "marble cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "marble cheese",
+                "plural_name": "marble cheeses"
+            },
+            "leicester": {
+                "aliases": [],
+                "description": "",
+                "name": "leicester",
+                "plural_name": "leicesters"
+            },
+            "kefalotyri": {
+                "aliases": [],
+                "description": "",
+                "name": "kefalotyri",
+                "plural_name": "kefalotyris"
+            },
+            "mizithra": {
+                "aliases": [],
+                "description": "",
+                "name": "mizithra",
+                "plural_name": "mizithras"
+            },
+            "lancashire": {
+                "aliases": [],
+                "description": "",
+                "name": "lancashire",
+                "plural_name": "lancashires"
+            },
+            "kasseri": {
+                "aliases": [],
+                "description": "",
+                "name": "kasseri",
+                "plural_name": "kasseris"
+            },
+            "babybel": {
+                "aliases": [],
+                "description": "",
+                "name": "babybel",
+                "plural_name": "babybels"
+            },
+            "panela cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "panela cheese",
+                "plural_name": "panela cheeses"
+            },
+            "longhorn": {
+                "aliases": [],
+                "description": "",
+                "name": "longhorn",
+                "plural_name": "longhorns"
+            },
+            "seasoned feta cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "seasoned feta cheese",
+                "plural_name": "seasoned feta cheeses"
+            },
+            "comt\u00e9": {
+                "aliases": [],
+                "description": "",
+                "name": "comt\u00e9",
+                "plural_name": "comt\u00e9s"
+            },
+            "graviera": {
+                "aliases": [],
+                "description": "",
+                "name": "graviera",
+                "plural_name": "gravieras"
+            },
+            "wensleydale": {
+                "aliases": [],
+                "description": "",
+                "name": "wensleydale",
+                "plural_name": "wensleydales"
+            },
+            "scamorza": {
+                "aliases": [],
+                "description": "",
+                "name": "scamorza",
+                "plural_name": "scamorzas"
+            },
+            "cambozola": {
+                "aliases": [],
+                "description": "",
+                "name": "cambozola",
+                "plural_name": "cambozolas"
+            },
+            "cheshire cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cheshire cheese",
+                "plural_name": "cheshire cheeses"
+            },
+            "anthotyro": {
+                "aliases": [],
+                "description": "",
+                "name": "anthotyro",
+                "plural_name": "anthotyros"
+            },
+            "chenna": {
+                "aliases": [],
+                "description": "",
+                "name": "chenna",
+                "plural_name": "chennas"
+            },
+            "hard goat cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "hard goat cheese",
+                "plural_name": "hard goat cheeses"
+            },
+            "kashkaval": {
+                "aliases": [],
+                "description": "",
+                "name": "kashkaval",
+                "plural_name": "kashkavals"
+            },
+            "sheep cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "sheep cheese",
+                "plural_name": "sheep cheeses"
+            },
+            "amul cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "amul cheese",
+                "plural_name": "amul cheeses"
+            },
+            "reblochon": {
+                "aliases": [],
+                "description": "",
+                "name": "reblochon",
+                "plural_name": "reblochons"
+            },
+            "robiola": {
+                "aliases": [],
+                "description": "",
+                "name": "robiola",
+                "plural_name": "robiolas"
+            },
+            "brick cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "brick cheese",
+                "plural_name": "brick cheeses"
+            },
+            "quick-melt cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "quick-melt cheese",
+                "plural_name": "quick-melt cheeses"
+            },
+            "farmer's cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "farmer's cheese",
+                "plural_name": "farmer's cheeses"
+            },
+            "manouri": {
+                "aliases": [],
+                "description": "",
+                "name": "manouri",
+                "plural_name": "manouris"
+            },
+            "mimolette": {
+                "aliases": [],
+                "description": "",
+                "name": "mimolette",
+                "plural_name": "mimolettes"
+            },
+            "queso quesadilla": {
+                "aliases": [],
+                "description": "",
+                "name": "queso quesadilla",
+                "plural_name": "queso quesadillas"
+            },
+            "caciocavallo": {
+                "aliases": [],
+                "description": "",
+                "name": "caciocavallo",
+                "plural_name": "caciocavalloes"
+            },
+            "requeij\u00e3o": {
+                "aliases": [],
+                "description": "",
+                "name": "requeij\u00e3o",
+                "plural_name": "requeij\u00e3oes"
+            },
+            "vacherin": {
+                "aliases": [],
+                "description": "",
+                "name": "vacherin",
+                "plural_name": "vacherins"
+            },
+            "brown cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "brown cheese",
+                "plural_name": "brown cheeses"
+            },
+            "gloucester": {
+                "aliases": [],
+                "description": "",
+                "name": "gloucester",
+                "plural_name": "gloucesters"
+            },
+            "port salut": {
+                "aliases": [],
+                "description": "",
+                "name": "port salut",
+                "plural_name": "port saluts"
+            },
+            "derby cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "derby cheese",
+                "plural_name": "derby cheeses"
+            },
+            "fontal": {
+                "aliases": [],
+                "description": "",
+                "name": "fontal",
+                "plural_name": "fontals"
+            },
+            "salad cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "salad cheese",
+                "plural_name": "salad cheeses"
+            },
+            "truffle cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "truffle cheese",
+                "plural_name": "truffle cheeses"
+            },
+            "epoisses cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "epoisses cheese",
+                "plural_name": "epoisses cheeses"
+            },
+            "maasdam": {
+                "aliases": [],
+                "description": "",
+                "name": "maasdam",
+                "plural_name": "maasdams"
+            },
+            "petit-suisse": {
+                "aliases": [],
+                "description": "",
+                "name": "petit-suisse",
+                "plural_name": "petit-suisses"
+            },
+            "sbrinz": {
+                "aliases": [],
+                "description": "",
+                "name": "sbrinz",
+                "plural_name": "sbrinzzes"
+            }
+        }
+    },
+    "Dairy & Eggs": {
+        "foods": {
+            "butter": {
+                "aliases": [],
+                "description": "",
+                "name": "butter",
+                "plural_name": "butter"
+            },
+            "egg": {
+                "aliases": [],
+                "description": "",
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "milk": {
+                "aliases": [],
+                "description": "",
+                "name": "milk",
+                "plural_name": "milks"
+            },
+            "heavy cream": {
+                "aliases": [],
+                "description": "",
+                "name": "heavy cream",
+                "plural_name": "heavy creams"
+            },
+            "sour cream": {
+                "aliases": [],
+                "description": "",
+                "name": "sour cream",
+                "plural_name": "sour creams"
+            },
+            "buttermilk": {
+                "aliases": [],
+                "description": "",
+                "name": "buttermilk",
+                "plural_name": "buttermilks"
+            },
+            "yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "yogurt",
+                "plural_name": "yogurts"
+            },
+            "greek yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "greek yogurt",
+                "plural_name": "greek yogurts"
+            },
+            "cream": {
+                "aliases": [],
+                "description": "",
+                "name": "cream",
+                "plural_name": "creams"
+            },
+            "whipped cream": {
+                "aliases": [],
+                "description": "",
+                "name": "whipped cream",
+                "plural_name": "whipped creams"
+            },
+            "ghee": {
+                "aliases": [
+                    "clarified butter"
+                ],
+                "description": "",
+                "name": "ghee",
+                "plural_name": "ghees"
+            },
+            "shortening": {
+                "aliases": [],
+                "description": "",
+                "name": "shortening",
+                "plural_name": "shortenings"
+            },
+            "condensed milk": {
+                "aliases": [],
+                "description": "",
+                "name": "condensed milk",
+                "plural_name": "condensed milks"
+            },
+            "half and half": {
+                "aliases": [],
+                "description": "",
+                "name": "half and half",
+                "plural_name": "half and halves"
+            },
+            "sweetened condensed milk": {
+                "aliases": [],
+                "description": "",
+                "name": "sweetened condensed milk",
+                "plural_name": "sweetened condensed milks"
+            },
+            "ice cream": {
+                "aliases": [],
+                "description": "",
+                "name": "ice cream",
+                "plural_name": "ice creams"
+            },
+            "margarine": {
+                "aliases": [],
+                "description": "",
+                "name": "margarine",
+                "plural_name": "margarines"
+            },
+            "creme fraiche": {
+                "aliases": [],
+                "description": "",
+                "name": "creme fraiche",
+                "plural_name": "creme fraiches"
+            },
+            "frosting": {
+                "aliases": [],
+                "description": "",
+                "name": "frosting",
+                "plural_name": "frostings"
+            },
+            "milk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "milk powder",
+                "plural_name": "milk powders"
+            },
+            "curd": {
+                "aliases": [],
+                "description": "",
+                "name": "curd",
+                "plural_name": "curds"
+            },
+            "thickened cream": {
+                "aliases": [],
+                "description": "",
+                "name": "thickened cream",
+                "plural_name": "thickened creams"
+            },
+            "lemon curd": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon curd",
+                "plural_name": "lemon curds"
+            },
+            "dulce de leche": {
+                "aliases": [],
+                "description": "",
+                "name": "dulce de leche",
+                "plural_name": "dulce de leche"
+            },
+            "custard": {
+                "aliases": [],
+                "description": "",
+                "name": "custard",
+                "plural_name": "custards"
+            },
+            "chocolate frosting": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate frosting",
+                "plural_name": "chocolate frostings"
+            },
+            "kefir": {
+                "aliases": [],
+                "description": "",
+                "name": "kefir",
+                "plural_name": "kefirs"
+            },
+            "sherbet": {
+                "aliases": [],
+                "description": "",
+                "name": "sherbet",
+                "plural_name": "sherbets"
+            },
+            "chocolate milk": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate milk",
+                "plural_name": "chocolate milks"
+            },
+            "liquid egg substitute": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid egg substitute",
+                "plural_name": "liquid egg substitutes"
+            },
+            "whey": {
+                "aliases": [],
+                "description": "",
+                "name": "whey",
+                "plural_name": "wheys"
+            },
+            "hung curd": {
+                "aliases": [],
+                "description": "",
+                "name": "hung curd",
+                "plural_name": "hung curds"
+            },
+            "quail egg": {
+                "aliases": [],
+                "description": "",
+                "name": "quail egg",
+                "plural_name": "quail eggs"
+            },
+            "buttermilk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "buttermilk powder",
+                "plural_name": "buttermilk powders"
+            },
+            "frozen yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen yogurt",
+                "plural_name": "frozen yogurts"
+            },
+            "khoya": {
+                "aliases": [],
+                "description": "",
+                "name": "khoya",
+                "plural_name": "khoyas"
+            },
+            "milk cream": {
+                "aliases": [],
+                "description": "",
+                "name": "milk cream",
+                "plural_name": "milk creams"
+            },
+            "coffee creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee creamer",
+                "plural_name": "coffee creamers"
+            },
+            "clotted cream": {
+                "aliases": [],
+                "description": "",
+                "name": "clotted cream",
+                "plural_name": "clotted creams"
+            },
+            "goat milk": {
+                "aliases": [],
+                "description": "",
+                "name": "goat milk",
+                "plural_name": "goat milks"
+            },
+            "cheese curd": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese curd",
+                "plural_name": "cheese curds"
+            },
+            "sour milk": {
+                "aliases": [],
+                "description": "",
+                "name": "sour milk",
+                "plural_name": "sour milks"
+            },
+            "ganache": {
+                "aliases": [],
+                "description": "",
+                "name": "ganache",
+                "plural_name": "ganaches"
+            },
+            "cajeta": {
+                "aliases": [],
+                "description": "",
+                "name": "cajeta",
+                "plural_name": "cajetas"
+            },
+            "duck egg": {
+                "aliases": [],
+                "description": "",
+                "name": "duck egg",
+                "plural_name": "duck eggs"
+            },
+            "salted egg": {
+                "aliases": [],
+                "description": "",
+                "name": "salted egg",
+                "plural_name": "salted eggs"
+            },
+            "skyr": {
+                "aliases": [],
+                "description": "",
+                "name": "skyr",
+                "plural_name": "skyrs"
+            },
+            "pumpkin spice coffee creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin spice coffee creamer",
+                "plural_name": "pumpkin spice coffee creamers"
+            },
+            "raw milk": {
+                "aliases": [],
+                "description": "",
+                "name": "raw milk",
+                "plural_name": "raw milks"
+            },
+            "lime curd": {
+                "aliases": [],
+                "description": "",
+                "name": "lime curd",
+                "plural_name": "lime curds"
+            },
+            "powdered coffee creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "powdered coffee creamer",
+                "plural_name": "powdered coffee creamers"
+            },
+            "chantilly": {
+                "aliases": [],
+                "description": "",
+                "name": "chantilly",
+                "plural_name": "chantillies"
+            },
+            "milkfat": {
+                "aliases": [],
+                "description": "",
+                "name": "milkfat",
+                "plural_name": "milkfats"
+            },
+            "yogurt starter": {
+                "aliases": [],
+                "description": "",
+                "name": "yogurt starter",
+                "plural_name": "yogurt starters"
+            },
+            "rainbow sherbet": {
+                "aliases": [],
+                "description": "",
+                "name": "rainbow sherbet",
+                "plural_name": "rainbow sherbets"
+            },
+            "strawberry frosting": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry frosting",
+                "plural_name": "strawberry frostings"
+            },
+            "honey greek yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "honey greek yogurt",
+                "plural_name": "honey greek yogurts"
+            },
+            "amul butter": {
+                "aliases": [],
+                "description": "",
+                "name": "amul butter",
+                "plural_name": "amul butter"
+            },
+            "honey butter": {
+                "aliases": [],
+                "description": "",
+                "name": "honey butter",
+                "plural_name": "honey butter"
+            },
+            "strawberry cream cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry cream cheese",
+                "plural_name": "strawberry cream cheeses"
+            },
+            "goat butter": {
+                "aliases": [],
+                "description": "",
+                "name": "goat butter",
+                "plural_name": "goat butter"
+            },
+            "century egg": {
+                "aliases": [],
+                "description": "",
+                "name": "century egg",
+                "plural_name": "century eggs"
+            },
+            "orange curd": {
+                "aliases": [],
+                "description": "",
+                "name": "orange curd",
+                "plural_name": "orange curds"
+            },
+            "goat yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "goat yogurt",
+                "plural_name": "goat yogurts"
+            },
+            "dahi": {
+                "aliases": [],
+                "description": "",
+                "name": "dahi",
+                "plural_name": "dahis"
+            },
+            "cinnamon sugar butter spread": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon sugar butter spread",
+                "plural_name": "cinnamon sugar butter spreads"
+            },
+            "bulgarian yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "bulgarian yogurt",
+                "plural_name": "bulgarian yogurts"
+            },
+            "tvorog": {
+                "aliases": [],
+                "description": "",
+                "name": "tvorog",
+                "plural_name": "tvorogs"
+            },
+            "chocolate milk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate milk powder",
+                "plural_name": "chocolate milk powders"
+            },
+            "liquid rennet": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid rennet",
+                "plural_name": "liquid rennets"
+            },
+            "sheep\u2019s milk yoghurt": {
+                "aliases": [],
+                "description": "",
+                "name": "sheep\u2019s milk yoghurt",
+                "plural_name": "sheep\u2019s milk yoghurts"
+            },
+            "strawberry milk": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry milk",
+                "plural_name": "strawberry milks"
+            },
+            "ayran": {
+                "aliases": [],
+                "description": "",
+                "name": "ayran",
+                "plural_name": "ayrans"
+            },
+            "cuajada": {
+                "aliases": [],
+                "description": "",
+                "name": "cuajada",
+                "plural_name": "cuajadas"
+            },
+            "yogurt drink": {
+                "aliases": [],
+                "description": "",
+                "name": "yogurt drink",
+                "plural_name": "yogurt drinks"
+            },
+            "passion-fruit curd": {
+                "aliases": [],
+                "description": "",
+                "name": "passion-fruit curd",
+                "plural_name": "passion-fruit curds"
+            },
+            "pickled egg": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled egg",
+                "plural_name": "pickled eggs"
+            },
+            "sheep milk": {
+                "aliases": [],
+                "description": "",
+                "name": "sheep milk",
+                "plural_name": "sheep milks"
+            },
+            "starter culture": {
+                "aliases": [],
+                "description": "",
+                "name": "starter culture",
+                "plural_name": "starter cultures"
+            },
+            "kashk": {
+                "aliases": [],
+                "description": "",
+                "name": "kashk",
+                "plural_name": "kashks"
+            },
+            "ostrich egg": {
+                "aliases": [],
+                "description": "",
+                "name": "ostrich egg",
+                "plural_name": "ostrich eggs"
+            },
+            "vanilla milk": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla milk",
+                "plural_name": "vanilla milks"
+            },
+            "yoplait whip": {
+                "aliases": [],
+                "description": "",
+                "name": "yoplait whip",
+                "plural_name": "yoplait whips"
+            },
+            "buffalo milk": {
+                "aliases": [],
+                "description": "",
+                "name": "buffalo milk",
+                "plural_name": "buffalo milks"
+            },
+            "goat kefir": {
+                "aliases": [],
+                "description": "",
+                "name": "goat kefir",
+                "plural_name": "goat kefirs"
+            },
+            "lebneh": {
+                "aliases": [],
+                "description": "",
+                "name": "lebneh",
+                "plural_name": "lebnehs"
+            }
+        }
+    },
+    "Dairy-Free & Meat Substitutes": {
+        "foods": {
+            "coconut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut milk",
+                "plural_name": "coconut milks"
+            },
+            "almond milk": {
+                "aliases": [],
+                "description": "",
+                "name": "almond milk",
+                "plural_name": "almond milks"
+            },
+            "almond butter": {
+                "aliases": [],
+                "description": "",
+                "name": "almond butter",
+                "plural_name": "almond butter"
+            },
+            "tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "tofu",
+                "plural_name": "tofus"
+            },
+            "coconut cream": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut cream",
+                "plural_name": "coconut creams"
+            },
+            "vegan butter": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan butter",
+                "plural_name": "vegan butter"
+            },
+            "non-dairy milk": {
+                "aliases": [],
+                "description": "",
+                "name": "non-dairy milk",
+                "plural_name": "non-dairy milks"
+            },
+            "soy milk": {
+                "aliases": [],
+                "description": "",
+                "name": "soy milk",
+                "plural_name": "soy milks"
+            },
+            "extra firm tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "extra firm tofu",
+                "plural_name": "extra firm tofus"
+            },
+            "silken tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "silken tofu",
+                "plural_name": "silken tofus"
+            },
+            "kala namak salt": {
+                "aliases": [],
+                "description": "",
+                "name": "kala namak salt",
+                "plural_name": "kala namak salts"
+            },
+            "coconut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut butter",
+                "plural_name": "coconut butter"
+            },
+            "egg replacer": {
+                "aliases": [],
+                "description": "",
+                "name": "egg replacer",
+                "plural_name": "egg replacers"
+            },
+            "vegan mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan mayonnaise",
+                "plural_name": "vegan mayonnaises"
+            },
+            "vegan cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan cheese",
+                "plural_name": "vegan cheeses"
+            },
+            "cashew butter": {
+                "aliases": [],
+                "description": "",
+                "name": "cashew butter",
+                "plural_name": "cashew butter"
+            },
+            "tempeh": {
+                "aliases": [],
+                "description": "",
+                "name": "tempeh",
+                "plural_name": "tempehs"
+            },
+            "vegan cream cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan cream cheese",
+                "plural_name": "vegan cream cheeses"
+            },
+            "coconut yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut yogurt",
+                "plural_name": "coconut yogurts"
+            },
+            "non-dairy yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "non-dairy yogurt",
+                "plural_name": "non-dairy yogurts"
+            },
+            "seed butter": {
+                "aliases": [],
+                "description": "",
+                "name": "seed butter",
+                "plural_name": "seed butter"
+            },
+            "cashew milk": {
+                "aliases": [],
+                "description": "",
+                "name": "cashew milk",
+                "plural_name": "cashew milks"
+            },
+            "oat milk": {
+                "aliases": [],
+                "description": "",
+                "name": "oat milk",
+                "plural_name": "oat milks"
+            },
+            "nut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "nut butter",
+                "plural_name": "nut butter"
+            },
+            "rice milk": {
+                "aliases": [],
+                "description": "",
+                "name": "rice milk",
+                "plural_name": "rice milks"
+            },
+            "vegan sour cream": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan sour cream",
+                "plural_name": "vegan sour creams"
+            },
+            "textured vegetable protein": {
+                "aliases": [],
+                "description": "",
+                "name": "textured vegetable protein",
+                "plural_name": "textured vegetable proteins"
+            },
+            "vegan worcestershire": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan worcestershire",
+                "plural_name": "vegan worcestershires"
+            },
+            "soy yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "soy yogurt",
+                "plural_name": "soy yogurts"
+            },
+            "vegan mozzarella": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan mozzarella",
+                "plural_name": "vegan mozzarellas"
+            },
+            "non-dairy creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "non-dairy creamer",
+                "plural_name": "non-dairy creamers"
+            },
+            "vegan sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan sausage",
+                "plural_name": "vegan sausages"
+            },
+            "coconut whipped cream": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut whipped cream",
+                "plural_name": "coconut whipped creams"
+            },
+            "smoked tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked tofu",
+                "plural_name": "smoked tofus"
+            },
+            "coconut powder": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut powder",
+                "plural_name": "coconut powders"
+            },
+            "soy cream": {
+                "aliases": [],
+                "description": "",
+                "name": "soy cream",
+                "plural_name": "soy creams"
+            },
+            "seitan": {
+                "aliases": [],
+                "description": "",
+                "name": "seitan",
+                "plural_name": "seitans"
+            },
+            "coconut milk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut milk powder",
+                "plural_name": "coconut milk powders"
+            },
+            "non-dairy whipped topping": {
+                "aliases": [],
+                "description": "",
+                "name": "non-dairy whipped topping",
+                "plural_name": "non-dairy whipped toppings"
+            },
+            "nut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "nut milk",
+                "plural_name": "nut milks"
+            },
+            "non-dairy cream": {
+                "aliases": [],
+                "description": "",
+                "name": "non-dairy cream",
+                "plural_name": "non-dairy creams"
+            },
+            "vegan burger patty": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan burger patty",
+                "plural_name": "vegan burger patties"
+            },
+            "condensed coconut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "condensed coconut milk",
+                "plural_name": "condensed coconut milks"
+            },
+            "vegan ground beef": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan ground beef",
+                "plural_name": "vegan ground beefs"
+            },
+            "pulled oat": {
+                "aliases": [],
+                "description": "",
+                "name": "pulled oat",
+                "plural_name": "pulled oats"
+            },
+            "vegan bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan bacon",
+                "plural_name": "vegan bacons"
+            },
+            "soy curl": {
+                "aliases": [],
+                "description": "",
+                "name": "soy curl",
+                "plural_name": "soy curls"
+            },
+            "vegan pesto": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan pesto",
+                "plural_name": "vegan pestoes"
+            },
+            "marinated tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "marinated tofu",
+                "plural_name": "marinated tofus"
+            },
+            "vegan feta": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan feta",
+                "plural_name": "vegan fetas"
+            },
+            "soy chorizo": {
+                "aliases": [],
+                "description": "",
+                "name": "soy chorizo",
+                "plural_name": "soy chorizoes"
+            },
+            "hemp milk": {
+                "aliases": [],
+                "description": "",
+                "name": "hemp milk",
+                "plural_name": "hemp milks"
+            },
+            "vegan beef": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan beef",
+                "plural_name": "vegan beefs"
+            },
+            "hazelnut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut butter",
+                "plural_name": "hazelnut butter"
+            },
+            "vegan ranch": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan ranch",
+                "plural_name": "vegan ranches"
+            },
+            "vegan chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan chicken",
+                "plural_name": "vegan chickens"
+            },
+            "coconut paste": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut paste",
+                "plural_name": "coconut pastes"
+            },
+            "vegetable suet": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable suet",
+                "plural_name": "vegetable suets"
+            },
+            "dairy-free ice-cream": {
+                "aliases": [],
+                "description": "",
+                "name": "dairy-free ice-cream",
+                "plural_name": "dairy-free ice-creams"
+            },
+            "almond-coconut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "almond-coconut milk",
+                "plural_name": "almond-coconut milks"
+            },
+            "banana blossom": {
+                "aliases": [],
+                "description": "",
+                "name": "banana blossom",
+                "plural_name": "banana blossoms"
+            },
+            "vegan fish sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan fish sauce",
+                "plural_name": "vegan fish sauces"
+            },
+            "vegetarian hot dog": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetarian hot dog",
+                "plural_name": "vegetarian hot dogs"
+            },
+            "hazelnut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut milk",
+                "plural_name": "hazelnut milks"
+            },
+            "maple almond butter": {
+                "aliases": [],
+                "description": "",
+                "name": "maple almond butter",
+                "plural_name": "maple almond butter"
+            },
+            "vegan meatball": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan meatball",
+                "plural_name": "vegan meatballs"
+            },
+            "almond-milk yogurt": {
+                "aliases": [],
+                "description": "",
+                "name": "almond-milk yogurt",
+                "plural_name": "almond-milk yogurts"
+            },
+            "almond creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "almond creamer",
+                "plural_name": "almond creamers"
+            },
+            "soy milk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "soy milk powder",
+                "plural_name": "soy milk powders"
+            },
+            "vegan cream cheese frosting": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan cream cheese frosting",
+                "plural_name": "vegan cream cheese frostings"
+            },
+            "coconut manna": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut manna",
+                "plural_name": "coconut mannas"
+            },
+            "falafel mix": {
+                "aliases": [],
+                "description": "",
+                "name": "falafel mix",
+                "plural_name": "falafel mixes"
+            },
+            "ready-made falafel": {
+                "aliases": [],
+                "description": "",
+                "name": "ready-made falafel",
+                "plural_name": "ready-made falafels"
+            },
+            "vegan gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan gravy",
+                "plural_name": "vegan gravies"
+            },
+            "cashew cheese sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "cashew cheese sauce",
+                "plural_name": "cashew cheese sauces"
+            },
+            "coconut fat": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut fat",
+                "plural_name": "coconut fats"
+            },
+            "flax milk": {
+                "aliases": [],
+                "description": "",
+                "name": "flax milk",
+                "plural_name": "flax milks"
+            },
+            "hazelnut creamer": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut creamer",
+                "plural_name": "hazelnut creamers"
+            },
+            "quorn": {
+                "aliases": [],
+                "description": "",
+                "name": "quorn",
+                "plural_name": "quorns"
+            },
+            "soy-free butter": {
+                "aliases": [],
+                "description": "",
+                "name": "soy-free butter",
+                "plural_name": "soy-free butter"
+            },
+            "tofurky": {
+                "aliases": [],
+                "description": "",
+                "name": "tofurky",
+                "plural_name": "tofurkies"
+            },
+            "vegan nutella": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan nutella",
+                "plural_name": "vegan nutellas"
+            },
+            "vegan tzatziki": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan tzatziki",
+                "plural_name": "vegan tzatzikis"
+            },
+            "cashew cream cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "cashew cream cheese",
+                "plural_name": "cashew cream cheeses"
+            },
+            "cricket flour": {
+                "aliases": [],
+                "description": "",
+                "name": "cricket flour",
+                "plural_name": "cricket flours"
+            },
+            "macadamia butter": {
+                "aliases": [],
+                "description": "",
+                "name": "macadamia butter",
+                "plural_name": "macadamia butter"
+            },
+            "okara": {
+                "aliases": [],
+                "description": "",
+                "name": "okara",
+                "plural_name": "okaras"
+            },
+            "egg tofu": {
+                "aliases": [],
+                "description": "",
+                "name": "egg tofu",
+                "plural_name": "egg tofus"
+            },
+            "protein drink": {
+                "aliases": [],
+                "description": "",
+                "name": "protein drink",
+                "plural_name": "protein drinks"
+            },
+            "macadamia milk": {
+                "aliases": [],
+                "description": "",
+                "name": "macadamia milk",
+                "plural_name": "macadamia milks"
+            },
+            "vegan taco meat": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan taco meat",
+                "plural_name": "vegan taco meats"
+            },
+            "walnut taco meat": {
+                "aliases": [],
+                "description": "",
+                "name": "walnut taco meat",
+                "plural_name": "walnut taco meats"
+            },
+            "vegan yogurt starter": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan yogurt starter",
+                "plural_name": "vegan yogurt starters"
+            },
+            "banana milk": {
+                "aliases": [],
+                "description": "",
+                "name": "banana milk",
+                "plural_name": "banana milks"
+            },
+            "soy quark": {
+                "aliases": [],
+                "description": "",
+                "name": "soy quark",
+                "plural_name": "soy quarks"
+            },
+            "vegan chicken nugget": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan chicken nugget",
+                "plural_name": "vegan chicken nuggets"
+            },
+            "vegan starter culture": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan starter culture",
+                "plural_name": "vegan starter cultures"
+            },
+            "walnut milk": {
+                "aliases": [],
+                "description": "",
+                "name": "walnut milk",
+                "plural_name": "walnut milks"
+            },
+            "latik": {
+                "aliases": [],
+                "description": "",
+                "name": "latik",
+                "plural_name": "latiks"
+            },
+            "rice cream": {
+                "aliases": [],
+                "description": "",
+                "name": "rice cream",
+                "plural_name": "rice creams"
+            }
+        }
+    },
+    "Meats": {
+        "foods": {
+            "bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "bacon",
+                "plural_name": "bacons"
+            },
+            "chopped bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "chopped bacon",
+                "plural_name": "chopped bacons"
+            },
+            "ground beef": {
+                "aliases": [],
+                "description": "",
+                "name": "ground beef",
+                "plural_name": "ground beefs"
+            },
+            "beef steak": {
+                "aliases": [],
+                "description": "",
+                "name": "beef steak",
+                "plural_name": "beef steaks"
+            },
+            "ham": {
+                "aliases": [],
+                "description": "",
+                "name": "ham",
+                "plural_name": "hams"
+            },
+            "pork chop": {
+                "aliases": [],
+                "description": "",
+                "name": "pork chop",
+                "plural_name": "pork chops"
+            },
+            "sweet italian sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet italian sausage",
+                "plural_name": "sweet italian sausages"
+            },
+            "pork loin": {
+                "aliases": [],
+                "description": "",
+                "name": "pork loin",
+                "plural_name": "pork loins"
+            },
+            "prosciutto": {
+                "aliases": [],
+                "description": "",
+                "name": "prosciutto",
+                "plural_name": "prosciuttoes"
+            },
+            "sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "sausage",
+                "plural_name": "sausages"
+            },
+            "beef roast": {
+                "aliases": [],
+                "description": "",
+                "name": "beef roast",
+                "plural_name": "beef roasts"
+            },
+            "ground pork": {
+                "aliases": [],
+                "description": "",
+                "name": "ground pork",
+                "plural_name": "ground porks"
+            },
+            "beef stew meat": {
+                "aliases": [],
+                "description": "",
+                "name": "beef stew meat",
+                "plural_name": "beef stew meats"
+            },
+            "pepperoni": {
+                "aliases": [],
+                "description": "",
+                "name": "pepperoni",
+                "plural_name": "pepperonis"
+            },
+            "chorizo": {
+                "aliases": [],
+                "description": "",
+                "name": "chorizo",
+                "plural_name": "chorizoes"
+            },
+            "pancetta": {
+                "aliases": [],
+                "description": "",
+                "name": "pancetta",
+                "plural_name": "pancettas"
+            },
+            "pork fillet": {
+                "aliases": [],
+                "description": "",
+                "name": "pork fillet",
+                "plural_name": "pork fillets"
+            },
+            "pork shoulder": {
+                "aliases": [],
+                "description": "",
+                "name": "pork shoulder",
+                "plural_name": "pork shoulders"
+            },
+            "ground lamb": {
+                "aliases": [],
+                "description": "",
+                "name": "ground lamb",
+                "plural_name": "ground lambs"
+            },
+            "pork rib": {
+                "aliases": [],
+                "description": "",
+                "name": "pork rib",
+                "plural_name": "pork ribs"
+            },
+            "smoked sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked sausage",
+                "plural_name": "smoked sausages"
+            },
+            "breakfast sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "breakfast sausage",
+                "plural_name": "breakfast sausages"
+            },
+            "hot dog": {
+                "aliases": [],
+                "description": "",
+                "name": "hot dog",
+                "plural_name": "hot dogs"
+            },
+            "beef sirloin": {
+                "aliases": [],
+                "description": "",
+                "name": "beef sirloin",
+                "plural_name": "beef sirloins"
+            },
+            "salami": {
+                "aliases": [],
+                "description": "",
+                "name": "salami",
+                "plural_name": "salamis"
+            },
+            "brisket": {
+                "aliases": [],
+                "description": "",
+                "name": "brisket",
+                "plural_name": "briskets"
+            },
+            "deli ham": {
+                "aliases": [],
+                "description": "",
+                "name": "deli ham",
+                "plural_name": "deli hams"
+            },
+            "leg of lamb": {
+                "aliases": [],
+                "description": "",
+                "name": "leg of lamb",
+                "plural_name": "leg of lamb"
+            },
+            "beef short rib": {
+                "aliases": [],
+                "description": "",
+                "name": "beef short rib",
+                "plural_name": "beef short ribs"
+            },
+            "kielbasa": {
+                "aliases": [],
+                "description": "",
+                "name": "kielbasa",
+                "plural_name": "kielbasas"
+            },
+            "pork belly": {
+                "aliases": [],
+                "description": "",
+                "name": "pork belly",
+                "plural_name": "pork bellies"
+            },
+            "andouille": {
+                "aliases": [],
+                "description": "",
+                "name": "andouille",
+                "plural_name": "andouilles"
+            },
+            "boneless lamb": {
+                "aliases": [],
+                "description": "",
+                "name": "boneless lamb",
+                "plural_name": "boneless lambs"
+            },
+            "ground sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "ground sausage",
+                "plural_name": "ground sausages"
+            },
+            "ground pork sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "ground pork sausage",
+                "plural_name": "ground pork sausages"
+            },
+            "roast beef": {
+                "aliases": [],
+                "description": "",
+                "name": "roast beef",
+                "plural_name": "roast beefs"
+            },
+            "bacon bit": {
+                "aliases": [],
+                "description": "",
+                "name": "bacon bit",
+                "plural_name": "bacon bits"
+            },
+            "pork roast": {
+                "aliases": [],
+                "description": "",
+                "name": "pork roast",
+                "plural_name": "pork roasts"
+            },
+            "hot italian sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "hot italian sausage",
+                "plural_name": "hot italian sausages"
+            },
+            "pork spare rib": {
+                "aliases": [],
+                "description": "",
+                "name": "pork spare rib",
+                "plural_name": "pork spare ribs"
+            },
+            "lamb shoulder": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb shoulder",
+                "plural_name": "lamb shoulders"
+            },
+            "beef rib": {
+                "aliases": [],
+                "description": "",
+                "name": "beef rib",
+                "plural_name": "beef ribs"
+            },
+            "veal steak": {
+                "aliases": [],
+                "description": "",
+                "name": "veal steak",
+                "plural_name": "veal steaks"
+            },
+            "lamb chop": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb chop",
+                "plural_name": "lamb chops"
+            },
+            "bone-in ham": {
+                "aliases": [],
+                "description": "",
+                "name": "bone-in ham",
+                "plural_name": "bone-in hams"
+            },
+            "pork butt": {
+                "aliases": [],
+                "description": "",
+                "name": "pork butt",
+                "plural_name": "pork butts"
+            },
+            "canadian bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "canadian bacon",
+                "plural_name": "canadian bacons"
+            },
+            "beef sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "beef sausage",
+                "plural_name": "beef sausages"
+            },
+            "lamb shank": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb shank",
+                "plural_name": "lamb shanks"
+            },
+            "mutton": {
+                "aliases": [],
+                "description": "",
+                "name": "mutton",
+                "plural_name": "muttons"
+            },
+            "ham steak": {
+                "aliases": [],
+                "description": "",
+                "name": "ham steak",
+                "plural_name": "ham steaks"
+            },
+            "venison": {
+                "aliases": [],
+                "description": "",
+                "name": "venison",
+                "plural_name": "venisons"
+            },
+            "bratwurst": {
+                "aliases": [],
+                "description": "",
+                "name": "bratwurst",
+                "plural_name": "bratwursts"
+            },
+            "pulled pork": {
+                "aliases": [],
+                "description": "",
+                "name": "pulled pork",
+                "plural_name": "pulled porks"
+            },
+            "ham hock": {
+                "aliases": [],
+                "description": "",
+                "name": "ham hock",
+                "plural_name": "ham hocks"
+            },
+            "frozen meatball": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen meatball",
+                "plural_name": "frozen meatballs"
+            },
+            "mixed ground meat": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed ground meat",
+                "plural_name": "mixed ground meats"
+            },
+            "rabbit": {
+                "aliases": [],
+                "description": "",
+                "name": "rabbit",
+                "plural_name": "rabbits"
+            },
+            "pork cutlet": {
+                "aliases": [],
+                "description": "",
+                "name": "pork cutlet",
+                "plural_name": "pork cutlets"
+            },
+            "veal cutlet": {
+                "aliases": [],
+                "description": "",
+                "name": "veal cutlet",
+                "plural_name": "veal cutlets"
+            },
+            "soup bone": {
+                "aliases": [],
+                "description": "",
+                "name": "soup bone",
+                "plural_name": "soup bones"
+            },
+            "lamb loin": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb loin",
+                "plural_name": "lamb loins"
+            },
+            "pork steak": {
+                "aliases": [],
+                "description": "",
+                "name": "pork steak",
+                "plural_name": "pork steaks"
+            },
+            "mexican chorizo": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican chorizo",
+                "plural_name": "mexican chorizoes"
+            },
+            "rack of lamb": {
+                "aliases": [],
+                "description": "",
+                "name": "rack of lamb",
+                "plural_name": "rack of lamb"
+            },
+            "pork back rib": {
+                "aliases": [],
+                "description": "",
+                "name": "pork back rib",
+                "plural_name": "pork back ribs"
+            },
+            "country style rib": {
+                "aliases": [],
+                "description": "",
+                "name": "country style rib",
+                "plural_name": "country style ribs"
+            },
+            "black forest ham": {
+                "aliases": [],
+                "description": "",
+                "name": "black forest ham",
+                "plural_name": "black forest hams"
+            },
+            "oxtail": {
+                "aliases": [],
+                "description": "",
+                "name": "oxtail",
+                "plural_name": "oxtails"
+            },
+            "smoked ham hock": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked ham hock",
+                "plural_name": "smoked ham hocks"
+            },
+            "serrano ham": {
+                "aliases": [],
+                "description": "",
+                "name": "serrano ham",
+                "plural_name": "serrano hams"
+            },
+            "raw chorizo": {
+                "aliases": [],
+                "description": "",
+                "name": "raw chorizo",
+                "plural_name": "raw chorizoes"
+            },
+            "beef liver": {
+                "aliases": [],
+                "description": "",
+                "name": "beef liver",
+                "plural_name": "beef livers"
+            },
+            "pastrami": {
+                "aliases": [],
+                "description": "",
+                "name": "pastrami",
+                "plural_name": "pastramis"
+            },
+            "cocktail sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "cocktail sausage",
+                "plural_name": "cocktail sausages"
+            },
+            "hard salami": {
+                "aliases": [],
+                "description": "",
+                "name": "hard salami",
+                "plural_name": "hard salamis"
+            },
+            "back bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "back bacon",
+                "plural_name": "back bacons"
+            },
+            "salt pork": {
+                "aliases": [],
+                "description": "",
+                "name": "salt pork",
+                "plural_name": "salt porks"
+            },
+            "veal shank": {
+                "aliases": [],
+                "description": "",
+                "name": "veal shank",
+                "plural_name": "veal shanks"
+            },
+            "ground venison": {
+                "aliases": [],
+                "description": "",
+                "name": "ground venison",
+                "plural_name": "ground venisons"
+            },
+            "beef shank": {
+                "aliases": [],
+                "description": "",
+                "name": "beef shank",
+                "plural_name": "beef shanks"
+            },
+            "lap cheong": {
+                "aliases": [],
+                "description": "",
+                "name": "lap cheong",
+                "plural_name": "lap cheongs"
+            },
+            "blood sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "blood sausage",
+                "plural_name": "blood sausages"
+            },
+            "dried beef": {
+                "aliases": [],
+                "description": "",
+                "name": "dried beef",
+                "plural_name": "dried beefs"
+            },
+            "gammon joint": {
+                "aliases": [],
+                "description": "",
+                "name": "gammon joint",
+                "plural_name": "gammon joints"
+            },
+            "boneless beef short rib": {
+                "aliases": [],
+                "description": "",
+                "name": "boneless beef short rib",
+                "plural_name": "boneless beef short ribs"
+            },
+            "country ham": {
+                "aliases": [],
+                "description": "",
+                "name": "country ham",
+                "plural_name": "country hams"
+            },
+            "boneless ham": {
+                "aliases": [],
+                "description": "",
+                "name": "boneless ham",
+                "plural_name": "boneless hams"
+            },
+            "mortadella": {
+                "aliases": [],
+                "description": "",
+                "name": "mortadella",
+                "plural_name": "mortadellas"
+            },
+            "ground bison": {
+                "aliases": [],
+                "description": "",
+                "name": "ground bison",
+                "plural_name": "ground bisons"
+            },
+            "fresh sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh sausage",
+                "plural_name": "fresh sausages"
+            },
+            "bologna": {
+                "aliases": [],
+                "description": "",
+                "name": "bologna",
+                "plural_name": "bolognas"
+            },
+            "burger patty": {
+                "aliases": [],
+                "description": "",
+                "name": "burger patty",
+                "plural_name": "burger patties"
+            },
+            "smoked pork chop": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked pork chop",
+                "plural_name": "smoked pork chops"
+            },
+            "lamb neck": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb neck",
+                "plural_name": "lamb necks"
+            },
+            "sausage patty": {
+                "aliases": [],
+                "description": "",
+                "name": "sausage patty",
+                "plural_name": "sausage patties"
+            },
+            "beef suet": {
+                "aliases": [],
+                "description": "",
+                "name": "beef suet",
+                "plural_name": "beef suets"
+            },
+            "veal roast": {
+                "aliases": [],
+                "description": "",
+                "name": "veal roast",
+                "plural_name": "veal roasts"
+            },
+            "beef shoulder": {
+                "aliases": [],
+                "description": "",
+                "name": "beef shoulder",
+                "plural_name": "beef shoulders"
+            },
+            "steak tip": {
+                "aliases": [],
+                "description": "",
+                "name": "steak tip",
+                "plural_name": "steak tips"
+            },
+            "veal chop": {
+                "aliases": [],
+                "description": "",
+                "name": "veal chop",
+                "plural_name": "veal chops"
+            }
+        }
+    },
+    "Poultry": {
+        "foods": {
+            "chicken breast": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken breast",
+                "plural_name": "chicken breasts"
+            },
+            "chicken thigh": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken thigh",
+                "plural_name": "chicken thighs"
+            },
+            "cooked chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "cooked chicken",
+                "plural_name": "cooked chickens"
+            },
+            "ground turkey": {
+                "aliases": [],
+                "description": "",
+                "name": "ground turkey",
+                "plural_name": "ground turkeys"
+            },
+            "whole chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "whole chicken",
+                "plural_name": "whole chickens"
+            },
+            "whole turkey": {
+                "aliases": [],
+                "description": "",
+                "name": "whole turkey",
+                "plural_name": "whole turkeys"
+            },
+            "chicken leg": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken leg",
+                "plural_name": "chicken legs"
+            },
+            "chicken wing": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken wing",
+                "plural_name": "chicken wings"
+            },
+            "turkey breast": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey breast",
+                "plural_name": "turkey breasts"
+            },
+            "ground chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "ground chicken",
+                "plural_name": "ground chickens"
+            },
+            "rotisserie chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "rotisserie chicken",
+                "plural_name": "rotisserie chickens"
+            },
+            "chicken tender": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken tender",
+                "plural_name": "chicken tenders"
+            },
+            "turkey sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey sausage",
+                "plural_name": "turkey sausages"
+            },
+            "chicken sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken sausage",
+                "plural_name": "chicken sausages"
+            },
+            "turkey bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey bacon",
+                "plural_name": "turkey bacons"
+            },
+            "duck": {
+                "aliases": [],
+                "description": "",
+                "name": "duck",
+                "plural_name": "ducks"
+            },
+            "duck breast": {
+                "aliases": [],
+                "description": "",
+                "name": "duck breast",
+                "plural_name": "duck breasts"
+            },
+            "boneless chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "boneless chicken",
+                "plural_name": "boneless chickens"
+            },
+            "chicken liver": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken liver",
+                "plural_name": "chicken livers"
+            },
+            "cornish hen": {
+                "aliases": [],
+                "description": "",
+                "name": "cornish hen",
+                "plural_name": "cornish hens"
+            },
+            "deli turkey": {
+                "aliases": [],
+                "description": "",
+                "name": "deli turkey",
+                "plural_name": "deli turkeys"
+            },
+            "smoked turkey": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked turkey",
+                "plural_name": "smoked turkeys"
+            },
+            "turkey meat": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey meat",
+                "plural_name": "turkey meats"
+            },
+            "chicken quarter": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken quarter",
+                "plural_name": "chicken quarters"
+            },
+            "ground turkey sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "ground turkey sausage",
+                "plural_name": "ground turkey sausages"
+            },
+            "quail": {
+                "aliases": [],
+                "description": "",
+                "name": "quail",
+                "plural_name": "quails"
+            },
+            "smoked turkey sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked turkey sausage",
+                "plural_name": "smoked turkey sausages"
+            },
+            "smoked chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked chicken",
+                "plural_name": "smoked chickens"
+            },
+            "turkey leg": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey leg",
+                "plural_name": "turkey legs"
+            },
+            "pheasant": {
+                "aliases": [],
+                "description": "",
+                "name": "pheasant",
+                "plural_name": "pheasants"
+            },
+            "goose": {
+                "aliases": [],
+                "description": "",
+                "name": "goose",
+                "plural_name": "geese"
+            },
+            "turkey pepperoni": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey pepperoni",
+                "plural_name": "turkey pepperonis"
+            },
+            "turkey ham": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey ham",
+                "plural_name": "turkey hams"
+            },
+            "turkey thigh": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey thigh",
+                "plural_name": "turkey thighs"
+            },
+            "chicken bone": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken bone",
+                "plural_name": "chicken bones"
+            },
+            "turkey meatball": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey meatball",
+                "plural_name": "turkey meatballs"
+            },
+            "foie gra": {
+                "aliases": [],
+                "description": "",
+                "name": "foie gra",
+                "plural_name": "foie gras"
+            },
+            "chicken giblet": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken giblet",
+                "plural_name": "chicken giblets"
+            },
+            "turkey wing": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey wing",
+                "plural_name": "turkey wings"
+            },
+            "turkey giblet": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey giblet",
+                "plural_name": "turkey giblets"
+            },
+            "turkey neck": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey neck",
+                "plural_name": "turkey necks"
+            },
+            "chicken nugget": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken nugget",
+                "plural_name": "chicken nuggets"
+            },
+            "turkey burger": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey burger",
+                "plural_name": "turkey burgers"
+            },
+            "chicken andouille": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken andouille",
+                "plural_name": "chicken andouilles"
+            },
+            "chicken gizzard": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken gizzard",
+                "plural_name": "chicken gizzards"
+            },
+            "smoked turkey leg": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked turkey leg",
+                "plural_name": "smoked turkey legs"
+            },
+            "chicken italian sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken italian sausage",
+                "plural_name": "chicken italian sausages"
+            },
+            "crispy chicken strip": {
+                "aliases": [],
+                "description": "",
+                "name": "crispy chicken strip",
+                "plural_name": "crispy chicken strips"
+            },
+            "ostrich": {
+                "aliases": [],
+                "description": "",
+                "name": "ostrich",
+                "plural_name": "ostriches"
+            },
+            "popcorn chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "popcorn chicken",
+                "plural_name": "popcorn chickens"
+            },
+            "turkey kielbasa": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey kielbasa",
+                "plural_name": "turkey kielbasas"
+            },
+            "chicken-apple sausage": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken-apple sausage",
+                "plural_name": "chicken-apple sausages"
+            },
+            "chicken foot": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken foot",
+                "plural_name": "chicken feet"
+            },
+            "pulled chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "pulled chicken",
+                "plural_name": "pulled chickens"
+            },
+            "deli chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "deli chicken",
+                "plural_name": "deli chickens"
+            },
+            "smoked duck breast": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked duck breast",
+                "plural_name": "smoked duck breasts"
+            },
+            "pigeon": {
+                "aliases": [],
+                "description": "",
+                "name": "pigeon",
+                "plural_name": "pigeons"
+            },
+            "wild game bird": {
+                "aliases": [],
+                "description": "",
+                "name": "wild game bird",
+                "plural_name": "wild game birds"
+            },
+            "turkey liver": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey liver",
+                "plural_name": "turkey livers"
+            },
+            "chicken neck": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken neck",
+                "plural_name": "chicken necks"
+            },
+            "duck confit": {
+                "aliases": [],
+                "description": "",
+                "name": "duck confit",
+                "plural_name": "duck confits"
+            },
+            "roast duck": {
+                "aliases": [],
+                "description": "",
+                "name": "roast duck",
+                "plural_name": "roast ducks"
+            },
+            "chicken meatball": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken meatball",
+                "plural_name": "chicken meatballs"
+            },
+            "duck liver": {
+                "aliases": [],
+                "description": "",
+                "name": "duck liver",
+                "plural_name": "duck livers"
+            },
+            "guinea fowl": {
+                "aliases": [],
+                "description": "",
+                "name": "guinea fowl",
+                "plural_name": "guinea fowls"
+            },
+            "smoked turkey wing": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked turkey wing",
+                "plural_name": "smoked turkey wings"
+            },
+            "chicken curry-cut": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken curry-cut",
+                "plural_name": "chicken curry-cuts"
+            },
+            "chicken schnitzel": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken schnitzel",
+                "plural_name": "chicken schnitzels"
+            },
+            "grouse": {
+                "aliases": [],
+                "description": "",
+                "name": "grouse",
+                "plural_name": "grouses"
+            },
+            "chicken roast": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken roast",
+                "plural_name": "chicken roasts"
+            },
+            "goose liver": {
+                "aliases": [],
+                "description": "",
+                "name": "goose liver",
+                "plural_name": "goose livers"
+            },
+            "turkey bone": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey bone",
+                "plural_name": "turkey bones"
+            },
+            "turkey lunch meat": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey lunch meat",
+                "plural_name": "turkey lunch meats"
+            },
+            "turkey roast": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey roast",
+                "plural_name": "turkey roasts"
+            },
+            "capon": {
+                "aliases": [],
+                "description": "",
+                "name": "capon",
+                "plural_name": "capons"
+            },
+            "smoked turkey bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked turkey bacon",
+                "plural_name": "smoked turkey bacons"
+            },
+            "chicken bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken bacon",
+                "plural_name": "chicken bacons"
+            },
+            "turkey rissole": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey rissole",
+                "plural_name": "turkey rissoles"
+            },
+            "chicken kebab": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken kebab",
+                "plural_name": "chicken kebabs"
+            },
+            "chicken ham": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken ham",
+                "plural_name": "chicken hams"
+            },
+            "duck neck": {
+                "aliases": [],
+                "description": "",
+                "name": "duck neck",
+                "plural_name": "duck necks"
+            },
+            "chicken chorizo": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken chorizo",
+                "plural_name": "chicken chorizoes"
+            },
+            "chicken frame": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken frame",
+                "plural_name": "chicken frames"
+            },
+            "duck bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "duck bacon",
+                "plural_name": "duck bacons"
+            },
+            "pulled turkey": {
+                "aliases": [],
+                "description": "",
+                "name": "pulled turkey",
+                "plural_name": "pulled turkeys"
+            },
+            "chicken gyro": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken gyro",
+                "plural_name": "chicken gyros"
+            },
+            "chicken patty": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken patty",
+                "plural_name": "chicken patties"
+            },
+            "chicken rib": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken rib",
+                "plural_name": "chicken ribs"
+            },
+            "turkey tail": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey tail",
+                "plural_name": "turkey tails"
+            },
+            "chicken milanesa": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken milanesa",
+                "plural_name": "chicken milanesas"
+            }
+        }
+    },
+    "Fish": {
+        "foods": {
+            "salmon": {
+                "aliases": [],
+                "description": "",
+                "name": "salmon",
+                "plural_name": "salmon"
+            },
+            "smoked salmon": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked salmon",
+                "plural_name": "smoked salmon"
+            },
+            "cod": {
+                "aliases": [],
+                "description": "",
+                "name": "cod",
+                "plural_name": "cod"
+            },
+            "tilapia": {
+                "aliases": [],
+                "description": "",
+                "name": "tilapia",
+                "plural_name": "tilapias"
+            },
+            "tuna steak": {
+                "aliases": [],
+                "description": "",
+                "name": "tuna steak",
+                "plural_name": "tuna steaks"
+            },
+            "whitefish": {
+                "aliases": [],
+                "description": "",
+                "name": "whitefish",
+                "plural_name": "whitefish"
+            },
+            "halibut": {
+                "aliases": [],
+                "description": "",
+                "name": "halibut",
+                "plural_name": "halibuts"
+            },
+            "red snapper": {
+                "aliases": [],
+                "description": "",
+                "name": "red snapper",
+                "plural_name": "red snappers"
+            },
+            "sea bas": {
+                "aliases": [],
+                "description": "",
+                "name": "sea bas",
+                "plural_name": "sea bass"
+            },
+            "fish fillet": {
+                "aliases": [],
+                "description": "",
+                "name": "fish fillet",
+                "plural_name": "fish fillets"
+            },
+            "trout": {
+                "aliases": [],
+                "description": "",
+                "name": "trout",
+                "plural_name": "trout"
+            },
+            "catfish": {
+                "aliases": [],
+                "description": "",
+                "name": "catfish",
+                "plural_name": "catfishes"
+            },
+            "surimi": {
+                "aliases": [],
+                "description": "",
+                "name": "surimi",
+                "plural_name": "surimis"
+            },
+            "swordfish": {
+                "aliases": [],
+                "description": "",
+                "name": "swordfish",
+                "plural_name": "swordfish"
+            },
+            "sardine": {
+                "aliases": [],
+                "description": "",
+                "name": "sardine",
+                "plural_name": "sardines"
+            },
+            "sole": {
+                "aliases": [],
+                "description": "",
+                "name": "sole",
+                "plural_name": "soles"
+            },
+            "mahi mahi": {
+                "aliases": [],
+                "description": "",
+                "name": "mahi mahi",
+                "plural_name": "mahi mahis"
+            },
+            "mackerel": {
+                "aliases": [],
+                "description": "",
+                "name": "mackerel",
+                "plural_name": "mackerel"
+            },
+            "smoked trout": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked trout",
+                "plural_name": "smoked trout"
+            },
+            "caviar": {
+                "aliases": [],
+                "description": "",
+                "name": "caviar",
+                "plural_name": "caviars"
+            },
+            "haddock": {
+                "aliases": [],
+                "description": "",
+                "name": "haddock",
+                "plural_name": "haddocks"
+            },
+            "monkfish": {
+                "aliases": [],
+                "description": "",
+                "name": "monkfish",
+                "plural_name": "monkfish"
+            },
+            "smoked haddock": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked haddock",
+                "plural_name": "smoked haddocks"
+            },
+            "flounder": {
+                "aliases": [],
+                "description": "",
+                "name": "flounder",
+                "plural_name": "flounder"
+            },
+            "perch": {
+                "aliases": [],
+                "description": "",
+                "name": "perch",
+                "plural_name": "perches"
+            },
+            "hake": {
+                "aliases": [],
+                "description": "",
+                "name": "hake",
+                "plural_name": "hakes"
+            },
+            "pollock": {
+                "aliases": [],
+                "description": "",
+                "name": "pollock",
+                "plural_name": "pollocks"
+            },
+            "salt cod": {
+                "aliases": [],
+                "description": "",
+                "name": "salt cod",
+                "plural_name": "salt cod"
+            },
+            "smoked mackerel": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked mackerel",
+                "plural_name": "smoked mackerel"
+            },
+            "sea bream": {
+                "aliases": [],
+                "description": "",
+                "name": "sea bream",
+                "plural_name": "sea bream"
+            },
+            "rainbow trout": {
+                "aliases": [],
+                "description": "",
+                "name": "rainbow trout",
+                "plural_name": "rainbow trout"
+            },
+            "carp": {
+                "aliases": [],
+                "description": "",
+                "name": "carp",
+                "plural_name": "carp"
+            },
+            "cuttlefish": {
+                "aliases": [],
+                "description": "",
+                "name": "cuttlefish",
+                "plural_name": "cuttlefish"
+            },
+            "grouper": {
+                "aliases": [],
+                "description": "",
+                "name": "grouper",
+                "plural_name": "groupers"
+            },
+            "herring": {
+                "aliases": [],
+                "description": "",
+                "name": "herring",
+                "plural_name": "herrings"
+            },
+            "salmon roe": {
+                "aliases": [],
+                "description": "",
+                "name": "salmon roe",
+                "plural_name": "salmon roes"
+            },
+            "steelhead trout": {
+                "aliases": [],
+                "description": "",
+                "name": "steelhead trout",
+                "plural_name": "steelhead trout"
+            },
+            "roe": {
+                "aliases": [],
+                "description": "",
+                "name": "roe",
+                "plural_name": "roes"
+            },
+            "barramundi": {
+                "aliases": [],
+                "description": "",
+                "name": "barramundi",
+                "plural_name": "barramundis"
+            },
+            "black cod": {
+                "aliases": [],
+                "description": "",
+                "name": "black cod",
+                "plural_name": "black cod"
+            },
+            "kingfish": {
+                "aliases": [],
+                "description": "",
+                "name": "kingfish",
+                "plural_name": "kingfish"
+            },
+            "orange roughy": {
+                "aliases": [],
+                "description": "",
+                "name": "orange roughy",
+                "plural_name": "orange roughies"
+            },
+            "turbot": {
+                "aliases": [],
+                "description": "",
+                "name": "turbot",
+                "plural_name": "turbots"
+            },
+            "bangu": {
+                "aliases": [],
+                "description": "",
+                "name": "bangu",
+                "plural_name": "bangus"
+            },
+            "rockfish": {
+                "aliases": [],
+                "description": "",
+                "name": "rockfish",
+                "plural_name": "rockfish"
+            },
+            "branzino": {
+                "aliases": [],
+                "description": "",
+                "name": "branzino",
+                "plural_name": "branzinoes"
+            },
+            "pomfret": {
+                "aliases": [],
+                "description": "",
+                "name": "pomfret",
+                "plural_name": "pomfrets"
+            },
+            "eel": {
+                "aliases": [],
+                "description": "",
+                "name": "eel",
+                "plural_name": "eels"
+            },
+            "dried anchovy": {
+                "aliases": [],
+                "description": "",
+                "name": "dried anchovy",
+                "plural_name": "dried anchovies"
+            },
+            "arctic char": {
+                "aliases": [],
+                "description": "",
+                "name": "arctic char",
+                "plural_name": "arctic chars"
+            },
+            "fresh anchovy": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh anchovy",
+                "plural_name": "fresh anchovies"
+            },
+            "lemon sole": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon sole",
+                "plural_name": "lemon soles"
+            },
+            "yellowtail": {
+                "aliases": [],
+                "description": "",
+                "name": "yellowtail",
+                "plural_name": "yellowtails"
+            },
+            "battered fish": {
+                "aliases": [],
+                "description": "",
+                "name": "battered fish",
+                "plural_name": "battered fish"
+            },
+            "pike": {
+                "aliases": [],
+                "description": "",
+                "name": "pike",
+                "plural_name": "pikes"
+            },
+            "pickled herring": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled herring",
+                "plural_name": "pickled herrings"
+            },
+            "john dory": {
+                "aliases": [],
+                "description": "",
+                "name": "john dory",
+                "plural_name": "john dories"
+            },
+            "swai fish": {
+                "aliases": [],
+                "description": "",
+                "name": "swai fish",
+                "plural_name": "swai fish"
+            },
+            "walleye": {
+                "aliases": [],
+                "description": "",
+                "name": "walleye",
+                "plural_name": "walleyes"
+            },
+            "fresh mackerel": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh mackerel",
+                "plural_name": "fresh mackerel"
+            },
+            "salmon trout": {
+                "aliases": [],
+                "description": "",
+                "name": "salmon trout",
+                "plural_name": "salmon trout"
+            },
+            "basa fish": {
+                "aliases": [],
+                "description": "",
+                "name": "basa fish",
+                "plural_name": "basa fish"
+            },
+            "smoked eel": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked eel",
+                "plural_name": "smoked eels"
+            },
+            "fish ball": {
+                "aliases": [],
+                "description": "",
+                "name": "fish ball",
+                "plural_name": "fish balls"
+            },
+            "sturgeon": {
+                "aliases": [],
+                "description": "",
+                "name": "sturgeon",
+                "plural_name": "sturgeons"
+            },
+            "bluefish": {
+                "aliases": [],
+                "description": "",
+                "name": "bluefish",
+                "plural_name": "bluefish"
+            },
+            "red mullet": {
+                "aliases": [],
+                "description": "",
+                "name": "red mullet",
+                "plural_name": "red mullets"
+            },
+            "gurnard": {
+                "aliases": [],
+                "description": "",
+                "name": "gurnard",
+                "plural_name": "gurnards"
+            },
+            "plaice": {
+                "aliases": [],
+                "description": "",
+                "name": "plaice",
+                "plural_name": "plaices"
+            },
+            "pompano": {
+                "aliases": [],
+                "description": "",
+                "name": "pompano",
+                "plural_name": "pompanoes"
+            },
+            "smoked fish": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked fish",
+                "plural_name": "smoked fish"
+            },
+            "fish head": {
+                "aliases": [],
+                "description": "",
+                "name": "fish head",
+                "plural_name": "fish heads"
+            },
+            "rohu fish": {
+                "aliases": [],
+                "description": "",
+                "name": "rohu fish",
+                "plural_name": "rohu fish"
+            },
+            "dried fish": {
+                "aliases": [],
+                "description": "",
+                "name": "dried fish",
+                "plural_name": "dried fish"
+            },
+            "flathead": {
+                "aliases": [],
+                "description": "",
+                "name": "flathead",
+                "plural_name": "flatheads"
+            },
+            "fish cake": {
+                "aliases": [],
+                "description": "",
+                "name": "fish cake",
+                "plural_name": "fish cakes"
+            },
+            "salt fish": {
+                "aliases": [],
+                "description": "",
+                "name": "salt fish",
+                "plural_name": "salt fish"
+            },
+            "smoked herring": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked herring",
+                "plural_name": "smoked herrings"
+            },
+            "whiting": {
+                "aliases": [],
+                "description": "",
+                "name": "whiting",
+                "plural_name": "whiting"
+            },
+            "salmon burger meat": {
+                "aliases": [],
+                "description": "",
+                "name": "salmon burger meat",
+                "plural_name": "salmon burger meats"
+            },
+            "shark meat": {
+                "aliases": [],
+                "description": "",
+                "name": "shark meat",
+                "plural_name": "shark meats"
+            },
+            "garoupa": {
+                "aliases": [],
+                "description": "",
+                "name": "garoupa",
+                "plural_name": "garoupas"
+            },
+            "gilt-head bream": {
+                "aliases": [],
+                "description": "",
+                "name": "gilt-head bream",
+                "plural_name": "gilt-head bream"
+            },
+            "pangasiu": {
+                "aliases": [],
+                "description": "",
+                "name": "pangasiu",
+                "plural_name": "pangasius"
+            },
+            "salt herring": {
+                "aliases": [],
+                "description": "",
+                "name": "salt herring",
+                "plural_name": "salt herrings"
+            },
+            "soused herring": {
+                "aliases": [],
+                "description": "",
+                "name": "soused herring",
+                "plural_name": "soused herrings"
+            },
+            "tinapa": {
+                "aliases": [],
+                "description": "",
+                "name": "tinapa",
+                "plural_name": "tinapas"
+            },
+            "zander": {
+                "aliases": [],
+                "description": "",
+                "name": "zander",
+                "plural_name": "zanders"
+            },
+            "amberjack": {
+                "aliases": [],
+                "description": "",
+                "name": "amberjack",
+                "plural_name": "amberjacks"
+            },
+            "korean fish cake": {
+                "aliases": [],
+                "description": "",
+                "name": "korean fish cake",
+                "plural_name": "korean fish cakes"
+            },
+            "mullet": {
+                "aliases": [],
+                "description": "",
+                "name": "mullet",
+                "plural_name": "mullets"
+            },
+            "skipjack tuna": {
+                "aliases": [],
+                "description": "",
+                "name": "skipjack tuna",
+                "plural_name": "skipjack tuna"
+            },
+            "bottarga": {
+                "aliases": [],
+                "description": "",
+                "name": "bottarga",
+                "plural_name": "bottargas"
+            },
+            "dried baby sardine": {
+                "aliases": [],
+                "description": "",
+                "name": "dried baby sardine",
+                "plural_name": "dried baby sardines"
+            },
+            "marlin": {
+                "aliases": [],
+                "description": "",
+                "name": "marlin",
+                "plural_name": "marlins"
+            },
+            "threadfin": {
+                "aliases": [],
+                "description": "",
+                "name": "threadfin",
+                "plural_name": "threadfins"
+            },
+            "tiny fish": {
+                "aliases": [],
+                "description": "",
+                "name": "tiny fish",
+                "plural_name": "tiny fish"
+            },
+            "tuna belly": {
+                "aliases": [],
+                "description": "",
+                "name": "tuna belly",
+                "plural_name": "tuna bellies"
+            },
+            "beluga caviar": {
+                "aliases": [],
+                "description": "",
+                "name": "beluga caviar",
+                "plural_name": "beluga caviars"
+            },
+            "bombay duck": {
+                "aliases": [],
+                "description": "",
+                "name": "bombay duck",
+                "plural_name": "bombay ducks"
+            }
+        }
+    },
+    "Seafood & Seaweed": {
+        "foods": {
+            "shrimp": {
+                "aliases": [],
+                "description": "",
+                "name": "shrimp",
+                "plural_name": "shrimps"
+            },
+            "octopuse": {
+                "aliases": [],
+                "description": "",
+                "name": "octopuse",
+                "plural_name": "octopi"
+            },
+            "prawn": {
+                "aliases": [],
+                "description": "",
+                "name": "prawn",
+                "plural_name": "prawns"
+            },
+            "crab": {
+                "aliases": [],
+                "description": "",
+                "name": "crab",
+                "plural_name": "crabs"
+            },
+            "scallop": {
+                "aliases": [],
+                "description": "",
+                "name": "scallop",
+                "plural_name": "scallops"
+            },
+            "mussel": {
+                "aliases": [],
+                "description": "",
+                "name": "mussel",
+                "plural_name": "mussels"
+            },
+            "clam": {
+                "aliases": [],
+                "description": "",
+                "name": "clam",
+                "plural_name": "clams"
+            },
+            "squid": {
+                "aliases": [],
+                "description": "",
+                "name": "squid",
+                "plural_name": "squids"
+            },
+            "nori": {
+                "aliases": [],
+                "description": "",
+                "name": "nori",
+                "plural_name": "noris"
+            },
+            "lobster": {
+                "aliases": [],
+                "description": "",
+                "name": "lobster",
+                "plural_name": "lobsters"
+            },
+            "oyster": {
+                "aliases": [],
+                "description": "",
+                "name": "oyster",
+                "plural_name": "oysters"
+            },
+            "lobster tail": {
+                "aliases": [],
+                "description": "",
+                "name": "lobster tail",
+                "plural_name": "lobster tails"
+            },
+            "crawfish": {
+                "aliases": [],
+                "description": "",
+                "name": "crawfish",
+                "plural_name": "crawfish"
+            },
+            "octopu": {
+                "aliases": [],
+                "description": "",
+                "name": "octopu",
+                "plural_name": "octopus"
+            },
+            "kombu": {
+                "aliases": [],
+                "description": "",
+                "name": "kombu",
+                "plural_name": "kombus"
+            },
+            "dried shrimp": {
+                "aliases": [],
+                "description": "",
+                "name": "dried shrimp",
+                "plural_name": "dried shrimps"
+            },
+            "bay scallop": {
+                "aliases": [],
+                "description": "",
+                "name": "bay scallop",
+                "plural_name": "bay scallops"
+            },
+            "wakame": {
+                "aliases": [],
+                "description": "",
+                "name": "wakame",
+                "plural_name": "wakames"
+            },
+            "soft-shell crab": {
+                "aliases": [],
+                "description": "",
+                "name": "soft-shell crab",
+                "plural_name": "soft-shell crabs"
+            },
+            "scampi": {
+                "aliases": [],
+                "description": "",
+                "name": "scampi",
+                "plural_name": "scampis"
+            },
+            "king crab": {
+                "aliases": [],
+                "description": "",
+                "name": "king crab",
+                "plural_name": "king crabs"
+            },
+            "mixed seafood": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed seafood",
+                "plural_name": "mixed seafoods"
+            },
+            "baby squid": {
+                "aliases": [],
+                "description": "",
+                "name": "baby squid",
+                "plural_name": "baby squids"
+            },
+            "squid ink": {
+                "aliases": [],
+                "description": "",
+                "name": "squid ink",
+                "plural_name": "squid inks"
+            },
+            "dried prawn": {
+                "aliases": [],
+                "description": "",
+                "name": "dried prawn",
+                "plural_name": "dried prawns"
+            },
+            "dulse seaweed": {
+                "aliases": [],
+                "description": "",
+                "name": "dulse seaweed",
+                "plural_name": "dulse seaweeds"
+            },
+            "roasted seaweed": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted seaweed",
+                "plural_name": "roasted seaweeds"
+            },
+            "smoked oyster": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked oyster",
+                "plural_name": "smoked oysters"
+            },
+            "kelp": {
+                "aliases": [],
+                "description": "",
+                "name": "kelp",
+                "plural_name": "kelps"
+            },
+            "kizami nori": {
+                "aliases": [],
+                "description": "",
+                "name": "kizami nori",
+                "plural_name": "kizami noris"
+            },
+            "hijiki": {
+                "aliases": [],
+                "description": "",
+                "name": "hijiki",
+                "plural_name": "hijikis"
+            },
+            "salted shrimp": {
+                "aliases": [],
+                "description": "",
+                "name": "salted shrimp",
+                "plural_name": "salted shrimps"
+            },
+            "yaki-nori": {
+                "aliases": [],
+                "description": "",
+                "name": "yaki-nori",
+                "plural_name": "yaki-noris"
+            },
+            "conch": {
+                "aliases": [],
+                "description": "",
+                "name": "conch",
+                "plural_name": "conches"
+            },
+            "arame": {
+                "aliases": [],
+                "description": "",
+                "name": "arame",
+                "plural_name": "arames"
+            },
+            "calamari steak": {
+                "aliases": [],
+                "description": "",
+                "name": "calamari steak",
+                "plural_name": "calamari steaks"
+            },
+            "mud crab": {
+                "aliases": [],
+                "description": "",
+                "name": "mud crab",
+                "plural_name": "mud crabs"
+            },
+            "sea urchin": {
+                "aliases": [],
+                "description": "",
+                "name": "sea urchin",
+                "plural_name": "sea urchins"
+            },
+            "abalone": {
+                "aliases": [],
+                "description": "",
+                "name": "abalone",
+                "plural_name": "abalones"
+            },
+            "seaweed salad": {
+                "aliases": [],
+                "description": "",
+                "name": "seaweed salad",
+                "plural_name": "seaweed salads"
+            },
+            "dulse": {
+                "aliases": [],
+                "description": "",
+                "name": "dulse",
+                "plural_name": "dulses"
+            },
+            "smoked mussel": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked mussel",
+                "plural_name": "smoked mussels"
+            },
+            "sea snail": {
+                "aliases": [],
+                "description": "",
+                "name": "sea snail",
+                "plural_name": "sea snails"
+            },
+            "aonori": {
+                "aliases": [],
+                "description": "",
+                "name": "aonori",
+                "plural_name": "aonoris"
+            },
+            "prepared crab cake": {
+                "aliases": [],
+                "description": "",
+                "name": "prepared crab cake",
+                "plural_name": "prepared crab cakes"
+            },
+            "sea lettuce": {
+                "aliases": [],
+                "description": "",
+                "name": "sea lettuce",
+                "plural_name": "sea lettuces"
+            },
+            "korean seaweed": {
+                "aliases": [],
+                "description": "",
+                "name": "korean seaweed",
+                "plural_name": "korean seaweeds"
+            },
+            "ogo seaweed": {
+                "aliases": [],
+                "description": "",
+                "name": "ogo seaweed",
+                "plural_name": "ogo seaweeds"
+            },
+            "seaweed caviar": {
+                "aliases": [],
+                "description": "",
+                "name": "seaweed caviar",
+                "plural_name": "seaweed caviars"
+            },
+            "haddock": {
+                "aliases": [],
+                "description": "",
+                "name": "haddock",
+                "plural_name": "haddocks"
+            },
+            "sea mos": {
+                "aliases": [],
+                "description": "",
+                "name": "sea mos",
+                "plural_name": "sea moss"
+            },
+            "langoustine": {
+                "aliases": [],
+                "description": "",
+                "name": "langoustine",
+                "plural_name": "langoustines"
+            }
+        }
+    },
+    "Herbs & Spices": {
+        "foods": {
+            "cinnamon": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon",
+                "plural_name": "cinnamons"
+            },
+            "parsley": {
+                "aliases": [],
+                "description": "",
+                "name": "parsley",
+                "plural_name": "parsleys"
+            },
+            "cilantro": {
+                "aliases": [],
+                "description": "",
+                "name": "cilantro",
+                "plural_name": "cilantros"
+            },
+            "cumin": {
+                "aliases": [],
+                "description": "",
+                "name": "cumin",
+                "plural_name": "cumins"
+            },
+            "basil": {
+                "aliases": [],
+                "description": "",
+                "name": "basil",
+                "plural_name": "basils"
+            },
+            "thyme": {
+                "aliases": [],
+                "description": "",
+                "name": "thyme",
+                "plural_name": "thymes"
+            },
+            "ginger root": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger root",
+                "plural_name": "ginger roots"
+            },
+            "garlic powder": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic powder",
+                "plural_name": "garlic powders"
+            },
+            "oregano": {
+                "aliases": [],
+                "description": "",
+                "name": "oregano",
+                "plural_name": "oreganos"
+            },
+            "nutmeg": {
+                "aliases": [],
+                "description": "",
+                "name": "nutmeg",
+                "plural_name": "nutmegs"
+            },
+            "chili flake": {
+                "aliases": [],
+                "description": "",
+                "name": "chili flake",
+                "plural_name": "chili flakes"
+            },
+            "chili powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chili powder",
+                "plural_name": "chili powders"
+            },
+            "paprika": {
+                "aliases": [],
+                "description": "",
+                "name": "paprika",
+                "plural_name": "paprikas"
+            },
+            "cayenne": {
+                "aliases": [],
+                "description": "",
+                "name": "cayenne",
+                "plural_name": "cayennes"
+            },
+            "rosemary": {
+                "aliases": [],
+                "description": "",
+                "name": "rosemary",
+                "plural_name": "rosemaries"
+            },
+            "bay leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "bay leaf",
+                "plural_name": "bay leaves"
+            },
+            "turmeric": {
+                "aliases": [],
+                "description": "",
+                "name": "turmeric",
+                "plural_name": "turmerics"
+            },
+            "clove": {
+                "aliases": [],
+                "description": "",
+                "name": "clove",
+                "plural_name": "cloves"
+            },
+            "onion powder": {
+                "aliases": [],
+                "description": "",
+                "name": "onion powder",
+                "plural_name": "onion powders"
+            },
+            "ginger powder": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger powder",
+                "plural_name": "ginger powders"
+            },
+            "panch puran": {
+                "aliases": [],
+                "description": "",
+                "name": "panch puran",
+                "plural_name": "panch purans"
+            },
+            "dill": {
+                "aliases": [],
+                "description": "",
+                "name": "dill",
+                "plural_name": "dills"
+            },
+            "chive": {
+                "aliases": [],
+                "description": "",
+                "name": "chive",
+                "plural_name": "chives"
+            },
+            "mint": {
+                "aliases": [],
+                "description": "",
+                "name": "mint",
+                "plural_name": "mints"
+            },
+            "green cardamom": {
+                "aliases": [],
+                "description": "",
+                "name": "green cardamom",
+                "plural_name": "green cardamoms"
+            },
+            "smoked paprika": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked paprika",
+                "plural_name": "smoked paprikas"
+            },
+            "fresh mint": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh mint",
+                "plural_name": "fresh mints"
+            },
+            "coriander powder": {
+                "aliases": [],
+                "description": "",
+                "name": "coriander powder",
+                "plural_name": "coriander powders"
+            },
+            "sage": {
+                "aliases": [],
+                "description": "",
+                "name": "sage",
+                "plural_name": "sages"
+            },
+            "coriander": {
+                "aliases": [],
+                "description": "",
+                "name": "coriander",
+                "plural_name": "corianders"
+            },
+            "allspice": {
+                "aliases": [],
+                "description": "",
+                "name": "allspice",
+                "plural_name": "allspices"
+            },
+            "cracked pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "cracked pepper",
+                "plural_name": "cracked peppers"
+            },
+            "peppercorn": {
+                "aliases": [],
+                "description": "",
+                "name": "peppercorn",
+                "plural_name": "peppercorns"
+            },
+            "mustard seed": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard seed",
+                "plural_name": "mustard seeds"
+            },
+            "white pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "white pepper",
+                "plural_name": "white peppers"
+            },
+            "curry leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "curry leaf",
+                "plural_name": "curry leaves"
+            },
+            "fennel seed": {
+                "aliases": [],
+                "description": "",
+                "name": "fennel seed",
+                "plural_name": "fennel seeds"
+            },
+            "tarragon": {
+                "aliases": [],
+                "description": "",
+                "name": "tarragon",
+                "plural_name": "tarragons"
+            },
+            "saffron": {
+                "aliases": [],
+                "description": "",
+                "name": "saffron",
+                "plural_name": "saffrons"
+            },
+            "asafoetida": {
+                "aliases": [],
+                "description": "",
+                "name": "asafoetida",
+                "plural_name": "asafoetidas"
+            },
+            "star anise": {
+                "aliases": [],
+                "description": "",
+                "name": "star anise",
+                "plural_name": "star anises"
+            },
+            "marjoram": {
+                "aliases": [],
+                "description": "",
+                "name": "marjoram",
+                "plural_name": "marjorams"
+            },
+            "lemongras": {
+                "aliases": [],
+                "description": "",
+                "name": "lemongras",
+                "plural_name": "lemongrass"
+            },
+            "caraway": {
+                "aliases": [],
+                "description": "",
+                "name": "caraway",
+                "plural_name": "caraways"
+            },
+            "garlic granule": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic granule",
+                "plural_name": "garlic granules"
+            },
+            "celery seed": {
+                "aliases": [],
+                "description": "",
+                "name": "celery seed",
+                "plural_name": "celery seeds"
+            },
+            "chipotle powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chipotle powder",
+                "plural_name": "chipotle powders"
+            },
+            "chipotle": {
+                "aliases": [],
+                "description": "",
+                "name": "chipotle",
+                "plural_name": "chipotles"
+            },
+            "fenugreek": {
+                "aliases": [],
+                "description": "",
+                "name": "fenugreek",
+                "plural_name": "fenugreeks"
+            },
+            "onion flake": {
+                "aliases": [],
+                "description": "",
+                "name": "onion flake",
+                "plural_name": "onion flakes"
+            },
+            "matcha powder": {
+                "aliases": [],
+                "description": "",
+                "name": "matcha powder",
+                "plural_name": "matcha powders"
+            },
+            "ancho chile powder": {
+                "aliases": [],
+                "description": "",
+                "name": "ancho chile powder",
+                "plural_name": "ancho chile powders"
+            },
+            "sumac": {
+                "aliases": [],
+                "description": "",
+                "name": "sumac",
+                "plural_name": "sumacs"
+            },
+            "dried parsley flake": {
+                "aliases": [],
+                "description": "",
+                "name": "dried parsley flake",
+                "plural_name": "dried parsley flakes"
+            },
+            "fenugreek seed": {
+                "aliases": [],
+                "description": "",
+                "name": "fenugreek seed",
+                "plural_name": "fenugreek seeds"
+            },
+            "kashmiri red chilli": {
+                "aliases": [],
+                "description": "",
+                "name": "kashmiri red chilli",
+                "plural_name": "kashmiri red chillis"
+            },
+            "thai basil": {
+                "aliases": [],
+                "description": "",
+                "name": "thai basil",
+                "plural_name": "thai basils"
+            },
+            "edible flower": {
+                "aliases": [],
+                "description": "",
+                "name": "edible flower",
+                "plural_name": "edible flowers"
+            },
+            "aniseed": {
+                "aliases": [],
+                "description": "",
+                "name": "aniseed",
+                "plural_name": "aniseeds"
+            },
+            "kaffir lime leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "kaffir lime leaf",
+                "plural_name": "kaffir lime leaves"
+            },
+            "chervil": {
+                "aliases": [],
+                "description": "",
+                "name": "chervil",
+                "plural_name": "chervils"
+            },
+            "lavender": {
+                "aliases": [],
+                "description": "",
+                "name": "lavender",
+                "plural_name": "lavenders"
+            },
+            "carom seed": {
+                "aliases": [],
+                "description": "",
+                "name": "carom seed",
+                "plural_name": "carom seeds"
+            },
+            "mexican oregano": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican oregano",
+                "plural_name": "mexican oreganos"
+            },
+            "mace": {
+                "aliases": [],
+                "description": "",
+                "name": "mace",
+                "plural_name": "maces"
+            },
+            "mango powder": {
+                "aliases": [],
+                "description": "",
+                "name": "mango powder",
+                "plural_name": "mango powders"
+            },
+            "black mustard seed": {
+                "aliases": [],
+                "description": "",
+                "name": "black mustard seed",
+                "plural_name": "black mustard seeds"
+            },
+            "dried chili": {
+                "aliases": [],
+                "description": "",
+                "name": "dried chili",
+                "plural_name": "dried chilies"
+            },
+            "black cardamom": {
+                "aliases": [],
+                "description": "",
+                "name": "black cardamom",
+                "plural_name": "black cardamoms"
+            },
+            "saffron strand": {
+                "aliases": [],
+                "description": "",
+                "name": "saffron strand",
+                "plural_name": "saffron strands"
+            },
+            "guajillo pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "guajillo pepper",
+                "plural_name": "guajillo peppers"
+            },
+            "pink peppercorn": {
+                "aliases": [],
+                "description": "",
+                "name": "pink peppercorn",
+                "plural_name": "pink peppercorns"
+            },
+            "hot paprika": {
+                "aliases": [],
+                "description": "",
+                "name": "hot paprika",
+                "plural_name": "hot paprikas"
+            },
+            "lemon thyme": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon thyme",
+                "plural_name": "lemon thymes"
+            },
+            "galangal": {
+                "aliases": [],
+                "description": "",
+                "name": "galangal",
+                "plural_name": "galangals"
+            },
+            "garlic flake": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic flake",
+                "plural_name": "garlic flakes"
+            },
+            "dried cilantro": {
+                "aliases": [],
+                "description": "",
+                "name": "dried cilantro",
+                "plural_name": "dried cilantros"
+            },
+            "lemon balm": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon balm",
+                "plural_name": "lemon balms"
+            },
+            "dill seed": {
+                "aliases": [],
+                "description": "",
+                "name": "dill seed",
+                "plural_name": "dill seeds"
+            },
+            "green peppercorn": {
+                "aliases": [],
+                "description": "",
+                "name": "green peppercorn",
+                "plural_name": "green peppercorns"
+            },
+            "aleppo pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "aleppo pepper",
+                "plural_name": "aleppo peppers"
+            },
+            "wasabi powder": {
+                "aliases": [],
+                "description": "",
+                "name": "wasabi powder",
+                "plural_name": "wasabi powders"
+            },
+            "achiote seed": {
+                "aliases": [],
+                "description": "",
+                "name": "achiote seed",
+                "plural_name": "achiote seeds"
+            },
+            "savory herb": {
+                "aliases": [],
+                "description": "",
+                "name": "savory herb",
+                "plural_name": "savory herbs"
+            },
+            "pandan leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "pandan leaf",
+                "plural_name": "pandan leaves"
+            },
+            "sorrel": {
+                "aliases": [],
+                "description": "",
+                "name": "sorrel",
+                "plural_name": "sorrels"
+            },
+            "gochugaru": {
+                "aliases": [],
+                "description": "",
+                "name": "gochugaru",
+                "plural_name": "gochugarus"
+            },
+            "saigon cinnamon": {
+                "aliases": [],
+                "description": "",
+                "name": "saigon cinnamon",
+                "plural_name": "saigon cinnamons"
+            },
+            "lemongrass paste": {
+                "aliases": [],
+                "description": "",
+                "name": "lemongrass paste",
+                "plural_name": "lemongrass pastes"
+            },
+            "shiso": {
+                "aliases": [],
+                "description": "",
+                "name": "shiso",
+                "plural_name": "shisoes"
+            },
+            "celery powder": {
+                "aliases": [],
+                "description": "",
+                "name": "celery powder",
+                "plural_name": "celery powders"
+            },
+            "black cumin": {
+                "aliases": [],
+                "description": "",
+                "name": "black cumin",
+                "plural_name": "black cumins"
+            },
+            "anardana": {
+                "aliases": [],
+                "description": "",
+                "name": "anardana",
+                "plural_name": "anardanas"
+            },
+            "vietnamese mint": {
+                "aliases": [],
+                "description": "",
+                "name": "vietnamese mint",
+                "plural_name": "vietnamese mints"
+            },
+            "dried orange peel": {
+                "aliases": [],
+                "description": "",
+                "name": "dried orange peel",
+                "plural_name": "dried orange peels"
+            },
+            "espelette pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "espelette pepper",
+                "plural_name": "espelette peppers"
+            },
+            "lemon verbena": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon verbena",
+                "plural_name": "lemon verbenas"
+            },
+            "raw stevia": {
+                "aliases": [],
+                "description": "",
+                "name": "raw stevia",
+                "plural_name": "raw stevias"
+            },
+            "achiote paste": {
+                "aliases": [],
+                "description": "",
+                "name": "achiote paste",
+                "plural_name": "achiote pastes"
+            },
+            "summer savory": {
+                "aliases": [],
+                "description": "",
+                "name": "summer savory",
+                "plural_name": "summer savories"
+            },
+            "fennel pollen": {
+                "aliases": [],
+                "description": "",
+                "name": "fennel pollen",
+                "plural_name": "fennel pollens"
+            }
+        }
+    },
+    "Sugar & Sweeteners": {
+        "foods": {
+            "sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "sugar",
+                "plural_name": "sugars"
+            },
+            "brown sugar": {
+                "aliases": [
+                    "turbinado sugar"
+                ],
+                "description": "",
+                "name": "brown sugar",
+                "plural_name": "brown sugars"
+            },
+            "confectioners sugar": {
+                "aliases": [
+                    "powdered sugar",
+                    "icing sugar"
+                ],
+                "description": "",
+                "name": "confectioners sugar",
+                "plural_name": "confectioners sugars"
+            },
+            "bar sugar": {
+                "aliases": [
+                    "castor sugar"
+                ],
+                "description": "",
+                "name": "bar sugar",
+                "plural_name": "bar sugars"
+            },
+            "maple syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "maple syrup",
+                "plural_name": "maple syrups"
+            },
+            "corn syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "corn syrup",
+                "plural_name": "corn syrups"
+            },
+            "coconut sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut sugar",
+                "plural_name": "coconut sugars"
+            },
+            "molass": {
+                "aliases": [],
+                "description": "",
+                "name": "molass",
+                "plural_name": "molasses"
+            },
+            "stevia": {
+                "aliases": [],
+                "description": "",
+                "name": "stevia",
+                "plural_name": "stevias"
+            },
+            "agave nectar": {
+                "aliases": [],
+                "description": "",
+                "name": "agave nectar",
+                "plural_name": "agave nectars"
+            },
+            "sugar syrup": {
+                "aliases": [],
+                "description": "sugar free sweetner",
+                "name": "sugar syrup",
+                "plural_name": "sugar syrups"
+            },
+            "isomalt": {
+                "aliases": [],
+                "description": "",
+                "name": "isomalt",
+                "plural_name": "isomalts"
+            },
+            "erythritol": {
+                "aliases": [],
+                "description": "",
+                "name": "erythritol",
+                "plural_name": "erythritols"
+            },
+            "vanilla sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla sugar",
+                "plural_name": "vanilla sugars"
+            },
+            "demerara sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "demerara sugar",
+                "plural_name": "demerara sugars"
+            },
+            "caramel syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "caramel syrup",
+                "plural_name": "caramel syrups"
+            },
+            "chocolate syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate syrup",
+                "plural_name": "chocolate syrups"
+            },
+            "jaggery": {
+                "aliases": [],
+                "description": "",
+                "name": "jaggery",
+                "plural_name": "jaggeries"
+            },
+            "raw sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "raw sugar",
+                "plural_name": "raw sugars"
+            },
+            "golden syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "golden syrup",
+                "plural_name": "golden syrups"
+            },
+            "cinnamon sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon sugar",
+                "plural_name": "cinnamon sugars"
+            },
+            "liquid stevia": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid stevia",
+                "plural_name": "liquid stevias"
+            },
+            "grenadine": {
+                "aliases": [],
+                "description": "",
+                "name": "grenadine",
+                "plural_name": "grenadines"
+            },
+            "coarse sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "coarse sugar",
+                "plural_name": "coarse sugars"
+            },
+            "salted caramel syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "salted caramel syrup",
+                "plural_name": "salted caramel syrups"
+            },
+            "sanding sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "sanding sugar",
+                "plural_name": "sanding sugars"
+            },
+            "dark corn syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "dark corn syrup",
+                "plural_name": "dark corn syrups"
+            },
+            "sucralose": {
+                "aliases": [],
+                "description": "",
+                "name": "sucralose",
+                "plural_name": "sucraloses"
+            },
+            "monk fruit sweetener": {
+                "aliases": [],
+                "description": "",
+                "name": "monk fruit sweetener",
+                "plural_name": "monk fruit sweeteners"
+            },
+            "maple sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "maple sugar",
+                "plural_name": "maple sugars"
+            },
+            "blackstrap molass": {
+                "aliases": [],
+                "description": "",
+                "name": "blackstrap molass",
+                "plural_name": "blackstrap molasses"
+            },
+            "glucose": {
+                "aliases": [],
+                "description": "",
+                "name": "glucose",
+                "plural_name": "glucoses"
+            },
+            "rock sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "rock sugar",
+                "plural_name": "rock sugars"
+            },
+            "confectioners' sweetener": {
+                "aliases": [],
+                "description": "",
+                "name": "confectioners' sweetener",
+                "plural_name": "confectioners' sweeteners"
+            },
+            "xylitol": {
+                "aliases": [],
+                "description": "",
+                "name": "xylitol",
+                "plural_name": "xylitols"
+            },
+            "jam sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "jam sugar",
+                "plural_name": "jam sugars"
+            },
+            "brown rice syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "brown rice syrup",
+                "plural_name": "brown rice syrups"
+            },
+            "brown sugar substitute": {
+                "aliases": [],
+                "description": "",
+                "name": "brown sugar substitute",
+                "plural_name": "brown sugar substitutes"
+            },
+            "strawberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry syrup",
+                "plural_name": "strawberry syrups"
+            },
+            "vanilla syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla syrup",
+                "plural_name": "vanilla syrups"
+            },
+            "ginger syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger syrup",
+                "plural_name": "ginger syrups"
+            },
+            "orgeat": {
+                "aliases": [],
+                "description": "",
+                "name": "orgeat",
+                "plural_name": "orgeats"
+            },
+            "rice malt syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "rice malt syrup",
+                "plural_name": "rice malt syrups"
+            },
+            "pancake syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "pancake syrup",
+                "plural_name": "pancake syrups"
+            },
+            "raspberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry syrup",
+                "plural_name": "raspberry syrups"
+            },
+            "date syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "date syrup",
+                "plural_name": "date syrups"
+            },
+            "black treacle": {
+                "aliases": [],
+                "description": "",
+                "name": "black treacle",
+                "plural_name": "black treacles"
+            },
+            "date paste": {
+                "aliases": [],
+                "description": "",
+                "name": "date paste",
+                "plural_name": "date pastes"
+            },
+            "coconut syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut syrup",
+                "plural_name": "coconut syrups"
+            },
+            "mint syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "mint syrup",
+                "plural_name": "mint syrups"
+            },
+            "treacle": {
+                "aliases": [],
+                "description": "",
+                "name": "treacle",
+                "plural_name": "treacles"
+            },
+            "rice syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "rice syrup",
+                "plural_name": "rice syrups"
+            },
+            "manuka honey": {
+                "aliases": [],
+                "description": "",
+                "name": "manuka honey",
+                "plural_name": "manuka honeys"
+            },
+            "maple butter": {
+                "aliases": [],
+                "description": "",
+                "name": "maple butter",
+                "plural_name": "maple butter"
+            },
+            "blueberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "blueberry syrup",
+                "plural_name": "blueberry syrups"
+            },
+            "apple syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "apple syrup",
+                "plural_name": "apple syrups"
+            },
+            "allulose": {
+                "aliases": [],
+                "description": "",
+                "name": "allulose",
+                "plural_name": "alluloses"
+            },
+            "blackberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "blackberry syrup",
+                "plural_name": "blackberry syrups"
+            },
+            "piloncillo": {
+                "aliases": [],
+                "description": "",
+                "name": "piloncillo",
+                "plural_name": "piloncilloes"
+            },
+            "cherry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry syrup",
+                "plural_name": "cherry syrups"
+            },
+            "hibiscus syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "hibiscus syrup",
+                "plural_name": "hibiscus syrups"
+            },
+            "lavender syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "lavender syrup",
+                "plural_name": "lavender syrups"
+            },
+            "fresh sugar cane": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh sugar cane",
+                "plural_name": "fresh sugar canes"
+            },
+            "hazelnut syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut syrup",
+                "plural_name": "hazelnut syrups"
+            },
+            "white chocolate sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "white chocolate sauce",
+                "plural_name": "white chocolate sauces"
+            },
+            "pumpkin spice syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin spice syrup",
+                "plural_name": "pumpkin spice syrups"
+            },
+            "glycerine": {
+                "aliases": [],
+                "description": "",
+                "name": "glycerine",
+                "plural_name": "glycerines"
+            },
+            "sorghum syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "sorghum syrup",
+                "plural_name": "sorghum syrups"
+            },
+            "lucuma powder": {
+                "aliases": [],
+                "description": "",
+                "name": "lucuma powder",
+                "plural_name": "lucuma powders"
+            },
+            "black sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "black sugar",
+                "plural_name": "black sugars"
+            },
+            "cranberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry syrup",
+                "plural_name": "cranberry syrups"
+            },
+            "golden sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "golden sugar",
+                "plural_name": "golden sugars"
+            },
+            "cane syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "cane syrup",
+                "plural_name": "cane syrups"
+            },
+            "mango syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "mango syrup",
+                "plural_name": "mango syrups"
+            },
+            "malt syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "malt syrup",
+                "plural_name": "malt syrups"
+            },
+            "hot honey": {
+                "aliases": [],
+                "description": "",
+                "name": "hot honey",
+                "plural_name": "hot honeys"
+            },
+            "gula melaka": {
+                "aliases": [],
+                "description": "",
+                "name": "gula melaka",
+                "plural_name": "gula melakas"
+            },
+            "elderberry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "elderberry syrup",
+                "plural_name": "elderberry syrups"
+            },
+            "rosemary syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "rosemary syrup",
+                "plural_name": "rosemary syrups"
+            },
+            "dark chocolate syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "dark chocolate syrup",
+                "plural_name": "dark chocolate syrups"
+            },
+            "inulin": {
+                "aliases": [],
+                "description": "",
+                "name": "inulin",
+                "plural_name": "inulins"
+            },
+            "sweet'n low": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet'n low",
+                "plural_name": "sweet'n lows"
+            },
+            "fructose": {
+                "aliases": [],
+                "description": "",
+                "name": "fructose",
+                "plural_name": "fructoses"
+            },
+            "honey powder": {
+                "aliases": [],
+                "description": "",
+                "name": "honey powder",
+                "plural_name": "honey powders"
+            },
+            "berry syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "berry syrup",
+                "plural_name": "berry syrups"
+            },
+            "grape syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "grape syrup",
+                "plural_name": "grape syrups"
+            },
+            "brown butter syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "brown butter syrup",
+                "plural_name": "brown butter syrups"
+            },
+            "date sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "date sugar",
+                "plural_name": "date sugars"
+            },
+            "mastic gum": {
+                "aliases": [],
+                "description": "",
+                "name": "mastic gum",
+                "plural_name": "mastic gums"
+            },
+            "gum syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "gum syrup",
+                "plural_name": "gum syrups"
+            },
+            "irish cream syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "irish cream syrup",
+                "plural_name": "irish cream syrups"
+            },
+            "prickly pear syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "prickly pear syrup",
+                "plural_name": "prickly pear syrups"
+            },
+            "cookie butter syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "cookie butter syrup",
+                "plural_name": "cookie butter syrups"
+            },
+            "creamed honey": {
+                "aliases": [],
+                "description": "",
+                "name": "creamed honey",
+                "plural_name": "creamed honeys"
+            },
+            "buttermilk syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "buttermilk syrup",
+                "plural_name": "buttermilk syrups"
+            },
+            "chocolate sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate sugar",
+                "plural_name": "chocolate sugars"
+            },
+            "flavored syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "flavored syrup",
+                "plural_name": "flavored syrups"
+            },
+            "elderflower syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "elderflower syrup",
+                "plural_name": "elderflower syrups"
+            },
+            "malt sugar": {
+                "aliases": [],
+                "description": "",
+                "name": "malt sugar",
+                "plural_name": "malt sugars"
+            },
+            "buckwheat honey": {
+                "aliases": [],
+                "description": "",
+                "name": "buckwheat honey",
+                "plural_name": "buckwheat honeys"
+            },
+            "truffle honey": {
+                "aliases": [],
+                "description": "",
+                "name": "truffle honey",
+                "plural_name": "truffle honeys"
+            }
+        }
+    },
+    "Seasonings & Spice Blends": {
+        "foods": {
+            "italian seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "italian seasoning",
+                "plural_name": "italian seasonings"
+            },
+            "ranch dressing packet": {
+                "aliases": [],
+                "description": "",
+                "name": "ranch dressing packet",
+                "plural_name": "ranch dressing packets"
+            },
+            "seasoned salt": {
+                "aliases": [],
+                "description": "",
+                "name": "seasoned salt",
+                "plural_name": "seasoned salts"
+            },
+            "curry": {
+                "aliases": [],
+                "description": "",
+                "name": "curry",
+                "plural_name": "curries"
+            },
+            "garam masala": {
+                "aliases": [],
+                "description": "",
+                "name": "garam masala",
+                "plural_name": "garam masalas"
+            },
+            "pumpkin pie spice": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin pie spice",
+                "plural_name": "pumpkin pie spices"
+            },
+            "mustard powder": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard powder",
+                "plural_name": "mustard powders"
+            },
+            "taco seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "taco seasoning",
+                "plural_name": "taco seasonings"
+            },
+            "cajun seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "cajun seasoning",
+                "plural_name": "cajun seasonings"
+            },
+            "dry ranch seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "dry ranch seasoning",
+                "plural_name": "dry ranch seasonings"
+            },
+            "white miso": {
+                "aliases": [],
+                "description": "",
+                "name": "white miso",
+                "plural_name": "white misoes"
+            },
+            "himalayan salt": {
+                "aliases": [],
+                "description": "",
+                "name": "himalayan salt",
+                "plural_name": "himalayan salts"
+            },
+            "lemon & pepper seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon & pepper seasoning",
+                "plural_name": "lemon & pepper seasonings"
+            },
+            "liquid smoke": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid smoke",
+                "plural_name": "liquid smokes"
+            },
+            "poultry seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "poultry seasoning",
+                "plural_name": "poultry seasonings"
+            },
+            "chinese five spice": {
+                "aliases": [],
+                "description": "",
+                "name": "chinese five spice",
+                "plural_name": "chinese five spices"
+            },
+            "red curry": {
+                "aliases": [],
+                "description": "",
+                "name": "red curry",
+                "plural_name": "red curries"
+            },
+            "old bay seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "old bay seasoning",
+                "plural_name": "old bay seasonings"
+            },
+            "herbe de provence": {
+                "aliases": [],
+                "description": "",
+                "name": "herbe de provence",
+                "plural_name": "herbes de provence"
+            },
+            "chaat masala": {
+                "aliases": [],
+                "description": "",
+                "name": "chaat masala",
+                "plural_name": "chaat masalas"
+            },
+            "creole seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "creole seasoning",
+                "plural_name": "creole seasonings"
+            },
+            "steak seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "steak seasoning",
+                "plural_name": "steak seasonings"
+            },
+            "mixed spice": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed spice",
+                "plural_name": "mixed spices"
+            },
+            "fleur de sel": {
+                "aliases": [],
+                "description": "",
+                "name": "fleur de sel",
+                "plural_name": "fleur de sel"
+            },
+            "thai red curry paste": {
+                "aliases": [],
+                "description": "",
+                "name": "thai red curry paste",
+                "plural_name": "thai red curry pastes"
+            },
+            "mixed herb": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed herb",
+                "plural_name": "mixed herbs"
+            },
+            "green curry": {
+                "aliases": [],
+                "description": "",
+                "name": "green curry",
+                "plural_name": "green curries"
+            },
+            "barbecue seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "barbecue seasoning",
+                "plural_name": "barbecue seasonings"
+            },
+            "apple pie spice": {
+                "aliases": [],
+                "description": "",
+                "name": "apple pie spice",
+                "plural_name": "apple pie spices"
+            },
+            "za'atar": {
+                "aliases": [],
+                "description": "",
+                "name": "za'atar",
+                "plural_name": "za'atars"
+            },
+            "ras el hanout": {
+                "aliases": [],
+                "description": "",
+                "name": "ras el hanout",
+                "plural_name": "ras el hanouts"
+            },
+            "all-purpose seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "all-purpose seasoning",
+                "plural_name": "all-purpose seasonings"
+            },
+            "seafood seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "seafood seasoning",
+                "plural_name": "seafood seasonings"
+            },
+            "bagel seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "bagel seasoning",
+                "plural_name": "bagel seasonings"
+            },
+            "fajita seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "fajita seasoning",
+                "plural_name": "fajita seasonings"
+            },
+            "tandoori spice": {
+                "aliases": [],
+                "description": "",
+                "name": "tandoori spice",
+                "plural_name": "tandoori spices"
+            },
+            "pickling spice": {
+                "aliases": [],
+                "description": "",
+                "name": "pickling spice",
+                "plural_name": "pickling spices"
+            },
+            "caribbean jerk seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "caribbean jerk seasoning",
+                "plural_name": "caribbean jerk seasonings"
+            },
+            "gravy mix": {
+                "aliases": [],
+                "description": "",
+                "name": "gravy mix",
+                "plural_name": "gravy mixes"
+            },
+            "garlic & herb seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic & herb seasoning",
+                "plural_name": "garlic & herb seasonings"
+            },
+            "garlic-pepper seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic-pepper seasoning",
+                "plural_name": "garlic-pepper seasonings"
+            },
+            "pickling salt": {
+                "aliases": [],
+                "description": "",
+                "name": "pickling salt",
+                "plural_name": "pickling salts"
+            },
+            "greek seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "greek seasoning",
+                "plural_name": "greek seasonings"
+            },
+            "msg": {
+                "aliases": [],
+                "description": "",
+                "name": "msg",
+                "plural_name": "msgs"
+            },
+            "teriyaki marinade": {
+                "aliases": [],
+                "description": "",
+                "name": "teriyaki marinade",
+                "plural_name": "teriyaki marinades"
+            },
+            "adobo seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "adobo seasoning",
+                "plural_name": "adobo seasonings"
+            },
+            "sambar powder": {
+                "aliases": [],
+                "description": "",
+                "name": "sambar powder",
+                "plural_name": "sambar powders"
+            },
+            "smoked salt": {
+                "aliases": [],
+                "description": "",
+                "name": "smoked salt",
+                "plural_name": "smoked salts"
+            },
+            "dash seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "dash seasoning",
+                "plural_name": "dash seasonings"
+            },
+            "red miso": {
+                "aliases": [],
+                "description": "",
+                "name": "red miso",
+                "plural_name": "red misoes"
+            },
+            "hot curry": {
+                "aliases": [],
+                "description": "",
+                "name": "hot curry",
+                "plural_name": "hot curries"
+            },
+            "salt-free seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "salt-free seasoning",
+                "plural_name": "salt-free seasonings"
+            },
+            "carne asada seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "carne asada seasoning",
+                "plural_name": "carne asada seasonings"
+            },
+            "bouquet garni": {
+                "aliases": [],
+                "description": "",
+                "name": "bouquet garni",
+                "plural_name": "bouquet garnis"
+            },
+            "yellow miso": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow miso",
+                "plural_name": "yellow misoes"
+            },
+            "dukkah": {
+                "aliases": [],
+                "description": "",
+                "name": "dukkah",
+                "plural_name": "dukkahs"
+            },
+            "pav bhaji masala": {
+                "aliases": [],
+                "description": "",
+                "name": "pav bhaji masala",
+                "plural_name": "pav bhaji masalas"
+            },
+            "curing salt": {
+                "aliases": [],
+                "description": "",
+                "name": "curing salt",
+                "plural_name": "curing salts"
+            },
+            "mexican seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican seasoning",
+                "plural_name": "mexican seasonings"
+            },
+            "tajin seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "tajin seasoning",
+                "plural_name": "tajin seasonings"
+            },
+            "seasoned pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "seasoned pepper",
+                "plural_name": "seasoned peppers"
+            },
+            "crab boil seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "crab boil seasoning",
+                "plural_name": "crab boil seasonings"
+            },
+            "shichimi togarashi": {
+                "aliases": [],
+                "description": "",
+                "name": "shichimi togarashi",
+                "plural_name": "shichimi togarashis"
+            },
+            "rib rub": {
+                "aliases": [],
+                "description": "",
+                "name": "rib rub",
+                "plural_name": "rib rubs"
+            },
+            "truffle salt": {
+                "aliases": [],
+                "description": "",
+                "name": "truffle salt",
+                "plural_name": "truffle salts"
+            },
+            "biryani masala": {
+                "aliases": [],
+                "description": "",
+                "name": "biryani masala",
+                "plural_name": "biryani masalas"
+            },
+            "furikake": {
+                "aliases": [],
+                "description": "",
+                "name": "furikake",
+                "plural_name": "furikakes"
+            },
+            "togarashi": {
+                "aliases": [],
+                "description": "",
+                "name": "togarashi",
+                "plural_name": "togarashis"
+            },
+            "chipotle seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "chipotle seasoning",
+                "plural_name": "chipotle seasonings"
+            },
+            "meat masala": {
+                "aliases": [],
+                "description": "",
+                "name": "meat masala",
+                "plural_name": "meat masalas"
+            },
+            "harissa spice blend": {
+                "aliases": [],
+                "description": "",
+                "name": "harissa spice blend",
+                "plural_name": "harissa spice blends"
+            },
+            "chana masala": {
+                "aliases": [],
+                "description": "",
+                "name": "chana masala",
+                "plural_name": "chana masalas"
+            },
+            "chicken gravy mix": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken gravy mix",
+                "plural_name": "chicken gravy mixes"
+            },
+            "grey sea salt": {
+                "aliases": [],
+                "description": "",
+                "name": "grey sea salt",
+                "plural_name": "grey sea salts"
+            },
+            "chicken taco seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken taco seasoning",
+                "plural_name": "chicken taco seasonings"
+            },
+            "mushroom seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "mushroom seasoning",
+                "plural_name": "mushroom seasonings"
+            },
+            "au jus mix": {
+                "aliases": [],
+                "description": "",
+                "name": "au jus mix",
+                "plural_name": "au jus mixes"
+            },
+            "gingerbread spice": {
+                "aliases": [],
+                "description": "",
+                "name": "gingerbread spice",
+                "plural_name": "gingerbread spices"
+            },
+            "popcorn seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "popcorn seasoning",
+                "plural_name": "popcorn seasonings"
+            },
+            "berbere": {
+                "aliases": [],
+                "description": "",
+                "name": "berbere",
+                "plural_name": "berberes"
+            },
+            "chili-lime seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "chili-lime seasoning",
+                "plural_name": "chili-lime seasonings"
+            },
+            "brown miso": {
+                "aliases": [],
+                "description": "",
+                "name": "brown miso",
+                "plural_name": "brown misoes"
+            },
+            "blackening seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "blackening seasoning",
+                "plural_name": "blackening seasonings"
+            },
+            "pizza seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "pizza seasoning",
+                "plural_name": "pizza seasonings"
+            },
+            "fines herbe": {
+                "aliases": [],
+                "description": "",
+                "name": "fines herbe",
+                "plural_name": "fines herbes"
+            },
+            "shawarma seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "shawarma seasoning",
+                "plural_name": "shawarma seasonings"
+            },
+            "chai masala": {
+                "aliases": [],
+                "description": "",
+                "name": "chai masala",
+                "plural_name": "chai masalas"
+            },
+            "panang curry": {
+                "aliases": [],
+                "description": "",
+                "name": "panang curry",
+                "plural_name": "panang curries"
+            },
+            "kitchen king masala": {
+                "aliases": [],
+                "description": "",
+                "name": "kitchen king masala",
+                "plural_name": "kitchen king masalas"
+            },
+            "lemon & herb seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon & herb seasoning",
+                "plural_name": "lemon & herb seasonings"
+            },
+            "vanilla salt": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla salt",
+                "plural_name": "vanilla salts"
+            },
+            "thai seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "thai seasoning",
+                "plural_name": "thai seasonings"
+            },
+            "mulling spice": {
+                "aliases": [],
+                "description": "",
+                "name": "mulling spice",
+                "plural_name": "mulling spices"
+            },
+            "sriracha seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "sriracha seasoning",
+                "plural_name": "sriracha seasonings"
+            },
+            "coffee rub": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee rub",
+                "plural_name": "coffee rubs"
+            },
+            "hawaiian salt": {
+                "aliases": [],
+                "description": "",
+                "name": "hawaiian salt",
+                "plural_name": "hawaiian salts"
+            },
+            "mesquite seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "mesquite seasoning",
+                "plural_name": "mesquite seasonings"
+            },
+            "tom yum paste": {
+                "aliases": [],
+                "description": "",
+                "name": "tom yum paste",
+                "plural_name": "tom yum pastes"
+            },
+            "fish masala": {
+                "aliases": [],
+                "description": "",
+                "name": "fish masala",
+                "plural_name": "fish masalas"
+            },
+            "fresh mixed herb": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh mixed herb",
+                "plural_name": "fresh mixed herbs"
+            },
+            "southwest chipotle seasoning": {
+                "aliases": [],
+                "description": "",
+                "name": "southwest chipotle seasoning",
+                "plural_name": "southwest chipotle seasonings"
+            }
+        }
+    },
+    "Baking": {
+        "foods": {
+            "flour": {
+                "aliases": [],
+                "description": "",
+                "name": "flour",
+                "plural_name": "flours"
+            },
+            "vanilla extract": {
+                "aliases": [
+                    "vanilla",
+                    "vanillas"
+                ],
+                "description": "",
+                "name": "vanilla extract",
+                "plural_name": "vanilla extracts"
+            },
+            "baking powder": {
+                "aliases": [],
+                "description": "",
+                "name": "baking powder",
+                "plural_name": "baking powders"
+            },
+            "baking soda": {
+                "aliases": [],
+                "description": "",
+                "name": "baking soda",
+                "plural_name": "baking sodas"
+            },
+            "cornstarch": {
+                "aliases": [],
+                "description": "",
+                "name": "cornstarch",
+                "plural_name": "cornstarches"
+            },
+            "yeast": {
+                "aliases": [],
+                "description": "",
+                "name": "yeast",
+                "plural_name": "yeasts"
+            },
+            "chocolate chip": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate chip",
+                "plural_name": "chocolate chips"
+            },
+            "dark chocolate chip": {
+                "aliases": [],
+                "description": "",
+                "name": "dark chocolate chip",
+                "plural_name": "dark chocolate chips"
+            },
+            "whole-wheat flour": {
+                "aliases": [
+                    "whole wheat flour"
+                ],
+                "description": "",
+                "name": "whole-wheat flour",
+                "plural_name": "whole-wheat flours"
+            },
+            "almond flour": {
+                "aliases": [],
+                "description": "",
+                "name": "almond flour",
+                "plural_name": "almond flours"
+            },
+            "self-raising flour": {
+                "aliases": [],
+                "description": "",
+                "name": "self-raising flour",
+                "plural_name": "self-raising flours"
+            },
+            "shredded coconut": {
+                "aliases": [],
+                "description": "",
+                "name": "shredded coconut",
+                "plural_name": "shredded coconuts"
+            },
+            "cornmeal": {
+                "aliases": [],
+                "description": "",
+                "name": "cornmeal",
+                "plural_name": "cornmeals"
+            },
+            "coconut flake": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut flake",
+                "plural_name": "coconut flakes"
+            },
+            "gelatin": {
+                "aliases": [],
+                "description": "",
+                "name": "gelatin",
+                "plural_name": "gelatins"
+            },
+            "pastry flour": {
+                "aliases": [],
+                "description": "",
+                "name": "pastry flour",
+                "plural_name": "pastry flours"
+            },
+            "coconut flour": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut flour",
+                "plural_name": "coconut flours"
+            },
+            "baking mix": {
+                "aliases": [],
+                "description": "",
+                "name": "baking mix",
+                "plural_name": "baking mixes"
+            },
+            "cake flour": {
+                "aliases": [],
+                "description": "",
+                "name": "cake flour",
+                "plural_name": "cake flours"
+            },
+            "corn flour": {
+                "aliases": [],
+                "description": "",
+                "name": "corn flour",
+                "plural_name": "corn flours"
+            },
+            "cream of tartar": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of tartar",
+                "plural_name": "cream of tartar"
+            },
+            "bread flour": {
+                "aliases": [],
+                "description": "",
+                "name": "bread flour",
+                "plural_name": "bread flours"
+            },
+            "almond meal": {
+                "aliases": [],
+                "description": "",
+                "name": "almond meal",
+                "plural_name": "almond meals"
+            },
+            "unbleached all-purpose flour": {
+                "aliases": [
+                    "unbleached flour",
+                    "all-purpose flour",
+                    "all purpose flour"
+                ],
+                "description": "",
+                "name": "unbleached all-purpose flour",
+                "plural_name": "unbleached all-purpose flours"
+            },
+            "white baking chip": {
+                "aliases": [],
+                "description": "",
+                "name": "white baking chip",
+                "plural_name": "white baking chips"
+            },
+            "gluten-free flour": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free flour",
+                "plural_name": "gluten-free flours"
+            },
+            "rice flour": {
+                "aliases": [],
+                "description": "",
+                "name": "rice flour",
+                "plural_name": "rice flours"
+            },
+            "desiccated coconut": {
+                "aliases": [],
+                "description": "",
+                "name": "desiccated coconut",
+                "plural_name": "desiccated coconuts"
+            },
+            "tapioca starch": {
+                "aliases": [],
+                "description": "",
+                "name": "tapioca starch",
+                "plural_name": "tapioca starches"
+            },
+            "yellow cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow cake mix",
+                "plural_name": "yellow cake mixes"
+            },
+            "chickpea flour": {
+                "aliases": [],
+                "description": "",
+                "name": "chickpea flour",
+                "plural_name": "chickpea flours"
+            },
+            "xanthan gum": {
+                "aliases": [],
+                "description": "",
+                "name": "xanthan gum",
+                "plural_name": "xanthan gums"
+            },
+            "oat flour": {
+                "aliases": [],
+                "description": "",
+                "name": "oat flour",
+                "plural_name": "oat flours"
+            },
+            "whole-wheat pastry flour": {
+                "aliases": [],
+                "description": "",
+                "name": "whole-wheat pastry flour",
+                "plural_name": "whole-wheat pastry flours"
+            },
+            "whole-wheat": {
+                "aliases": [
+                    "whole wheat",
+                    "whole wheats"
+                ],
+                "description": "",
+                "name": "whole-wheat",
+                "plural_name": "whole-wheats"
+            },
+            "candy sprinkle": {
+                "aliases": [],
+                "description": "",
+                "name": "candy sprinkle",
+                "plural_name": "candy sprinkles"
+            },
+            "spelt": {
+                "aliases": [],
+                "description": "",
+                "name": "spelt",
+                "plural_name": "spelts"
+            },
+            "brownie mix": {
+                "aliases": [],
+                "description": "",
+                "name": "brownie mix",
+                "plural_name": "brownie mixes"
+            },
+            "arrowroot flour": {
+                "aliases": [],
+                "description": "",
+                "name": "arrowroot flour",
+                "plural_name": "arrowroot flours"
+            },
+            "flaxseed meal": {
+                "aliases": [],
+                "description": "",
+                "name": "flaxseed meal",
+                "plural_name": "flaxseed meals"
+            },
+            "chocolate cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate cake mix",
+                "plural_name": "chocolate cake mixes"
+            },
+            "potato starch": {
+                "aliases": [],
+                "description": "",
+                "name": "potato starch",
+                "plural_name": "potato starches"
+            },
+            "jello": {
+                "aliases": [],
+                "description": "",
+                "name": "jello",
+                "plural_name": "jelloes"
+            },
+            "butterscotch chip": {
+                "aliases": [],
+                "description": "",
+                "name": "butterscotch chip",
+                "plural_name": "butterscotch chips"
+            },
+            "peanut butter chip": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut butter chip",
+                "plural_name": "peanut butter chips"
+            },
+            "crystallized ginger": {
+                "aliases": [],
+                "description": "",
+                "name": "crystallized ginger",
+                "plural_name": "crystallized gingers"
+            },
+            "buckwheat flour": {
+                "aliases": [],
+                "description": "",
+                "name": "buckwheat flour",
+                "plural_name": "buckwheat flours"
+            },
+            "brown rice flour": {
+                "aliases": [],
+                "description": "",
+                "name": "brown rice flour",
+                "plural_name": "brown rice flours"
+            },
+            "pectin": {
+                "aliases": [],
+                "description": "",
+                "name": "pectin",
+                "plural_name": "pectins"
+            },
+            "rye flour": {
+                "aliases": [],
+                "description": "",
+                "name": "rye flour",
+                "plural_name": "rye flours"
+            },
+            "psyllium husk": {
+                "aliases": [],
+                "description": "",
+                "name": "psyllium husk",
+                "plural_name": "psyllium husks"
+            },
+            "semolina flour": {
+                "aliases": [],
+                "description": "",
+                "name": "semolina flour",
+                "plural_name": "semolina flours"
+            },
+            "glutinous rice flour": {
+                "aliases": [],
+                "description": "",
+                "name": "glutinous rice flour",
+                "plural_name": "glutinous rice flours"
+            },
+            "pancake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "pancake mix",
+                "plural_name": "pancake mixes"
+            },
+            "refined flour": {
+                "aliases": [],
+                "description": "",
+                "name": "refined flour",
+                "plural_name": "refined flours"
+            },
+            "muffin mix": {
+                "aliases": [],
+                "description": "",
+                "name": "muffin mix",
+                "plural_name": "muffin mixes"
+            },
+            "marzipan": {
+                "aliases": [],
+                "description": "",
+                "name": "marzipan",
+                "plural_name": "marzipans"
+            },
+            "coffee bean": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee bean",
+                "plural_name": "coffee beans"
+            },
+            "toffee bit": {
+                "aliases": [],
+                "description": "",
+                "name": "toffee bit",
+                "plural_name": "toffee bits"
+            },
+            "cornbread mix": {
+                "aliases": [],
+                "description": "",
+                "name": "cornbread mix",
+                "plural_name": "cornbread mixes"
+            },
+            "spice cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "spice cake mix",
+                "plural_name": "spice cake mixes"
+            },
+            "devil's food cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "devil's food cake mix",
+                "plural_name": "devil's food cake mixes"
+            },
+            "sorghum flour": {
+                "aliases": [],
+                "description": "",
+                "name": "sorghum flour",
+                "plural_name": "sorghum flours"
+            },
+            "potato flake": {
+                "aliases": [],
+                "description": "",
+                "name": "potato flake",
+                "plural_name": "potato flakes"
+            },
+            "masa harina": {
+                "aliases": [],
+                "description": "",
+                "name": "masa harina",
+                "plural_name": "masa harinas"
+            },
+            "cinnamon chip": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon chip",
+                "plural_name": "cinnamon chips"
+            },
+            "agar agar": {
+                "aliases": [],
+                "description": "",
+                "name": "agar agar",
+                "plural_name": "agar agars"
+            },
+            "red velvet cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "red velvet cake mix",
+                "plural_name": "red velvet cake mixes"
+            },
+            "matzo meal": {
+                "aliases": [],
+                "description": "",
+                "name": "matzo meal",
+                "plural_name": "matzo meals"
+            },
+            "sago": {
+                "aliases": [],
+                "description": "",
+                "name": "sago",
+                "plural_name": "sagos"
+            },
+            "white baking chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "white baking chocolate",
+                "plural_name": "white baking chocolates"
+            },
+            "cassava flour": {
+                "aliases": [],
+                "description": "",
+                "name": "cassava flour",
+                "plural_name": "cassava flours"
+            },
+            "whipped cream stabilizer": {
+                "aliases": [],
+                "description": "",
+                "name": "whipped cream stabilizer",
+                "plural_name": "whipped cream stabilizers"
+            },
+            "sugar cookie mix": {
+                "aliases": [],
+                "description": "",
+                "name": "sugar cookie mix",
+                "plural_name": "sugar cookie mixes"
+            },
+            "vital wheat gluten": {
+                "aliases": [],
+                "description": "",
+                "name": "vital wheat gluten",
+                "plural_name": "vital wheat glutens"
+            },
+            "baking chip": {
+                "aliases": [],
+                "description": "",
+                "name": "baking chip",
+                "plural_name": "baking chips"
+            },
+            "meringue powder": {
+                "aliases": [],
+                "description": "",
+                "name": "meringue powder",
+                "plural_name": "meringue powders"
+            },
+            "hazelnut flour": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut flour",
+                "plural_name": "hazelnut flours"
+            },
+            "citric acid": {
+                "aliases": [],
+                "description": "",
+                "name": "citric acid",
+                "plural_name": "citric acids"
+            },
+            "coconut chip": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut chip",
+                "plural_name": "coconut chips"
+            },
+            "quinoa flour": {
+                "aliases": [],
+                "description": "",
+                "name": "quinoa flour",
+                "plural_name": "quinoa flours"
+            },
+            "finger millet flour": {
+                "aliases": [],
+                "description": "",
+                "name": "finger millet flour",
+                "plural_name": "finger millet flours"
+            },
+            "fondant": {
+                "aliases": [],
+                "description": "",
+                "name": "fondant",
+                "plural_name": "fondants"
+            },
+            "mint baking chip": {
+                "aliases": [],
+                "description": "",
+                "name": "mint baking chip",
+                "plural_name": "mint baking chips"
+            },
+            "angel food cake mix": {
+                "aliases": [],
+                "description": "",
+                "name": "angel food cake mix",
+                "plural_name": "angel food cake mixes"
+            },
+            "white cornmeal": {
+                "aliases": [],
+                "description": "",
+                "name": "white cornmeal",
+                "plural_name": "white cornmeals"
+            },
+            "millet flour": {
+                "aliases": [],
+                "description": "",
+                "name": "millet flour",
+                "plural_name": "millet flours"
+            },
+            "mincemeat": {
+                "aliases": [],
+                "description": "",
+                "name": "mincemeat",
+                "plural_name": "mincemeats"
+            },
+            "gluten-free baking flour": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free baking flour",
+                "plural_name": "gluten-free baking flours"
+            },
+            "einkorn flour": {
+                "aliases": [],
+                "description": "",
+                "name": "einkorn flour",
+                "plural_name": "einkorn flours"
+            },
+            "self-rising cornmeal": {
+                "aliases": [],
+                "description": "",
+                "name": "self-rising cornmeal",
+                "plural_name": "self-rising cornmeals"
+            },
+            "gluten-free self-raising flour": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free self-raising flour",
+                "plural_name": "gluten-free self-raising flours"
+            },
+            "peanut flour": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut flour",
+                "plural_name": "peanut flours"
+            },
+            "sweet bean paste": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet bean paste",
+                "plural_name": "sweet bean pastes"
+            },
+            "carob powder": {
+                "aliases": [],
+                "description": "",
+                "name": "carob powder",
+                "plural_name": "carob powders"
+            },
+            "tapioca pearl": {
+                "aliases": [],
+                "description": "",
+                "name": "tapioca pearl",
+                "plural_name": "tapioca pearls"
+            },
+            "teff flour": {
+                "aliases": [],
+                "description": "",
+                "name": "teff flour",
+                "plural_name": "teff flours"
+            },
+            "guar gum": {
+                "aliases": [],
+                "description": "",
+                "name": "guar gum",
+                "plural_name": "guar gums"
+            },
+            "potato flour": {
+                "aliases": [],
+                "description": "",
+                "name": "potato flour",
+                "plural_name": "potato flours"
+            },
+            "ready-made icing": {
+                "aliases": [],
+                "description": "",
+                "name": "ready-made icing",
+                "plural_name": "ready-made icings"
+            },
+            "fruit salt": {
+                "aliases": [],
+                "description": "",
+                "name": "fruit salt",
+                "plural_name": "fruit salts"
+            }
+        }
+    },
+    "Pre-Made Doughs & Wrappers": {
+        "foods": {
+            "pie crust": {
+                "aliases": [],
+                "description": "",
+                "name": "pie crust",
+                "plural_name": "pie crusts"
+            },
+            "puff pastry": {
+                "aliases": [],
+                "description": "",
+                "name": "puff pastry",
+                "plural_name": "puff pastries"
+            },
+            "pizza crust": {
+                "aliases": [],
+                "description": "",
+                "name": "pizza crust",
+                "plural_name": "pizza crusts"
+            },
+            "pizza dough": {
+                "aliases": [],
+                "description": "",
+                "name": "pizza dough",
+                "plural_name": "pizza doughs"
+            },
+            "phyllo": {
+                "aliases": [],
+                "description": "",
+                "name": "phyllo",
+                "plural_name": "phylloes"
+            },
+            "refrigerated crescent roll": {
+                "aliases": [],
+                "description": "",
+                "name": "refrigerated crescent roll",
+                "plural_name": "refrigerated crescent rolls"
+            },
+            "biscuit dough": {
+                "aliases": [],
+                "description": "",
+                "name": "biscuit dough",
+                "plural_name": "biscuit doughs"
+            },
+            "dumpling wrapper": {
+                "aliases": [],
+                "description": "",
+                "name": "dumpling wrapper",
+                "plural_name": "dumpling wrappers"
+            },
+            "rice paper": {
+                "aliases": [],
+                "description": "",
+                "name": "rice paper",
+                "plural_name": "rice papers"
+            },
+            "sourdough starter": {
+                "aliases": [],
+                "description": "",
+                "name": "sourdough starter",
+                "plural_name": "sourdough starters"
+            },
+            "cookie dough": {
+                "aliases": [],
+                "description": "",
+                "name": "cookie dough",
+                "plural_name": "cookie doughs"
+            },
+            "egg roll wrapper": {
+                "aliases": [],
+                "description": "",
+                "name": "egg roll wrapper",
+                "plural_name": "egg roll wrappers"
+            },
+            "bread dough": {
+                "aliases": [],
+                "description": "",
+                "name": "bread dough",
+                "plural_name": "bread doughs"
+            },
+            "butter puff pastry": {
+                "aliases": [],
+                "description": "",
+                "name": "butter puff pastry",
+                "plural_name": "butter puff pastries"
+            },
+            "frozen dinner roll": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen dinner roll",
+                "plural_name": "frozen dinner rolls"
+            },
+            "cinnamon roll dough": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon roll dough",
+                "plural_name": "cinnamon roll doughs"
+            },
+            "dosa batter": {
+                "aliases": [],
+                "description": "",
+                "name": "dosa batter",
+                "plural_name": "dosa batters"
+            },
+            "puff pastry shell": {
+                "aliases": [],
+                "description": "",
+                "name": "puff pastry shell",
+                "plural_name": "puff pastry shells"
+            },
+            "wonton": {
+                "aliases": [],
+                "description": "",
+                "name": "wonton",
+                "plural_name": "wontons"
+            },
+            "gyoza wrapper": {
+                "aliases": [],
+                "description": "",
+                "name": "gyoza wrapper",
+                "plural_name": "gyoza wrappers"
+            },
+            "wonton strip": {
+                "aliases": [],
+                "description": "",
+                "name": "wonton strip",
+                "plural_name": "wonton strips"
+            },
+            "gluten-free pizza crust": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free pizza crust",
+                "plural_name": "gluten-free pizza crusts"
+            },
+            "fresh pasta dough": {
+                "aliases": [],
+                "description": "",
+                "name": "fresh pasta dough",
+                "plural_name": "fresh pasta doughs"
+            },
+            "idli batter": {
+                "aliases": [],
+                "description": "",
+                "name": "idli batter",
+                "plural_name": "idli batters"
+            },
+            "potsticker wrapper": {
+                "aliases": [],
+                "description": "",
+                "name": "potsticker wrapper",
+                "plural_name": "potsticker wrappers"
+            },
+            "chocolate pie crust": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate pie crust",
+                "plural_name": "chocolate pie crusts"
+            },
+            "croissant dough": {
+                "aliases": [],
+                "description": "",
+                "name": "croissant dough",
+                "plural_name": "croissant doughs"
+            },
+            "tofu skin": {
+                "aliases": [],
+                "description": "",
+                "name": "tofu skin",
+                "plural_name": "tofu skins"
+            },
+            "brisee": {
+                "aliases": [],
+                "description": "",
+                "name": "brisee",
+                "plural_name": "brisees"
+            },
+            "sausage roll": {
+                "aliases": [],
+                "description": "",
+                "name": "sausage roll",
+                "plural_name": "sausage rolls"
+            },
+            "kataifi": {
+                "aliases": [],
+                "description": "",
+                "name": "kataifi",
+                "plural_name": "kataifis"
+            },
+            "korean rice cake": {
+                "aliases": [],
+                "description": "",
+                "name": "korean rice cake",
+                "plural_name": "korean rice cakes"
+            },
+            "corn dog": {
+                "aliases": [],
+                "description": "",
+                "name": "corn dog",
+                "plural_name": "corn dogs"
+            },
+            "tortilla dough": {
+                "aliases": [],
+                "description": "",
+                "name": "tortilla dough",
+                "plural_name": "tortilla doughs"
+            },
+            "empanada wrapper": {
+                "aliases": [],
+                "description": "",
+                "name": "empanada wrapper",
+                "plural_name": "empanada wrappers"
+            },
+            "rough-puff pastry": {
+                "aliases": [],
+                "description": "",
+                "name": "rough-puff pastry",
+                "plural_name": "rough-puff pastries"
+            },
+            "gingerbread cookie dough": {
+                "aliases": [],
+                "description": "",
+                "name": "gingerbread cookie dough",
+                "plural_name": "gingerbread cookie doughs"
+            },
+            "yufka": {
+                "aliases": [],
+                "description": "",
+                "name": "yufka",
+                "plural_name": "yufkas"
+            },
+            "cob loaf": {
+                "aliases": [],
+                "description": "",
+                "name": "cob loaf",
+                "plural_name": "cob loaves"
+            },
+            "egg wrap": {
+                "aliases": [],
+                "description": "",
+                "name": "egg wrap",
+                "plural_name": "egg wraps"
+            },
+            "samosa sheet": {
+                "aliases": [],
+                "description": "",
+                "name": "samosa sheet",
+                "plural_name": "samosa sheets"
+            },
+            "frozen pizza roll": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen pizza roll",
+                "plural_name": "frozen pizza rolls"
+            },
+            "brick pastry": {
+                "aliases": [],
+                "description": "",
+                "name": "brick pastry",
+                "plural_name": "brick pastries"
+            }
+        }
+    },
+    "Grains & Cereals": {
+        "foods": {
+            "rolled oat": {
+                "aliases": [],
+                "description": "",
+                "name": "rolled oat",
+                "plural_name": "rolled oats"
+            },
+            "rice": {
+                "aliases": [],
+                "description": "",
+                "name": "rice",
+                "plural_name": "rices"
+            },
+            "Rice Krispie Cereal": {
+                "aliases": [
+                    "Rice Krispie"
+                ],
+                "description": "",
+                "name": "Rice Krispie Cereal",
+                "plural_name": "Rice Krispie Cereal"
+            },
+            "quinoa": {
+                "aliases": [],
+                "description": "",
+                "name": "quinoa",
+                "plural_name": "quinoas"
+            },
+            "basmati rice": {
+                "aliases": [],
+                "description": "",
+                "name": "basmati rice",
+                "plural_name": "basmati rices"
+            },
+            "brown rice": {
+                "aliases": [],
+                "description": "",
+                "name": "brown rice",
+                "plural_name": "brown rices"
+            },
+            "quick-cooking oat": {
+                "aliases": [],
+                "description": "",
+                "name": "quick-cooking oat",
+                "plural_name": "quick-cooking oats"
+            },
+            "breakfast cereal": {
+                "aliases": [],
+                "description": "",
+                "name": "breakfast cereal",
+                "plural_name": "breakfast cereals"
+            },
+            "risotto rice": {
+                "aliases": [],
+                "description": "",
+                "name": "risotto rice",
+                "plural_name": "risotto rices"
+            },
+            "couscou": {
+                "aliases": [],
+                "description": "",
+                "name": "couscou",
+                "plural_name": "couscous"
+            },
+            "rice cereal": {
+                "aliases": [],
+                "description": "",
+                "name": "rice cereal",
+                "plural_name": "rice cereals"
+            },
+            "wild rice": {
+                "aliases": [],
+                "description": "",
+                "name": "wild rice",
+                "plural_name": "wild rices"
+            },
+            "semolina": {
+                "aliases": [],
+                "description": "",
+                "name": "semolina",
+                "plural_name": "semolinas"
+            },
+            "jasmine rice": {
+                "aliases": [],
+                "description": "",
+                "name": "jasmine rice",
+                "plural_name": "jasmine rices"
+            },
+            "polenta": {
+                "aliases": [],
+                "description": "",
+                "name": "polenta",
+                "plural_name": "polentas"
+            },
+            "granola cereal": {
+                "aliases": [],
+                "description": "",
+                "name": "granola cereal",
+                "plural_name": "granola cereals"
+            },
+            "bulgur": {
+                "aliases": [],
+                "description": "",
+                "name": "bulgur",
+                "plural_name": "bulgurs"
+            },
+            "pearl barley": {
+                "aliases": [],
+                "description": "",
+                "name": "pearl barley",
+                "plural_name": "pearl barleys"
+            },
+            "farro": {
+                "aliases": [],
+                "description": "",
+                "name": "farro",
+                "plural_name": "farroes"
+            },
+            "barley": {
+                "aliases": [],
+                "description": "",
+                "name": "barley",
+                "plural_name": "barleys"
+            },
+            "wheat germ": {
+                "aliases": [],
+                "description": "",
+                "name": "wheat germ",
+                "plural_name": "wheat germs"
+            },
+            "grit": {
+                "aliases": [],
+                "description": "",
+                "name": "grit",
+                "plural_name": "grits"
+            },
+            "steel cut oat": {
+                "aliases": [],
+                "description": "",
+                "name": "steel cut oat",
+                "plural_name": "steel cut oats"
+            },
+            "millet": {
+                "aliases": [],
+                "description": "",
+                "name": "millet",
+                "plural_name": "millets"
+            },
+            "oat bran": {
+                "aliases": [],
+                "description": "",
+                "name": "oat bran",
+                "plural_name": "oat brans"
+            },
+            "sushi rice": {
+                "aliases": [],
+                "description": "",
+                "name": "sushi rice",
+                "plural_name": "sushi rices"
+            },
+            "glutinous rice": {
+                "aliases": [],
+                "description": "",
+                "name": "glutinous rice",
+                "plural_name": "glutinous rices"
+            },
+            "instant rice": {
+                "aliases": [],
+                "description": "",
+                "name": "instant rice",
+                "plural_name": "instant rices"
+            },
+            "hominy": {
+                "aliases": [],
+                "description": "",
+                "name": "hominy",
+                "plural_name": "hominies"
+            },
+            "red quinoa": {
+                "aliases": [],
+                "description": "",
+                "name": "red quinoa",
+                "plural_name": "red quinoas"
+            },
+            "raw buckwheat": {
+                "aliases": [],
+                "description": "",
+                "name": "raw buckwheat",
+                "plural_name": "raw buckwheats"
+            },
+            "wheat bran": {
+                "aliases": [],
+                "description": "",
+                "name": "wheat bran",
+                "plural_name": "wheat brans"
+            },
+            "instant oat": {
+                "aliases": [],
+                "description": "",
+                "name": "instant oat",
+                "plural_name": "instant oats"
+            },
+            "wheat berry": {
+                "aliases": [],
+                "description": "",
+                "name": "wheat berry",
+                "plural_name": "wheat berries"
+            },
+            "poha": {
+                "aliases": [],
+                "description": "",
+                "name": "poha",
+                "plural_name": "pohas"
+            },
+            "black rice": {
+                "aliases": [],
+                "description": "",
+                "name": "black rice",
+                "plural_name": "black rices"
+            },
+            "yellow rice": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow rice",
+                "plural_name": "yellow rices"
+            },
+            "fine semolina": {
+                "aliases": [],
+                "description": "",
+                "name": "fine semolina",
+                "plural_name": "fine semolinas"
+            },
+            "muesli": {
+                "aliases": [],
+                "description": "",
+                "name": "muesli",
+                "plural_name": "mueslis"
+            },
+            "amaranth": {
+                "aliases": [],
+                "description": "",
+                "name": "amaranth",
+                "plural_name": "amaranths"
+            },
+            "kasha": {
+                "aliases": [],
+                "description": "",
+                "name": "kasha",
+                "plural_name": "kashas"
+            },
+            "quinoa flake": {
+                "aliases": [],
+                "description": "",
+                "name": "quinoa flake",
+                "plural_name": "quinoa flakes"
+            },
+            "puffed rice": {
+                "aliases": [],
+                "description": "",
+                "name": "puffed rice",
+                "plural_name": "puffed rices"
+            },
+            "pearled farro": {
+                "aliases": [],
+                "description": "",
+                "name": "pearled farro",
+                "plural_name": "pearled farroes"
+            },
+            "cracked wheat": {
+                "aliases": [],
+                "description": "",
+                "name": "cracked wheat",
+                "plural_name": "cracked wheats"
+            },
+            "freekeh": {
+                "aliases": [],
+                "description": "",
+                "name": "freekeh",
+                "plural_name": "freekehs"
+            },
+            "paella rice": {
+                "aliases": [],
+                "description": "",
+                "name": "paella rice",
+                "plural_name": "paella rices"
+            },
+            "sorghum": {
+                "aliases": [],
+                "description": "",
+                "name": "sorghum",
+                "plural_name": "sorghums"
+            },
+            "red rice": {
+                "aliases": [],
+                "description": "",
+                "name": "red rice",
+                "plural_name": "red rices"
+            },
+            "mexican rice": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican rice",
+                "plural_name": "mexican rices"
+            },
+            "idli rice": {
+                "aliases": [],
+                "description": "",
+                "name": "idli rice",
+                "plural_name": "idli rices"
+            },
+            "brown jasmine rice": {
+                "aliases": [],
+                "description": "",
+                "name": "brown jasmine rice",
+                "plural_name": "brown jasmine rices"
+            },
+            "cream of wheat": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of wheat",
+                "plural_name": "cream of wheat"
+            },
+            "rice pilaf": {
+                "aliases": [],
+                "description": "",
+                "name": "rice pilaf",
+                "plural_name": "rice pilafs"
+            },
+            "barnyard millet": {
+                "aliases": [],
+                "description": "",
+                "name": "barnyard millet",
+                "plural_name": "barnyard millets"
+            },
+            "weetabix": {
+                "aliases": [],
+                "description": "",
+                "name": "weetabix",
+                "plural_name": "weetabixes"
+            },
+            "jambalaya rice mix": {
+                "aliases": [],
+                "description": "",
+                "name": "jambalaya rice mix",
+                "plural_name": "jambalaya rice mixes"
+            },
+            "black glutinous rice": {
+                "aliases": [],
+                "description": "",
+                "name": "black glutinous rice",
+                "plural_name": "black glutinous rices"
+            },
+            "whole-grain oat": {
+                "aliases": [],
+                "description": "",
+                "name": "whole-grain oat",
+                "plural_name": "whole-grain oats"
+            },
+            "puffed quinoa": {
+                "aliases": [],
+                "description": "",
+                "name": "puffed quinoa",
+                "plural_name": "puffed quinoas"
+            },
+            "cilantro lime rice": {
+                "aliases": [],
+                "description": "",
+                "name": "cilantro lime rice",
+                "plural_name": "cilantro lime rices"
+            },
+            "dirty rice mix": {
+                "aliases": [],
+                "description": "",
+                "name": "dirty rice mix",
+                "plural_name": "dirty rice mixes"
+            },
+            "puffed wheat": {
+                "aliases": [],
+                "description": "",
+                "name": "puffed wheat",
+                "plural_name": "puffed wheats"
+            },
+            "hulled barley": {
+                "aliases": [],
+                "description": "",
+                "name": "hulled barley",
+                "plural_name": "hulled barleys"
+            },
+            "brown long grain rice": {
+                "aliases": [],
+                "description": "",
+                "name": "brown long grain rice",
+                "plural_name": "brown long grain rices"
+            },
+            "finger millet": {
+                "aliases": [],
+                "description": "",
+                "name": "finger millet",
+                "plural_name": "finger millets"
+            },
+            "foxtail millet": {
+                "aliases": [],
+                "description": "",
+                "name": "foxtail millet",
+                "plural_name": "foxtail millets"
+            },
+            "matta rice": {
+                "aliases": [],
+                "description": "",
+                "name": "matta rice",
+                "plural_name": "matta rices"
+            },
+            "rye berry": {
+                "aliases": [],
+                "description": "",
+                "name": "rye berry",
+                "plural_name": "rye berries"
+            },
+            "spelt flake": {
+                "aliases": [],
+                "description": "",
+                "name": "spelt flake",
+                "plural_name": "spelt flakes"
+            },
+            "kodo millet": {
+                "aliases": [],
+                "description": "",
+                "name": "kodo millet",
+                "plural_name": "kodo millets"
+            },
+            "oat groat": {
+                "aliases": [],
+                "description": "",
+                "name": "oat groat",
+                "plural_name": "oat groats"
+            },
+            "teff": {
+                "aliases": [],
+                "description": "",
+                "name": "teff",
+                "plural_name": "teffs"
+            },
+            "rye flake": {
+                "aliases": [],
+                "description": "",
+                "name": "rye flake",
+                "plural_name": "rye flakes"
+            },
+            "little millet": {
+                "aliases": [],
+                "description": "",
+                "name": "little millet",
+                "plural_name": "little millets"
+            },
+            "gluten-free breakfast cereal": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free breakfast cereal",
+                "plural_name": "gluten-free breakfast cereals"
+            },
+            "puffed amaranth": {
+                "aliases": [],
+                "description": "",
+                "name": "puffed amaranth",
+                "plural_name": "puffed amaranths"
+            },
+            "coconut rice": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut rice",
+                "plural_name": "coconut rices"
+            },
+            "amaranth flake": {
+                "aliases": [],
+                "description": "",
+                "name": "amaranth flake",
+                "plural_name": "amaranth flakes"
+            },
+            "puffed kamut": {
+                "aliases": [],
+                "description": "",
+                "name": "puffed kamut",
+                "plural_name": "puffed kamuts"
+            },
+            "bamboo rice": {
+                "aliases": [],
+                "description": "",
+                "name": "bamboo rice",
+                "plural_name": "bamboo rices"
+            },
+            "pearled sorghum": {
+                "aliases": [],
+                "description": "",
+                "name": "pearled sorghum",
+                "plural_name": "pearled sorghums"
+            },
+            "shirataki rice": {
+                "aliases": [],
+                "description": "",
+                "name": "shirataki rice",
+                "plural_name": "shirataki rices"
+            },
+            "vegetable fried rice": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable fried rice",
+                "plural_name": "vegetable fried rices"
+            },
+            "gr\u00fcnkern": {
+                "aliases": [],
+                "description": "",
+                "name": "gr\u00fcnkern",
+                "plural_name": "gr\u00fcnkerns"
+            },
+            "jeera rice": {
+                "aliases": [],
+                "description": "",
+                "name": "jeera rice",
+                "plural_name": "jeera rices"
+            },
+            "fonio": {
+                "aliases": [],
+                "description": "",
+                "name": "fonio",
+                "plural_name": "fonios"
+            },
+            "kamut flake": {
+                "aliases": [],
+                "description": "",
+                "name": "kamut flake",
+                "plural_name": "kamut flakes"
+            },
+            "texmati rice": {
+                "aliases": [],
+                "description": "",
+                "name": "texmati rice",
+                "plural_name": "texmati rices"
+            },
+            "cream of rice": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of rice",
+                "plural_name": "cream of rice"
+            },
+            "ka\u00f1iwa": {
+                "aliases": [],
+                "description": "",
+                "name": "ka\u00f1iwa",
+                "plural_name": "ka\u00f1iwas"
+            },
+            "proso millet": {
+                "aliases": [],
+                "description": "",
+                "name": "proso millet",
+                "plural_name": "proso millets"
+            }
+        }
+    },
+    "Legumes": {
+        "foods": {
+            "pea": {
+                "aliases": [],
+                "description": "",
+                "name": "pea",
+                "plural_name": "peas"
+            },
+            "green bean": {
+                "aliases": [],
+                "description": "",
+                "name": "green bean",
+                "plural_name": "green beans"
+            },
+            "chickpea": {
+                "aliases": [],
+                "description": "",
+                "name": "chickpea",
+                "plural_name": "chickpeas"
+            },
+            "black bean": {
+                "aliases": [],
+                "description": "",
+                "name": "black bean",
+                "plural_name": "black beans"
+            },
+            "kidney bean": {
+                "aliases": [],
+                "description": "",
+                "name": "kidney bean",
+                "plural_name": "kidney beans"
+            },
+            "white bean": {
+                "aliases": [],
+                "description": "",
+                "name": "white bean",
+                "plural_name": "white beans"
+            },
+            "lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "lentil",
+                "plural_name": "lentils"
+            },
+            "pinto bean": {
+                "aliases": [],
+                "description": "",
+                "name": "pinto bean",
+                "plural_name": "pinto beans"
+            },
+            "snow pea": {
+                "aliases": [],
+                "description": "",
+                "name": "snow pea",
+                "plural_name": "snow peas"
+            },
+            "snap pea": {
+                "aliases": [],
+                "description": "",
+                "name": "snap pea",
+                "plural_name": "snap peas"
+            },
+            "red lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "red lentil",
+                "plural_name": "red lentils"
+            },
+            "cannellini bean": {
+                "aliases": [],
+                "description": "",
+                "name": "cannellini bean",
+                "plural_name": "cannellini beans"
+            },
+            "bean sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "bean sprout",
+                "plural_name": "bean sprouts"
+            },
+            "edamame": {
+                "aliases": [],
+                "description": "",
+                "name": "edamame",
+                "plural_name": "edamames"
+            },
+            "green lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "green lentil",
+                "plural_name": "green lentils"
+            },
+            "urad dal": {
+                "aliases": [],
+                "description": "",
+                "name": "urad dal",
+                "plural_name": "urad dals"
+            },
+            "lima bean": {
+                "aliases": [],
+                "description": "",
+                "name": "lima bean",
+                "plural_name": "lima beans"
+            },
+            "chana dal": {
+                "aliases": [],
+                "description": "",
+                "name": "chana dal",
+                "plural_name": "chana dals"
+            },
+            "fava bean": {
+                "aliases": [],
+                "description": "",
+                "name": "fava bean",
+                "plural_name": "fava beans"
+            },
+            "black-eyed pea": {
+                "aliases": [],
+                "description": "",
+                "name": "black-eyed pea",
+                "plural_name": "black-eyed peas"
+            },
+            "moong dal": {
+                "aliases": [],
+                "description": "",
+                "name": "moong dal",
+                "plural_name": "moong dals"
+            },
+            "split pea": {
+                "aliases": [],
+                "description": "",
+                "name": "split pea",
+                "plural_name": "split peas"
+            },
+            "pigeon pea": {
+                "aliases": [],
+                "description": "",
+                "name": "pigeon pea",
+                "plural_name": "pigeon peas"
+            },
+            "red bean": {
+                "aliases": [],
+                "description": "",
+                "name": "red bean",
+                "plural_name": "red beans"
+            },
+            "mung bean sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "mung bean sprout",
+                "plural_name": "mung bean sprouts"
+            },
+            "soybean": {
+                "aliases": [],
+                "description": "",
+                "name": "soybean",
+                "plural_name": "soybeans"
+            },
+            "mung bean": {
+                "aliases": [],
+                "description": "",
+                "name": "mung bean",
+                "plural_name": "mung beans"
+            },
+            "string bean": {
+                "aliases": [],
+                "description": "",
+                "name": "string bean",
+                "plural_name": "string beans"
+            },
+            "yellow split pea": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow split pea",
+                "plural_name": "yellow split peas"
+            },
+            "black lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "black lentil",
+                "plural_name": "black lentils"
+            },
+            "borlotti bean": {
+                "aliases": [],
+                "description": "",
+                "name": "borlotti bean",
+                "plural_name": "borlotti beans"
+            },
+            "aquafaba": {
+                "aliases": [],
+                "description": "",
+                "name": "aquafaba",
+                "plural_name": "aquafabas"
+            },
+            "chana": {
+                "aliases": [],
+                "description": "",
+                "name": "chana",
+                "plural_name": "chanas"
+            },
+            "snake bean": {
+                "aliases": [],
+                "description": "",
+                "name": "snake bean",
+                "plural_name": "snake beans"
+            },
+            "yellow lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "yellow lentil",
+                "plural_name": "yellow lentils"
+            },
+            "mixed bean": {
+                "aliases": [],
+                "description": "",
+                "name": "mixed bean",
+                "plural_name": "mixed beans"
+            },
+            "kala chana": {
+                "aliases": [],
+                "description": "",
+                "name": "kala chana",
+                "plural_name": "kala chanas"
+            },
+            "fermented black bean": {
+                "aliases": [],
+                "description": "",
+                "name": "fermented black bean",
+                "plural_name": "fermented black beans"
+            },
+            "black gram": {
+                "aliases": [],
+                "description": "",
+                "name": "black gram",
+                "plural_name": "black grams"
+            },
+            "wax bean": {
+                "aliases": [],
+                "description": "",
+                "name": "wax bean",
+                "plural_name": "wax beans"
+            },
+            "dried pea": {
+                "aliases": [],
+                "description": "",
+                "name": "dried pea",
+                "plural_name": "dried peas"
+            },
+            "pink bean": {
+                "aliases": [],
+                "description": "",
+                "name": "pink bean",
+                "plural_name": "pink beans"
+            },
+            "lentil sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "lentil sprout",
+                "plural_name": "lentil sprouts"
+            },
+            "white pea": {
+                "aliases": [],
+                "description": "",
+                "name": "white pea",
+                "plural_name": "white peas"
+            },
+            "black soybean": {
+                "aliases": [],
+                "description": "",
+                "name": "black soybean",
+                "plural_name": "black soybeans"
+            },
+            "field pea": {
+                "aliases": [],
+                "description": "",
+                "name": "field pea",
+                "plural_name": "field peas"
+            },
+            "gigante": {
+                "aliases": [],
+                "description": "",
+                "name": "gigante",
+                "plural_name": "gigantes"
+            },
+            "flageolet": {
+                "aliases": [],
+                "description": "",
+                "name": "flageolet",
+                "plural_name": "flageolets"
+            },
+            "horse gram": {
+                "aliases": [],
+                "description": "",
+                "name": "horse gram",
+                "plural_name": "horse grams"
+            },
+            "soy sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "soy sprout",
+                "plural_name": "soy sprouts"
+            },
+            "honey bean": {
+                "aliases": [],
+                "description": "",
+                "name": "honey bean",
+                "plural_name": "honey beans"
+            },
+            "cluster bean": {
+                "aliases": [],
+                "description": "",
+                "name": "cluster bean",
+                "plural_name": "cluster beans"
+            },
+            "brown bean": {
+                "aliases": [],
+                "description": "",
+                "name": "brown bean",
+                "plural_name": "brown beans"
+            },
+            "mayocoba bean": {
+                "aliases": [],
+                "description": "",
+                "name": "mayocoba bean",
+                "plural_name": "mayocoba beans"
+            },
+            "winged bean": {
+                "aliases": [],
+                "description": "",
+                "name": "winged bean",
+                "plural_name": "winged beans"
+            },
+            "castelluccio lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "castelluccio lentil",
+                "plural_name": "castelluccio lentils"
+            },
+            "golden wax bean": {
+                "aliases": [],
+                "description": "",
+                "name": "golden wax bean",
+                "plural_name": "golden wax beans"
+            },
+            "moth bean": {
+                "aliases": [],
+                "description": "",
+                "name": "moth bean",
+                "plural_name": "moth beans"
+            },
+            "chickpea sprout": {
+                "aliases": [],
+                "description": "",
+                "name": "chickpea sprout",
+                "plural_name": "chickpea sprouts"
+            },
+            "hara chana": {
+                "aliases": [],
+                "description": "",
+                "name": "hara chana",
+                "plural_name": "hara chanas"
+            },
+            "lupini bean": {
+                "aliases": [],
+                "description": "",
+                "name": "lupini bean",
+                "plural_name": "lupini beans"
+            },
+            "natto": {
+                "aliases": [],
+                "description": "",
+                "name": "natto",
+                "plural_name": "nattoes"
+            },
+            "hyacinth bean": {
+                "aliases": [],
+                "description": "",
+                "name": "hyacinth bean",
+                "plural_name": "hyacinth beans"
+            },
+            "petai": {
+                "aliases": [],
+                "description": "",
+                "name": "petai",
+                "plural_name": "petais"
+            },
+            "scarlet runner bean": {
+                "aliases": [],
+                "description": "",
+                "name": "scarlet runner bean",
+                "plural_name": "scarlet runner beans"
+            },
+            "soy flake": {
+                "aliases": [],
+                "description": "",
+                "name": "soy flake",
+                "plural_name": "soy flakes"
+            }
+        }
+    },
+    "Pasta": {
+        "foods": {
+            "short-cut pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "short-cut pasta",
+                "plural_name": "short-cut pastas"
+            },
+            "spaghetti": {
+                "aliases": [],
+                "description": "",
+                "name": "spaghetti",
+                "plural_name": "spaghettis"
+            },
+            "macaroni": {
+                "aliases": [],
+                "description": "",
+                "name": "macaroni",
+                "plural_name": "macaronis"
+            },
+            "egg noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "egg noodle",
+                "plural_name": "egg noodles"
+            },
+            "spiral pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "spiral pasta",
+                "plural_name": "spiral pastas"
+            },
+            "lasagna noodle": {
+                "aliases": [
+                    "lasagnas"
+                ],
+                "description": "",
+                "name": "lasagna noodle",
+                "plural_name": "lasagna noodles"
+            },
+            "linguine": {
+                "aliases": [],
+                "description": "",
+                "name": "linguine",
+                "plural_name": "linguines"
+            },
+            "fettuccine": {
+                "aliases": [],
+                "description": "",
+                "name": "fettuccine",
+                "plural_name": "fettuccines"
+            },
+            "orzo": {
+                "aliases": [],
+                "description": "",
+                "name": "orzo",
+                "plural_name": "orzoes"
+            },
+            "pasta shell": {
+                "aliases": [],
+                "description": "",
+                "name": "pasta shell",
+                "plural_name": "pasta shells"
+            },
+            "bow-tie pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "bow-tie pasta",
+                "plural_name": "bow-tie pastas"
+            },
+            "noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "noodle",
+                "plural_name": "noodles"
+            },
+            "tortellini": {
+                "aliases": [],
+                "description": "",
+                "name": "tortellini",
+                "plural_name": "tortellinis"
+            },
+            "cheese tortellini": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese tortellini",
+                "plural_name": "cheese tortellinis"
+            },
+            "rice noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "rice noodle",
+                "plural_name": "rice noodles"
+            },
+            "rigatoni": {
+                "aliases": [],
+                "description": "",
+                "name": "rigatoni",
+                "plural_name": "rigatonis"
+            },
+            "gnocchi": {
+                "aliases": [],
+                "description": "",
+                "name": "gnocchi",
+                "plural_name": "gnocchis"
+            },
+            "angel hair pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "angel hair pasta",
+                "plural_name": "angel hair pastas"
+            },
+            "ramen noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "ramen noodle",
+                "plural_name": "ramen noodles"
+            },
+            "vermicelli": {
+                "aliases": [],
+                "description": "",
+                "name": "vermicelli",
+                "plural_name": "vermicellis"
+            },
+            "tagliatelle": {
+                "aliases": [],
+                "description": "",
+                "name": "tagliatelle",
+                "plural_name": "tagliatelles"
+            },
+            "soba noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "soba noodle",
+                "plural_name": "soba noodles"
+            },
+            "ravioli": {
+                "aliases": [],
+                "description": "",
+                "name": "ravioli",
+                "plural_name": "raviolis"
+            },
+            "ziti": {
+                "aliases": [],
+                "description": "",
+                "name": "ziti",
+                "plural_name": "zitis"
+            },
+            "orecchiette": {
+                "aliases": [],
+                "description": "",
+                "name": "orecchiette",
+                "plural_name": "orecchiettes"
+            },
+            "israeli couscou": {
+                "aliases": [],
+                "description": "",
+                "name": "israeli couscou",
+                "plural_name": "israeli couscous"
+            },
+            "zoodle": {
+                "aliases": [],
+                "description": "",
+                "name": "zoodle",
+                "plural_name": "zoodles"
+            },
+            "udon noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "udon noodle",
+                "plural_name": "udon noodles"
+            },
+            "ditalini": {
+                "aliases": [],
+                "description": "",
+                "name": "ditalini",
+                "plural_name": "ditalinis"
+            },
+            "rice vermicelli": {
+                "aliases": [],
+                "description": "",
+                "name": "rice vermicelli",
+                "plural_name": "rice vermicellis"
+            },
+            "pappardelle": {
+                "aliases": [],
+                "description": "",
+                "name": "pappardelle",
+                "plural_name": "pappardelles"
+            },
+            "glass noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "glass noodle",
+                "plural_name": "glass noodles"
+            },
+            "gluten-free pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free pasta",
+                "plural_name": "gluten-free pastas"
+            },
+            "mac 'n cheese": {
+                "aliases": [],
+                "description": "",
+                "name": "mac 'n cheese",
+                "plural_name": "mac 'n cheeses"
+            },
+            "penne rigate": {
+                "aliases": [],
+                "description": "",
+                "name": "penne rigate",
+                "plural_name": "penne rigates"
+            },
+            "manicotti": {
+                "aliases": [],
+                "description": "",
+                "name": "manicotti",
+                "plural_name": "manicottis"
+            },
+            "bucatini": {
+                "aliases": [],
+                "description": "",
+                "name": "bucatini",
+                "plural_name": "bucatinis"
+            },
+            "cannelloni": {
+                "aliases": [],
+                "description": "",
+                "name": "cannelloni",
+                "plural_name": "cannellonis"
+            },
+            "thai rice noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "thai rice noodle",
+                "plural_name": "thai rice noodles"
+            },
+            "brown rice pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "brown rice pasta",
+                "plural_name": "brown rice pastas"
+            },
+            "rotelle": {
+                "aliases": [],
+                "description": "",
+                "name": "rotelle",
+                "plural_name": "rotelles"
+            },
+            "shirataki noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "shirataki noodle",
+                "plural_name": "shirataki noodles"
+            },
+            "chicken raman": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken raman",
+                "plural_name": "chicken ramen"
+            },
+            "pierogi": {
+                "aliases": [],
+                "description": "",
+                "name": "pierogi",
+                "plural_name": "pierogis"
+            },
+            "soup pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "soup pasta",
+                "plural_name": "soup pastas"
+            },
+            "sweet potato noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet potato noodle",
+                "plural_name": "sweet potato noodles"
+            },
+            "acini di pepe": {
+                "aliases": [],
+                "description": "",
+                "name": "acini di pepe",
+                "plural_name": "acini di pepes"
+            },
+            "cavatelli": {
+                "aliases": [],
+                "description": "",
+                "name": "cavatelli",
+                "plural_name": "cavatellis"
+            },
+            "instant noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "instant noodle",
+                "plural_name": "instant noodles"
+            },
+            "somen noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "somen noodle",
+                "plural_name": "somen noodles"
+            },
+            "yakisoba noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "yakisoba noodle",
+                "plural_name": "yakisoba noodles"
+            },
+            "beef ravioli": {
+                "aliases": [],
+                "description": "",
+                "name": "beef ravioli",
+                "plural_name": "beef raviolis"
+            },
+            "hakka noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "hakka noodle",
+                "plural_name": "hakka noodles"
+            },
+            "kelp noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "kelp noodle",
+                "plural_name": "kelp noodles"
+            },
+            "fideo pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "fideo pasta",
+                "plural_name": "fideo pastas"
+            },
+            "spaetzle": {
+                "aliases": [],
+                "description": "",
+                "name": "spaetzle",
+                "plural_name": "spaetzles"
+            },
+            "radiatore": {
+                "aliases": [],
+                "description": "",
+                "name": "radiatore",
+                "plural_name": "radiatores"
+            },
+            "paccheri": {
+                "aliases": [],
+                "description": "",
+                "name": "paccheri",
+                "plural_name": "paccheris"
+            },
+            "kluski noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "kluski noodle",
+                "plural_name": "kluski noodles"
+            },
+            "yolk-free noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "yolk-free noodle",
+                "plural_name": "yolk-free noodles"
+            },
+            "black bean pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "black bean pasta",
+                "plural_name": "black bean pastas"
+            },
+            "matzo farfel": {
+                "aliases": [],
+                "description": "",
+                "name": "matzo farfel",
+                "plural_name": "matzo farfels"
+            },
+            "spinach fettuccine": {
+                "aliases": [],
+                "description": "",
+                "name": "spinach fettuccine",
+                "plural_name": "spinach fettuccines"
+            },
+            "rice-a-roni": {
+                "aliases": [],
+                "description": "",
+                "name": "rice-a-roni",
+                "plural_name": "rice-a-ronis"
+            },
+            "frozen dumpling": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen dumpling",
+                "plural_name": "frozen dumplings"
+            },
+            "fregola": {
+                "aliases": [],
+                "description": "",
+                "name": "fregola",
+                "plural_name": "fregolas"
+            },
+            "beef tortellini": {
+                "aliases": [],
+                "description": "",
+                "name": "beef tortellini",
+                "plural_name": "beef tortellinis"
+            },
+            "banh pho": {
+                "aliases": [],
+                "description": "",
+                "name": "banh pho",
+                "plural_name": "banh phoes"
+            },
+            "butternut squash noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "butternut squash noodle",
+                "plural_name": "butternut squash noodles"
+            },
+            "mie noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "mie noodle",
+                "plural_name": "mie noodles"
+            },
+            "trahana": {
+                "aliases": [],
+                "description": "",
+                "name": "trahana",
+                "plural_name": "trahanas"
+            },
+            "busiate": {
+                "aliases": [],
+                "description": "",
+                "name": "busiate",
+                "plural_name": "busiates"
+            },
+            "lobster ravioli": {
+                "aliases": [],
+                "description": "",
+                "name": "lobster ravioli",
+                "plural_name": "lobster raviolis"
+            },
+            "mafalde": {
+                "aliases": [],
+                "description": "",
+                "name": "mafalde",
+                "plural_name": "mafaldes"
+            },
+            "misua": {
+                "aliases": [],
+                "description": "",
+                "name": "misua",
+                "plural_name": "misuas"
+            },
+            "palmini": {
+                "aliases": [],
+                "description": "",
+                "name": "palmini",
+                "plural_name": "palminis"
+            },
+            "trottole": {
+                "aliases": [],
+                "description": "",
+                "name": "trottole",
+                "plural_name": "trottoles"
+            },
+            "mandu": {
+                "aliases": [],
+                "description": "",
+                "name": "mandu",
+                "plural_name": "mandus"
+            },
+            "pasta salad mix": {
+                "aliases": [],
+                "description": "",
+                "name": "pasta salad mix",
+                "plural_name": "pasta salad mixes"
+            },
+            "pot pie noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "pot pie noodle",
+                "plural_name": "pot pie noodles"
+            },
+            "casarecce": {
+                "aliases": [],
+                "description": "",
+                "name": "casarecce",
+                "plural_name": "casarecces"
+            },
+            "quinoa pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "quinoa pasta",
+                "plural_name": "quinoa pastas"
+            },
+            "bean pasta": {
+                "aliases": [],
+                "description": "",
+                "name": "bean pasta",
+                "plural_name": "bean pastas"
+            },
+            "bean sheet": {
+                "aliases": [],
+                "description": "",
+                "name": "bean sheet",
+                "plural_name": "bean sheets"
+            },
+            "hilopite": {
+                "aliases": [],
+                "description": "",
+                "name": "hilopite",
+                "plural_name": "hilopites"
+            },
+            "jjolmyeon": {
+                "aliases": [],
+                "description": "",
+                "name": "jjolmyeon",
+                "plural_name": "jjolmyeons"
+            },
+            "naengmyeon noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "naengmyeon noodle",
+                "plural_name": "naengmyeon noodles"
+            },
+            "yuba noodle": {
+                "aliases": [],
+                "description": "",
+                "name": "yuba noodle",
+                "plural_name": "yuba noodles"
+            }
+        }
+    },
+    "Bread & Salty Snackssta": {
+        "foods": {
+            "bread": {
+                "aliases": [],
+                "description": "",
+                "name": "bread",
+                "plural_name": "breads"
+            }
+        }
+    },
+    "Bread & Salty Snacks": {
+        "foods": {
+            "bread crumb": {
+                "aliases": [],
+                "description": "",
+                "name": "bread crumb",
+                "plural_name": "bread crumbs"
+            },
+            "panko": {
+                "aliases": [],
+                "description": "",
+                "name": "panko",
+                "plural_name": "pankoes"
+            },
+            "flour tortilla": {
+                "aliases": [],
+                "description": "",
+                "name": "flour tortilla",
+                "plural_name": "flour tortillas"
+            },
+            "almond flour tortilla": {
+                "aliases": [],
+                "description": "",
+                "name": "almond flour tortilla",
+                "plural_name": "almond flour tortillas"
+            },
+            "corn tortilla": {
+                "aliases": [],
+                "description": "",
+                "name": "corn tortilla",
+                "plural_name": "corn tortillas"
+            },
+            "cracker": {
+                "aliases": [],
+                "description": "",
+                "name": "cracker",
+                "plural_name": "crackers"
+            },
+            "baguette": {
+                "aliases": [],
+                "description": "",
+                "name": "baguette",
+                "plural_name": "baguettes"
+            },
+            "tortilla chip": {
+                "aliases": [],
+                "description": "",
+                "name": "tortilla chip",
+                "plural_name": "tortilla chips"
+            },
+            "pita": {
+                "aliases": [],
+                "description": "",
+                "name": "pita",
+                "plural_name": "pitas"
+            },
+            "pretzel": {
+                "aliases": [],
+                "description": "",
+                "name": "pretzel",
+                "plural_name": "pretzels"
+            },
+            "sourdough bread": {
+                "aliases": [],
+                "description": "",
+                "name": "sourdough bread",
+                "plural_name": "sourdough breads"
+            },
+            "rustic italian bread": {
+                "aliases": [],
+                "description": "",
+                "name": "rustic italian bread",
+                "plural_name": "rustic italian breads"
+            },
+            "popcorn": {
+                "aliases": [],
+                "description": "",
+                "name": "popcorn",
+                "plural_name": "popcorns"
+            },
+            "crouton": {
+                "aliases": [],
+                "description": "",
+                "name": "crouton",
+                "plural_name": "croutons"
+            },
+            "whole-wheat tortilla": {
+                "aliases": [],
+                "description": "",
+                "name": "whole-wheat tortilla",
+                "plural_name": "whole-wheat tortillas"
+            },
+            "english muffin": {
+                "aliases": [],
+                "description": "",
+                "name": "english muffin",
+                "plural_name": "english muffins"
+            },
+            "brioche": {
+                "aliases": [],
+                "description": "",
+                "name": "brioche",
+                "plural_name": "brioches"
+            },
+            "italian bread crumb": {
+                "aliases": [],
+                "description": "",
+                "name": "italian bread crumb",
+                "plural_name": "italian bread crumbs"
+            },
+            "rye bread": {
+                "aliases": [],
+                "description": "",
+                "name": "rye bread",
+                "plural_name": "rye breads"
+            },
+            "flatbread": {
+                "aliases": [],
+                "description": "",
+                "name": "flatbread",
+                "plural_name": "flatbreads"
+            },
+            "dry-roasted peanut": {
+                "aliases": [],
+                "description": "",
+                "name": "dry-roasted peanut",
+                "plural_name": "dry-roasted peanuts"
+            },
+            "potato chip": {
+                "aliases": [],
+                "description": "",
+                "name": "potato chip",
+                "plural_name": "potato chips"
+            },
+            "naan": {
+                "aliases": [],
+                "description": "",
+                "name": "naan",
+                "plural_name": "naans"
+            },
+            "stuffing mix": {
+                "aliases": [],
+                "description": "",
+                "name": "stuffing mix",
+                "plural_name": "stuffing mixes"
+            },
+            "cornbread": {
+                "aliases": [],
+                "description": "",
+                "name": "cornbread",
+                "plural_name": "cornbreads"
+            },
+            "taco shell": {
+                "aliases": [],
+                "description": "",
+                "name": "taco shell",
+                "plural_name": "taco shells"
+            },
+            "tater tot": {
+                "aliases": [],
+                "description": "",
+                "name": "tater tot",
+                "plural_name": "tater tots"
+            },
+            "bagel": {
+                "aliases": [],
+                "description": "",
+                "name": "bagel",
+                "plural_name": "bagels"
+            },
+            "corn chip": {
+                "aliases": [],
+                "description": "",
+                "name": "corn chip",
+                "plural_name": "corn chips"
+            },
+            "unpopped popcorn": {
+                "aliases": [],
+                "description": "",
+                "name": "unpopped popcorn",
+                "plural_name": "unpopped popcorns"
+            },
+            "croissant": {
+                "aliases": [],
+                "description": "",
+                "name": "croissant",
+                "plural_name": "croissants"
+            },
+            "pork rind": {
+                "aliases": [],
+                "description": "",
+                "name": "pork rind",
+                "plural_name": "pork rinds"
+            },
+            "pumpernickel": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpernickel",
+                "plural_name": "pumpernickels"
+            },
+            "sweet bread": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet bread",
+                "plural_name": "sweet breads"
+            },
+            "hawaiian roll": {
+                "aliases": [],
+                "description": "",
+                "name": "hawaiian roll",
+                "plural_name": "hawaiian rolls"
+            },
+            "pita chip": {
+                "aliases": [],
+                "description": "",
+                "name": "pita chip",
+                "plural_name": "pita chips"
+            },
+            "gluten free bread": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten free bread",
+                "plural_name": "gluten free breads"
+            },
+            "potato bread": {
+                "aliases": [],
+                "description": "",
+                "name": "potato bread",
+                "plural_name": "potato breads"
+            },
+            "muffin": {
+                "aliases": [],
+                "description": "",
+                "name": "muffin",
+                "plural_name": "muffins"
+            },
+            "breadstick": {
+                "aliases": [],
+                "description": "",
+                "name": "breadstick",
+                "plural_name": "breadsticks"
+            },
+            "focaccia": {
+                "aliases": [],
+                "description": "",
+                "name": "focaccia",
+                "plural_name": "focaccias"
+            },
+            "gluten-free bread crumb": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten-free bread crumb",
+                "plural_name": "gluten-free bread crumbs"
+            },
+            "tostada shell": {
+                "aliases": [],
+                "description": "",
+                "name": "tostada shell",
+                "plural_name": "tostada shells"
+            },
+            "crispy fried onion": {
+                "aliases": [],
+                "description": "",
+                "name": "crispy fried onion",
+                "plural_name": "crispy fried onions"
+            },
+            "matzo": {
+                "aliases": [],
+                "description": "",
+                "name": "matzo",
+                "plural_name": "matzoes"
+            },
+            "garlic bread": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic bread",
+                "plural_name": "garlic breads"
+            },
+            "yeast extract spread": {
+                "aliases": [],
+                "description": "",
+                "name": "yeast extract spread",
+                "plural_name": "yeast extract spreads"
+            },
+            "challah": {
+                "aliases": [],
+                "description": "",
+                "name": "challah",
+                "plural_name": "challahs"
+            },
+            "roasted gram": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted gram",
+                "plural_name": "roasted grams"
+            },
+            "crostini": {
+                "aliases": [],
+                "description": "",
+                "name": "crostini",
+                "plural_name": "crostinis"
+            },
+            "rice cake": {
+                "aliases": [],
+                "description": "",
+                "name": "rice cake",
+                "plural_name": "rice cakes"
+            },
+            "panettone": {
+                "aliases": [],
+                "description": "",
+                "name": "panettone",
+                "plural_name": "panettones"
+            },
+            "sweet potato fry": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet potato fry",
+                "plural_name": "sweet potato fries"
+            },
+            "sev": {
+                "aliases": [],
+                "description": "",
+                "name": "sev",
+                "plural_name": "sevs"
+            },
+            "vegetable chip": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable chip",
+                "plural_name": "vegetable chips"
+            },
+            "papad": {
+                "aliases": [],
+                "description": "",
+                "name": "papad",
+                "plural_name": "papads"
+            },
+            "spinach wrap": {
+                "aliases": [],
+                "description": "",
+                "name": "spinach wrap",
+                "plural_name": "spinach wraps"
+            },
+            "plantain chip": {
+                "aliases": [],
+                "description": "",
+                "name": "plantain chip",
+                "plural_name": "plantain chips"
+            },
+            "roasted chickpea": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted chickpea",
+                "plural_name": "roasted chickpeas"
+            },
+            "cheeto": {
+                "aliases": [],
+                "description": "",
+                "name": "cheeto",
+                "plural_name": "cheetos"
+            },
+            "chapati": {
+                "aliases": [],
+                "description": "",
+                "name": "chapati",
+                "plural_name": "chapatis"
+            },
+            "crumpet": {
+                "aliases": [],
+                "description": "",
+                "name": "crumpet",
+                "plural_name": "crumpets"
+            },
+            "seed bread": {
+                "aliases": [],
+                "description": "",
+                "name": "seed bread",
+                "plural_name": "seed breads"
+            },
+            "keto bread": {
+                "aliases": [],
+                "description": "",
+                "name": "keto bread",
+                "plural_name": "keto breads"
+            },
+            "bread bowl": {
+                "aliases": [],
+                "description": "",
+                "name": "bread bowl",
+                "plural_name": "bread bowls"
+            },
+            "sprouted grain bread": {
+                "aliases": [],
+                "description": "",
+                "name": "sprouted grain bread",
+                "plural_name": "sprouted grain breads"
+            },
+            "cornbread stuffing mix": {
+                "aliases": [],
+                "description": "",
+                "name": "cornbread stuffing mix",
+                "plural_name": "cornbread stuffing mixes"
+            },
+            "low-carb wrap": {
+                "aliases": [],
+                "description": "",
+                "name": "low-carb wrap",
+                "plural_name": "low-carb wraps"
+            },
+            "frozen onion ring": {
+                "aliases": [],
+                "description": "",
+                "name": "frozen onion ring",
+                "plural_name": "frozen onion rings"
+            },
+            "corn muffin": {
+                "aliases": [],
+                "description": "",
+                "name": "corn muffin",
+                "plural_name": "corn muffins"
+            },
+            "pav bun": {
+                "aliases": [],
+                "description": "",
+                "name": "pav bun",
+                "plural_name": "pav buns"
+            },
+            "corn nut": {
+                "aliases": [],
+                "description": "",
+                "name": "corn nut",
+                "plural_name": "corn nuts"
+            },
+            "rice cracker": {
+                "aliases": [],
+                "description": "",
+                "name": "rice cracker",
+                "plural_name": "rice crackers"
+            },
+            "rusk": {
+                "aliases": [],
+                "description": "",
+                "name": "rusk",
+                "plural_name": "rusks"
+            },
+            "fruit bread": {
+                "aliases": [],
+                "description": "",
+                "name": "fruit bread",
+                "plural_name": "fruit breads"
+            },
+            "sprouted bread": {
+                "aliases": [],
+                "description": "",
+                "name": "sprouted bread",
+                "plural_name": "sprouted breads"
+            },
+            "pretzel bun": {
+                "aliases": [],
+                "description": "",
+                "name": "pretzel bun",
+                "plural_name": "pretzel buns"
+            },
+            "roti bread": {
+                "aliases": [],
+                "description": "",
+                "name": "roti bread",
+                "plural_name": "roti breads"
+            },
+            "crispbread": {
+                "aliases": [],
+                "description": "",
+                "name": "crispbread",
+                "plural_name": "crispbreads"
+            },
+            "chocolate muffin": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate muffin",
+                "plural_name": "chocolate muffins"
+            },
+            "milk bread": {
+                "aliases": [],
+                "description": "",
+                "name": "milk bread",
+                "plural_name": "milk breads"
+            },
+            "popcorn shrimp": {
+                "aliases": [],
+                "description": "",
+                "name": "popcorn shrimp",
+                "plural_name": "popcorn shrimps"
+            },
+            "prawn cracker": {
+                "aliases": [],
+                "description": "",
+                "name": "prawn cracker",
+                "plural_name": "prawn crackers"
+            },
+            "bao bun": {
+                "aliases": [],
+                "description": "",
+                "name": "bao bun",
+                "plural_name": "bao buns"
+            },
+            "ezekiel bread": {
+                "aliases": [],
+                "description": "",
+                "name": "ezekiel bread",
+                "plural_name": "ezekiel breads"
+            },
+            "wasabi pea": {
+                "aliases": [],
+                "description": "",
+                "name": "wasabi pea",
+                "plural_name": "wasabi peas"
+            },
+            "arabic bread": {
+                "aliases": [],
+                "description": "",
+                "name": "arabic bread",
+                "plural_name": "arabic breads"
+            },
+            "boboli": {
+                "aliases": [],
+                "description": "",
+                "name": "boboli",
+                "plural_name": "bobolis"
+            },
+            "zwieback": {
+                "aliases": [],
+                "description": "",
+                "name": "zwieback",
+                "plural_name": "zwiebacks"
+            },
+            "oven chip": {
+                "aliases": [],
+                "description": "",
+                "name": "oven chip",
+                "plural_name": "oven chips"
+            },
+            "taco kit": {
+                "aliases": [],
+                "description": "",
+                "name": "taco kit",
+                "plural_name": "taco kits"
+            },
+            "gluten free pita": {
+                "aliases": [],
+                "description": "",
+                "name": "gluten free pita",
+                "plural_name": "gluten free pitas"
+            },
+            "ready-made arepa": {
+                "aliases": [],
+                "description": "",
+                "name": "ready-made arepa",
+                "plural_name": "ready-made arepas"
+            },
+            "ready-made pancake": {
+                "aliases": [],
+                "description": "",
+                "name": "ready-made pancake",
+                "plural_name": "ready-made pancakes"
+            },
+            "breading mix": {
+                "aliases": [],
+                "description": "",
+                "name": "breading mix",
+                "plural_name": "breading mixes"
+            },
+            "japanese peanut": {
+                "aliases": [],
+                "description": "",
+                "name": "japanese peanut",
+                "plural_name": "japanese peanuts"
+            },
+            "khari boondi": {
+                "aliases": [],
+                "description": "",
+                "name": "khari boondi",
+                "plural_name": "khari boondis"
+            },
+            "potato waffle": {
+                "aliases": [],
+                "description": "",
+                "name": "potato waffle",
+                "plural_name": "potato waffles"
+            },
+            "tartlet shell": {
+                "aliases": [],
+                "description": "",
+                "name": "tartlet shell",
+                "plural_name": "tartlet shells"
+            }
+        }
+    },
+    "Oils & Fats": {
+        "foods": {
+            "olive oil": {
+                "aliases": [],
+                "description": "",
+                "name": "olive oil",
+                "plural_name": "olive oils"
+            },
+            "vegetable oil": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable oil",
+                "plural_name": "vegetable oils"
+            },
+            "extra virgin olive oil": {
+                "aliases": [],
+                "description": "",
+                "name": "extra virgin olive oil",
+                "plural_name": "extra virgin olive oils"
+            },
+            "canola oil": {
+                "aliases": [],
+                "description": "",
+                "name": "canola oil",
+                "plural_name": "canola oils"
+            },
+            "coconut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut oil",
+                "plural_name": "coconut oils"
+            },
+            "cooking spray": {
+                "aliases": [],
+                "description": "",
+                "name": "cooking spray",
+                "plural_name": "cooking sprays"
+            },
+            "sesame oil": {
+                "aliases": [],
+                "description": "",
+                "name": "sesame oil",
+                "plural_name": "sesame oils"
+            },
+            "frying oil": {
+                "aliases": [],
+                "description": "",
+                "name": "frying oil",
+                "plural_name": "frying oils"
+            },
+            "sunflower oil": {
+                "aliases": [],
+                "description": "",
+                "name": "sunflower oil",
+                "plural_name": "sunflower oils"
+            },
+            "avocado oil": {
+                "aliases": [],
+                "description": "",
+                "name": "avocado oil",
+                "plural_name": "avocado oils"
+            },
+            "toasted sesame oil": {
+                "aliases": [],
+                "description": "",
+                "name": "toasted sesame oil",
+                "plural_name": "toasted sesame oils"
+            },
+            "peanut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut oil",
+                "plural_name": "peanut oils"
+            },
+            "grapeseed oil": {
+                "aliases": [
+                    "grape seed oil"
+                ],
+                "description": "",
+                "name": "grapeseed oil",
+                "plural_name": "grapeseed oils"
+            },
+            "lard": {
+                "aliases": [],
+                "description": "",
+                "name": "lard",
+                "plural_name": "lards"
+            },
+            "corn oil": {
+                "aliases": [],
+                "description": "",
+                "name": "corn oil",
+                "plural_name": "corn oils"
+            },
+            "virgin coconut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "virgin coconut oil",
+                "plural_name": "virgin coconut oils"
+            },
+            "chili oil": {
+                "aliases": [],
+                "description": "",
+                "name": "chili oil",
+                "plural_name": "chili oils"
+            },
+            "mustard oil": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard oil",
+                "plural_name": "mustard oils"
+            },
+            "walnut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "walnut oil",
+                "plural_name": "walnut oils"
+            },
+            "garlic oil": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic oil",
+                "plural_name": "garlic oils"
+            },
+            "truffle oil": {
+                "aliases": [],
+                "description": "",
+                "name": "truffle oil",
+                "plural_name": "truffle oils"
+            },
+            "bacon grease": {
+                "aliases": [],
+                "description": "",
+                "name": "bacon grease",
+                "plural_name": "bacon greases"
+            },
+            "safflower oil": {
+                "aliases": [],
+                "description": "",
+                "name": "safflower oil",
+                "plural_name": "safflower oils"
+            },
+            "cacao butter": {
+                "aliases": [],
+                "description": "",
+                "name": "cacao butter",
+                "plural_name": "cacao butter"
+            },
+            "salad oil": {
+                "aliases": [],
+                "description": "",
+                "name": "salad oil",
+                "plural_name": "salad oils"
+            },
+            "duck fat": {
+                "aliases": [],
+                "description": "",
+                "name": "duck fat",
+                "plural_name": "duck fats"
+            },
+            "rice bran oil": {
+                "aliases": [],
+                "description": "",
+                "name": "rice bran oil",
+                "plural_name": "rice bran oils"
+            },
+            "soybean oil": {
+                "aliases": [],
+                "description": "",
+                "name": "soybean oil",
+                "plural_name": "soybean oils"
+            },
+            "butter-flavored cooking spray": {
+                "aliases": [],
+                "description": "",
+                "name": "butter-flavored cooking spray",
+                "plural_name": "butter-flavored cooking sprays"
+            },
+            "medium-chain triglyceride": {
+                "aliases": [],
+                "description": "",
+                "name": "medium-chain triglyceride",
+                "plural_name": "medium-chain triglycerides"
+            },
+            "flaxseed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "flaxseed oil",
+                "plural_name": "flaxseed oils"
+            },
+            "white truffle oil": {
+                "aliases": [],
+                "description": "",
+                "name": "white truffle oil",
+                "plural_name": "white truffle oils"
+            },
+            "pumpkin seed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin seed oil",
+                "plural_name": "pumpkin seed oils"
+            },
+            "hazelnut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut oil",
+                "plural_name": "hazelnut oils"
+            },
+            "coconut oil spray": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut oil spray",
+                "plural_name": "coconut oil sprays"
+            },
+            "almond oil": {
+                "aliases": [],
+                "description": "",
+                "name": "almond oil",
+                "plural_name": "almond oils"
+            },
+            "lemon oil": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon oil",
+                "plural_name": "lemon oils"
+            },
+            "macadamia oil": {
+                "aliases": [],
+                "description": "",
+                "name": "macadamia oil",
+                "plural_name": "macadamia oils"
+            },
+            "goose fat": {
+                "aliases": [],
+                "description": "",
+                "name": "goose fat",
+                "plural_name": "goose fats"
+            },
+            "palm oil": {
+                "aliases": [],
+                "description": "",
+                "name": "palm oil",
+                "plural_name": "palm oils"
+            },
+            "basil oil": {
+                "aliases": [],
+                "description": "",
+                "name": "basil oil",
+                "plural_name": "basil oils"
+            },
+            "pork fat": {
+                "aliases": [],
+                "description": "",
+                "name": "pork fat",
+                "plural_name": "pork fats"
+            },
+            "beef dripping": {
+                "aliases": [],
+                "description": "",
+                "name": "beef dripping",
+                "plural_name": "beef drippings"
+            },
+            "schmaltz": {
+                "aliases": [],
+                "description": "",
+                "name": "schmaltz",
+                "plural_name": "schmaltzzes"
+            },
+            "tallow": {
+                "aliases": [],
+                "description": "",
+                "name": "tallow",
+                "plural_name": "tallows"
+            },
+            "sushi vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "sushi vinegar",
+                "plural_name": "sushi vinegars"
+            },
+            "pistachio oil": {
+                "aliases": [],
+                "description": "",
+                "name": "pistachio oil",
+                "plural_name": "pistachio oils"
+            },
+            "herb-infused olive oil": {
+                "aliases": [],
+                "description": "",
+                "name": "herb-infused olive oil",
+                "plural_name": "herb-infused olive oils"
+            },
+            "roasted peanut oil": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted peanut oil",
+                "plural_name": "roasted peanut oils"
+            },
+            "argan oil": {
+                "aliases": [],
+                "description": "",
+                "name": "argan oil",
+                "plural_name": "argan oils"
+            },
+            "beef fat": {
+                "aliases": [],
+                "description": "",
+                "name": "beef fat",
+                "plural_name": "beef fats"
+            },
+            "pecan oil": {
+                "aliases": [],
+                "description": "",
+                "name": "pecan oil",
+                "plural_name": "pecan oils"
+            },
+            "crisco oil": {
+                "aliases": [],
+                "description": "",
+                "name": "crisco oil",
+                "plural_name": "crisco oils"
+            },
+            "red palm oil": {
+                "aliases": [],
+                "description": "",
+                "name": "red palm oil",
+                "plural_name": "red palm oils"
+            },
+            "shea butter": {
+                "aliases": [],
+                "description": "",
+                "name": "shea butter",
+                "plural_name": "shea butter"
+            },
+            "lamb fat": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb fat",
+                "plural_name": "lamb fats"
+            },
+            "castor oil": {
+                "aliases": [],
+                "description": "",
+                "name": "castor oil",
+                "plural_name": "castor oils"
+            },
+            "chicken dripping": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken dripping",
+                "plural_name": "chicken drippings"
+            },
+            "shallot oil": {
+                "aliases": [],
+                "description": "",
+                "name": "shallot oil",
+                "plural_name": "shallot oils"
+            },
+            "achiote oil": {
+                "aliases": [],
+                "description": "",
+                "name": "achiote oil",
+                "plural_name": "achiote oils"
+            },
+            "jojoba oil": {
+                "aliases": [],
+                "description": "",
+                "name": "jojoba oil",
+                "plural_name": "jojoba oils"
+            },
+            "oregano oil": {
+                "aliases": [],
+                "description": "",
+                "name": "oregano oil",
+                "plural_name": "oregano oils"
+            },
+            "hemp seed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "hemp seed oil",
+                "plural_name": "hemp seed oils"
+            },
+            "wheat germ oil": {
+                "aliases": [],
+                "description": "",
+                "name": "wheat germ oil",
+                "plural_name": "wheat germ oils"
+            },
+            "ginger oil": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger oil",
+                "plural_name": "ginger oils"
+            },
+            "cottonseed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "cottonseed oil",
+                "plural_name": "cottonseed oils"
+            },
+            "pork dripping": {
+                "aliases": [],
+                "description": "",
+                "name": "pork dripping",
+                "plural_name": "pork drippings"
+            },
+            "rosehip seed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "rosehip seed oil",
+                "plural_name": "rosehip seed oils"
+            },
+            "camelina oil": {
+                "aliases": [],
+                "description": "",
+                "name": "camelina oil",
+                "plural_name": "camelina oils"
+            },
+            "marula oil": {
+                "aliases": [],
+                "description": "",
+                "name": "marula oil",
+                "plural_name": "marula oils"
+            },
+            "moringa seed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "moringa seed oil",
+                "plural_name": "moringa seed oils"
+            },
+            "white cacao butter": {
+                "aliases": [],
+                "description": "",
+                "name": "white cacao butter",
+                "plural_name": "white cacao butter"
+            },
+            "black seed oil": {
+                "aliases": [],
+                "description": "",
+                "name": "black seed oil",
+                "plural_name": "black seed oils"
+            }
+        }
+    },
+    "Dressings & Vinegars": {
+        "foods": {
+            "mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "mayonnaise",
+                "plural_name": "mayonnaises"
+            },
+            "apple cider vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "apple cider vinegar",
+                "plural_name": "apple cider vinegars"
+            },
+            "balsamic vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "balsamic vinegar",
+                "plural_name": "balsamic vinegars"
+            },
+            "vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "vinegar",
+                "plural_name": "vinegars"
+            },
+            "red wine vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "red wine vinegar",
+                "plural_name": "red wine vinegars"
+            },
+            "rice wine vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "rice wine vinegar",
+                "plural_name": "rice wine vinegars"
+            },
+            "white wine vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "white wine vinegar",
+                "plural_name": "white wine vinegars"
+            },
+            "ranch dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "ranch dressing",
+                "plural_name": "ranch dressings"
+            },
+            "italian dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "italian dressing",
+                "plural_name": "italian dressings"
+            },
+            "sherry vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "sherry vinegar",
+                "plural_name": "sherry vinegars"
+            },
+            "distilled white vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "distilled white vinegar",
+                "plural_name": "distilled white vinegars"
+            },
+            "sweet chilli sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet chilli sauce",
+                "plural_name": "sweet chilli sauces"
+            },
+            "white balsamic vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "white balsamic vinegar",
+                "plural_name": "white balsamic vinegars"
+            },
+            "champagne vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "champagne vinegar",
+                "plural_name": "champagne vinegars"
+            },
+            "vinaigrette dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "vinaigrette dressing",
+                "plural_name": "vinaigrette dressings"
+            },
+            "balsamic vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "balsamic vinaigrette",
+                "plural_name": "balsamic vinaigrettes"
+            },
+            "blue cheese dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "blue cheese dressing",
+                "plural_name": "blue cheese dressings"
+            },
+            "caesar dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "caesar dressing",
+                "plural_name": "caesar dressings"
+            },
+            "thousand island": {
+                "aliases": [],
+                "description": "",
+                "name": "thousand island",
+                "plural_name": "thousand islands"
+            },
+            "malt vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "malt vinegar",
+                "plural_name": "malt vinegars"
+            },
+            "black vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "black vinegar",
+                "plural_name": "black vinegars"
+            },
+            "canola mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "canola mayonnaise",
+                "plural_name": "canola mayonnaises"
+            },
+            "raspberry vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry vinegar",
+                "plural_name": "raspberry vinegars"
+            },
+            "japanese mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "japanese mayonnaise",
+                "plural_name": "japanese mayonnaises"
+            },
+            "tarragon vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "tarragon vinegar",
+                "plural_name": "tarragon vinegars"
+            },
+            "greek vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "greek vinaigrette",
+                "plural_name": "greek vinaigrettes"
+            },
+            "sesame dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "sesame dressing",
+                "plural_name": "sesame dressings"
+            },
+            "honey mustard dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "honey mustard dressing",
+                "plural_name": "honey mustard dressings"
+            },
+            "aioli sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "aioli sauce",
+                "plural_name": "aioli sauces"
+            },
+            "french dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "french dressing",
+                "plural_name": "french dressings"
+            },
+            "spicy mayo": {
+                "aliases": [],
+                "description": "",
+                "name": "spicy mayo",
+                "plural_name": "spicy mayoes"
+            },
+            "poppyseed dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "poppyseed dressing",
+                "plural_name": "poppyseed dressings"
+            },
+            "catalina dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "catalina dressing",
+                "plural_name": "catalina dressings"
+            },
+            "verjuice": {
+                "aliases": [],
+                "description": "",
+                "name": "verjuice",
+                "plural_name": "verjuices"
+            },
+            "cane vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "cane vinegar",
+                "plural_name": "cane vinegars"
+            },
+            "raspberry vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry vinaigrette",
+                "plural_name": "raspberry vinaigrettes"
+            },
+            "red wine vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "red wine vinaigrette",
+                "plural_name": "red wine vinaigrettes"
+            },
+            "russian dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "russian dressing",
+                "plural_name": "russian dressings"
+            },
+            "avocado oil mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "avocado oil mayonnaise",
+                "plural_name": "avocado oil mayonnaises"
+            },
+            "creamy balsamic dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "creamy balsamic dressing",
+                "plural_name": "creamy balsamic dressings"
+            },
+            "champagne vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "champagne vinaigrette",
+                "plural_name": "champagne vinaigrettes"
+            },
+            "sun-dried tomato vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "sun-dried tomato vinaigrette",
+                "plural_name": "sun-dried tomato vinaigrettes"
+            },
+            "garlic mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic mayonnaise",
+                "plural_name": "garlic mayonnaises"
+            },
+            "brown rice vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "brown rice vinegar",
+                "plural_name": "brown rice vinegars"
+            },
+            "coconut vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut vinegar",
+                "plural_name": "coconut vinegars"
+            },
+            "ume plum vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "ume plum vinegar",
+                "plural_name": "ume plum vinegars"
+            },
+            "buttermilk ranch dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "buttermilk ranch dressing",
+                "plural_name": "buttermilk ranch dressings"
+            },
+            "cilantro dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "cilantro dressing",
+                "plural_name": "cilantro dressings"
+            },
+            "spicy ranch dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "spicy ranch dressing",
+                "plural_name": "spicy ranch dressings"
+            },
+            "fig balsamic": {
+                "aliases": [],
+                "description": "",
+                "name": "fig balsamic",
+                "plural_name": "fig balsamics"
+            },
+            "green goddess dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "green goddess dressing",
+                "plural_name": "green goddess dressings"
+            },
+            "creamy dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "creamy dressing",
+                "plural_name": "creamy dressings"
+            },
+            "onion salad dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "onion salad dressing",
+                "plural_name": "onion salad dressings"
+            },
+            "miso dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "miso dressing",
+                "plural_name": "miso dressings"
+            },
+            "white balsamic vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "white balsamic vinaigrette",
+                "plural_name": "white balsamic vinaigrettes"
+            },
+            "chardonnay vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "chardonnay vinegar",
+                "plural_name": "chardonnay vinegars"
+            },
+            "prepared coleslaw dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "prepared coleslaw dressing",
+                "plural_name": "prepared coleslaw dressings"
+            },
+            "honey vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "honey vinegar",
+                "plural_name": "honey vinegars"
+            },
+            "tandoori mayonnaise": {
+                "aliases": [],
+                "description": "",
+                "name": "tandoori mayonnaise",
+                "plural_name": "tandoori mayonnaises"
+            },
+            "chili vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "chili vinegar",
+                "plural_name": "chili vinegars"
+            },
+            "chili-lime dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "chili-lime dressing",
+                "plural_name": "chili-lime dressings"
+            },
+            "moscatel vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "moscatel vinegar",
+                "plural_name": "moscatel vinegars"
+            },
+            "vinegar powder": {
+                "aliases": [],
+                "description": "",
+                "name": "vinegar powder",
+                "plural_name": "vinegar powders"
+            },
+            "caramelised onion dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "caramelised onion dressing",
+                "plural_name": "caramelised onion dressings"
+            },
+            "mango vinaigrette": {
+                "aliases": [],
+                "description": "",
+                "name": "mango vinaigrette",
+                "plural_name": "mango vinaigrettes"
+            },
+            "sugarcane vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "sugarcane vinegar",
+                "plural_name": "sugarcane vinegars"
+            },
+            "avocado-lime dressing": {
+                "aliases": [],
+                "description": "",
+                "name": "avocado-lime dressing",
+                "plural_name": "avocado-lime dressings"
+            },
+            "spicy vinegar": {
+                "aliases": [],
+                "description": "",
+                "name": "spicy vinegar",
+                "plural_name": "spicy vinegars"
+            }
+        }
+    },
+    "Condiments": {
+        "foods": {
+            "soy sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "soy sauce",
+                "plural_name": "soy sauces"
+            },
+            "dijon mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "dijon mustard",
+                "plural_name": "dijon mustards"
+            },
+            "worcestershire": {
+                "aliases": [],
+                "description": "",
+                "name": "worcestershire",
+                "plural_name": "worcestershires"
+            },
+            "hot sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "hot sauce",
+                "plural_name": "hot sauces"
+            },
+            "worcestershire sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "worcestershire sauce",
+                "plural_name": "worcestershire sauces"
+            },
+            "ketchup": {
+                "aliases": [],
+                "description": "",
+                "name": "ketchup",
+                "plural_name": "ketchups"
+            },
+            "mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard",
+                "plural_name": "mustards"
+            },
+            "fish sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "fish sauce",
+                "plural_name": "fish sauces"
+            },
+            "bbq sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "bbq sauce",
+                "plural_name": "bbq sauces"
+            },
+            "sriracha": {
+                "aliases": [],
+                "description": "",
+                "name": "sriracha",
+                "plural_name": "srirachas"
+            },
+            "wholegrain mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "wholegrain mustard",
+                "plural_name": "wholegrain mustards"
+            },
+            "tamari": {
+                "aliases": [],
+                "description": "",
+                "name": "tamari",
+                "plural_name": "tamaris"
+            },
+            "oyster sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "oyster sauce",
+                "plural_name": "oyster sauces"
+            },
+            "chili sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "chili sauce",
+                "plural_name": "chili sauces"
+            },
+            "ginger-garlic paste": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger-garlic paste",
+                "plural_name": "ginger-garlic pastes"
+            },
+            "brown mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "brown mustard",
+                "plural_name": "brown mustards"
+            },
+            "wing sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "wing sauce",
+                "plural_name": "wing sauces"
+            },
+            "teriyaki sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "teriyaki sauce",
+                "plural_name": "teriyaki sauces"
+            },
+            "prepared horseradish": {
+                "aliases": [],
+                "description": "",
+                "name": "prepared horseradish",
+                "plural_name": "prepared horseradishes"
+            },
+            "ginger paste": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger paste",
+                "plural_name": "ginger pastes"
+            },
+            "dark soy sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "dark soy sauce",
+                "plural_name": "dark soy sauces"
+            },
+            "coconut amino": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut amino",
+                "plural_name": "coconut aminos"
+            },
+            "chili paste": {
+                "aliases": [],
+                "description": "",
+                "name": "chili paste",
+                "plural_name": "chili pastes"
+            },
+            "cranberry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry sauce",
+                "plural_name": "cranberry sauces"
+            },
+            "harissa": {
+                "aliases": [],
+                "description": "",
+                "name": "harissa",
+                "plural_name": "harissas"
+            },
+            "chili-garlic sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "chili-garlic sauce",
+                "plural_name": "chili-garlic sauces"
+            },
+            "tamarind paste": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind paste",
+                "plural_name": "tamarind pastes"
+            },
+            "pomegranate molass": {
+                "aliases": [],
+                "description": "",
+                "name": "pomegranate molass",
+                "plural_name": "pomegranate molasses"
+            },
+            "gochujang": {
+                "aliases": [],
+                "description": "",
+                "name": "gochujang",
+                "plural_name": "gochujangs"
+            },
+            "wasabi": {
+                "aliases": [],
+                "description": "",
+                "name": "wasabi",
+                "plural_name": "wasabis"
+            },
+            "honey mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "honey mustard",
+                "plural_name": "honey mustards"
+            },
+            "mango chutney": {
+                "aliases": [],
+                "description": "",
+                "name": "mango chutney",
+                "plural_name": "mango chutneys"
+            },
+            "english mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "english mustard",
+                "plural_name": "english mustards"
+            },
+            "sambal oelek": {
+                "aliases": [],
+                "description": "",
+                "name": "sambal oelek",
+                "plural_name": "sambal oeleks"
+            },
+            "preserved lemon": {
+                "aliases": [],
+                "description": "",
+                "name": "preserved lemon",
+                "plural_name": "preserved lemons"
+            },
+            "kecap mani": {
+                "aliases": [],
+                "description": "",
+                "name": "kecap mani",
+                "plural_name": "kecap manis"
+            },
+            "chutney": {
+                "aliases": [],
+                "description": "",
+                "name": "chutney",
+                "plural_name": "chutneys"
+            },
+            "shrimp paste": {
+                "aliases": [],
+                "description": "",
+                "name": "shrimp paste",
+                "plural_name": "shrimp pastes"
+            },
+            "picante sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "picante sauce",
+                "plural_name": "picante sauces"
+            },
+            "thai sweet chili sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "thai sweet chili sauce",
+                "plural_name": "thai sweet chili sauces"
+            },
+            "sweet and sour sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet and sour sauce",
+                "plural_name": "sweet and sour sauces"
+            },
+            "liquid amino": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid amino",
+                "plural_name": "liquid aminos"
+            },
+            "tartar sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "tartar sauce",
+                "plural_name": "tartar sauces"
+            },
+            "hot pepper jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "hot pepper jelly",
+                "plural_name": "hot pepper jellies"
+            },
+            "chili-garlic paste": {
+                "aliases": [],
+                "description": "",
+                "name": "chili-garlic paste",
+                "plural_name": "chili-garlic pastes"
+            },
+            "bonito flake": {
+                "aliases": [],
+                "description": "",
+                "name": "bonito flake",
+                "plural_name": "bonito flakes"
+            },
+            "green chutney": {
+                "aliases": [],
+                "description": "",
+                "name": "green chutney",
+                "plural_name": "green chutneys"
+            },
+            "mexican hot sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican hot sauce",
+                "plural_name": "mexican hot sauces"
+            },
+            "ponzu": {
+                "aliases": [],
+                "description": "",
+                "name": "ponzu",
+                "plural_name": "ponzus"
+            },
+            "green chilli sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "green chilli sauce",
+                "plural_name": "green chilli sauces"
+            },
+            "sambal": {
+                "aliases": [],
+                "description": "",
+                "name": "sambal",
+                "plural_name": "sambals"
+            },
+            "crispy onion": {
+                "aliases": [],
+                "description": "",
+                "name": "crispy onion",
+                "plural_name": "crispy onions"
+            },
+            "red pepper jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "red pepper jelly",
+                "plural_name": "red pepper jellies"
+            },
+            "thai chili paste": {
+                "aliases": [],
+                "description": "",
+                "name": "thai chili paste",
+                "plural_name": "thai chili pastes"
+            },
+            "peri peri": {
+                "aliases": [],
+                "description": "",
+                "name": "peri peri",
+                "plural_name": "peri peris"
+            },
+            "green chilli paste": {
+                "aliases": [],
+                "description": "",
+                "name": "green chilli paste",
+                "plural_name": "green chilli pastes"
+            },
+            "mint jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "mint jelly",
+                "plural_name": "mint jellies"
+            },
+            "horseradish mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "horseradish mustard",
+                "plural_name": "horseradish mustards"
+            },
+            "mustard paste": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard paste",
+                "plural_name": "mustard pastes"
+            },
+            "aji amarillo": {
+                "aliases": [],
+                "description": "",
+                "name": "aji amarillo",
+                "plural_name": "aji amarilloes"
+            },
+            "pepper paste": {
+                "aliases": [],
+                "description": "",
+                "name": "pepper paste",
+                "plural_name": "pepper pastes"
+            },
+            "yuzu juice": {
+                "aliases": [],
+                "description": "",
+                "name": "yuzu juice",
+                "plural_name": "yuzu juices"
+            },
+            "tonkatsu sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "tonkatsu sauce",
+                "plural_name": "tonkatsu sauces"
+            },
+            "chermoula": {
+                "aliases": [],
+                "description": "",
+                "name": "chermoula",
+                "plural_name": "chermoulas"
+            },
+            "tamarind chutney": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind chutney",
+                "plural_name": "tamarind chutneys"
+            },
+            "hp sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "hp sauce",
+                "plural_name": "hp sauces"
+            },
+            "duck sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "duck sauce",
+                "plural_name": "duck sauces"
+            },
+            "ginger chili paste": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger chili paste",
+                "plural_name": "ginger chili pastes"
+            },
+            "onion marmalade": {
+                "aliases": [],
+                "description": "",
+                "name": "onion marmalade",
+                "plural_name": "onion marmalades"
+            },
+            "giardiniera": {
+                "aliases": [],
+                "description": "",
+                "name": "giardiniera",
+                "plural_name": "giardinieras"
+            },
+            "black soy sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "black soy sauce",
+                "plural_name": "black soy sauces"
+            },
+            "doubanjiang": {
+                "aliases": [],
+                "description": "",
+                "name": "doubanjiang",
+                "plural_name": "doubanjiangs"
+            },
+            "korean bbq sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "korean bbq sauce",
+                "plural_name": "korean bbq sauces"
+            },
+            "maggi sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "maggi sauce",
+                "plural_name": "maggi sauces"
+            },
+            "chinese mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "chinese mustard",
+                "plural_name": "chinese mustards"
+            },
+            "chamoy": {
+                "aliases": [],
+                "description": "",
+                "name": "chamoy",
+                "plural_name": "chamoys"
+            },
+            "lime pickle": {
+                "aliases": [],
+                "description": "",
+                "name": "lime pickle",
+                "plural_name": "lime pickles"
+            },
+            "doenjang": {
+                "aliases": [],
+                "description": "",
+                "name": "doenjang",
+                "plural_name": "doenjangs"
+            },
+            "chili crisp": {
+                "aliases": [],
+                "description": "",
+                "name": "chili crisp",
+                "plural_name": "chili crisps"
+            },
+            "karashi": {
+                "aliases": [],
+                "description": "",
+                "name": "karashi",
+                "plural_name": "karashis"
+            },
+            "mushroom soy sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "mushroom soy sauce",
+                "plural_name": "mushroom soy sauces"
+            },
+            "yuzu kosho": {
+                "aliases": [],
+                "description": "",
+                "name": "yuzu kosho",
+                "plural_name": "yuzu koshoes"
+            },
+            "german mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "german mustard",
+                "plural_name": "german mustards"
+            },
+            "taucheo": {
+                "aliases": [],
+                "description": "",
+                "name": "taucheo",
+                "plural_name": "taucheos"
+            },
+            "eel sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "eel sauce",
+                "plural_name": "eel sauces"
+            },
+            "hot bean paste": {
+                "aliases": [],
+                "description": "",
+                "name": "hot bean paste",
+                "plural_name": "hot bean pastes"
+            },
+            "pati": {
+                "aliases": [],
+                "description": "",
+                "name": "pati",
+                "plural_name": "patis"
+            },
+            "remoulade": {
+                "aliases": [],
+                "description": "",
+                "name": "remoulade",
+                "plural_name": "remoulades"
+            },
+            "white bbq sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "white bbq sauce",
+                "plural_name": "white bbq sauces"
+            },
+            "pickapeppa sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "pickapeppa sauce",
+                "plural_name": "pickapeppa sauces"
+            },
+            "salsa lizano": {
+                "aliases": [],
+                "description": "",
+                "name": "salsa lizano",
+                "plural_name": "salsa lizanoes"
+            },
+            "shrimp sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "shrimp sauce",
+                "plural_name": "shrimp sauces"
+            },
+            "sweet soybean paste": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet soybean paste",
+                "plural_name": "sweet soybean pastes"
+            },
+            "grape must": {
+                "aliases": [],
+                "description": "",
+                "name": "grape must",
+                "plural_name": "grape musts"
+            },
+            "shrimp powder": {
+                "aliases": [],
+                "description": "",
+                "name": "shrimp powder",
+                "plural_name": "shrimp powders"
+            },
+            "banana ketchup": {
+                "aliases": [],
+                "description": "",
+                "name": "banana ketchup",
+                "plural_name": "banana ketchups"
+            },
+            "chili puree": {
+                "aliases": [],
+                "description": "",
+                "name": "chili puree",
+                "plural_name": "chili purees"
+            },
+            "green harissa": {
+                "aliases": [],
+                "description": "",
+                "name": "green harissa",
+                "plural_name": "green harissas"
+            },
+            "crab paste": {
+                "aliases": [],
+                "description": "",
+                "name": "crab paste",
+                "plural_name": "crab pastes"
+            },
+            "beer mustard": {
+                "aliases": [],
+                "description": "",
+                "name": "beer mustard",
+                "plural_name": "beer mustards"
+            },
+            "guk ganjang": {
+                "aliases": [],
+                "description": "",
+                "name": "guk ganjang",
+                "plural_name": "guk ganjangs"
+            }
+        }
+    },
+    "Canned Food": {
+        "foods": {
+            "canned tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "canned tomato",
+                "plural_name": "canned tomatoes"
+            },
+            "caper": {
+                "aliases": [],
+                "description": "",
+                "name": "caper",
+                "plural_name": "capers"
+            },
+            "green olive": {
+                "aliases": [],
+                "description": "",
+                "name": "green olive",
+                "plural_name": "green olives"
+            },
+            "canned chickpea": {
+                "aliases": [],
+                "description": "",
+                "name": "canned chickpea",
+                "plural_name": "canned chickpeas"
+            },
+            "black olive": {
+                "aliases": [],
+                "description": "",
+                "name": "black olive",
+                "plural_name": "black olives"
+            },
+            "canned black bean": {
+                "aliases": [],
+                "description": "",
+                "name": "canned black bean",
+                "plural_name": "canned black beans"
+            },
+            "canned pumpkin": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pumpkin",
+                "plural_name": "canned pumpkins"
+            },
+            "kalamata olive": {
+                "aliases": [],
+                "description": "",
+                "name": "kalamata olive",
+                "plural_name": "kalamata olives"
+            },
+            "canned tuna": {
+                "aliases": [],
+                "description": "",
+                "name": "canned tuna",
+                "plural_name": "canned tuna"
+            },
+            "pickle": {
+                "aliases": [],
+                "description": "",
+                "name": "pickle",
+                "plural_name": "pickles"
+            },
+            "canned pineapple": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pineapple",
+                "plural_name": "canned pineapples"
+            },
+            "chipotle in adobo": {
+                "aliases": [],
+                "description": "",
+                "name": "chipotle in adobo",
+                "plural_name": "chipotle in adobo"
+            },
+            "canned anchovy": {
+                "aliases": [],
+                "description": "",
+                "name": "canned anchovy",
+                "plural_name": "canned anchovies"
+            },
+            "roasted red pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted red pepper",
+                "plural_name": "roasted red peppers"
+            },
+            "tomato with green chiles": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato with green chiles",
+                "plural_name": "tomatoes with green chiles"
+            },
+            "canned artichoke": {
+                "aliases": [],
+                "description": "",
+                "name": "canned artichoke",
+                "plural_name": "canned artichokes"
+            },
+            "canned corn": {
+                "aliases": [],
+                "description": "",
+                "name": "canned corn",
+                "plural_name": "canned corns"
+            },
+            "canned kidney bean": {
+                "aliases": [],
+                "description": "",
+                "name": "canned kidney bean",
+                "plural_name": "canned kidney beans"
+            },
+            "canned pie filling": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pie filling",
+                "plural_name": "canned pie fillings"
+            },
+            "canned cannellini bean": {
+                "aliases": [],
+                "description": "",
+                "name": "canned cannellini bean",
+                "plural_name": "canned cannellini beans"
+            },
+            "refried bean": {
+                "aliases": [],
+                "description": "",
+                "name": "refried bean",
+                "plural_name": "refried beans"
+            },
+            "canned whole tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "canned whole tomato",
+                "plural_name": "canned whole tomatoes"
+            },
+            "sweet pickle relish": {
+                "aliases": [],
+                "description": "",
+                "name": "sweet pickle relish",
+                "plural_name": "sweet pickle relishes"
+            },
+            "sauerkraut": {
+                "aliases": [],
+                "description": "",
+                "name": "sauerkraut",
+                "plural_name": "sauerkrauts"
+            },
+            "creamed corn": {
+                "aliases": [],
+                "description": "",
+                "name": "creamed corn",
+                "plural_name": "creamed corns"
+            },
+            "corned beef": {
+                "aliases": [],
+                "description": "",
+                "name": "corned beef",
+                "plural_name": "corned beefs"
+            },
+            "canned bean": {
+                "aliases": [],
+                "description": "",
+                "name": "canned bean",
+                "plural_name": "canned beans"
+            },
+            "pickled jalapeno": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled jalapeno",
+                "plural_name": "pickled jalapenos"
+            },
+            "diced green chile": {
+                "aliases": [],
+                "description": "",
+                "name": "diced green chile",
+                "plural_name": "diced green chiles"
+            },
+            "sun-dried tomato in oil": {
+                "aliases": [],
+                "description": "",
+                "name": "sun-dried tomato in oil",
+                "plural_name": "sun-dried tomatoes in oil"
+            },
+            "kimchi": {
+                "aliases": [],
+                "description": "",
+                "name": "kimchi",
+                "plural_name": "kimchis"
+            },
+            "canned mandarin orange": {
+                "aliases": [],
+                "description": "",
+                "name": "canned mandarin orange",
+                "plural_name": "canned mandarin oranges"
+            },
+            "chili bean": {
+                "aliases": [],
+                "description": "",
+                "name": "chili bean",
+                "plural_name": "chili beans"
+            },
+            "canned crab": {
+                "aliases": [],
+                "description": "",
+                "name": "canned crab",
+                "plural_name": "canned crabs"
+            },
+            "bamboo shoot": {
+                "aliases": [],
+                "description": "",
+                "name": "bamboo shoot",
+                "plural_name": "bamboo shoots"
+            },
+            "canned mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "canned mushroom",
+                "plural_name": "canned mushrooms"
+            },
+            "baked bean": {
+                "aliases": [],
+                "description": "",
+                "name": "baked bean",
+                "plural_name": "baked beans"
+            },
+            "canned salmon": {
+                "aliases": [],
+                "description": "",
+                "name": "canned salmon",
+                "plural_name": "canned salmon"
+            },
+            "pickling juice": {
+                "aliases": [],
+                "description": "",
+                "name": "pickling juice",
+                "plural_name": "pickling juices"
+            },
+            "dill pickle relish": {
+                "aliases": [],
+                "description": "",
+                "name": "dill pickle relish",
+                "plural_name": "dill pickle relishes"
+            },
+            "canned peach": {
+                "aliases": [],
+                "description": "",
+                "name": "canned peach",
+                "plural_name": "canned peaches"
+            },
+            "canned black-eyed pea": {
+                "aliases": [],
+                "description": "",
+                "name": "canned black-eyed pea",
+                "plural_name": "canned black-eyed peas"
+            },
+            "pickled ginger": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled ginger",
+                "plural_name": "pickled gingers"
+            },
+            "canned apple": {
+                "aliases": [],
+                "description": "",
+                "name": "canned apple",
+                "plural_name": "canned apples"
+            },
+            "canned green bean": {
+                "aliases": [],
+                "description": "",
+                "name": "canned green bean",
+                "plural_name": "canned green beans"
+            },
+            "spam": {
+                "aliases": [],
+                "description": "",
+                "name": "spam",
+                "plural_name": "spams"
+            },
+            "canned clam": {
+                "aliases": [],
+                "description": "",
+                "name": "canned clam",
+                "plural_name": "canned clams"
+            },
+            "chili with beans": {
+                "aliases": [],
+                "description": "",
+                "name": "chili with beans",
+                "plural_name": "chili with beans"
+            },
+            "pickled onion": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled onion",
+                "plural_name": "pickled onions"
+            },
+            "fruit cocktail": {
+                "aliases": [],
+                "description": "",
+                "name": "fruit cocktail",
+                "plural_name": "fruit cocktails"
+            },
+            "canned lentil": {
+                "aliases": [],
+                "description": "",
+                "name": "canned lentil",
+                "plural_name": "canned lentils"
+            },
+            "canned pea": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pea",
+                "plural_name": "canned peas"
+            },
+            "pickled red onion": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled red onion",
+                "plural_name": "pickled red onions"
+            },
+            "pimiento-stuffed green olive": {
+                "aliases": [],
+                "description": "",
+                "name": "pimiento-stuffed green olive",
+                "plural_name": "pimiento-stuffed green olives"
+            },
+            "canned pork": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pork",
+                "plural_name": "canned porks"
+            },
+            "pickled beet": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled beet",
+                "plural_name": "pickled beets"
+            },
+            "canned cherry tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "canned cherry tomato",
+                "plural_name": "canned cherry tomatoes"
+            },
+            "bread & butter pickle": {
+                "aliases": [],
+                "description": "",
+                "name": "bread & butter pickle",
+                "plural_name": "bread & butter pickles"
+            },
+            "canned apricot": {
+                "aliases": [],
+                "description": "",
+                "name": "canned apricot",
+                "plural_name": "canned apricots"
+            },
+            "canned sweet potato": {
+                "aliases": [],
+                "description": "",
+                "name": "canned sweet potato",
+                "plural_name": "canned sweet potatoes"
+            },
+            "canned pear": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pear",
+                "plural_name": "canned pears"
+            },
+            "peppadew pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "peppadew pepper",
+                "plural_name": "peppadew peppers"
+            },
+            "pickled vegetable": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled vegetable",
+                "plural_name": "pickled vegetables"
+            },
+            "onion paste": {
+                "aliases": [],
+                "description": "",
+                "name": "onion paste",
+                "plural_name": "onion pastes"
+            },
+            "canned baby corn": {
+                "aliases": [],
+                "description": "",
+                "name": "canned baby corn",
+                "plural_name": "canned baby corns"
+            },
+            "mexican-style corn": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican-style corn",
+                "plural_name": "mexican-style corns"
+            },
+            "chili without bean": {
+                "aliases": [],
+                "description": "",
+                "name": "chili without bean",
+                "plural_name": "chili without beans"
+            },
+            "pork and bean": {
+                "aliases": [],
+                "description": "",
+                "name": "pork and bean",
+                "plural_name": "pork and beans"
+            },
+            "ranch-style bean": {
+                "aliases": [],
+                "description": "",
+                "name": "ranch-style bean",
+                "plural_name": "ranch-style beans"
+            },
+            "canned chicken breast": {
+                "aliases": [],
+                "description": "",
+                "name": "canned chicken breast",
+                "plural_name": "canned chicken breasts"
+            },
+            "canned carrot": {
+                "aliases": [],
+                "description": "",
+                "name": "canned carrot",
+                "plural_name": "canned carrots"
+            },
+            "banana pepper ring": {
+                "aliases": [],
+                "description": "",
+                "name": "banana pepper ring",
+                "plural_name": "banana pepper rings"
+            },
+            "canned lychee": {
+                "aliases": [],
+                "description": "",
+                "name": "canned lychee",
+                "plural_name": "canned lychees"
+            },
+            "pumpkin pie filling": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin pie filling",
+                "plural_name": "pumpkin pie fillings"
+            },
+            "canned sardine": {
+                "aliases": [],
+                "description": "",
+                "name": "canned sardine",
+                "plural_name": "canned sardines"
+            },
+            "pickled pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled pepper",
+                "plural_name": "pickled peppers"
+            },
+            "tomato relish": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato relish",
+                "plural_name": "tomato relishes"
+            },
+            "canned jackfruit": {
+                "aliases": [],
+                "description": "",
+                "name": "canned jackfruit",
+                "plural_name": "canned jackfruits"
+            },
+            "taggiasca olive": {
+                "aliases": [],
+                "description": "",
+                "name": "taggiasca olive",
+                "plural_name": "taggiasca olives"
+            },
+            "cranberry relish": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry relish",
+                "plural_name": "cranberry relishes"
+            },
+            "red pepper relish": {
+                "aliases": [],
+                "description": "",
+                "name": "red pepper relish",
+                "plural_name": "red pepper relishes"
+            },
+            "canned asparagu": {
+                "aliases": [],
+                "description": "",
+                "name": "canned asparagu",
+                "plural_name": "canned asparagus"
+            },
+            "fire-roasted green chile": {
+                "aliases": [],
+                "description": "",
+                "name": "fire-roasted green chile",
+                "plural_name": "fire-roasted green chiles"
+            },
+            "pickled hot pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled hot pepper",
+                "plural_name": "pickled hot peppers"
+            },
+            "canned peas and carrot": {
+                "aliases": [],
+                "description": "",
+                "name": "canned peas and carrot",
+                "plural_name": "canned peas and carrots"
+            },
+            "corn relish": {
+                "aliases": [],
+                "description": "",
+                "name": "corn relish",
+                "plural_name": "corn relishes"
+            },
+            "golden hominy": {
+                "aliases": [],
+                "description": "",
+                "name": "golden hominy",
+                "plural_name": "golden hominies"
+            },
+            "canned mackerel": {
+                "aliases": [],
+                "description": "",
+                "name": "canned mackerel",
+                "plural_name": "canned mackerel"
+            },
+            "pickled cherry pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled cherry pepper",
+                "plural_name": "pickled cherry peppers"
+            },
+            "candied jalapeno": {
+                "aliases": [],
+                "description": "",
+                "name": "candied jalapeno",
+                "plural_name": "candied jalapenos"
+            },
+            "umeboshi": {
+                "aliases": [],
+                "description": "",
+                "name": "umeboshi",
+                "plural_name": "umeboshis"
+            },
+            "canned pimento": {
+                "aliases": [],
+                "description": "",
+                "name": "canned pimento",
+                "plural_name": "canned pimentos"
+            },
+            "canned potato": {
+                "aliases": [],
+                "description": "",
+                "name": "canned potato",
+                "plural_name": "canned potatoes"
+            },
+            "okra pickle": {
+                "aliases": [],
+                "description": "",
+                "name": "okra pickle",
+                "plural_name": "okra pickles"
+            },
+            "tomato confit": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato confit",
+                "plural_name": "tomato confits"
+            },
+            "brandied cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "brandied cherry",
+                "plural_name": "brandied cherries"
+            },
+            "macapuno": {
+                "aliases": [],
+                "description": "",
+                "name": "macapuno",
+                "plural_name": "macapunoes"
+            },
+            "canned four-bean mix": {
+                "aliases": [],
+                "description": "",
+                "name": "canned four-bean mix",
+                "plural_name": "canned four-bean mixes"
+            },
+            "half-sour pickle": {
+                "aliases": [],
+                "description": "",
+                "name": "half-sour pickle",
+                "plural_name": "half-sour pickles"
+            },
+            "pickled green bean": {
+                "aliases": [],
+                "description": "",
+                "name": "pickled green bean",
+                "plural_name": "pickled green beans"
+            }
+        }
+    },
+    "Sauces, Spreads & Dips": {
+        "foods": {
+            "peanut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut butter",
+                "plural_name": "peanut butters"
+            },
+            "tomato paste": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato paste",
+                "plural_name": "tomato pastes"
+            },
+            "tomato sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato sauce",
+                "plural_name": "tomato sauces"
+            },
+            "salsa": {
+                "aliases": [],
+                "description": "",
+                "name": "salsa",
+                "plural_name": "salsas"
+            },
+            "tahini": {
+                "aliases": [],
+                "description": "",
+                "name": "tahini",
+                "plural_name": "tahinis"
+            },
+            "pesto": {
+                "aliases": [],
+                "description": "",
+                "name": "pesto",
+                "plural_name": "pestoes"
+            },
+            "marinara sauce": {
+                "aliases": [
+                    "marinara sauce - jarred"
+                ],
+                "description": "",
+                "name": "marinara sauce",
+                "plural_name": "marinara sauces"
+            },
+            "pasta sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "pasta sauce",
+                "plural_name": "pasta sauces"
+            },
+            "hoisin sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "hoisin sauce",
+                "plural_name": "hoisin sauces"
+            },
+            "pico de gallo": {
+                "aliases": [],
+                "description": "",
+                "name": "pico de gallo",
+                "plural_name": "pico de gallo"
+            },
+            "stewed tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "stewed tomato",
+                "plural_name": "stewed tomatoes"
+            },
+            "guacamole": {
+                "aliases": [],
+                "description": "",
+                "name": "guacamole",
+                "plural_name": "guacamoles"
+            },
+            "hummu": {
+                "aliases": [],
+                "description": "",
+                "name": "hummu",
+                "plural_name": "hummus"
+            },
+            "enchilada sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "enchilada sauce",
+                "plural_name": "enchilada sauces"
+            },
+            "fire-roasted tomato": {
+                "aliases": [],
+                "description": "",
+                "name": "fire-roasted tomato",
+                "plural_name": "fire-roasted tomatoes"
+            },
+            "salsa verde": {
+                "aliases": [],
+                "description": "",
+                "name": "salsa verde",
+                "plural_name": "salsa verdes"
+            },
+            "alfredo sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "alfredo sauce",
+                "plural_name": "alfredo sauces"
+            },
+            "balsamic glaze": {
+                "aliases": [],
+                "description": "",
+                "name": "balsamic glaze",
+                "plural_name": "balsamic glazes"
+            },
+            "anchovy paste": {
+                "aliases": [],
+                "description": "",
+                "name": "anchovy paste",
+                "plural_name": "anchovy pastes"
+            },
+            "red enchilada sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "red enchilada sauce",
+                "plural_name": "red enchilada sauces"
+            },
+            "steak sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "steak sauce",
+                "plural_name": "steak sauces"
+            },
+            "chunky peanut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "chunky peanut butter",
+                "plural_name": "chunky peanut butter"
+            },
+            "tzatziki": {
+                "aliases": [],
+                "description": "",
+                "name": "tzatziki",
+                "plural_name": "tzatzikis"
+            },
+            "taco sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "taco sauce",
+                "plural_name": "taco sauces"
+            },
+            "beef gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "beef gravy",
+                "plural_name": "beef gravies"
+            },
+            "sun-dried tomato pesto": {
+                "aliases": [],
+                "description": "",
+                "name": "sun-dried tomato pesto",
+                "plural_name": "sun-dried tomato pestoes"
+            },
+            "b\u00e9chamel sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "b\u00e9chamel sauce",
+                "plural_name": "b\u00e9chamel sauces"
+            },
+            "horseradish sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "horseradish sauce",
+                "plural_name": "horseradish sauces"
+            },
+            "plum sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "plum sauce",
+                "plural_name": "plum sauces"
+            },
+            "garlic butter": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic butter",
+                "plural_name": "garlic butter"
+            },
+            "hollandaise sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "hollandaise sauce",
+                "plural_name": "hollandaise sauces"
+            },
+            "cocktail sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "cocktail sauce",
+                "plural_name": "cocktail sauces"
+            },
+            "cheese dip": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese dip",
+                "plural_name": "cheese dips"
+            },
+            "black bean sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "black bean sauce",
+                "plural_name": "black bean sauces"
+            },
+            "tapenade": {
+                "aliases": [],
+                "description": "",
+                "name": "tapenade",
+                "plural_name": "tapenades"
+            },
+            "turkey gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey gravy",
+                "plural_name": "turkey gravies"
+            },
+            "stir-fry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "stir-fry sauce",
+                "plural_name": "stir-fry sauces"
+            },
+            "thai peanut sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "thai peanut sauce",
+                "plural_name": "thai peanut sauces"
+            },
+            "chicken gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken gravy",
+                "plural_name": "chicken gravies"
+            },
+            "sloppy joe sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "sloppy joe sauce",
+                "plural_name": "sloppy joe sauces"
+            },
+            "pimento cheese spread": {
+                "aliases": [],
+                "description": "",
+                "name": "pimento cheese spread",
+                "plural_name": "pimento cheese spreads"
+            },
+            "sofrito": {
+                "aliases": [],
+                "description": "",
+                "name": "sofrito",
+                "plural_name": "sofritoes"
+            },
+            "mustard sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "mustard sauce",
+                "plural_name": "mustard sauces"
+            },
+            "sun-dried tomato paste": {
+                "aliases": [],
+                "description": "",
+                "name": "sun-dried tomato paste",
+                "plural_name": "sun-dried tomato pastes"
+            },
+            "queso dip": {
+                "aliases": [],
+                "description": "",
+                "name": "queso dip",
+                "plural_name": "queso dips"
+            },
+            "demi-glace": {
+                "aliases": [],
+                "description": "",
+                "name": "demi-glace",
+                "plural_name": "demi-glaces"
+            },
+            "chimichurri sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "chimichurri sauce",
+                "plural_name": "chimichurri sauces"
+            },
+            "french onion dip": {
+                "aliases": [],
+                "description": "",
+                "name": "french onion dip",
+                "plural_name": "french onion dips"
+            },
+            "herb butter": {
+                "aliases": [],
+                "description": "",
+                "name": "herb butter",
+                "plural_name": "herb butter"
+            },
+            "bolognese sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "bolognese sauce",
+                "plural_name": "bolognese sauces"
+            },
+            "curry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "curry sauce",
+                "plural_name": "curry sauces"
+            },
+            "liver spread": {
+                "aliases": [],
+                "description": "",
+                "name": "liver spread",
+                "plural_name": "liver spreads"
+            },
+            "browning sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "browning sauce",
+                "plural_name": "browning sauces"
+            },
+            "schezwan sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "schezwan sauce",
+                "plural_name": "schezwan sauces"
+            },
+            "mushroom gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "mushroom gravy",
+                "plural_name": "mushroom gravies"
+            },
+            "pork gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "pork gravy",
+                "plural_name": "pork gravies"
+            },
+            "country gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "country gravy",
+                "plural_name": "country gravies"
+            },
+            "orange sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "orange sauce",
+                "plural_name": "orange sauces"
+            },
+            "pineapple salsa": {
+                "aliases": [],
+                "description": "",
+                "name": "pineapple salsa",
+                "plural_name": "pineapple salsas"
+            },
+            "artichoke dip": {
+                "aliases": [],
+                "description": "",
+                "name": "artichoke dip",
+                "plural_name": "artichoke dips"
+            },
+            "japanese curry": {
+                "aliases": [],
+                "description": "",
+                "name": "japanese curry",
+                "plural_name": "japanese curries"
+            },
+            "mango salsa": {
+                "aliases": [],
+                "description": "",
+                "name": "mango salsa",
+                "plural_name": "mango salsas"
+            },
+            "olive paste": {
+                "aliases": [],
+                "description": "",
+                "name": "olive paste",
+                "plural_name": "olive pastes"
+            },
+            "spinach dip": {
+                "aliases": [],
+                "description": "",
+                "name": "spinach dip",
+                "plural_name": "spinach dips"
+            },
+            "black truffle butter": {
+                "aliases": [],
+                "description": "",
+                "name": "black truffle butter",
+                "plural_name": "black truffle butter"
+            },
+            "roasted red pepper hummu": {
+                "aliases": [],
+                "description": "",
+                "name": "roasted red pepper hummu",
+                "plural_name": "roasted red pepper hummus"
+            },
+            "bacon jam": {
+                "aliases": [],
+                "description": "",
+                "name": "bacon jam",
+                "plural_name": "bacon jams"
+            },
+            "tikka masala sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "tikka masala sauce",
+                "plural_name": "tikka masala sauces"
+            },
+            "vodka sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "vodka sauce",
+                "plural_name": "vodka sauces"
+            },
+            "whipped cream cheese spread": {
+                "aliases": [],
+                "description": "",
+                "name": "whipped cream cheese spread",
+                "plural_name": "whipped cream cheese spreads"
+            },
+            "kung pao sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "kung pao sauce",
+                "plural_name": "kung pao sauces"
+            },
+            "mole paste": {
+                "aliases": [],
+                "description": "",
+                "name": "mole paste",
+                "plural_name": "mole pastes"
+            },
+            "onion gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "onion gravy",
+                "plural_name": "onion gravies"
+            },
+            "sesame sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "sesame sauce",
+                "plural_name": "sesame sauces"
+            },
+            "cheese spread": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese spread",
+                "plural_name": "cheese spreads"
+            },
+            "corn salsa": {
+                "aliases": [],
+                "description": "",
+                "name": "corn salsa",
+                "plural_name": "corn salsas"
+            },
+            "pad thai sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "pad thai sauce",
+                "plural_name": "pad thai sauces"
+            },
+            "sausage gravy": {
+                "aliases": [],
+                "description": "",
+                "name": "sausage gravy",
+                "plural_name": "sausage gravies"
+            },
+            "deviled ham spread": {
+                "aliases": [],
+                "description": "",
+                "name": "deviled ham spread",
+                "plural_name": "deviled ham spreads"
+            },
+            "butter chicken sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "butter chicken sauce",
+                "plural_name": "butter chicken sauces"
+            },
+            "garlic spread": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic spread",
+                "plural_name": "garlic spreads"
+            },
+            "black pepper sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "black pepper sauce",
+                "plural_name": "black pepper sauces"
+            },
+            "char siu sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "char siu sauce",
+                "plural_name": "char siu sauces"
+            },
+            "garlic pasta sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "garlic pasta sauce",
+                "plural_name": "garlic pasta sauces"
+            },
+            "green olive tapenade": {
+                "aliases": [],
+                "description": "",
+                "name": "green olive tapenade",
+                "plural_name": "green olive tapenades"
+            },
+            "schezwan chutney": {
+                "aliases": [],
+                "description": "",
+                "name": "schezwan chutney",
+                "plural_name": "schezwan chutneys"
+            },
+            "mentsuyu": {
+                "aliases": [],
+                "description": "",
+                "name": "mentsuyu",
+                "plural_name": "mentsuyus"
+            },
+            "thai red curry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "thai red curry sauce",
+                "plural_name": "thai red curry sauces"
+            },
+            "tarama": {
+                "aliases": [],
+                "description": "",
+                "name": "tarama",
+                "plural_name": "taramas"
+            },
+            "ssamjang": {
+                "aliases": [],
+                "description": "",
+                "name": "ssamjang",
+                "plural_name": "ssamjangs"
+            },
+            "white pizza sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "white pizza sauce",
+                "plural_name": "white pizza sauces"
+            },
+            "tomato tapenade": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato tapenade",
+                "plural_name": "tomato tapenades"
+            },
+            "yum yum sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "yum yum sauce",
+                "plural_name": "yum yum sauces"
+            },
+            "honey garlic sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "honey garlic sauce",
+                "plural_name": "honey garlic sauces"
+            },
+            "mole sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "mole sauce",
+                "plural_name": "mole sauces"
+            },
+            "nuoc cham": {
+                "aliases": [],
+                "description": "",
+                "name": "nuoc cham",
+                "plural_name": "nuoc chams"
+            },
+            "white clam sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "white clam sauce",
+                "plural_name": "white clam sauces"
+            },
+            "bean dip": {
+                "aliases": [],
+                "description": "",
+                "name": "bean dip",
+                "plural_name": "bean dips"
+            },
+            "eggplant dip": {
+                "aliases": [],
+                "description": "",
+                "name": "eggplant dip",
+                "plural_name": "eggplant dips"
+            },
+            "pomegranate sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "pomegranate sauce",
+                "plural_name": "pomegranate sauces"
+            }
+        }
+    },
+    "Soups, Stews & Stocks": {
+        "foods": {
+            "chicken broth": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken broth",
+                "plural_name": "chicken broths"
+            },
+            "vegetable broth": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable broth",
+                "plural_name": "vegetable broths"
+            },
+            "chicken stock": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken stock",
+                "plural_name": "chicken stocks"
+            },
+            "beef broth": {
+                "aliases": [],
+                "description": "",
+                "name": "beef broth",
+                "plural_name": "beef broths"
+            },
+            "beef stock": {
+                "aliases": [],
+                "description": "",
+                "name": "beef stock",
+                "plural_name": "beef stocks"
+            },
+            "cream of mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of mushroom",
+                "plural_name": "cream of mushroom"
+            },
+            "bouillon cube": {
+                "aliases": [],
+                "description": "",
+                "name": "bouillon cube",
+                "plural_name": "bouillon cubes"
+            },
+            "cream of chicken": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of chicken",
+                "plural_name": "cream of chicken"
+            },
+            "onion soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "onion soup mix",
+                "plural_name": "onion soup mixes"
+            },
+            "tomato soup": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato soup",
+                "plural_name": "tomato soups"
+            },
+            "fish stock": {
+                "aliases": [],
+                "description": "",
+                "name": "fish stock",
+                "plural_name": "fish stocks"
+            },
+            "cream of celery": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of celery",
+                "plural_name": "cream of celery"
+            },
+            "better than bouillon": {
+                "aliases": [],
+                "description": "",
+                "name": "better than bouillon",
+                "plural_name": "better than bouillons"
+            },
+            "clam juice": {
+                "aliases": [],
+                "description": "",
+                "name": "clam juice",
+                "plural_name": "clam juices"
+            },
+            "cheese soup": {
+                "aliases": [],
+                "description": "",
+                "name": "cheese soup",
+                "plural_name": "cheese soups"
+            },
+            "bone broth": {
+                "aliases": [],
+                "description": "",
+                "name": "bone broth",
+                "plural_name": "bone broths"
+            },
+            "dashi": {
+                "aliases": [],
+                "description": "",
+                "name": "dashi",
+                "plural_name": "dashis"
+            },
+            "onion soup": {
+                "aliases": [],
+                "description": "",
+                "name": "onion soup",
+                "plural_name": "onion soups"
+            },
+            "chicken soup": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken soup",
+                "plural_name": "chicken soups"
+            },
+            "veal stock": {
+                "aliases": [],
+                "description": "",
+                "name": "veal stock",
+                "plural_name": "veal stocks"
+            },
+            "chicken bone broth": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken bone broth",
+                "plural_name": "chicken bone broths"
+            },
+            "turkey stock": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey stock",
+                "plural_name": "turkey stocks"
+            },
+            "lamb stock": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb stock",
+                "plural_name": "lamb stocks"
+            },
+            "turkey broth": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey broth",
+                "plural_name": "turkey broths"
+            },
+            "beef consomm\u00e9": {
+                "aliases": [],
+                "description": "",
+                "name": "beef consomm\u00e9",
+                "plural_name": "beef consomm\u00e9s"
+            },
+            "stock paste": {
+                "aliases": [],
+                "description": "",
+                "name": "stock paste",
+                "plural_name": "stock pastes"
+            },
+            "cream of potato": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of potato",
+                "plural_name": "cream of potato"
+            },
+            "golden mushroom soup": {
+                "aliases": [],
+                "description": "",
+                "name": "golden mushroom soup",
+                "plural_name": "golden mushroom soups"
+            },
+            "seafood stock": {
+                "aliases": [],
+                "description": "",
+                "name": "seafood stock",
+                "plural_name": "seafood stocks"
+            },
+            "mushroom broth": {
+                "aliases": [],
+                "description": "",
+                "name": "mushroom broth",
+                "plural_name": "mushroom broths"
+            },
+            "vegetable soup": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable soup",
+                "plural_name": "vegetable soups"
+            },
+            "chicken noodle soup": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken noodle soup",
+                "plural_name": "chicken noodle soups"
+            },
+            "vegetable soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable soup mix",
+                "plural_name": "vegetable soup mixes"
+            },
+            "chicken consomm\u00e9": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken consomm\u00e9",
+                "plural_name": "chicken consomm\u00e9s"
+            },
+            "shrimp stock": {
+                "aliases": [],
+                "description": "",
+                "name": "shrimp stock",
+                "plural_name": "shrimp stocks"
+            },
+            "nacho cheese soup": {
+                "aliases": [],
+                "description": "",
+                "name": "nacho cheese soup",
+                "plural_name": "nacho cheese soups"
+            },
+            "ramen noodle soup": {
+                "aliases": [],
+                "description": "",
+                "name": "ramen noodle soup",
+                "plural_name": "ramen noodle soups"
+            },
+            "cream of broccoli": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of broccoli",
+                "plural_name": "cream of broccoli"
+            },
+            "lobster stock": {
+                "aliases": [],
+                "description": "",
+                "name": "lobster stock",
+                "plural_name": "lobster stocks"
+            },
+            "pork stock": {
+                "aliases": [],
+                "description": "",
+                "name": "pork stock",
+                "plural_name": "pork stocks"
+            },
+            "chicken rice soup": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken rice soup",
+                "plural_name": "chicken rice soups"
+            },
+            "beefy onion soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "beefy onion soup mix",
+                "plural_name": "beefy onion soup mixes"
+            },
+            "butternut squash soup": {
+                "aliases": [],
+                "description": "",
+                "name": "butternut squash soup",
+                "plural_name": "butternut squash soups"
+            },
+            "chicken stock paste": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken stock paste",
+                "plural_name": "chicken stock pastes"
+            },
+            "miso soup": {
+                "aliases": [],
+                "description": "",
+                "name": "miso soup",
+                "plural_name": "miso soups"
+            },
+            "broccoli-cheese soup": {
+                "aliases": [],
+                "description": "",
+                "name": "broccoli-cheese soup",
+                "plural_name": "broccoli-cheese soups"
+            },
+            "duck stock": {
+                "aliases": [],
+                "description": "",
+                "name": "duck stock",
+                "plural_name": "duck stocks"
+            },
+            "clam broth": {
+                "aliases": [],
+                "description": "",
+                "name": "clam broth",
+                "plural_name": "clam broths"
+            },
+            "vegan chicken broth": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan chicken broth",
+                "plural_name": "vegan chicken broths"
+            },
+            "cream of asparagus": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of asparagus",
+                "plural_name": "cream of asparagus"
+            },
+            "pork broth": {
+                "aliases": [],
+                "description": "",
+                "name": "pork broth",
+                "plural_name": "pork broths"
+            },
+            "beefy mushroom soup": {
+                "aliases": [],
+                "description": "",
+                "name": "beefy mushroom soup",
+                "plural_name": "beefy mushroom soups"
+            },
+            "new england clam chowder": {
+                "aliases": [],
+                "description": "",
+                "name": "new england clam chowder",
+                "plural_name": "new england clam chowders"
+            },
+            "bean soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "bean soup mix",
+                "plural_name": "bean soup mixes"
+            },
+            "black bean soup": {
+                "aliases": [],
+                "description": "",
+                "name": "black bean soup",
+                "plural_name": "black bean soups"
+            },
+            "ham stock": {
+                "aliases": [],
+                "description": "",
+                "name": "ham stock",
+                "plural_name": "ham stocks"
+            },
+            "lentil soup": {
+                "aliases": [],
+                "description": "",
+                "name": "lentil soup",
+                "plural_name": "lentil soups"
+            },
+            "cream of shrimp soup": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of shrimp soup",
+                "plural_name": "cream of shrimp soup"
+            },
+            "veal broth": {
+                "aliases": [],
+                "description": "",
+                "name": "veal broth",
+                "plural_name": "veal broths"
+            },
+            "vegetable beef soup": {
+                "aliases": [],
+                "description": "",
+                "name": "vegetable beef soup",
+                "plural_name": "vegetable beef soups"
+            },
+            "chicken soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken soup mix",
+                "plural_name": "chicken soup mixes"
+            },
+            "cream of bacon": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of bacon",
+                "plural_name": "cream of bacon"
+            },
+            "lobster bisque": {
+                "aliases": [],
+                "description": "",
+                "name": "lobster bisque",
+                "plural_name": "lobster bisques"
+            },
+            "bean with bacon soup": {
+                "aliases": [],
+                "description": "",
+                "name": "bean with bacon soup",
+                "plural_name": "bean with bacon soup"
+            },
+            "clam chowder": {
+                "aliases": [],
+                "description": "",
+                "name": "clam chowder",
+                "plural_name": "clam chowders"
+            },
+            "condensed chicken gumbo soup": {
+                "aliases": [],
+                "description": "",
+                "name": "condensed chicken gumbo soup",
+                "plural_name": "condensed chicken gumbo soups"
+            },
+            "tortilla soup base": {
+                "aliases": [],
+                "description": "",
+                "name": "tortilla soup base",
+                "plural_name": "tortilla soup bases"
+            },
+            "turkey bone broth": {
+                "aliases": [],
+                "description": "",
+                "name": "turkey bone broth",
+                "plural_name": "turkey bone broths"
+            },
+            "anchovy stock": {
+                "aliases": [],
+                "description": "",
+                "name": "anchovy stock",
+                "plural_name": "anchovy stocks"
+            },
+            "cream of chicken soup mix:": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of chicken soup mix:",
+                "plural_name": "cream of chicken soup mix:"
+            },
+            "noodle soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "noodle soup mix",
+                "plural_name": "noodle soup mixes"
+            },
+            "lamb broth": {
+                "aliases": [],
+                "description": "",
+                "name": "lamb broth",
+                "plural_name": "lamb broths"
+            },
+            "minestrone": {
+                "aliases": [],
+                "description": "",
+                "name": "minestrone",
+                "plural_name": "minestrones"
+            },
+            "thai chicken broth": {
+                "aliases": [],
+                "description": "",
+                "name": "thai chicken broth",
+                "plural_name": "thai chicken broths"
+            },
+            "tomato bisque": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato bisque",
+                "plural_name": "tomato bisques"
+            },
+            "venison stock": {
+                "aliases": [],
+                "description": "",
+                "name": "venison stock",
+                "plural_name": "venison stocks"
+            },
+            "beef stock paste": {
+                "aliases": [],
+                "description": "",
+                "name": "beef stock paste",
+                "plural_name": "beef stock pastes"
+            },
+            "bovril": {
+                "aliases": [],
+                "description": "",
+                "name": "bovril",
+                "plural_name": "bovrils"
+            },
+            "chicken corn chowder": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken corn chowder",
+                "plural_name": "chicken corn chowders"
+            },
+            "pork & bean": {
+                "aliases": [],
+                "description": "",
+                "name": "pork & bean",
+                "plural_name": "pork & beans"
+            },
+            "sun-dried tomato bisque mix": {
+                "aliases": [],
+                "description": "",
+                "name": "sun-dried tomato bisque mix",
+                "plural_name": "sun-dried tomato bisque mixes"
+            },
+            "ham-flavored concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "ham-flavored concentrate",
+                "plural_name": "ham-flavored concentrates"
+            },
+            "oxtail soup": {
+                "aliases": [],
+                "description": "",
+                "name": "oxtail soup",
+                "plural_name": "oxtail soups"
+            },
+            "potato soup mix": {
+                "aliases": [],
+                "description": "",
+                "name": "potato soup mix",
+                "plural_name": "potato soup mixes"
+            },
+            "callaloo": {
+                "aliases": [],
+                "description": "",
+                "name": "callaloo",
+                "plural_name": "callaloos"
+            },
+            "split pea soup": {
+                "aliases": [],
+                "description": "",
+                "name": "split pea soup",
+                "plural_name": "split pea soups"
+            },
+            "chicken and mushroom soup": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken and mushroom soup",
+                "plural_name": "chicken and mushroom soups"
+            },
+            "chili beef soup": {
+                "aliases": [],
+                "description": "",
+                "name": "chili beef soup",
+                "plural_name": "chili beef soups"
+            },
+            "corn chowder": {
+                "aliases": [],
+                "description": "",
+                "name": "corn chowder",
+                "plural_name": "corn chowders"
+            },
+            "cream of cauliflower": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of cauliflower",
+                "plural_name": "cream of cauliflower"
+            },
+            "dashida": {
+                "aliases": [],
+                "description": "",
+                "name": "dashida",
+                "plural_name": "dashidas"
+            },
+            "green pea soup": {
+                "aliases": [],
+                "description": "",
+                "name": "green pea soup",
+                "plural_name": "green pea soups"
+            },
+            "pho broth": {
+                "aliases": [],
+                "description": "",
+                "name": "pho broth",
+                "plural_name": "pho broths"
+            }
+        }
+    },
+    "Desserts & Sweet Snacks": {
+        "foods": {
+            "cocoa": {
+                "aliases": [],
+                "description": "",
+                "name": "cocoa",
+                "plural_name": "cocoas"
+            },
+            "dark chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "dark chocolate",
+                "plural_name": "dark chocolates"
+            },
+            "dark cocoa": {
+                "aliases": [],
+                "description": "",
+                "name": "dark cocoa",
+                "plural_name": "dark cocoas"
+            },
+            "chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate",
+                "plural_name": "chocolates"
+            },
+            "graham cracker": {
+                "aliases": [],
+                "description": "",
+                "name": "graham cracker",
+                "plural_name": "graham crackers"
+            },
+            "baking chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "baking chocolate",
+                "plural_name": "baking chocolates"
+            },
+            "marshmallow": {
+                "aliases": [],
+                "description": "",
+                "name": "marshmallow",
+                "plural_name": "marshmallows"
+            },
+            "mini arshmallow": {
+                "aliases": [],
+                "description": "",
+                "name": "mini arshmallow",
+                "plural_name": "mini marshmallows"
+            },
+            "applesauce": {
+                "aliases": [],
+                "description": "",
+                "name": "applesauce",
+                "plural_name": "applesauces"
+            },
+            "white chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "white chocolate",
+                "plural_name": "white chocolates"
+            },
+            "oreo": {
+                "aliases": [],
+                "description": "",
+                "name": "oreo",
+                "plural_name": "oreos"
+            },
+            "chocolate hazelnut spread": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate hazelnut spread",
+                "plural_name": "chocolate hazelnut spreads"
+            },
+            "instant pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "instant pudding",
+                "plural_name": "instant puddings"
+            },
+            "chocolate candy": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate candy",
+                "plural_name": "chocolate candies"
+            },
+            "chocolate cream-filled chocolate sandwich cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate cream-filled chocolate sandwich cookie",
+                "plural_name": "chocolate cream-filled chocolate sandwich cookies"
+            },
+            "dutch-process cocoa": {
+                "aliases": [],
+                "description": "",
+                "name": "dutch-process cocoa",
+                "plural_name": "dutch-process cocoas"
+            },
+            "raspberry jam": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry jam",
+                "plural_name": "raspberry jams"
+            },
+            "apricot jam": {
+                "aliases": [],
+                "description": "",
+                "name": "apricot jam",
+                "plural_name": "apricot jams"
+            },
+            "caramel sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "caramel sauce",
+                "plural_name": "caramel sauces"
+            },
+            "candy coating": {
+                "aliases": [],
+                "description": "",
+                "name": "candy coating",
+                "plural_name": "candy coatings"
+            },
+            "raw cacao powder": {
+                "aliases": [],
+                "description": "",
+                "name": "raw cacao powder",
+                "plural_name": "raw cacao powders"
+            },
+            "strawberry jam": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry jam",
+                "plural_name": "strawberry jams"
+            },
+            "biscuit": {
+                "aliases": [],
+                "description": "",
+                "name": "biscuit",
+                "plural_name": "biscuits"
+            },
+            "marshmallow creme": {
+                "aliases": [],
+                "description": "",
+                "name": "marshmallow creme",
+                "plural_name": "marshmallow cremes"
+            },
+            "candy": {
+                "aliases": [],
+                "description": "",
+                "name": "candy",
+                "plural_name": "candies"
+            },
+            "jam": {
+                "aliases": [],
+                "description": "",
+                "name": "jam",
+                "plural_name": "jams"
+            },
+            "orange marmalade": {
+                "aliases": [],
+                "description": "",
+                "name": "orange marmalade",
+                "plural_name": "orange marmalades"
+            },
+            "wafer": {
+                "aliases": [],
+                "description": "",
+                "name": "wafer",
+                "plural_name": "wafers"
+            },
+            "cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "cookie",
+                "plural_name": "cookies"
+            },
+            "peanut butter cup": {
+                "aliases": [
+                    "Reeses PB cup",
+                    "Reeses Peanut Buttercup"
+                ],
+                "description": "",
+                "name": "peanut butter cup",
+                "plural_name": "peanut butter cups"
+            },
+            "chocolate pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate pudding",
+                "plural_name": "chocolate puddings"
+            },
+            "candy cane": {
+                "aliases": [],
+                "description": "",
+                "name": "candy cane",
+                "plural_name": "candy canes"
+            },
+            "ginger snap": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger snap",
+                "plural_name": "ginger snaps"
+            },
+            "cacao nib": {
+                "aliases": [],
+                "description": "",
+                "name": "cacao nib",
+                "plural_name": "cacao nibs"
+            },
+            "lady finger": {
+                "aliases": [],
+                "description": "",
+                "name": "lady finger",
+                "plural_name": "lady fingers"
+            },
+            "chocolate chip cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate chip cookie",
+                "plural_name": "chocolate chip cookies"
+            },
+            "fudge sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "fudge sauce",
+                "plural_name": "fudge sauces"
+            },
+            "chocolate cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate cookie",
+                "plural_name": "chocolate cookies"
+            },
+            "digestive biscuit": {
+                "aliases": [],
+                "description": "",
+                "name": "digestive biscuit",
+                "plural_name": "digestive biscuits"
+            },
+            "apple butter": {
+                "aliases": [],
+                "description": "",
+                "name": "apple butter",
+                "plural_name": "apple butter"
+            },
+            "peppermint candy": {
+                "aliases": [],
+                "description": "",
+                "name": "peppermint candy",
+                "plural_name": "peppermint candies"
+            },
+            "cinnamon roll": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon roll",
+                "plural_name": "cinnamon rolls"
+            },
+            "butter cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "butter cookie",
+                "plural_name": "butter cookies"
+            },
+            "candied cherry": {
+                "aliases": [],
+                "description": "",
+                "name": "candied cherry",
+                "plural_name": "candied cherries"
+            },
+            "caramel candy": {
+                "aliases": [],
+                "description": "",
+                "name": "caramel candy",
+                "plural_name": "caramel candies"
+            },
+            "vanilla pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla pudding",
+                "plural_name": "vanilla puddings"
+            },
+            "currant jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "currant jelly",
+                "plural_name": "currant jellies"
+            },
+            "candied ginger": {
+                "aliases": [],
+                "description": "",
+                "name": "candied ginger",
+                "plural_name": "candied gingers"
+            },
+            "angel food cake": {
+                "aliases": [],
+                "description": "",
+                "name": "angel food cake",
+                "plural_name": "angel food cakes"
+            },
+            "peach preserve": {
+                "aliases": [],
+                "description": "",
+                "name": "peach preserve",
+                "plural_name": "peach preserves"
+            },
+            "chocolate wafer": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate wafer",
+                "plural_name": "chocolate wafers"
+            },
+            "candied peel": {
+                "aliases": [],
+                "description": "",
+                "name": "candied peel",
+                "plural_name": "candied peels"
+            },
+            "nutella": {
+                "aliases": [],
+                "description": "",
+                "name": "nutella",
+                "plural_name": "nutellas"
+            },
+            "cherry jam": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry jam",
+                "plural_name": "cherry jams"
+            },
+            "dark couverture chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "dark couverture chocolate",
+                "plural_name": "dark couverture chocolates"
+            },
+            "couverture chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "couverture chocolate",
+                "plural_name": "couverture chocolates"
+            },
+            "grape jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "grape jelly",
+                "plural_name": "grape jellies"
+            },
+            "waffle": {
+                "aliases": [],
+                "description": "",
+                "name": "waffle",
+                "plural_name": "waffles"
+            },
+            "tartlet shell": {
+                "aliases": [],
+                "description": "",
+                "name": "tartlet shell",
+                "plural_name": "tartlet shells"
+            },
+            "cookie butter": {
+                "aliases": [],
+                "description": "",
+                "name": "cookie butter",
+                "plural_name": "cookie butter"
+            },
+            "fig jam": {
+                "aliases": [],
+                "description": "",
+                "name": "fig jam",
+                "plural_name": "fig jams"
+            },
+            "butterscotch": {
+                "aliases": [],
+                "description": "",
+                "name": "butterscotch",
+                "plural_name": "butterscotches"
+            },
+            "blueberry jam": {
+                "aliases": [],
+                "description": "",
+                "name": "blueberry jam",
+                "plural_name": "blueberry jams"
+            },
+            "candied fruit": {
+                "aliases": [],
+                "description": "",
+                "name": "candied fruit",
+                "plural_name": "candied fruits"
+            },
+            "almond cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "almond cookie",
+                "plural_name": "almond cookies"
+            },
+            "gummy": {
+                "aliases": [],
+                "description": "",
+                "name": "gummy",
+                "plural_name": "gummies"
+            },
+            "apple jelly": {
+                "aliases": [],
+                "description": "",
+                "name": "apple jelly",
+                "plural_name": "apple jellies"
+            },
+            "blackberry preserve": {
+                "aliases": [],
+                "description": "",
+                "name": "blackberry preserve",
+                "plural_name": "blackberry preserves"
+            },
+            "candy corn": {
+                "aliases": [],
+                "description": "",
+                "name": "candy corn",
+                "plural_name": "candy corns"
+            },
+            "ice-cream cone": {
+                "aliases": [],
+                "description": "",
+                "name": "ice-cream cone",
+                "plural_name": "ice-cream cones"
+            },
+            "sugar cookie": {
+                "aliases": [],
+                "description": "",
+                "name": "sugar cookie",
+                "plural_name": "sugar cookies"
+            },
+            "marmalade": {
+                "aliases": [],
+                "description": "",
+                "name": "marmalade",
+                "plural_name": "marmalades"
+            },
+            "egg candy": {
+                "aliases": [],
+                "description": "",
+                "name": "egg candy",
+                "plural_name": "egg candies"
+            },
+            "strawberry puree": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry puree",
+                "plural_name": "strawberry purees"
+            },
+            "chocolate powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate powder",
+                "plural_name": "chocolate powders"
+            },
+            "sponge cake": {
+                "aliases": [],
+                "description": "",
+                "name": "sponge cake",
+                "plural_name": "sponge cakes"
+            },
+            "chocolate-covered espresso bean": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate-covered espresso bean",
+                "plural_name": "chocolate-covered espresso beans"
+            },
+            "pineapple jam": {
+                "aliases": [],
+                "description": "",
+                "name": "pineapple jam",
+                "plural_name": "pineapple jams"
+            },
+            "licorice": {
+                "aliases": [],
+                "description": "",
+                "name": "licorice",
+                "plural_name": "licorices"
+            },
+            "plum jam": {
+                "aliases": [],
+                "description": "",
+                "name": "plum jam",
+                "plural_name": "plum jams"
+            },
+            "mexican chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "mexican chocolate",
+                "plural_name": "mexican chocolates"
+            },
+            "banana pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "banana pudding",
+                "plural_name": "banana puddings"
+            },
+            "white couverture": {
+                "aliases": [],
+                "description": "",
+                "name": "white couverture",
+                "plural_name": "white couvertures"
+            },
+            "sorbet": {
+                "aliases": [],
+                "description": "",
+                "name": "sorbet",
+                "plural_name": "sorbets"
+            },
+            "chocolate peanut butter": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate peanut butter",
+                "plural_name": "chocolate peanut butter"
+            },
+            "cinnamon candy": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon candy",
+                "plural_name": "cinnamon candies"
+            },
+            "pumpkin butter": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin butter",
+                "plural_name": "pumpkin butter"
+            },
+            "guava paste": {
+                "aliases": [],
+                "description": "",
+                "name": "guava paste",
+                "plural_name": "guava pastes"
+            },
+            "fudge": {
+                "aliases": [],
+                "description": "",
+                "name": "fudge",
+                "plural_name": "fudges"
+            },
+            "strawberry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry sauce",
+                "plural_name": "strawberry sauces"
+            },
+            "butterscotch pudding mix": {
+                "aliases": [],
+                "description": "",
+                "name": "butterscotch pudding mix",
+                "plural_name": "butterscotch pudding mixes"
+            },
+            "chocolate spread": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate spread",
+                "plural_name": "chocolate spreads"
+            },
+            "doughnut": {
+                "aliases": [],
+                "description": "",
+                "name": "doughnut",
+                "plural_name": "doughnuts"
+            },
+            "biscotti": {
+                "aliases": [],
+                "description": "",
+                "name": "biscotti",
+                "plural_name": "biscottis"
+            },
+            "cheesecake instant pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "cheesecake instant pudding",
+                "plural_name": "cheesecake instant puddings"
+            },
+            "peppermint patty": {
+                "aliases": [],
+                "description": "",
+                "name": "peppermint patty",
+                "plural_name": "peppermint patties"
+            },
+            "pistachio pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "pistachio pudding",
+                "plural_name": "pistachio puddings"
+            },
+            "chocolate fudge": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate fudge",
+                "plural_name": "chocolate fudges"
+            },
+            "raspberry sauce": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry sauce",
+                "plural_name": "raspberry sauces"
+            },
+            "raspberry sorbet": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry sorbet",
+                "plural_name": "raspberry sorbets"
+            },
+            "candied pineapple": {
+                "aliases": [],
+                "description": "",
+                "name": "candied pineapple",
+                "plural_name": "candied pineapples"
+            },
+            "hershey kiss": {
+                "aliases": [],
+                "description": "",
+                "name": "hershey kiss",
+                "plural_name": "hershey kisses"
+            },
+            "pistachio instant pudding": {
+                "aliases": [],
+                "description": "",
+                "name": "pistachio instant pudding",
+                "plural_name": "pistachio instant puddings"
+            }
+        }
+    },
+    "Wine, Beer & Spirits": {
+        "foods": {
+            "white wine": {
+                "aliases": [],
+                "description": "",
+                "name": "white wine",
+                "plural_name": "white wines"
+            },
+            "red wine": {
+                "aliases": [],
+                "description": "",
+                "name": "red wine",
+                "plural_name": "red wines"
+            },
+            "whisky": {
+                "aliases": [],
+                "description": "",
+                "name": "whisky",
+                "plural_name": "whiskies"
+            },
+            "rum": {
+                "aliases": [],
+                "description": "",
+                "name": "rum",
+                "plural_name": "rums"
+            },
+            "vodka": {
+                "aliases": [],
+                "description": "",
+                "name": "vodka",
+                "plural_name": "vodkas"
+            },
+            "beer": {
+                "aliases": [],
+                "description": "",
+                "name": "beer",
+                "plural_name": "beers"
+            },
+            "orange liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "orange liqueur",
+                "plural_name": "orange liqueurs"
+            },
+            "cider": {
+                "aliases": [],
+                "description": "",
+                "name": "cider",
+                "plural_name": "ciders"
+            },
+            "tequila": {
+                "aliases": [],
+                "description": "",
+                "name": "tequila",
+                "plural_name": "tequilas"
+            },
+            "sherry": {
+                "aliases": [],
+                "description": "",
+                "name": "sherry",
+                "plural_name": "sherries"
+            },
+            "gin": {
+                "aliases": [],
+                "description": "",
+                "name": "gin",
+                "plural_name": "gins"
+            },
+            "brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "brandy",
+                "plural_name": "brandies"
+            },
+            "bitter": {
+                "aliases": [],
+                "description": "",
+                "name": "bitter",
+                "plural_name": "bitters"
+            },
+            "mirin": {
+                "aliases": [],
+                "description": "",
+                "name": "mirin",
+                "plural_name": "mirins"
+            },
+            "white rum": {
+                "aliases": [],
+                "description": "",
+                "name": "white rum",
+                "plural_name": "white rums"
+            },
+            "coffee liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee liqueur",
+                "plural_name": "coffee liqueurs"
+            },
+            "champagne": {
+                "aliases": [],
+                "description": "",
+                "name": "champagne",
+                "plural_name": "champagnes"
+            },
+            "irish cream": {
+                "aliases": [],
+                "description": "",
+                "name": "irish cream",
+                "plural_name": "irish creams"
+            },
+            "vermouth": {
+                "aliases": [],
+                "description": "",
+                "name": "vermouth",
+                "plural_name": "vermouths"
+            },
+            "amaretto": {
+                "aliases": [],
+                "description": "",
+                "name": "amaretto",
+                "plural_name": "amarettoes"
+            },
+            "marsala wine": {
+                "aliases": [],
+                "description": "",
+                "name": "marsala wine",
+                "plural_name": "marsala wines"
+            },
+            "cognac": {
+                "aliases": [],
+                "description": "",
+                "name": "cognac",
+                "plural_name": "cognacs"
+            },
+            "sparkling wine": {
+                "aliases": [],
+                "description": "",
+                "name": "sparkling wine",
+                "plural_name": "sparkling wines"
+            },
+            "sake": {
+                "aliases": [],
+                "description": "",
+                "name": "sake",
+                "plural_name": "sakes"
+            },
+            "rice wine": {
+                "aliases": [],
+                "description": "",
+                "name": "rice wine",
+                "plural_name": "rice wines"
+            },
+            "shaoxing wine": {
+                "aliases": [],
+                "description": "",
+                "name": "shaoxing wine",
+                "plural_name": "shaoxing wines"
+            },
+            "dry vermouth": {
+                "aliases": [],
+                "description": "",
+                "name": "dry vermouth",
+                "plural_name": "dry vermouths"
+            },
+            "liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "liqueur",
+                "plural_name": "liqueurs"
+            },
+            "coconut rum": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut rum",
+                "plural_name": "coconut rums"
+            },
+            "dessert wine": {
+                "aliases": [],
+                "description": "",
+                "name": "dessert wine",
+                "plural_name": "dessert wines"
+            },
+            "curacao": {
+                "aliases": [],
+                "description": "",
+                "name": "curacao",
+                "plural_name": "curacaos"
+            },
+            "port wine": {
+                "aliases": [],
+                "description": "",
+                "name": "port wine",
+                "plural_name": "port wines"
+            },
+            "kirsch": {
+                "aliases": [],
+                "description": "",
+                "name": "kirsch",
+                "plural_name": "kirsches"
+            },
+            "peach schnapp": {
+                "aliases": [],
+                "description": "",
+                "name": "peach schnapp",
+                "plural_name": "peach schnapps"
+            },
+            "apple brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "apple brandy",
+                "plural_name": "apple brandies"
+            },
+            "ros\u00e9 wine": {
+                "aliases": [],
+                "description": "",
+                "name": "ros\u00e9 wine",
+                "plural_name": "ros\u00e9 wines"
+            },
+            "anise liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "anise liqueur",
+                "plural_name": "anise liqueurs"
+            },
+            "herbal liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "herbal liqueur",
+                "plural_name": "herbal liqueurs"
+            },
+            "limoncello": {
+                "aliases": [],
+                "description": "",
+                "name": "limoncello",
+                "plural_name": "limoncellos"
+            },
+            "elderflower liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "elderflower liqueur",
+                "plural_name": "elderflower liqueurs"
+            },
+            "cooking wine": {
+                "aliases": [],
+                "description": "",
+                "name": "cooking wine",
+                "plural_name": "cooking wines"
+            },
+            "hazelnut liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut liqueur",
+                "plural_name": "hazelnut liqueurs"
+            },
+            "peach liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "peach liqueur",
+                "plural_name": "peach liqueurs"
+            },
+            "melon liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "melon liqueur",
+                "plural_name": "melon liqueurs"
+            },
+            "raspberry liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry liqueur",
+                "plural_name": "raspberry liqueurs"
+            },
+            "creme de cacao": {
+                "aliases": [],
+                "description": "",
+                "name": "creme de cacao",
+                "plural_name": "creme de cacao"
+            },
+            "schnapp": {
+                "aliases": [],
+                "description": "",
+                "name": "schnapp",
+                "plural_name": "schnapps"
+            },
+            "banana liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "banana liqueur",
+                "plural_name": "banana liqueurs"
+            },
+            "madeira wine": {
+                "aliases": [],
+                "description": "",
+                "name": "madeira wine",
+                "plural_name": "madeira wines"
+            },
+            "absinthe": {
+                "aliases": [],
+                "description": "",
+                "name": "absinthe",
+                "plural_name": "absinthes"
+            },
+            "white cooking wine": {
+                "aliases": [],
+                "description": "",
+                "name": "white cooking wine",
+                "plural_name": "white cooking wines"
+            },
+            "aperol": {
+                "aliases": [],
+                "description": "",
+                "name": "aperol",
+                "plural_name": "aperols"
+            },
+            "vanilla vodka": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla vodka",
+                "plural_name": "vanilla vodkas"
+            },
+            "cinnamon alcohol": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon alcohol",
+                "plural_name": "cinnamon alcohols"
+            },
+            "creme de menthe": {
+                "aliases": [],
+                "description": "",
+                "name": "creme de menthe",
+                "plural_name": "creme de menthe"
+            },
+            "apricot brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "apricot brandy",
+                "plural_name": "apricot brandies"
+            },
+            "cacha\u00e7a": {
+                "aliases": [],
+                "description": "",
+                "name": "cacha\u00e7a",
+                "plural_name": "cacha\u00e7as"
+            },
+            "elderflower cordial": {
+                "aliases": [],
+                "description": "",
+                "name": "elderflower cordial",
+                "plural_name": "elderflower cordials"
+            },
+            "chocolate liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate liqueur",
+                "plural_name": "chocolate liqueurs"
+            },
+            "ginger liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger liqueur",
+                "plural_name": "ginger liqueurs"
+            },
+            "sloe gin": {
+                "aliases": [],
+                "description": "",
+                "name": "sloe gin",
+                "plural_name": "sloe gins"
+            },
+            "maraschino": {
+                "aliases": [],
+                "description": "",
+                "name": "maraschino",
+                "plural_name": "maraschinoes"
+            },
+            "creme de cassis": {
+                "aliases": [],
+                "description": "",
+                "name": "creme de cassis",
+                "plural_name": "creme de cassis"
+            },
+            "bloody mary mix": {
+                "aliases": [],
+                "description": "",
+                "name": "bloody mary mix",
+                "plural_name": "bloody mary mixes"
+            },
+            "cream sherry": {
+                "aliases": [],
+                "description": "",
+                "name": "cream sherry",
+                "plural_name": "cream sherries"
+            },
+            "gold rum": {
+                "aliases": [],
+                "description": "",
+                "name": "gold rum",
+                "plural_name": "gold rums"
+            },
+            "red cooking wine": {
+                "aliases": [],
+                "description": "",
+                "name": "red cooking wine",
+                "plural_name": "red cooking wines"
+            },
+            "sparkling ros\u00e9": {
+                "aliases": [],
+                "description": "",
+                "name": "sparkling ros\u00e9",
+                "plural_name": "sparkling ros\u00e9s"
+            },
+            "grappa": {
+                "aliases": [],
+                "description": "",
+                "name": "grappa",
+                "plural_name": "grappas"
+            },
+            "lime cordial": {
+                "aliases": [],
+                "description": "",
+                "name": "lime cordial",
+                "plural_name": "lime cordials"
+            },
+            "mezcal": {
+                "aliases": [],
+                "description": "",
+                "name": "mezcal",
+                "plural_name": "mezcals"
+            },
+            "strawberry liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry liqueur",
+                "plural_name": "strawberry liqueurs"
+            },
+            "drambuie": {
+                "aliases": [],
+                "description": "",
+                "name": "drambuie",
+                "plural_name": "drambuies"
+            },
+            "ginger wine": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger wine",
+                "plural_name": "ginger wines"
+            },
+            "pumpkin ale": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin ale",
+                "plural_name": "pumpkin ales"
+            },
+            "white port": {
+                "aliases": [],
+                "description": "",
+                "name": "white port",
+                "plural_name": "white ports"
+            },
+            "peppermint liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "peppermint liqueur",
+                "plural_name": "peppermint liqueurs"
+            },
+            "advocaat": {
+                "aliases": [],
+                "description": "",
+                "name": "advocaat",
+                "plural_name": "advocaats"
+            },
+            "pi\u00f1a colada mix": {
+                "aliases": [],
+                "description": "",
+                "name": "pi\u00f1a colada mix",
+                "plural_name": "pi\u00f1a colada mixes"
+            },
+            "b\u00e9n\u00e9dictine": {
+                "aliases": [],
+                "description": "",
+                "name": "b\u00e9n\u00e9dictine",
+                "plural_name": "b\u00e9n\u00e9dictines"
+            },
+            "rumchata liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "rumchata liqueur",
+                "plural_name": "rumchata liqueurs"
+            },
+            "coconut liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut liqueur",
+                "plural_name": "coconut liqueurs"
+            },
+            "daiquiri mix": {
+                "aliases": [],
+                "description": "",
+                "name": "daiquiri mix",
+                "plural_name": "daiquiri mixes"
+            },
+            "galliano": {
+                "aliases": [],
+                "description": "",
+                "name": "galliano",
+                "plural_name": "gallianoes"
+            },
+            "blackberry brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "blackberry brandy",
+                "plural_name": "blackberry brandies"
+            },
+            "plum wine": {
+                "aliases": [],
+                "description": "",
+                "name": "plum wine",
+                "plural_name": "plum wines"
+            },
+            "pisco": {
+                "aliases": [],
+                "description": "",
+                "name": "pisco",
+                "plural_name": "piscoes"
+            },
+            "chocolate bitter": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate bitter",
+                "plural_name": "chocolate bitters"
+            },
+            "vanilla liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "vanilla liqueur",
+                "plural_name": "vanilla liqueurs"
+            },
+            "sangria": {
+                "aliases": [],
+                "description": "",
+                "name": "sangria",
+                "plural_name": "sangrias"
+            },
+            "grapefruit bitter": {
+                "aliases": [],
+                "description": "",
+                "name": "grapefruit bitter",
+                "plural_name": "grapefruit bitters"
+            },
+            "peach brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "peach brandy",
+                "plural_name": "peach brandies"
+            },
+            "white chocolate liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "white chocolate liqueur",
+                "plural_name": "white chocolate liqueurs"
+            },
+            "apple liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "apple liqueur",
+                "plural_name": "apple liqueurs"
+            },
+            "pear brandy": {
+                "aliases": [],
+                "description": "",
+                "name": "pear brandy",
+                "plural_name": "pear brandies"
+            },
+            "moonshine": {
+                "aliases": [],
+                "description": "",
+                "name": "moonshine",
+                "plural_name": "moonshines"
+            },
+            "rhum agricole": {
+                "aliases": [],
+                "description": "",
+                "name": "rhum agricole",
+                "plural_name": "rhum agricoles"
+            },
+            "armagnac": {
+                "aliases": [],
+                "description": "",
+                "name": "armagnac",
+                "plural_name": "armagnacs"
+            },
+            "bergamot liqueur": {
+                "aliases": [],
+                "description": "",
+                "name": "bergamot liqueur",
+                "plural_name": "bergamot liqueurs"
+            },
+            "cherry vodka": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry vodka",
+                "plural_name": "cherry vodkas"
+            }
+        }
+    },
+    "Beverages": {
+        "foods": {
+            "orange juice": {
+                "aliases": [],
+                "description": "",
+                "name": "orange juice",
+                "plural_name": "orange juices"
+            },
+            "coffee": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee",
+                "plural_name": "coffees"
+            },
+            "club soda": {
+                "aliases": [],
+                "description": "",
+                "name": "club soda",
+                "plural_name": "club sodas"
+            },
+            "espresso": {
+                "aliases": [],
+                "description": "",
+                "name": "espresso",
+                "plural_name": "espressos"
+            },
+            "pineapple juice": {
+                "aliases": [],
+                "description": "",
+                "name": "pineapple juice",
+                "plural_name": "pineapple juices"
+            },
+            "apple juice": {
+                "aliases": [],
+                "description": "",
+                "name": "apple juice",
+                "plural_name": "apple juices"
+            },
+            "tea": {
+                "aliases": [],
+                "description": "",
+                "name": "tea",
+                "plural_name": "teas"
+            },
+            "cranberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry juice",
+                "plural_name": "cranberry juices"
+            },
+            "tomato juice": {
+                "aliases": [],
+                "description": "",
+                "name": "tomato juice",
+                "plural_name": "tomato juices"
+            },
+            "coconut water": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut water",
+                "plural_name": "coconut waters"
+            },
+            "pomegranate juice": {
+                "aliases": [],
+                "description": "",
+                "name": "pomegranate juice",
+                "plural_name": "pomegranate juices"
+            },
+            "grapefruit juice": {
+                "aliases": [],
+                "description": "",
+                "name": "grapefruit juice",
+                "plural_name": "grapefruit juices"
+            },
+            "lemonade": {
+                "aliases": [],
+                "description": "",
+                "name": "lemonade",
+                "plural_name": "lemonades"
+            },
+            "coke": {
+                "aliases": [],
+                "description": "",
+                "name": "coke",
+                "plural_name": "cokes"
+            },
+            "eggnog": {
+                "aliases": [],
+                "description": "",
+                "name": "eggnog",
+                "plural_name": "eggnogs"
+            },
+            "ginger ale": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger ale",
+                "plural_name": "ginger ales"
+            },
+            "ginger beer": {
+                "aliases": [],
+                "description": "",
+                "name": "ginger beer",
+                "plural_name": "ginger beers"
+            },
+            "orange juice concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "orange juice concentrate",
+                "plural_name": "orange juice concentrates"
+            },
+            "lemon lime soda": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon lime soda",
+                "plural_name": "lemon lime sodas"
+            },
+            "cream of coconut": {
+                "aliases": [],
+                "description": "",
+                "name": "cream of coconut",
+                "plural_name": "cream of coconut"
+            },
+            "sprite": {
+                "aliases": [],
+                "description": "",
+                "name": "sprite",
+                "plural_name": "sprites"
+            },
+            "green tea": {
+                "aliases": [],
+                "description": "",
+                "name": "green tea",
+                "plural_name": "green teas"
+            },
+            "lemonade concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "lemonade concentrate",
+                "plural_name": "lemonade concentrates"
+            },
+            "chai tea": {
+                "aliases": [],
+                "description": "",
+                "name": "chai tea",
+                "plural_name": "chai teas"
+            },
+            "root beer": {
+                "aliases": [],
+                "description": "",
+                "name": "root beer",
+                "plural_name": "root beers"
+            },
+            "drinking chocolate": {
+                "aliases": [],
+                "description": "",
+                "name": "drinking chocolate",
+                "plural_name": "drinking chocolates"
+            },
+            "tonic water": {
+                "aliases": [],
+                "description": "",
+                "name": "tonic water",
+                "plural_name": "tonic waters"
+            },
+            "malted milk powder": {
+                "aliases": [],
+                "description": "",
+                "name": "malted milk powder",
+                "plural_name": "malted milk powders"
+            },
+            "mango juice": {
+                "aliases": [],
+                "description": "",
+                "name": "mango juice",
+                "plural_name": "mango juices"
+            },
+            "sour mix": {
+                "aliases": [],
+                "description": "",
+                "name": "sour mix",
+                "plural_name": "sour mixes"
+            },
+            "hibiscu": {
+                "aliases": [],
+                "description": "",
+                "name": "hibiscu",
+                "plural_name": "hibiscus"
+            },
+            "tea leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "tea leaf",
+                "plural_name": "tea leaves"
+            },
+            "grape juice": {
+                "aliases": [],
+                "description": "",
+                "name": "grape juice",
+                "plural_name": "grape juices"
+            },
+            "cherry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry juice",
+                "plural_name": "cherry juices"
+            },
+            "carrot juice": {
+                "aliases": [],
+                "description": "",
+                "name": "carrot juice",
+                "plural_name": "carrot juices"
+            },
+            "limeade concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "limeade concentrate",
+                "plural_name": "limeade concentrates"
+            },
+            "dr pepper": {
+                "aliases": [],
+                "description": "",
+                "name": "dr pepper",
+                "plural_name": "dr peppers"
+            },
+            "white grape juice": {
+                "aliases": [],
+                "description": "",
+                "name": "white grape juice",
+                "plural_name": "white grape juices"
+            },
+            "watermelon juice": {
+                "aliases": [],
+                "description": "",
+                "name": "watermelon juice",
+                "plural_name": "watermelon juices"
+            },
+            "tangerine juice": {
+                "aliases": [],
+                "description": "",
+                "name": "tangerine juice",
+                "plural_name": "tangerine juices"
+            },
+            "fruit juice": {
+                "aliases": [],
+                "description": "",
+                "name": "fruit juice",
+                "plural_name": "fruit juices"
+            },
+            "passion-fruit juice": {
+                "aliases": [],
+                "description": "",
+                "name": "passion-fruit juice",
+                "plural_name": "passion-fruit juices"
+            },
+            "iced tea": {
+                "aliases": [],
+                "description": "",
+                "name": "iced tea",
+                "plural_name": "iced teas"
+            },
+            "kombucha": {
+                "aliases": [],
+                "description": "",
+                "name": "kombucha",
+                "plural_name": "kombuchas"
+            },
+            "apricot juice": {
+                "aliases": [],
+                "description": "",
+                "name": "apricot juice",
+                "plural_name": "apricot juices"
+            },
+            "beet juice": {
+                "aliases": [],
+                "description": "",
+                "name": "beet juice",
+                "plural_name": "beet juices"
+            },
+            "peach juice": {
+                "aliases": [],
+                "description": "",
+                "name": "peach juice",
+                "plural_name": "peach juices"
+            },
+            "orange soda": {
+                "aliases": [],
+                "description": "",
+                "name": "orange soda",
+                "plural_name": "orange sodas"
+            },
+            "margarita mix": {
+                "aliases": [],
+                "description": "",
+                "name": "margarita mix",
+                "plural_name": "margarita mixes"
+            },
+            "kool aid": {
+                "aliases": [],
+                "description": "",
+                "name": "kool aid",
+                "plural_name": "kool aids"
+            },
+            "energy drink": {
+                "aliases": [],
+                "description": "",
+                "name": "energy drink",
+                "plural_name": "energy drinks"
+            },
+            "chamomile tea": {
+                "aliases": [],
+                "description": "",
+                "name": "chamomile tea",
+                "plural_name": "chamomile teas"
+            },
+            "pear juice": {
+                "aliases": [],
+                "description": "",
+                "name": "pear juice",
+                "plural_name": "pear juices"
+            },
+            "tamarind juice": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind juice",
+                "plural_name": "tamarind juices"
+            },
+            "cream soda": {
+                "aliases": [],
+                "description": "",
+                "name": "cream soda",
+                "plural_name": "cream sodas"
+            },
+            "tamarind water": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind water",
+                "plural_name": "tamarind waters"
+            },
+            "mountain dew": {
+                "aliases": [],
+                "description": "",
+                "name": "mountain dew",
+                "plural_name": "mountain dews"
+            },
+            "grapefruit soda": {
+                "aliases": [],
+                "description": "",
+                "name": "grapefruit soda",
+                "plural_name": "grapefruit sodas"
+            },
+            "rooibos tea": {
+                "aliases": [],
+                "description": "",
+                "name": "rooibos tea",
+                "plural_name": "rooibos teas"
+            },
+            "lime soda": {
+                "aliases": [],
+                "description": "",
+                "name": "lime soda",
+                "plural_name": "lime sodas"
+            },
+            "raspberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry juice",
+                "plural_name": "raspberry juices"
+            },
+            "guava juice": {
+                "aliases": [],
+                "description": "",
+                "name": "guava juice",
+                "plural_name": "guava juices"
+            },
+            "jasmine tea": {
+                "aliases": [],
+                "description": "",
+                "name": "jasmine tea",
+                "plural_name": "jasmine teas"
+            },
+            "clamato": {
+                "aliases": [],
+                "description": "",
+                "name": "clamato",
+                "plural_name": "clamatoes"
+            },
+            "strawberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry juice",
+                "plural_name": "strawberry juices"
+            },
+            "iced coffee concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "iced coffee concentrate",
+                "plural_name": "iced coffee concentrates"
+            },
+            "green tea leaf": {
+                "aliases": [],
+                "description": "",
+                "name": "green tea leaf",
+                "plural_name": "green tea leaves"
+            },
+            "beetroot juice": {
+                "aliases": [],
+                "description": "",
+                "name": "beetroot juice",
+                "plural_name": "beetroot juices"
+            },
+            "blueberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "blueberry juice",
+                "plural_name": "blueberry juices"
+            },
+            "lemonade mix": {
+                "aliases": [],
+                "description": "",
+                "name": "lemonade mix",
+                "plural_name": "lemonade mixes"
+            },
+            "rose syrup": {
+                "aliases": [],
+                "description": "",
+                "name": "rose syrup",
+                "plural_name": "rose syrups"
+            },
+            "v8 juice": {
+                "aliases": [],
+                "description": "",
+                "name": "v8 juice",
+                "plural_name": "v8 juices"
+            },
+            "thai tea": {
+                "aliases": [],
+                "description": "",
+                "name": "thai tea",
+                "plural_name": "thai teas"
+            },
+            "aloe vera juice": {
+                "aliases": [],
+                "description": "",
+                "name": "aloe vera juice",
+                "plural_name": "aloe vera juices"
+            },
+            "white tea": {
+                "aliases": [],
+                "description": "",
+                "name": "white tea",
+                "plural_name": "white teas"
+            },
+            "juice blend": {
+                "aliases": [],
+                "description": "",
+                "name": "juice blend",
+                "plural_name": "juice blends"
+            },
+            "prune juice": {
+                "aliases": [],
+                "description": "",
+                "name": "prune juice",
+                "plural_name": "prune juices"
+            },
+            "sparkling cider": {
+                "aliases": [],
+                "description": "",
+                "name": "sparkling cider",
+                "plural_name": null
+            },
+            "berry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "berry juice",
+                "plural_name": "berry juices"
+            },
+            "butterfly pea flower": {
+                "aliases": [],
+                "description": "",
+                "name": "butterfly pea flower",
+                "plural_name": "butterfly pea flowers"
+            },
+            "passion tea": {
+                "aliases": [],
+                "description": "",
+                "name": "passion tea",
+                "plural_name": "passion teas"
+            },
+            "strawberry soda": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry soda",
+                "plural_name": "strawberry sodas"
+            },
+            "lapsang souchong": {
+                "aliases": [],
+                "description": "",
+                "name": "lapsang souchong",
+                "plural_name": "lapsang souchongs"
+            },
+            "blackcurrant juice": {
+                "aliases": [],
+                "description": "",
+                "name": "blackcurrant juice",
+                "plural_name": "blackcurrant juices"
+            },
+            "herbal tea": {
+                "aliases": [],
+                "description": "",
+                "name": "herbal tea",
+                "plural_name": "herbal teas"
+            },
+            "banana juice": {
+                "aliases": [],
+                "description": "",
+                "name": "banana juice",
+                "plural_name": "banana juices"
+            },
+            "lychee juice": {
+                "aliases": [],
+                "description": "",
+                "name": "lychee juice",
+                "plural_name": "lychee juices"
+            },
+            "sugar cane juice": {
+                "aliases": [],
+                "description": "",
+                "name": "sugar cane juice",
+                "plural_name": "sugar cane juices"
+            },
+            "cranberry-raspberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry-raspberry juice",
+                "plural_name": "cranberry-raspberry juices"
+            },
+            "decaf coffee": {
+                "aliases": [],
+                "description": "",
+                "name": "decaf coffee",
+                "plural_name": "decaf coffees"
+            },
+            "pumpkin spice coffee": {
+                "aliases": [],
+                "description": "",
+                "name": "pumpkin spice coffee",
+                "plural_name": "pumpkin spice coffees"
+            },
+            "pepsi": {
+                "aliases": [],
+                "description": "",
+                "name": "pepsi",
+                "plural_name": "pepsis"
+            },
+            "cherry soda": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry soda",
+                "plural_name": "cherry sodas"
+            },
+            "peppermint tea": {
+                "aliases": [],
+                "description": "",
+                "name": "peppermint tea",
+                "plural_name": "peppermint teas"
+            },
+            "sports drink": {
+                "aliases": [],
+                "description": "",
+                "name": "sports drink",
+                "plural_name": "sports drinks"
+            },
+            "acai berry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "acai berry juice",
+                "plural_name": "acai berry juices"
+            },
+            "lemon crystal": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon crystal",
+                "plural_name": "lemon crystals"
+            },
+            "raspberry lemonade": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry lemonade",
+                "plural_name": "raspberry lemonades"
+            },
+            "chicory coffee": {
+                "aliases": [],
+                "description": "",
+                "name": "chicory coffee",
+                "plural_name": "chicory coffees"
+            },
+            "elderberry juice": {
+                "aliases": [],
+                "description": "",
+                "name": "elderberry juice",
+                "plural_name": "elderberry juices"
+            }
+        }
+    },
+    "Supplements & Extracts": {
+        "foods": {
+            "almond extract": {
+                "aliases": [],
+                "description": "",
+                "name": "almond extract",
+                "plural_name": "almond extracts"
+            },
+            "food coloring": {
+                "aliases": [],
+                "description": "",
+                "name": "food coloring",
+                "plural_name": "food colorings"
+            },
+            "nutritional yeast": {
+                "aliases": [],
+                "description": "",
+                "name": "nutritional yeast",
+                "plural_name": "nutritional yeasts"
+            },
+            "peppermint extract": {
+                "aliases": [],
+                "description": "",
+                "name": "peppermint extract",
+                "plural_name": "peppermint extracts"
+            },
+            "protein powder": {
+                "aliases": [],
+                "description": "",
+                "name": "protein powder",
+                "plural_name": "protein powders"
+            },
+            "lemon extract": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon extract",
+                "plural_name": "lemon extracts"
+            },
+            "coconut extract": {
+                "aliases": [],
+                "description": "",
+                "name": "coconut extract",
+                "plural_name": "coconut extracts"
+            },
+            "rose water": {
+                "aliases": [],
+                "description": "",
+                "name": "rose water",
+                "plural_name": "rose waters"
+            },
+            "orange extract": {
+                "aliases": [],
+                "description": "",
+                "name": "orange extract",
+                "plural_name": "orange extracts"
+            },
+            "rum extract": {
+                "aliases": [],
+                "description": "",
+                "name": "rum extract",
+                "plural_name": "rum extracts"
+            },
+            "maple extract": {
+                "aliases": [],
+                "description": "",
+                "name": "maple extract",
+                "plural_name": "maple extracts"
+            },
+            "collagen": {
+                "aliases": [],
+                "description": "",
+                "name": "collagen",
+                "plural_name": "collagens"
+            },
+            "chocolate protein powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate protein powder",
+                "plural_name": "chocolate protein powders"
+            },
+            "orange blossom water": {
+                "aliases": [],
+                "description": "",
+                "name": "orange blossom water",
+                "plural_name": "orange blossom waters"
+            },
+            "liquid egg white": {
+                "aliases": [],
+                "description": "",
+                "name": "liquid egg white",
+                "plural_name": "liquid egg whites"
+            },
+            "peanut butter powder": {
+                "aliases": [],
+                "description": "",
+                "name": "peanut butter powder",
+                "plural_name": "peanut butter powders"
+            },
+            "vegan protein powder": {
+                "aliases": [],
+                "description": "",
+                "name": "vegan protein powder",
+                "plural_name": "vegan protein powders"
+            },
+            "essence": {
+                "aliases": [],
+                "description": "",
+                "name": "essence",
+                "plural_name": "essences"
+            },
+            "maca powder": {
+                "aliases": [],
+                "description": "",
+                "name": "maca powder",
+                "plural_name": "maca powders"
+            },
+            "spirulina": {
+                "aliases": [],
+                "description": "",
+                "name": "spirulina",
+                "plural_name": "spirulinas"
+            },
+            "coffee extract": {
+                "aliases": [],
+                "description": "",
+                "name": "coffee extract",
+                "plural_name": "coffee extracts"
+            },
+            "brewer's yeast": {
+                "aliases": [],
+                "description": "",
+                "name": "brewer's yeast",
+                "plural_name": "brewer's yeasts"
+            },
+            "strawberry extract": {
+                "aliases": [],
+                "description": "",
+                "name": "strawberry extract",
+                "plural_name": "strawberry extracts"
+            },
+            "butter extract": {
+                "aliases": [],
+                "description": "",
+                "name": "butter extract",
+                "plural_name": "butter extracts"
+            },
+            "chocolate extract": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate extract",
+                "plural_name": "chocolate extracts"
+            },
+            "raspberry extract": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry extract",
+                "plural_name": "raspberry extracts"
+            },
+            "anise extract": {
+                "aliases": [],
+                "description": "",
+                "name": "anise extract",
+                "plural_name": "anise extracts"
+            },
+            "bee pollen": {
+                "aliases": [],
+                "description": "",
+                "name": "bee pollen",
+                "plural_name": "bee pollens"
+            },
+            "cannabi": {
+                "aliases": [],
+                "description": "",
+                "name": "cannabi",
+                "plural_name": "cannabis"
+            },
+            "banana extract": {
+                "aliases": [],
+                "description": "",
+                "name": "banana extract",
+                "plural_name": "banana extracts"
+            },
+            "lavender oil": {
+                "aliases": [],
+                "description": "",
+                "name": "lavender oil",
+                "plural_name": "lavender oils"
+            },
+            "essential oil": {
+                "aliases": [],
+                "description": "",
+                "name": "essential oil",
+                "plural_name": "essential oils"
+            },
+            "chicken essence": {
+                "aliases": [],
+                "description": "",
+                "name": "chicken essence",
+                "plural_name": "chicken essences"
+            },
+            "caramel extract": {
+                "aliases": [],
+                "description": "",
+                "name": "caramel extract",
+                "plural_name": "caramel extracts"
+            },
+            "egg white powder": {
+                "aliases": [],
+                "description": "",
+                "name": "egg white powder",
+                "plural_name": "egg white powders"
+            },
+            "cannabutter": {
+                "aliases": [],
+                "description": "",
+                "name": "cannabutter",
+                "plural_name": "cannabutter"
+            },
+            "root beer extract": {
+                "aliases": [],
+                "description": "",
+                "name": "root beer extract",
+                "plural_name": "root beer extracts"
+            },
+            "vitamin c": {
+                "aliases": [],
+                "description": "",
+                "name": "vitamin c",
+                "plural_name": "vitamin cs"
+            },
+            "acai powder": {
+                "aliases": [],
+                "description": "",
+                "name": "acai powder",
+                "plural_name": "acai powders"
+            },
+            "hemp protein": {
+                "aliases": [],
+                "description": "",
+                "name": "hemp protein",
+                "plural_name": "hemp proteins"
+            },
+            "ube flavoring": {
+                "aliases": [],
+                "description": "",
+                "name": "ube flavoring",
+                "plural_name": "ube flavorings"
+            },
+            "glucomannan": {
+                "aliases": [],
+                "description": "",
+                "name": "glucomannan",
+                "plural_name": "glucomannans"
+            },
+            "hazelnut extract": {
+                "aliases": [],
+                "description": "",
+                "name": "hazelnut extract",
+                "plural_name": "hazelnut extracts"
+            },
+            "freeze-dried strawberry powder": {
+                "aliases": [],
+                "description": "",
+                "name": "freeze-dried strawberry powder",
+                "plural_name": "freeze-dried strawberry powders"
+            },
+            "tamarind extract": {
+                "aliases": [],
+                "description": "",
+                "name": "tamarind extract",
+                "plural_name": "tamarind extracts"
+            },
+            "cherry extract": {
+                "aliases": [],
+                "description": "",
+                "name": "cherry extract",
+                "plural_name": "cherry extracts"
+            },
+            "butterscotch flavor": {
+                "aliases": [],
+                "description": "",
+                "name": "butterscotch flavor",
+                "plural_name": "butterscotch flavors"
+            },
+            "kewra water": {
+                "aliases": [],
+                "description": "",
+                "name": "kewra water",
+                "plural_name": "kewra waters"
+            },
+            "pineapple extract": {
+                "aliases": [],
+                "description": "",
+                "name": "pineapple extract",
+                "plural_name": "pineapple extracts"
+            },
+            "lemon juice concentrate": {
+                "aliases": [],
+                "description": "",
+                "name": "lemon juice concentrate",
+                "plural_name": "lemon juice concentrates"
+            },
+            "chocolate collagen": {
+                "aliases": [],
+                "description": "",
+                "name": "chocolate collagen",
+                "plural_name": "chocolate collagens"
+            },
+            "cinnamon extract": {
+                "aliases": [],
+                "description": "",
+                "name": "cinnamon extract",
+                "plural_name": "cinnamon extracts"
+            },
+            "cannabis milk": {
+                "aliases": [],
+                "description": "",
+                "name": "cannabis milk",
+                "plural_name": "cannabis milks"
+            },
+            "malt extract": {
+                "aliases": [],
+                "description": "",
+                "name": "malt extract",
+                "plural_name": "malt extracts"
+            },
+            "kombucha starter": {
+                "aliases": [],
+                "description": "",
+                "name": "kombucha starter",
+                "plural_name": "kombucha starters"
+            },
+            "pandan extract": {
+                "aliases": [],
+                "description": "",
+                "name": "pandan extract",
+                "plural_name": "pandan extracts"
+            },
+            "camu powder": {
+                "aliases": [],
+                "description": "",
+                "name": "camu powder",
+                "plural_name": "camu powders"
+            },
+            "soy lecithin": {
+                "aliases": [],
+                "description": "",
+                "name": "soy lecithin",
+                "plural_name": "soy lecithins"
+            },
+            "wheatgrass powder": {
+                "aliases": [],
+                "description": "",
+                "name": "wheatgrass powder",
+                "plural_name": "wheatgrass powders"
+            },
+            "ashwagandha": {
+                "aliases": [],
+                "description": "",
+                "name": "ashwagandha",
+                "plural_name": "ashwagandhas"
+            },
+            "casein": {
+                "aliases": [],
+                "description": "",
+                "name": "casein",
+                "plural_name": "caseins"
+            },
+            "cbd oil": {
+                "aliases": [],
+                "description": "",
+                "name": "cbd oil",
+                "plural_name": "cbd oils"
+            },
+            "chlorella": {
+                "aliases": [],
+                "description": "",
+                "name": "chlorella",
+                "plural_name": "chlorellas"
+            },
+            "fish oil": {
+                "aliases": [],
+                "description": "",
+                "name": "fish oil",
+                "plural_name": "fish oils"
+            },
+            "lime essential oil": {
+                "aliases": [],
+                "description": "",
+                "name": "lime essential oil",
+                "plural_name": "lime essential oils"
+            },
+            "probiotic": {
+                "aliases": [],
+                "description": "",
+                "name": "probiotic",
+                "plural_name": "probiotics"
+            },
+            "activated charcoal": {
+                "aliases": [],
+                "description": "",
+                "name": "activated charcoal",
+                "plural_name": "activated charcoals"
+            },
+            "egg powder": {
+                "aliases": [],
+                "description": "",
+                "name": "egg powder",
+                "plural_name": "egg powders"
+            },
+            "reishi mushroom": {
+                "aliases": [],
+                "description": "",
+                "name": "reishi mushroom",
+                "plural_name": "reishi mushrooms"
+            },
+            "vitamin e": {
+                "aliases": [],
+                "description": "",
+                "name": "vitamin e",
+                "plural_name": "vitamin es"
+            },
+            "wine yeast": {
+                "aliases": [],
+                "description": "",
+                "name": "wine yeast",
+                "plural_name": "wine yeasts"
+            },
+            "barley gras": {
+                "aliases": [],
+                "description": "",
+                "name": "barley gras",
+                "plural_name": "barley grass"
+            },
+            "greens powder": {
+                "aliases": [],
+                "description": "",
+                "name": "greens powder",
+                "plural_name": "greens powders"
+            },
+            "rice protein powder": {
+                "aliases": [],
+                "description": "",
+                "name": "rice protein powder",
+                "plural_name": "rice protein powders"
+            },
+            "tea-tree oil": {
+                "aliases": [],
+                "description": "",
+                "name": "tea-tree oil",
+                "plural_name": "tea-tree oils"
+            },
+            "vitamin d": {
+                "aliases": [],
+                "description": "",
+                "name": "vitamin d",
+                "plural_name": "vitamin ds"
+            },
+            "calcium lactate": {
+                "aliases": [],
+                "description": "",
+                "name": "calcium lactate",
+                "plural_name": "calcium lactates"
+            },
+            "mango extract": {
+                "aliases": [],
+                "description": "",
+                "name": "mango extract",
+                "plural_name": "mango extracts"
+            },
+            "raspberry powder": {
+                "aliases": [],
+                "description": "",
+                "name": "raspberry powder",
+                "plural_name": "raspberry powders"
+            },
+            "blueberry extract": {
+                "aliases": [],
+                "description": "",
+                "name": "blueberry extract",
+                "plural_name": "blueberry extracts"
+            },
+            "corn extract": {
+                "aliases": [],
+                "description": "",
+                "name": "corn extract",
+                "plural_name": "corn extracts"
+            },
+            "magnesium": {
+                "aliases": [],
+                "description": "",
+                "name": "magnesium",
+                "plural_name": "magnesiums"
+            },
+            "creatine": {
+                "aliases": [],
+                "description": "",
+                "name": "creatine",
+                "plural_name": "creatines"
+            },
+            "daily vitamin": {
+                "aliases": [],
+                "description": "",
+                "name": "daily vitamin",
+                "plural_name": "daily vitamins"
+            },
+            "moringa powder": {
+                "aliases": [],
+                "description": "",
+                "name": "moringa powder",
+                "plural_name": "moringa powders"
+            },
+            "pure lime extract": {
+                "aliases": [],
+                "description": "",
+                "name": "pure lime extract",
+                "plural_name": "pure lime extracts"
+            },
+            "sodium alginate": {
+                "aliases": [],
+                "description": "",
+                "name": "sodium alginate",
+                "plural_name": "sodium alginates"
+            },
+            "sunflower lecithin": {
+                "aliases": [],
+                "description": "",
+                "name": "sunflower lecithin",
+                "plural_name": "sunflower lecithins"
+            },
+            "thc": {
+                "aliases": [],
+                "description": "",
+                "name": "thc",
+                "plural_name": "thcs"
+            },
+            "berry powder": {
+                "aliases": [],
+                "description": "",
+                "name": "berry powder",
+                "plural_name": "berry powders"
+            },
+            "champagne yeast": {
+                "aliases": [],
+                "description": "",
+                "name": "champagne yeast",
+                "plural_name": "champagne yeasts"
+            },
+            "maqui": {
+                "aliases": [],
+                "description": "",
+                "name": "maqui",
+                "plural_name": "maquis"
+            },
+            "rose oil": {
+                "aliases": [],
+                "description": "",
+                "name": "rose oil",
+                "plural_name": "rose oils"
+            },
+            "banana powder": {
+                "aliases": [],
+                "description": "",
+                "name": "banana powder",
+                "plural_name": "banana powders"
+            },
+            "chaga mushroom powder": {
+                "aliases": [],
+                "description": "",
+                "name": "chaga mushroom powder",
+                "plural_name": "chaga mushroom powders"
+            },
+            "clove oil": {
+                "aliases": [],
+                "description": "",
+                "name": "clove oil",
+                "plural_name": "clove oils"
+            },
+            "cranberry powder": {
+                "aliases": [],
+                "description": "",
+                "name": "cranberry powder",
+                "plural_name": "cranberry powders"
+            },
+            "eucalyptus oil": {
+                "aliases": [],
+                "description": "",
+                "name": "eucalyptus oil",
+                "plural_name": "eucalyptus oils"
+            },
+            "goji berry powder": {
+                "aliases": [],
+                "description": "",
+                "name": "goji berry powder",
+                "plural_name": "goji berry powders"
+            },
+            "maltodextrin": {
+                "aliases": [],
+                "description": "",
+                "name": "maltodextrin",
+                "plural_name": "maltodextrins"
+            }
+        }
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/en-US.json
+++ b/mealie/repos/seed/resources/foods/locales/en-US.json
@@ -10570,12 +10570,6 @@
 			{
 				"aliases": [],
 				"description": "",
-				"name": null,
-				"pluralName": "achiote seeds"
-			},
-			{
-				"aliases": [],
-				"description": "",
 				"name": "arabic bread",
 				"pluralName": "arabic breads"
 			},

--- a/mealie/repos/seed/resources/foods/locales/es-ES.json
+++ b/mealie/repos/seed/resources/foods/locales/es-ES.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "calabaza bellota"
-	},
-	"alfalfa-sprouts": {
-		"name": "brotes de alfalfa"
-	},
-	"anchovies": {
-		"name": "anchoas"
-	},
-	"apples": {
-		"name": "manzana",
-		"plural_name": "manzanas"
-	},
-	"artichoke": {
-		"name": "alcachofa"
-	},
-	"arugula": {
-		"name": "rúcula"
-	},
-	"asparagus": {
-		"name": "espárragos"
-	},
-	"avocado": {
-		"name": "aguacate",
-		"plural_name": "palta"
-	},
-	"bacon": {
-		"name": "panceta"
-	},
-	"baking-powder": {
-		"name": "levadura"
-	},
-	"baking-soda": {
-		"name": "gaseosa (gasificante)"
-	},
-	"baking-sugar": {
-		"name": "azúcar glass"
-	},
-	"bar-sugar": {
-		"name": "azúcar de caña"
-	},
-	"basil": {
-		"name": "albahaca"
-	},
-	"beans": {
-		"name": "judías/alubias/frijoles"
-	},
-	"bell-peppers": {
-		"name": "pimiento morrón",
-		"plural_name": "pimiento morrón"
-	},
-	"blackberries": {
-		"name": "moras"
-	},
-	"bok-choy": {
-		"name": "col china (pak choi)"
-	},
-	"brassicas": {
-		"name": "coles"
-	},
-	"bread": {
-		"name": "pan"
-	},
-	"breadfruit": {
-		"name": "fruta del pan"
-	},
-	"broccoflower": {
-		"name": "romanesco"
-	},
-	"broccoli": {
-		"name": "brócoli"
-	},
-	"broccoli-rabe": {
-		"name": "grelos"
-	},
-	"broccolini": {
-		"name": "bimi"
-	},
-	"brown-sugar": {
-		"name": "azucar moreno"
-	},
-	"brussels-sprouts": {
-		"name": "coles de Bruselas"
-	},
-	"butter": {
-		"name": "mantequilla"
-	},
-	"butternut-pumpkin": {
-		"name": "calabaza cacahuete"
-	},
-	"butternut-squash": {
-		"name": "calabaza moscada"
-	},
-	"cabbage": {
-		"name": "repollo",
-		"plural_name": "repollos"
-	},
-	"cactus-edible": {
-		"name": "higo chumbo"
-	},
-	"calabrese": {
-		"name": "brócoli"
-	},
-	"cane-sugar": {
-		"name": "azúcar de caña"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "ñora"
-	},
-	"caraway": {
-		"name": "comino"
-	},
-	"carrot": {
-		"name": "zanahoria",
-		"plural_name": "zanahorias"
-	},
-	"caster-sugar": {
-		"name": "azúcar de caña"
-	},
-	"castor-sugar": {
-		"name": "azúcar"
-	},
-	"catfish": {
-		"name": "siluro"
-	},
-	"cauliflower": {
-		"name": "coliflor",
-		"plural_name": "coliflor"
-	},
-	"cayenne-pepper": {
-		"name": "pimienta de cayena"
-	},
-	"celeriac": {
-		"name": "apio nabo"
-	},
-	"celery": {
-		"name": "apio"
-	},
-	"cereal-grains": {
-		"name": "cereales en grano"
-	},
-	"chard": {
-		"name": "acelgas"
-	},
-	"cheese": {
-		"name": "queso"
-	},
-	"chicory": {
-		"name": "achicoria"
-	},
-	"chilli-peppers": {
-		"name": "chile/guindilla",
-		"plural_name": "chile/guindilla"
-	},
-	"chinese-leaves": {
-		"name": "col china"
-	},
-	"chives": {
-		"name": "cebollino"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "canela"
-	},
-	"clarified-butter": {
-		"name": "mantequilla clarificada"
-	},
-	"coconut": {
-		"name": "coco",
-		"plural_name": "cocos"
-	},
-	"coconut-milk": {
-		"name": "leche de coco"
-	},
-	"cod": {
-		"name": "bacalao"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "berza"
-	},
-	"confectioners-sugar": {
-		"name": "azúcar"
-	},
-	"coriander": {
-		"name": "cilantro"
-	},
-	"corn": {
-		"name": "maíz",
-		"plural_name": "maíz"
-	},
-	"corn-syrup": {
-		"name": "jarabe de maíz"
-	},
-	"cottonseed-oil": {
-		"name": "aceite de algodón"
-	},
-	"courgette": {
-		"name": "calabacín"
-	},
-	"cream-of-tartar": {
-		"name": "crémor tártaro"
-	},
-	"cucumber": {
-		"name": "pepino",
-		"plural_name": "pepino"
-	},
-	"cumin": {
-		"name": "comino"
-	},
-	"daikon": {
-		"name": "rábano japonés",
-		"plural_name": "rábanos japoneses"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "productos lácteos y sustitutos de lácteos"
-	},
-	"dandelion": {
-		"name": "diente de león"
-	},
-	"demerara-sugar": {
-		"name": "azúcar moreno"
-	},
-	"dough": {
-		"name": "masa"
-	},
-	"edible-cactus": {
-		"name": "higo chumbo"
-	},
-	"eggplant": {
-		"name": "berenjena",
-		"plural_name": "berenjenas"
-	},
-	"eggs": {
-		"name": "huevo",
-		"plural_name": "huevos"
-	},
-	"endive": {
-		"name": "endibia",
-		"plural_name": "endivias"
-	},
-	"fats": {
-		"name": "grasas"
-	},
-	"fava-beans": {
-		"name": "habas"
-	},
-	"fiddlehead": {
-		"name": "brotes de helecho"
-	},
-	"fiddlehead-fern": {
-		"name": "brotes de helecho",
-		"plural_name": "brotes de helecho"
-	},
-	"fish": {
-		"name": "pescado"
-	},
-	"five-spice-powder": {
-		"name": "cinco especias (espcias chinas)"
-	},
-	"flour": {
-		"name": "harina"
-	},
-	"frisee": {
-		"name": "lechuga rizada"
-	},
-	"fructose": {
-		"name": "fructosa"
-	},
-	"fruit": {
-		"name": "fruta"
-	},
-	"fruit-sugar": {
-		"name": "fructosa"
-	},
-	"ful": {
-		"name": "haba"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ajo",
-		"plural_name": "ajos"
-	},
-	"gem-squash": {
-		"name": "calabaza gem"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "menudillos"
-	},
-	"ginger": {
-		"name": "jengibre"
-	},
-	"grains": {
-		"name": "cereales"
-	},
-	"granulated-sugar": {
-		"name": "azúcar granulado"
-	},
-	"grape-seed-oil": {
-		"name": "aceite de pepitas de uva"
-	},
-	"green-onion": {
-		"name": "cebolleta",
-		"plural_name": "cebolletas"
-	},
-	"heart-of-palm": {
-		"name": "palmito",
-		"plural_name": "palmitos"
-	},
-	"hemp": {
-		"name": "cáñamo"
-	},
-	"herbs": {
-		"name": "hierbas"
-	},
-	"honey": {
-		"name": "miel"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "yaca",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "sazúcar de caña"
-	},
-	"jams": {
-		"name": "mermelada"
-	},
-	"jellies": {
-		"name": "gominolas"
-	},
-	"jerusalem-artichoke": {
-		"name": "alcachofa de Jerusalén"
-	},
-	"jicama": {
-		"name": "jícama"
-	},
-	"kale": {
-		"name": "col rizada"
-	},
-	"kohlrabi": {
-		"name": "colirrábano"
-	},
-	"kumara": {
-		"name": "batata/boniato"
-	},
-	"leavening-agents": {
-		"name": "agentes gasificantes"
-	},
-	"leek": {
-		"name": "puerro",
-		"plural_name": "puerros"
-	},
-	"legumes": {
-		"name": "legumbres"
-	},
-	"lemongrass": {
-		"name": "zacate limón"
-	},
-	"lentils": {
-		"name": "lentejas"
-	},
-	"lettuce": {
-		"name": "lechuga"
-	},
-	"liver": {
-		"name": "hígado",
-		"plural_name": "hígados"
-	},
-	"maize": {
-		"name": "maíz"
-	},
-	"maple-syrup": {
-		"name": "sirope de arce"
-	},
-	"meat": {
-		"name": "carne"
-	},
-	"milk": {
-		"name": "leche"
-	},
-	"mortadella": {
-		"name": "mortadela"
-	},
-	"mushroom": {
-		"name": "champiñón",
-		"plural_name": "setas"
-	},
-	"mussels": {
-		"name": "mejillones"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nuez moscada"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "levadura nutricional"
-	},
-	"nuts": {
-		"name": "frutos secos"
-	},
-	"octopuses": {
-		"name": "pulpo",
-		"plural_name": "pulpos"
-	},
-	"oils": {
-		"name": "aceites"
-	},
-	"okra": {
-		"name": "abelmosco"
-	},
-	"olive": {
-		"name": "aceituna"
-	},
-	"olive-oil": {
-		"name": "aceite de oliva"
-	},
-	"onion": {
-		"name": "cebolla"
-	},
-	"onion-family": {
-		"name": "cebollas"
-	},
-	"orange-blossom-water": {
-		"name": "agua de azahar"
-	},
-	"oranges": {
-		"name": "naranjas",
-		"plural_name": "naranjas"
-	},
-	"oregano": {
-		"name": "orégano"
-	},
-	"oysters": {
-		"name": "ostras"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "pimentón dulce"
-	},
-	"parsley": {
-		"name": "perejil"
-	},
-	"parsnip": {
-		"name": "chirivía",
-		"plural_name": "chirivías"
-	},
-	"pear": {
-		"name": "pera",
-		"plural_name": "peras"
-	},
-	"peas": {
-		"name": "guisantes/chícharos"
-	},
-	"pepper": {
-		"name": "pimiento",
-		"plural_name": "pimientos"
-	},
-	"pineapple": {
-		"name": "piña",
-		"plural_name": "piñas"
-	},
-	"plantain": {
-		"name": "plátano macho",
-		"plural_name": "plátanos"
-	},
-	"poppy-seeds": {
-		"name": "semillas de amapola"
-	},
-	"potato": {
-		"name": "papa/patata",
-		"plural_name": "patatas"
-	},
-	"poultry": {
-		"name": "aves de corral"
-	},
-	"powdered-sugar": {
-		"name": "azúcar en polvo"
-	},
-	"pumpkin": {
-		"name": "calabaza",
-		"plural_name": "calabazas"
-	},
-	"pumpkin-seeds": {
-		"name": "semillas de calabaza"
-	},
-	"radish": {
-		"name": "rábano",
-		"plural_name": "rábanos"
-	},
-	"raw-sugar": {
-		"name": "azúcar integral"
-	},
-	"refined-sugar": {
-		"name": "azúcar refinado"
-	},
-	"rice": {
-		"name": "arroz"
-	},
-	"rice-flour": {
-		"name": "harina de arroz"
-	},
-	"rock-sugar": {
-		"name": "azucar moreno"
-	},
-	"rum": {
-		"name": "ron"
-	},
-	"salmon": {
-		"name": "salmón"
-	},
-	"salt": {
-		"name": "sal"
-	},
-	"salt-cod": {
-		"name": "bacalao salado"
-	},
-	"scallion": {
-		"name": "cebollita china",
-		"plural_name": "cebolletas"
-	},
-	"seafood": {
-		"name": "marisco"
-	},
-	"seeds": {
-		"name": "semillas"
-	},
-	"sesame-seeds": {
-		"name": "semillas de sésamo"
-	},
-	"shallot": {
-		"name": "chalote",
-		"plural_name": "chalotes"
-	},
-	"skate": {
-		"name": "raya"
-	},
-	"soda": {
-		"name": "gaseosa"
-	},
-	"soda-baking": {
-		"name": "soda gasificante"
-	},
-	"soybean": {
-		"name": "soya/soja"
-	},
-	"spaghetti-squash": {
-		"name": "calabaza espagueti",
-		"plural_name": "calabaza espagueti"
-	},
-	"speck": {
-		"name": "speck (jamón)"
-	},
-	"spices": {
-		"name": "especias"
-	},
-	"spinach": {
-		"name": "espinacas"
-	},
-	"spring-onion": {
-		"name": "cebolleta",
-		"plural_name": "cebollino"
-	},
-	"squash": {
-		"name": "calabaza dulce",
-		"plural_name": "calabazas"
-	},
-	"squash-family": {
-		"name": "calabazas"
-	},
-	"stockfish": {
-		"name": "pescado seco"
-	},
-	"sugar": {
-		"name": "azúcar"
-	},
-	"sunchoke": {
-		"name": "girasol de Canadá",
-		"plural_name": "tupinambo"
-	},
-	"sunflower-seeds": {
-		"name": "pipas de girasol"
-	},
-	"superfine-sugar": {
-		"name": "azúcar superfina"
-	},
-	"sweet-potato": {
-		"name": "batata",
-		"plural_name": "batatas"
-	},
-	"sweetcorn": {
-		"name": "maíz dulce",
-		"plural_name": "maíz dulce"
-	},
-	"sweeteners": {
-		"name": "edulcorantes"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomates"
-	},
-	"trout": {
-		"name": "trucha"
-	},
-	"tubers": {
-		"name": "tubérculos",
-		"plural_name": "tubérculos"
-	},
-	"tuna": {
-		"name": "atún"
-	},
-	"turbanado-sugar": {
-		"name": "azúcar"
-	},
-	"turnip": {
-		"name": "nabo",
-		"plural_name": "nabos"
-	},
-	"unrefined-sugar": {
-		"name": "azúcar sin refinar"
-	},
-	"vanilla": {
-		"name": "vainilla"
-	},
-	"vegetables": {
-		"name": "verduras"
-	},
-	"watercress": {
-		"name": "berro de agua"
-	},
-	"watermelon": {
-		"name": "sandía/melón de agua",
-		"plural_name": "sandías"
-	},
-	"white-mushroom": {
-		"name": "champiñón blanco",
-		"plural_name": "champiñones blancos"
-	},
-	"white-sugar": {
-		"name": "azúcar blanco"
-	},
-	"xanthan-gum": {
-		"name": "goma xantana"
-	},
-	"yam": {
-		"name": "ñame",
-		"plural_name": "ñames"
-	},
-	"yeast": {
-		"name": "levadura"
-	},
-	"zucchini": {
-		"name": "calabacín",
-		"plural_name": "calabacines"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "calabaza bellota"
+            },
+            "alfalfa-sprouts": {
+                "name": "brotes de alfalfa"
+            },
+            "anchovies": {
+                "name": "anchoas"
+            },
+            "apples": {
+                "name": "manzana",
+                "plural_name": "manzanas"
+            },
+            "artichoke": {
+                "name": "alcachofa"
+            },
+            "arugula": {
+                "name": "rúcula"
+            },
+            "asparagus": {
+                "name": "espárragos"
+            },
+            "avocado": {
+                "name": "aguacate",
+                "plural_name": "palta"
+            },
+            "bacon": {
+                "name": "panceta"
+            },
+            "baking-powder": {
+                "name": "levadura"
+            },
+            "baking-soda": {
+                "name": "gaseosa (gasificante)"
+            },
+            "baking-sugar": {
+                "name": "azúcar glass"
+            },
+            "bar-sugar": {
+                "name": "azúcar de caña"
+            },
+            "basil": {
+                "name": "albahaca"
+            },
+            "beans": {
+                "name": "judías/alubias/frijoles"
+            },
+            "bell-peppers": {
+                "name": "pimiento morrón",
+                "plural_name": "pimiento morrón"
+            },
+            "blackberries": {
+                "name": "moras"
+            },
+            "bok-choy": {
+                "name": "col china (pak choi)"
+            },
+            "brassicas": {
+                "name": "coles"
+            },
+            "bread": {
+                "name": "pan"
+            },
+            "breadfruit": {
+                "name": "fruta del pan"
+            },
+            "broccoflower": {
+                "name": "romanesco"
+            },
+            "broccoli": {
+                "name": "brócoli"
+            },
+            "broccoli-rabe": {
+                "name": "grelos"
+            },
+            "broccolini": {
+                "name": "bimi"
+            },
+            "brown-sugar": {
+                "name": "azucar moreno"
+            },
+            "brussels-sprouts": {
+                "name": "coles de Bruselas"
+            },
+            "butter": {
+                "name": "mantequilla"
+            },
+            "butternut-pumpkin": {
+                "name": "calabaza cacahuete"
+            },
+            "butternut-squash": {
+                "name": "calabaza moscada"
+            },
+            "cabbage": {
+                "name": "repollo",
+                "plural_name": "repollos"
+            },
+            "cactus-edible": {
+                "name": "higo chumbo"
+            },
+            "calabrese": {
+                "name": "brócoli"
+            },
+            "cane-sugar": {
+                "name": "azúcar de caña"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "ñora"
+            },
+            "caraway": {
+                "name": "comino"
+            },
+            "carrot": {
+                "name": "zanahoria",
+                "plural_name": "zanahorias"
+            },
+            "caster-sugar": {
+                "name": "azúcar de caña"
+            },
+            "castor-sugar": {
+                "name": "azúcar"
+            },
+            "catfish": {
+                "name": "siluro"
+            },
+            "cauliflower": {
+                "name": "coliflor",
+                "plural_name": "coliflor"
+            },
+            "cayenne-pepper": {
+                "name": "pimienta de cayena"
+            },
+            "celeriac": {
+                "name": "apio nabo"
+            },
+            "celery": {
+                "name": "apio"
+            },
+            "cereal-grains": {
+                "name": "cereales en grano"
+            },
+            "chard": {
+                "name": "acelgas"
+            },
+            "cheese": {
+                "name": "queso"
+            },
+            "chicory": {
+                "name": "achicoria"
+            },
+            "chilli-peppers": {
+                "name": "chile/guindilla",
+                "plural_name": "chile/guindilla"
+            },
+            "chinese-leaves": {
+                "name": "col china"
+            },
+            "chives": {
+                "name": "cebollino"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "canela"
+            },
+            "clarified-butter": {
+                "name": "mantequilla clarificada"
+            },
+            "coconut": {
+                "name": "coco",
+                "plural_name": "cocos"
+            },
+            "coconut-milk": {
+                "name": "leche de coco"
+            },
+            "cod": {
+                "name": "bacalao"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "berza"
+            },
+            "confectioners-sugar": {
+                "name": "azúcar"
+            },
+            "coriander": {
+                "name": "cilantro"
+            },
+            "corn": {
+                "name": "maíz",
+                "plural_name": "maíz"
+            },
+            "corn-syrup": {
+                "name": "jarabe de maíz"
+            },
+            "cottonseed-oil": {
+                "name": "aceite de algodón"
+            },
+            "courgette": {
+                "name": "calabacín"
+            },
+            "cream-of-tartar": {
+                "name": "crémor tártaro"
+            },
+            "cucumber": {
+                "name": "pepino",
+                "plural_name": "pepino"
+            },
+            "cumin": {
+                "name": "comino"
+            },
+            "daikon": {
+                "name": "rábano japonés",
+                "plural_name": "rábanos japoneses"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "productos lácteos y sustitutos de lácteos"
+            },
+            "dandelion": {
+                "name": "diente de león"
+            },
+            "demerara-sugar": {
+                "name": "azúcar moreno"
+            },
+            "dough": {
+                "name": "masa"
+            },
+            "edible-cactus": {
+                "name": "higo chumbo"
+            },
+            "eggplant": {
+                "name": "berenjena",
+                "plural_name": "berenjenas"
+            },
+            "eggs": {
+                "name": "huevo",
+                "plural_name": "huevos"
+            },
+            "endive": {
+                "name": "endibia",
+                "plural_name": "endivias"
+            },
+            "fats": {
+                "name": "grasas"
+            },
+            "fava-beans": {
+                "name": "habas"
+            },
+            "fiddlehead": {
+                "name": "brotes de helecho"
+            },
+            "fiddlehead-fern": {
+                "name": "brotes de helecho",
+                "plural_name": "brotes de helecho"
+            },
+            "fish": {
+                "name": "pescado"
+            },
+            "five-spice-powder": {
+                "name": "cinco especias (espcias chinas)"
+            },
+            "flour": {
+                "name": "harina"
+            },
+            "frisee": {
+                "name": "lechuga rizada"
+            },
+            "fructose": {
+                "name": "fructosa"
+            },
+            "fruit": {
+                "name": "fruta"
+            },
+            "fruit-sugar": {
+                "name": "fructosa"
+            },
+            "ful": {
+                "name": "haba"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ajo",
+                "plural_name": "ajos"
+            },
+            "gem-squash": {
+                "name": "calabaza gem"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "menudillos"
+            },
+            "ginger": {
+                "name": "jengibre"
+            },
+            "grains": {
+                "name": "cereales"
+            },
+            "granulated-sugar": {
+                "name": "azúcar granulado"
+            },
+            "grape-seed-oil": {
+                "name": "aceite de pepitas de uva"
+            },
+            "green-onion": {
+                "name": "cebolleta",
+                "plural_name": "cebolletas"
+            },
+            "heart-of-palm": {
+                "name": "palmito",
+                "plural_name": "palmitos"
+            },
+            "hemp": {
+                "name": "cáñamo"
+            },
+            "herbs": {
+                "name": "hierbas"
+            },
+            "honey": {
+                "name": "miel"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "yaca",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "sazúcar de caña"
+            },
+            "jams": {
+                "name": "mermelada"
+            },
+            "jellies": {
+                "name": "gominolas"
+            },
+            "jerusalem-artichoke": {
+                "name": "alcachofa de Jerusalén"
+            },
+            "jicama": {
+                "name": "jícama"
+            },
+            "kale": {
+                "name": "col rizada"
+            },
+            "kohlrabi": {
+                "name": "colirrábano"
+            },
+            "kumara": {
+                "name": "batata/boniato"
+            },
+            "leavening-agents": {
+                "name": "agentes gasificantes"
+            },
+            "leek": {
+                "name": "puerro",
+                "plural_name": "puerros"
+            },
+            "legumes": {
+                "name": "legumbres"
+            },
+            "lemongrass": {
+                "name": "zacate limón"
+            },
+            "lentils": {
+                "name": "lentejas"
+            },
+            "lettuce": {
+                "name": "lechuga"
+            },
+            "liver": {
+                "name": "hígado",
+                "plural_name": "hígados"
+            },
+            "maize": {
+                "name": "maíz"
+            },
+            "maple-syrup": {
+                "name": "sirope de arce"
+            },
+            "meat": {
+                "name": "carne"
+            },
+            "milk": {
+                "name": "leche"
+            },
+            "mortadella": {
+                "name": "mortadela"
+            },
+            "mushroom": {
+                "name": "champiñón",
+                "plural_name": "setas"
+            },
+            "mussels": {
+                "name": "mejillones"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nuez moscada"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "levadura nutricional"
+            },
+            "nuts": {
+                "name": "frutos secos"
+            },
+            "octopuses": {
+                "name": "pulpo",
+                "plural_name": "pulpos"
+            },
+            "oils": {
+                "name": "aceites"
+            },
+            "okra": {
+                "name": "abelmosco"
+            },
+            "olive": {
+                "name": "aceituna"
+            },
+            "olive-oil": {
+                "name": "aceite de oliva"
+            },
+            "onion": {
+                "name": "cebolla"
+            },
+            "onion-family": {
+                "name": "cebollas"
+            },
+            "orange-blossom-water": {
+                "name": "agua de azahar"
+            },
+            "oranges": {
+                "name": "naranjas",
+                "plural_name": "naranjas"
+            },
+            "oregano": {
+                "name": "orégano"
+            },
+            "oysters": {
+                "name": "ostras"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "pimentón dulce"
+            },
+            "parsley": {
+                "name": "perejil"
+            },
+            "parsnip": {
+                "name": "chirivía",
+                "plural_name": "chirivías"
+            },
+            "pear": {
+                "name": "pera",
+                "plural_name": "peras"
+            },
+            "peas": {
+                "name": "guisantes/chícharos"
+            },
+            "pepper": {
+                "name": "pimiento",
+                "plural_name": "pimientos"
+            },
+            "pineapple": {
+                "name": "piña",
+                "plural_name": "piñas"
+            },
+            "plantain": {
+                "name": "plátano macho",
+                "plural_name": "plátanos"
+            },
+            "poppy-seeds": {
+                "name": "semillas de amapola"
+            },
+            "potato": {
+                "name": "papa/patata",
+                "plural_name": "patatas"
+            },
+            "poultry": {
+                "name": "aves de corral"
+            },
+            "powdered-sugar": {
+                "name": "azúcar en polvo"
+            },
+            "pumpkin": {
+                "name": "calabaza",
+                "plural_name": "calabazas"
+            },
+            "pumpkin-seeds": {
+                "name": "semillas de calabaza"
+            },
+            "radish": {
+                "name": "rábano",
+                "plural_name": "rábanos"
+            },
+            "raw-sugar": {
+                "name": "azúcar integral"
+            },
+            "refined-sugar": {
+                "name": "azúcar refinado"
+            },
+            "rice": {
+                "name": "arroz"
+            },
+            "rice-flour": {
+                "name": "harina de arroz"
+            },
+            "rock-sugar": {
+                "name": "azucar moreno"
+            },
+            "rum": {
+                "name": "ron"
+            },
+            "salmon": {
+                "name": "salmón"
+            },
+            "salt": {
+                "name": "sal"
+            },
+            "salt-cod": {
+                "name": "bacalao salado"
+            },
+            "scallion": {
+                "name": "cebollita china",
+                "plural_name": "cebolletas"
+            },
+            "seafood": {
+                "name": "marisco"
+            },
+            "seeds": {
+                "name": "semillas"
+            },
+            "sesame-seeds": {
+                "name": "semillas de sésamo"
+            },
+            "shallot": {
+                "name": "chalote",
+                "plural_name": "chalotes"
+            },
+            "skate": {
+                "name": "raya"
+            },
+            "soda": {
+                "name": "gaseosa"
+            },
+            "soda-baking": {
+                "name": "soda gasificante"
+            },
+            "soybean": {
+                "name": "soya/soja"
+            },
+            "spaghetti-squash": {
+                "name": "calabaza espagueti",
+                "plural_name": "calabaza espagueti"
+            },
+            "speck": {
+                "name": "speck (jamón)"
+            },
+            "spices": {
+                "name": "especias"
+            },
+            "spinach": {
+                "name": "espinacas"
+            },
+            "spring-onion": {
+                "name": "cebolleta",
+                "plural_name": "cebollino"
+            },
+            "squash": {
+                "name": "calabaza dulce",
+                "plural_name": "calabazas"
+            },
+            "squash-family": {
+                "name": "calabazas"
+            },
+            "stockfish": {
+                "name": "pescado seco"
+            },
+            "sugar": {
+                "name": "azúcar"
+            },
+            "sunchoke": {
+                "name": "girasol de Canadá",
+                "plural_name": "tupinambo"
+            },
+            "sunflower-seeds": {
+                "name": "pipas de girasol"
+            },
+            "superfine-sugar": {
+                "name": "azúcar superfina"
+            },
+            "sweet-potato": {
+                "name": "batata",
+                "plural_name": "batatas"
+            },
+            "sweetcorn": {
+                "name": "maíz dulce",
+                "plural_name": "maíz dulce"
+            },
+            "sweeteners": {
+                "name": "edulcorantes"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomates"
+            },
+            "trout": {
+                "name": "trucha"
+            },
+            "tubers": {
+                "name": "tubérculos",
+                "plural_name": "tubérculos"
+            },
+            "tuna": {
+                "name": "atún"
+            },
+            "turbanado-sugar": {
+                "name": "azúcar"
+            },
+            "turnip": {
+                "name": "nabo",
+                "plural_name": "nabos"
+            },
+            "unrefined-sugar": {
+                "name": "azúcar sin refinar"
+            },
+            "vanilla": {
+                "name": "vainilla"
+            },
+            "vegetables": {
+                "name": "verduras"
+            },
+            "watercress": {
+                "name": "berro de agua"
+            },
+            "watermelon": {
+                "name": "sandía/melón de agua",
+                "plural_name": "sandías"
+            },
+            "white-mushroom": {
+                "name": "champiñón blanco",
+                "plural_name": "champiñones blancos"
+            },
+            "white-sugar": {
+                "name": "azúcar blanco"
+            },
+            "xanthan-gum": {
+                "name": "goma xantana"
+            },
+            "yam": {
+                "name": "ñame",
+                "plural_name": "ñames"
+            },
+            "yeast": {
+                "name": "levadura"
+            },
+            "zucchini": {
+                "name": "calabacín",
+                "plural_name": "calabacines"
+            }
+        }
+    },
+    "Frutas y verduras": {
+        "foods": {}
+    },
+    "Cereales": {
+        "foods": {}
+    },
+    "Frutas": {
+        "foods": {}
+    },
+    "Verduras": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Pescado y marisco": {
+        "foods": {}
+    },
+    "Bebidas": {
+        "foods": {}
+    },
+    "Panadería y bollería": {
+        "foods": {}
+    },
+    "Productos enlatados": {
+        "foods": {}
+    },
+    "Condimentos": {
+        "foods": {}
+    },
+    "Repostería": {
+        "foods": {}
+    },
+    "Productos lácteos": {
+        "foods": {}
+    },
+    "Alimentos congelados": {
+        "foods": {}
+    },
+    "Alimentos saludables": {
+        "foods": {}
+    },
+    "Limpieza": {
+        "foods": {}
+    },
+    "Productos cárnicos": {
+        "foods": {}
+    },
+    "Aperitivos": {
+        "foods": {}
+    },
+    "Especias": {
+        "foods": {}
+    },
+    "Dulces": {
+        "foods": {}
+    },
+    "Bodega": {
+        "foods": {}
+    },
+    "Otros": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/fi-FI.json
+++ b/mealie/repos/seed/resources/foods/locales/fi-FI.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "koristekurpitsa"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfaidut"
-	},
-	"anchovies": {
-		"name": "anjovikset"
-	},
-	"apples": {
-		"name": "omenat",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artisokka"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "parsa"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "pekoni"
-	},
-	"baking-powder": {
-		"name": "leivinjauhe"
-	},
-	"baking-soda": {
-		"name": "ruokasooda"
-	},
-	"baking-sugar": {
-		"name": "leivontasokeri"
-	},
-	"bar-sugar": {
-		"name": "sirosokeri"
-	},
-	"basil": {
-		"name": "basilika"
-	},
-	"beans": {
-		"name": "pavut"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "karhunvatukat"
-	},
-	"bok-choy": {
-		"name": "paksoi"
-	},
-	"brassicas": {
-		"name": "kaalit"
-	},
-	"bread": {
-		"name": "leipä"
-	},
-	"breadfruit": {
-		"name": "leipäpuun hedelmä"
-	},
-	"broccoflower": {
-		"name": "parsakukkakaali"
-	},
-	"broccoli": {
-		"name": "parsakaali"
-	},
-	"broccoli-rabe": {
-		"name": "varsiparsakaali"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "fariinisokeri"
-	},
-	"brussels-sprouts": {
-		"name": "ruusukaalit"
-	},
-	"butter": {
-		"name": "voi"
-	},
-	"butternut-pumpkin": {
-		"name": "myskikurpitsa"
-	},
-	"butternut-squash": {
-		"name": "myskikurpitsa"
-	},
-	"cabbage": {
-		"name": "kaali",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "kaktus, syötävä"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "ruokosokeri"
-	},
-	"cannabis": {
-		"name": "kannabis"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "kumina"
-	},
-	"carrot": {
-		"name": "porkkana",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "castersokeri"
-	},
-	"castor-sugar": {
-		"name": "castor sokeri"
-	},
-	"catfish": {
-		"name": "monni"
-	},
-	"cauliflower": {
-		"name": "kukkakaali",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne-pippuri"
-	},
-	"celeriac": {
-		"name": "juuriselleri"
-	},
-	"celery": {
-		"name": "selleri"
-	},
-	"cereal-grains": {
-		"name": "viljanjyvät"
-	},
-	"chard": {
-		"name": "mangoldi"
-	},
-	"cheese": {
-		"name": "juusto"
-	},
-	"chicory": {
-		"name": "sikuri"
-	},
-	"chilli-peppers": {
-		"name": "chilipaprikat",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "kiinankaali"
-	},
-	"chives": {
-		"name": "ruohosipuli"
-	},
-	"chocolate": {
-		"name": "suklaa"
-	},
-	"cilantro": {
-		"name": "korianteri"
-	},
-	"cinnamon": {
-		"name": "kaneli"
-	},
-	"clarified-butter": {
-		"name": "kirkastettu voi"
-	},
-	"coconut": {
-		"name": "kookospähkinä",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "kookosmaito"
-	},
-	"cod": {
-		"name": "turska"
-	},
-	"coffee": {
-		"name": "kahvi"
-	},
-	"collard-greens": {
-		"name": "lehtikaali"
-	},
-	"confectioners-sugar": {
-		"name": "tomusokeri"
-	},
-	"coriander": {
-		"name": "korianteri"
-	},
-	"corn": {
-		"name": "maissi",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "maissisiirappi"
-	},
-	"cottonseed-oil": {
-		"name": "pellavansiemenöljy"
-	},
-	"courgette": {
-		"name": "kesäkurpitsa"
-	},
-	"cream-of-tartar": {
-		"name": "viinikivi"
-	},
-	"cucumber": {
-		"name": "kurkku",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "kumina"
-	},
-	"daikon": {
-		"name": "japaninretikka",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "maitotuotteet ja maidonkorvikkeet"
-	},
-	"dandelion": {
-		"name": "voikukka"
-	},
-	"demerara-sugar": {
-		"name": "fariinisokeri"
-	},
-	"dough": {
-		"name": "taikina"
-	},
-	"edible-cactus": {
-		"name": "syötävä kaktus"
-	},
-	"eggplant": {
-		"name": "munakoiso",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "munat",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endiivit",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "rasvat"
-	},
-	"fava-beans": {
-		"name": "härkäpapu"
-	},
-	"fiddlehead": {
-		"name": "viulunkierukka"
-	},
-	"fiddlehead-fern": {
-		"name": "viulunkierukka",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "kala"
-	},
-	"five-spice-powder": {
-		"name": "viiden mausteen seos"
-	},
-	"flour": {
-		"name": "jauho"
-	},
-	"frisee": {
-		"name": "friseesalaatti"
-	},
-	"fructose": {
-		"name": "fruktoosi"
-	},
-	"fruit": {
-		"name": "hedelmä"
-	},
-	"fruit-sugar": {
-		"name": "hedelmäsokeri"
-	},
-	"ful": {
-		"name": "ful-pavut"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "valkosipuli",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "kurpitsa"
-	},
-	"ghee": {
-		"name": "ghee-voi"
-	},
-	"giblets": {
-		"name": "linnun sisäelimet"
-	},
-	"ginger": {
-		"name": "inkivääri"
-	},
-	"grains": {
-		"name": "viljat"
-	},
-	"granulated-sugar": {
-		"name": "taloussokeri"
-	},
-	"grape-seed-oil": {
-		"name": "viinirypäleiden siemenöljy"
-	},
-	"green-onion": {
-		"name": "vihreä sipuli",
-		"plural_name": "vihreää sipulia"
-	},
-	"heart-of-palm": {
-		"name": "palmun sydän",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hamppu"
-	},
-	"herbs": {
-		"name": "yrtit"
-	},
-	"honey": {
-		"name": "hunaja"
-	},
-	"isomalt": {
-		"name": "isomaltoosi"
-	},
-	"jackfruit": {
-		"name": "jakkihedelmä",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "raakasokeri"
-	},
-	"jams": {
-		"name": "jamssi"
-	},
-	"jellies": {
-		"name": "hyytelöt"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalemin artisokka"
-	},
-	"jicama": {
-		"name": "pikkujamssipapu"
-	},
-	"kale": {
-		"name": "lehtikaali"
-	},
-	"kohlrabi": {
-		"name": "kyssäkaali"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "nostatusaineet"
-	},
-	"leek": {
-		"name": "purjo",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "palkokasvit"
-	},
-	"lemongrass": {
-		"name": "sitruunaruoho"
-	},
-	"lentils": {
-		"name": "linssit"
-	},
-	"lettuce": {
-		"name": "lehtisalaatti"
-	},
-	"liver": {
-		"name": "maksa",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maissi"
-	},
-	"maple-syrup": {
-		"name": "vaahterasiirappi"
-	},
-	"meat": {
-		"name": "liha"
-	},
-	"milk": {
-		"name": "maito"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "sieni",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "sinisimpukka"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo -palasekoitus"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muskottipähkinä"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "hiivahiutaleet"
-	},
-	"nuts": {
-		"name": "pähkinät"
-	},
-	"octopuses": {
-		"name": "mustekalat",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "öljyt"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliivi"
-	},
-	"olive-oil": {
-		"name": "oliiviöljy"
-	},
-	"onion": {
-		"name": "sipuli"
-	},
-	"onion-family": {
-		"name": "sipulit"
-	},
-	"orange-blossom-water": {
-		"name": "appelsiininkukkavesi"
-	},
-	"oranges": {
-		"name": "appelsiinit",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "osterit"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persilja"
-	},
-	"parsnip": {
-		"name": "palsternakka",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "päärynä",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "herneet"
-	},
-	"pepper": {
-		"name": "pippuri",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananasta"
-	},
-	"plantain": {
-		"name": "keittobanaani",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "unikonsiemenet"
-	},
-	"potato": {
-		"name": "peruna",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "siipikarja"
-	},
-	"powdered-sugar": {
-		"name": "tomusokeri"
-	},
-	"pumpkin": {
-		"name": "kurpitsa",
-		"plural_name": "kurpitsaa"
-	},
-	"pumpkin-seeds": {
-		"name": "kurpitsansiemen"
-	},
-	"radish": {
-		"name": "retiisi",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raakasokeri"
-	},
-	"refined-sugar": {
-		"name": "puhdistamaton sokeri"
-	},
-	"rice": {
-		"name": "riisi"
-	},
-	"rice-flour": {
-		"name": "riisijauho"
-	},
-	"rock-sugar": {
-		"name": "kivisokeri"
-	},
-	"rum": {
-		"name": "rommi"
-	},
-	"salmon": {
-		"name": "lohi"
-	},
-	"salt": {
-		"name": "suola"
-	},
-	"salt-cod": {
-		"name": "suolaturska"
-	},
-	"scallion": {
-		"name": "vihersipuli",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "merenelävät"
-	},
-	"seeds": {
-		"name": "siemenet"
-	},
-	"sesame-seeds": {
-		"name": "seesaminsiemenet"
-	},
-	"shallot": {
-		"name": "salottisipuli",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate-kala"
-	},
-	"soda": {
-		"name": "virvoitusjuoma"
-	},
-	"soda-baking": {
-		"name": "ruokasooda"
-	},
-	"soybean": {
-		"name": "soijapapu"
-	},
-	"spaghetti-squash": {
-		"name": "spagettikurpitsa",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck-kinkku"
-	},
-	"spices": {
-		"name": "mausteet"
-	},
-	"spinach": {
-		"name": "pinaatti"
-	},
-	"spring-onion": {
-		"name": "kevätsipuli",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "kurpitsa",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "kurpitsat"
-	},
-	"stockfish": {
-		"name": "kuivakala"
-	},
-	"sugar": {
-		"name": "sokeri"
-	},
-	"sunchoke": {
-		"name": "maa-artisokka",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "auringonkukansiemenet"
-	},
-	"superfine-sugar": {
-		"name": "erikoishieno sokeri"
-	},
-	"sweet-potato": {
-		"name": "bataatti",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "maissi",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "makeutusaineet"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taaro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomaatti",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "taimen"
-	},
-	"tubers": {
-		"name": "mukulat",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tonnikala"
-	},
-	"turbanado-sugar": {
-		"name": "ruskea raakasokeri"
-	},
-	"turnip": {
-		"name": "nauris",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "puhdistamaton sokeri"
-	},
-	"vanilla": {
-		"name": "vanilija"
-	},
-	"vegetables": {
-		"name": "vihannekset"
-	},
-	"watercress": {
-		"name": "vesikrassi"
-	},
-	"watermelon": {
-		"name": "vesimeloni",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "herkkusieni",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "valkoinen sokeri"
-	},
-	"xanthan-gum": {
-		"name": "ksantaanikumi"
-	},
-	"yam": {
-		"name": "hillo",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "hiiva"
-	},
-	"zucchini": {
-		"name": "kesäkurpitsa",
-		"plural_name": "zucchinis"
-	}
+    "acorn-squash": {
+        "name": "koristekurpitsa"
+    },
+    "alfalfa-sprouts": {
+        "name": "alfalfaidut"
+    },
+    "anchovies": {
+        "name": "anjovikset"
+    },
+    "apples": {
+        "name": "omenat",
+        "plural_name": "apples"
+    },
+    "artichoke": {
+        "name": "artisokka"
+    },
+    "arugula": {
+        "name": "rukola"
+    },
+    "asparagus": {
+        "name": "parsa"
+    },
+    "avocado": {
+        "name": "avokado",
+        "plural_name": "avocado"
+    },
+    "bacon": {
+        "name": "pekoni"
+    },
+    "baking-powder": {
+        "name": "leivinjauhe"
+    },
+    "baking-soda": {
+        "name": "ruokasooda"
+    },
+    "baking-sugar": {
+        "name": "leivontasokeri"
+    },
+    "bar-sugar": {
+        "name": "sirosokeri"
+    },
+    "basil": {
+        "name": "basilika"
+    },
+    "beans": {
+        "name": "pavut"
+    },
+    "bell-peppers": {
+        "name": "paprika",
+        "plural_name": "bell peppers"
+    },
+    "blackberries": {
+        "name": "karhunvatukat"
+    },
+    "bok-choy": {
+        "name": "paksoi"
+    },
+    "brassicas": {
+        "name": "kaalit"
+    },
+    "bread": {
+        "name": "leipä"
+    },
+    "breadfruit": {
+        "name": "leipäpuun hedelmä"
+    },
+    "broccoflower": {
+        "name": "parsakukkakaali"
+    },
+    "broccoli": {
+        "name": "parsakaali"
+    },
+    "broccoli-rabe": {
+        "name": "varsiparsakaali"
+    },
+    "broccolini": {
+        "name": "broccolini"
+    },
+    "brown-sugar": {
+        "name": "fariinisokeri"
+    },
+    "brussels-sprouts": {
+        "name": "ruusukaalit"
+    },
+    "butter": {
+        "name": "voi"
+    },
+    "butternut-pumpkin": {
+        "name": "myskikurpitsa"
+    },
+    "butternut-squash": {
+        "name": "myskikurpitsa"
+    },
+    "cabbage": {
+        "name": "kaali",
+        "plural_name": "cabbages"
+    },
+    "cactus-edible": {
+        "name": "kaktus, syötävä"
+    },
+    "calabrese": {
+        "name": "calabrese"
+    },
+    "cane-sugar": {
+        "name": "ruokosokeri"
+    },
+    "cannabis": {
+        "name": "kannabis"
+    },
+    "capsicum": {
+        "name": "paprika"
+    },
+    "caraway": {
+        "name": "kumina"
+    },
+    "carrot": {
+        "name": "porkkana",
+        "plural_name": "carrots"
+    },
+    "caster-sugar": {
+        "name": "castersokeri"
+    },
+    "castor-sugar": {
+        "name": "castor sokeri"
+    },
+    "catfish": {
+        "name": "monni"
+    },
+    "cauliflower": {
+        "name": "kukkakaali",
+        "plural_name": "cauliflowers"
+    },
+    "cayenne-pepper": {
+        "name": "cayenne-pippuri"
+    },
+    "celeriac": {
+        "name": "juuriselleri"
+    },
+    "celery": {
+        "name": "selleri"
+    },
+    "cereal-grains": {
+        "name": "viljanjyvät"
+    },
+    "chard": {
+        "name": "mangoldi"
+    },
+    "cheese": {
+        "name": "juusto"
+    },
+    "chicory": {
+        "name": "sikuri"
+    },
+    "chilli-peppers": {
+        "name": "chilipaprikat",
+        "plural_name": "chilli peppers"
+    },
+    "chinese-leaves": {
+        "name": "kiinankaali"
+    },
+    "chives": {
+        "name": "ruohosipuli"
+    },
+    "chocolate": {
+        "name": "suklaa"
+    },
+    "cilantro": {
+        "name": "korianteri"
+    },
+    "cinnamon": {
+        "name": "kaneli"
+    },
+    "clarified-butter": {
+        "name": "kirkastettu voi"
+    },
+    "coconut": {
+        "name": "kookospähkinä",
+        "plural_name": "coconuts"
+    },
+    "coconut-milk": {
+        "name": "kookosmaito"
+    },
+    "cod": {
+        "name": "turska"
+    },
+    "coffee": {
+        "name": "kahvi"
+    },
+    "collard-greens": {
+        "name": "lehtikaali"
+    },
+    "confectioners-sugar": {
+        "name": "tomusokeri"
+    },
+    "coriander": {
+        "name": "korianteri"
+    },
+    "corn": {
+        "name": "maissi",
+        "plural_name": "corns"
+    },
+    "corn-syrup": {
+        "name": "maissisiirappi"
+    },
+    "cottonseed-oil": {
+        "name": "pellavansiemenöljy"
+    },
+    "courgette": {
+        "name": "kesäkurpitsa"
+    },
+    "cream-of-tartar": {
+        "name": "viinikivi"
+    },
+    "cucumber": {
+        "name": "kurkku",
+        "plural_name": "cucumbers"
+    },
+    "cumin": {
+        "name": "kumina"
+    },
+    "daikon": {
+        "name": "japaninretikka",
+        "plural_name": "daikons"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "maitotuotteet ja maidonkorvikkeet"
+    },
+    "dandelion": {
+        "name": "voikukka"
+    },
+    "demerara-sugar": {
+        "name": "fariinisokeri"
+    },
+    "dough": {
+        "name": "taikina"
+    },
+    "edible-cactus": {
+        "name": "syötävä kaktus"
+    },
+    "eggplant": {
+        "name": "munakoiso",
+        "plural_name": "eggplants"
+    },
+    "eggs": {
+        "name": "munat",
+        "plural_name": "eggs"
+    },
+    "endive": {
+        "name": "endiivit",
+        "plural_name": "endives"
+    },
+    "fats": {
+        "name": "rasvat"
+    },
+    "fava-beans": {
+        "name": "härkäpapu"
+    },
+    "fiddlehead": {
+        "name": "viulunkierukka"
+    },
+    "fiddlehead-fern": {
+        "name": "viulunkierukka",
+        "plural_name": "fiddlehead ferns"
+    },
+    "fish": {
+        "name": "kala"
+    },
+    "five-spice-powder": {
+        "name": "viiden mausteen seos"
+    },
+    "flour": {
+        "name": "jauho"
+    },
+    "frisee": {
+        "name": "friseesalaatti"
+    },
+    "fructose": {
+        "name": "fruktoosi"
+    },
+    "fruit": {
+        "name": "hedelmä"
+    },
+    "fruit-sugar": {
+        "name": "hedelmäsokeri"
+    },
+    "ful": {
+        "name": "ful-pavut"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "valkosipuli",
+        "plural_name": "garlics"
+    },
+    "gem-squash": {
+        "name": "kurpitsa"
+    },
+    "ghee": {
+        "name": "ghee-voi"
+    },
+    "giblets": {
+        "name": "linnun sisäelimet"
+    },
+    "ginger": {
+        "name": "inkivääri"
+    },
+    "grains": {
+        "name": "viljat"
+    },
+    "granulated-sugar": {
+        "name": "taloussokeri"
+    },
+    "grape-seed-oil": {
+        "name": "viinirypäleiden siemenöljy"
+    },
+    "green-onion": {
+        "name": "vihreä sipuli",
+        "plural_name": "vihreää sipulia"
+    },
+    "heart-of-palm": {
+        "name": "palmun sydän",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "hamppu"
+    },
+    "herbs": {
+        "name": "yrtit"
+    },
+    "honey": {
+        "name": "hunaja"
+    },
+    "isomalt": {
+        "name": "isomaltoosi"
+    },
+    "jackfruit": {
+        "name": "jakkihedelmä",
+        "plural_name": "jackfruits"
+    },
+    "jaggery": {
+        "name": "raakasokeri"
+    },
+    "jams": {
+        "name": "jamssi"
+    },
+    "jellies": {
+        "name": "hyytelöt"
+    },
+    "jerusalem-artichoke": {
+        "name": "jerusalemin artisokka"
+    },
+    "jicama": {
+        "name": "pikkujamssipapu"
+    },
+    "kale": {
+        "name": "lehtikaali"
+    },
+    "kohlrabi": {
+        "name": "kyssäkaali"
+    },
+    "kumara": {
+        "name": "kumara"
+    },
+    "leavening-agents": {
+        "name": "nostatusaineet"
+    },
+    "leek": {
+        "name": "purjo",
+        "plural_name": "leeks"
+    },
+    "legumes": {
+        "name": "palkokasvit"
+    },
+    "lemongrass": {
+        "name": "sitruunaruoho"
+    },
+    "lentils": {
+        "name": "linssit"
+    },
+    "lettuce": {
+        "name": "lehtisalaatti"
+    },
+    "liver": {
+        "name": "maksa",
+        "plural_name": "livers"
+    },
+    "maize": {
+        "name": "maissi"
+    },
+    "maple-syrup": {
+        "name": "vaahterasiirappi"
+    },
+    "meat": {
+        "name": "liha"
+    },
+    "milk": {
+        "name": "maito"
+    },
+    "mortadella": {
+        "name": "mortadella"
+    },
+    "mushroom": {
+        "name": "sieni",
+        "plural_name": "mushrooms"
+    },
+    "mussels": {
+        "name": "sinisimpukka"
+    },
+    "nanaimo-bar-mix": {
+        "name": "nanaimo -palasekoitus"
+    },
+    "nori": {
+        "name": "nori"
+    },
+    "nutmeg": {
+        "name": "muskottipähkinä"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "hiivahiutaleet"
+    },
+    "nuts": {
+        "name": "pähkinät"
+    },
+    "octopuses": {
+        "name": "mustekalat",
+        "plural_name": "octopuses"
+    },
+    "oils": {
+        "name": "öljyt"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "oliivi"
+    },
+    "olive-oil": {
+        "name": "oliiviöljy"
+    },
+    "onion": {
+        "name": "sipuli"
+    },
+    "onion-family": {
+        "name": "sipulit"
+    },
+    "orange-blossom-water": {
+        "name": "appelsiininkukkavesi"
+    },
+    "oranges": {
+        "name": "appelsiinit",
+        "plural_name": "oranges"
+    },
+    "oregano": {
+        "name": "oregano"
+    },
+    "oysters": {
+        "name": "osterit"
+    },
+    "panch-puran": {
+        "name": "panch puran"
+    },
+    "paprika": {
+        "name": "paprika"
+    },
+    "parsley": {
+        "name": "persilja"
+    },
+    "parsnip": {
+        "name": "palsternakka",
+        "plural_name": "parsnips"
+    },
+    "pear": {
+        "name": "päärynä",
+        "plural_name": "pears"
+    },
+    "peas": {
+        "name": "herneet"
+    },
+    "pepper": {
+        "name": "pippuri",
+        "plural_name": "peppers"
+    },
+    "pineapple": {
+        "name": "ananas",
+        "plural_name": "ananasta"
+    },
+    "plantain": {
+        "name": "keittobanaani",
+        "plural_name": "plantains"
+    },
+    "poppy-seeds": {
+        "name": "unikonsiemenet"
+    },
+    "potato": {
+        "name": "peruna",
+        "plural_name": "potatoes"
+    },
+    "poultry": {
+        "name": "siipikarja"
+    },
+    "powdered-sugar": {
+        "name": "tomusokeri"
+    },
+    "pumpkin": {
+        "name": "kurpitsa",
+        "plural_name": "kurpitsaa"
+    },
+    "pumpkin-seeds": {
+        "name": "kurpitsansiemen"
+    },
+    "radish": {
+        "name": "retiisi",
+        "plural_name": "radishes"
+    },
+    "raw-sugar": {
+        "name": "raakasokeri"
+    },
+    "refined-sugar": {
+        "name": "puhdistamaton sokeri"
+    },
+    "rice": {
+        "name": "riisi"
+    },
+    "rice-flour": {
+        "name": "riisijauho"
+    },
+    "rock-sugar": {
+        "name": "kivisokeri"
+    },
+    "rum": {
+        "name": "rommi"
+    },
+    "salmon": {
+        "name": "lohi"
+    },
+    "salt": {
+        "name": "suola"
+    },
+    "salt-cod": {
+        "name": "suolaturska"
+    },
+    "scallion": {
+        "name": "vihersipuli",
+        "plural_name": "scallions"
+    },
+    "seafood": {
+        "name": "merenelävät"
+    },
+    "seeds": {
+        "name": "siemenet"
+    },
+    "sesame-seeds": {
+        "name": "seesaminsiemenet"
+    },
+    "shallot": {
+        "name": "salottisipuli",
+        "plural_name": "shallots"
+    },
+    "skate": {
+        "name": "skate-kala"
+    },
+    "soda": {
+        "name": "virvoitusjuoma"
+    },
+    "soda-baking": {
+        "name": "ruokasooda"
+    },
+    "soybean": {
+        "name": "soijapapu"
+    },
+    "spaghetti-squash": {
+        "name": "spagettikurpitsa",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "speck-kinkku"
+    },
+    "spices": {
+        "name": "mausteet"
+    },
+    "spinach": {
+        "name": "pinaatti"
+    },
+    "spring-onion": {
+        "name": "kevätsipuli",
+        "plural_name": "spring onions"
+    },
+    "squash": {
+        "name": "kurpitsa",
+        "plural_name": "squashes"
+    },
+    "squash-family": {
+        "name": "kurpitsat"
+    },
+    "stockfish": {
+        "name": "kuivakala"
+    },
+    "sugar": {
+        "name": "sokeri"
+    },
+    "sunchoke": {
+        "name": "maa-artisokka",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "auringonkukansiemenet"
+    },
+    "superfine-sugar": {
+        "name": "erikoishieno sokeri"
+    },
+    "sweet-potato": {
+        "name": "bataatti",
+        "plural_name": "sweet potatoes"
+    },
+    "sweetcorn": {
+        "name": "maissi",
+        "plural_name": "sweetcorns"
+    },
+    "sweeteners": {
+        "name": "makeutusaineet"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "taaro",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "teff"
+    },
+    "tomato": {
+        "name": "tomaatti",
+        "plural_name": "tomatoes"
+    },
+    "trout": {
+        "name": "taimen"
+    },
+    "tubers": {
+        "name": "mukulat",
+        "plural_name": "tubers"
+    },
+    "tuna": {
+        "name": "tonnikala"
+    },
+    "turbanado-sugar": {
+        "name": "ruskea raakasokeri"
+    },
+    "turnip": {
+        "name": "nauris",
+        "plural_name": "turnips"
+    },
+    "unrefined-sugar": {
+        "name": "puhdistamaton sokeri"
+    },
+    "vanilla": {
+        "name": "vanilija"
+    },
+    "vegetables": {
+        "name": "vihannekset"
+    },
+    "watercress": {
+        "name": "vesikrassi"
+    },
+    "watermelon": {
+        "name": "vesimeloni",
+        "plural_name": "watermelons"
+    },
+    "white-mushroom": {
+        "name": "herkkusieni",
+        "plural_name": "white mushrooms"
+    },
+    "white-sugar": {
+        "name": "valkoinen sokeri"
+    },
+    "xanthan-gum": {
+        "name": "ksantaanikumi"
+    },
+    "yam": {
+        "name": "hillo",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "hiiva"
+    },
+    "zucchini": {
+        "name": "kesäkurpitsa",
+        "plural_name": "zucchinis"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/fi-FI.json
+++ b/mealie/repos/seed/resources/foods/locales/fi-FI.json
@@ -1,692 +1,753 @@
 {
-    "acorn-squash": {
-        "name": "koristekurpitsa"
-    },
-    "alfalfa-sprouts": {
-        "name": "alfalfaidut"
-    },
-    "anchovies": {
-        "name": "anjovikset"
-    },
-    "apples": {
-        "name": "omenat",
-        "plural_name": "apples"
-    },
-    "artichoke": {
-        "name": "artisokka"
-    },
-    "arugula": {
-        "name": "rukola"
-    },
-    "asparagus": {
-        "name": "parsa"
-    },
-    "avocado": {
-        "name": "avokado",
-        "plural_name": "avocado"
-    },
-    "bacon": {
-        "name": "pekoni"
-    },
-    "baking-powder": {
-        "name": "leivinjauhe"
-    },
-    "baking-soda": {
-        "name": "ruokasooda"
-    },
-    "baking-sugar": {
-        "name": "leivontasokeri"
-    },
-    "bar-sugar": {
-        "name": "sirosokeri"
-    },
-    "basil": {
-        "name": "basilika"
-    },
-    "beans": {
-        "name": "pavut"
-    },
-    "bell-peppers": {
-        "name": "paprika",
-        "plural_name": "bell peppers"
-    },
-    "blackberries": {
-        "name": "karhunvatukat"
-    },
-    "bok-choy": {
-        "name": "paksoi"
-    },
-    "brassicas": {
-        "name": "kaalit"
-    },
-    "bread": {
-        "name": "leipä"
-    },
-    "breadfruit": {
-        "name": "leipäpuun hedelmä"
-    },
-    "broccoflower": {
-        "name": "parsakukkakaali"
-    },
-    "broccoli": {
-        "name": "parsakaali"
-    },
-    "broccoli-rabe": {
-        "name": "varsiparsakaali"
-    },
-    "broccolini": {
-        "name": "broccolini"
-    },
-    "brown-sugar": {
-        "name": "fariinisokeri"
-    },
-    "brussels-sprouts": {
-        "name": "ruusukaalit"
-    },
-    "butter": {
-        "name": "voi"
-    },
-    "butternut-pumpkin": {
-        "name": "myskikurpitsa"
-    },
-    "butternut-squash": {
-        "name": "myskikurpitsa"
-    },
-    "cabbage": {
-        "name": "kaali",
-        "plural_name": "cabbages"
-    },
-    "cactus-edible": {
-        "name": "kaktus, syötävä"
-    },
-    "calabrese": {
-        "name": "calabrese"
-    },
-    "cane-sugar": {
-        "name": "ruokosokeri"
-    },
-    "cannabis": {
-        "name": "kannabis"
-    },
-    "capsicum": {
-        "name": "paprika"
-    },
-    "caraway": {
-        "name": "kumina"
-    },
-    "carrot": {
-        "name": "porkkana",
-        "plural_name": "carrots"
-    },
-    "caster-sugar": {
-        "name": "castersokeri"
-    },
-    "castor-sugar": {
-        "name": "castor sokeri"
-    },
-    "catfish": {
-        "name": "monni"
-    },
-    "cauliflower": {
-        "name": "kukkakaali",
-        "plural_name": "cauliflowers"
-    },
-    "cayenne-pepper": {
-        "name": "cayenne-pippuri"
-    },
-    "celeriac": {
-        "name": "juuriselleri"
-    },
-    "celery": {
-        "name": "selleri"
-    },
-    "cereal-grains": {
-        "name": "viljanjyvät"
-    },
-    "chard": {
-        "name": "mangoldi"
-    },
-    "cheese": {
-        "name": "juusto"
-    },
-    "chicory": {
-        "name": "sikuri"
-    },
-    "chilli-peppers": {
-        "name": "chilipaprikat",
-        "plural_name": "chilli peppers"
-    },
-    "chinese-leaves": {
-        "name": "kiinankaali"
-    },
-    "chives": {
-        "name": "ruohosipuli"
-    },
-    "chocolate": {
-        "name": "suklaa"
-    },
-    "cilantro": {
-        "name": "korianteri"
-    },
-    "cinnamon": {
-        "name": "kaneli"
-    },
-    "clarified-butter": {
-        "name": "kirkastettu voi"
-    },
-    "coconut": {
-        "name": "kookospähkinä",
-        "plural_name": "coconuts"
-    },
-    "coconut-milk": {
-        "name": "kookosmaito"
-    },
-    "cod": {
-        "name": "turska"
-    },
-    "coffee": {
-        "name": "kahvi"
-    },
-    "collard-greens": {
-        "name": "lehtikaali"
-    },
-    "confectioners-sugar": {
-        "name": "tomusokeri"
-    },
-    "coriander": {
-        "name": "korianteri"
-    },
-    "corn": {
-        "name": "maissi",
-        "plural_name": "corns"
-    },
-    "corn-syrup": {
-        "name": "maissisiirappi"
-    },
-    "cottonseed-oil": {
-        "name": "pellavansiemenöljy"
-    },
-    "courgette": {
-        "name": "kesäkurpitsa"
-    },
-    "cream-of-tartar": {
-        "name": "viinikivi"
-    },
-    "cucumber": {
-        "name": "kurkku",
-        "plural_name": "cucumbers"
-    },
-    "cumin": {
-        "name": "kumina"
-    },
-    "daikon": {
-        "name": "japaninretikka",
-        "plural_name": "daikons"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "maitotuotteet ja maidonkorvikkeet"
-    },
-    "dandelion": {
-        "name": "voikukka"
-    },
-    "demerara-sugar": {
-        "name": "fariinisokeri"
-    },
-    "dough": {
-        "name": "taikina"
-    },
-    "edible-cactus": {
-        "name": "syötävä kaktus"
-    },
-    "eggplant": {
-        "name": "munakoiso",
-        "plural_name": "eggplants"
-    },
-    "eggs": {
-        "name": "munat",
-        "plural_name": "eggs"
-    },
-    "endive": {
-        "name": "endiivit",
-        "plural_name": "endives"
-    },
-    "fats": {
-        "name": "rasvat"
-    },
-    "fava-beans": {
-        "name": "härkäpapu"
-    },
-    "fiddlehead": {
-        "name": "viulunkierukka"
-    },
-    "fiddlehead-fern": {
-        "name": "viulunkierukka",
-        "plural_name": "fiddlehead ferns"
-    },
-    "fish": {
-        "name": "kala"
-    },
-    "five-spice-powder": {
-        "name": "viiden mausteen seos"
-    },
-    "flour": {
-        "name": "jauho"
-    },
-    "frisee": {
-        "name": "friseesalaatti"
-    },
-    "fructose": {
-        "name": "fruktoosi"
-    },
-    "fruit": {
-        "name": "hedelmä"
-    },
-    "fruit-sugar": {
-        "name": "hedelmäsokeri"
-    },
-    "ful": {
-        "name": "ful-pavut"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "valkosipuli",
-        "plural_name": "garlics"
-    },
-    "gem-squash": {
-        "name": "kurpitsa"
-    },
-    "ghee": {
-        "name": "ghee-voi"
-    },
-    "giblets": {
-        "name": "linnun sisäelimet"
-    },
-    "ginger": {
-        "name": "inkivääri"
-    },
-    "grains": {
-        "name": "viljat"
-    },
-    "granulated-sugar": {
-        "name": "taloussokeri"
-    },
-    "grape-seed-oil": {
-        "name": "viinirypäleiden siemenöljy"
-    },
-    "green-onion": {
-        "name": "vihreä sipuli",
-        "plural_name": "vihreää sipulia"
-    },
-    "heart-of-palm": {
-        "name": "palmun sydän",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "hamppu"
-    },
-    "herbs": {
-        "name": "yrtit"
-    },
-    "honey": {
-        "name": "hunaja"
-    },
-    "isomalt": {
-        "name": "isomaltoosi"
-    },
-    "jackfruit": {
-        "name": "jakkihedelmä",
-        "plural_name": "jackfruits"
-    },
-    "jaggery": {
-        "name": "raakasokeri"
-    },
-    "jams": {
-        "name": "jamssi"
-    },
-    "jellies": {
-        "name": "hyytelöt"
-    },
-    "jerusalem-artichoke": {
-        "name": "jerusalemin artisokka"
-    },
-    "jicama": {
-        "name": "pikkujamssipapu"
-    },
-    "kale": {
-        "name": "lehtikaali"
-    },
-    "kohlrabi": {
-        "name": "kyssäkaali"
-    },
-    "kumara": {
-        "name": "kumara"
-    },
-    "leavening-agents": {
-        "name": "nostatusaineet"
-    },
-    "leek": {
-        "name": "purjo",
-        "plural_name": "leeks"
-    },
-    "legumes": {
-        "name": "palkokasvit"
-    },
-    "lemongrass": {
-        "name": "sitruunaruoho"
-    },
-    "lentils": {
-        "name": "linssit"
-    },
-    "lettuce": {
-        "name": "lehtisalaatti"
-    },
-    "liver": {
-        "name": "maksa",
-        "plural_name": "livers"
-    },
-    "maize": {
-        "name": "maissi"
-    },
-    "maple-syrup": {
-        "name": "vaahterasiirappi"
-    },
-    "meat": {
-        "name": "liha"
-    },
-    "milk": {
-        "name": "maito"
-    },
-    "mortadella": {
-        "name": "mortadella"
-    },
-    "mushroom": {
-        "name": "sieni",
-        "plural_name": "mushrooms"
-    },
-    "mussels": {
-        "name": "sinisimpukka"
-    },
-    "nanaimo-bar-mix": {
-        "name": "nanaimo -palasekoitus"
-    },
-    "nori": {
-        "name": "nori"
-    },
-    "nutmeg": {
-        "name": "muskottipähkinä"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "hiivahiutaleet"
-    },
-    "nuts": {
-        "name": "pähkinät"
-    },
-    "octopuses": {
-        "name": "mustekalat",
-        "plural_name": "octopuses"
-    },
-    "oils": {
-        "name": "öljyt"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "oliivi"
-    },
-    "olive-oil": {
-        "name": "oliiviöljy"
-    },
-    "onion": {
-        "name": "sipuli"
-    },
-    "onion-family": {
-        "name": "sipulit"
-    },
-    "orange-blossom-water": {
-        "name": "appelsiininkukkavesi"
-    },
-    "oranges": {
-        "name": "appelsiinit",
-        "plural_name": "oranges"
-    },
-    "oregano": {
-        "name": "oregano"
-    },
-    "oysters": {
-        "name": "osterit"
-    },
-    "panch-puran": {
-        "name": "panch puran"
-    },
-    "paprika": {
-        "name": "paprika"
-    },
-    "parsley": {
-        "name": "persilja"
-    },
-    "parsnip": {
-        "name": "palsternakka",
-        "plural_name": "parsnips"
-    },
-    "pear": {
-        "name": "päärynä",
-        "plural_name": "pears"
-    },
-    "peas": {
-        "name": "herneet"
-    },
-    "pepper": {
-        "name": "pippuri",
-        "plural_name": "peppers"
-    },
-    "pineapple": {
-        "name": "ananas",
-        "plural_name": "ananasta"
-    },
-    "plantain": {
-        "name": "keittobanaani",
-        "plural_name": "plantains"
-    },
-    "poppy-seeds": {
-        "name": "unikonsiemenet"
-    },
-    "potato": {
-        "name": "peruna",
-        "plural_name": "potatoes"
-    },
-    "poultry": {
-        "name": "siipikarja"
-    },
-    "powdered-sugar": {
-        "name": "tomusokeri"
-    },
-    "pumpkin": {
-        "name": "kurpitsa",
-        "plural_name": "kurpitsaa"
-    },
-    "pumpkin-seeds": {
-        "name": "kurpitsansiemen"
-    },
-    "radish": {
-        "name": "retiisi",
-        "plural_name": "radishes"
-    },
-    "raw-sugar": {
-        "name": "raakasokeri"
-    },
-    "refined-sugar": {
-        "name": "puhdistamaton sokeri"
-    },
-    "rice": {
-        "name": "riisi"
-    },
-    "rice-flour": {
-        "name": "riisijauho"
-    },
-    "rock-sugar": {
-        "name": "kivisokeri"
-    },
-    "rum": {
-        "name": "rommi"
-    },
-    "salmon": {
-        "name": "lohi"
-    },
-    "salt": {
-        "name": "suola"
-    },
-    "salt-cod": {
-        "name": "suolaturska"
-    },
-    "scallion": {
-        "name": "vihersipuli",
-        "plural_name": "scallions"
-    },
-    "seafood": {
-        "name": "merenelävät"
-    },
-    "seeds": {
-        "name": "siemenet"
-    },
-    "sesame-seeds": {
-        "name": "seesaminsiemenet"
-    },
-    "shallot": {
-        "name": "salottisipuli",
-        "plural_name": "shallots"
-    },
-    "skate": {
-        "name": "skate-kala"
-    },
-    "soda": {
-        "name": "virvoitusjuoma"
-    },
-    "soda-baking": {
-        "name": "ruokasooda"
-    },
-    "soybean": {
-        "name": "soijapapu"
-    },
-    "spaghetti-squash": {
-        "name": "spagettikurpitsa",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "speck-kinkku"
-    },
-    "spices": {
-        "name": "mausteet"
-    },
-    "spinach": {
-        "name": "pinaatti"
-    },
-    "spring-onion": {
-        "name": "kevätsipuli",
-        "plural_name": "spring onions"
-    },
-    "squash": {
-        "name": "kurpitsa",
-        "plural_name": "squashes"
-    },
-    "squash-family": {
-        "name": "kurpitsat"
-    },
-    "stockfish": {
-        "name": "kuivakala"
-    },
-    "sugar": {
-        "name": "sokeri"
-    },
-    "sunchoke": {
-        "name": "maa-artisokka",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "auringonkukansiemenet"
-    },
-    "superfine-sugar": {
-        "name": "erikoishieno sokeri"
-    },
-    "sweet-potato": {
-        "name": "bataatti",
-        "plural_name": "sweet potatoes"
-    },
-    "sweetcorn": {
-        "name": "maissi",
-        "plural_name": "sweetcorns"
-    },
-    "sweeteners": {
-        "name": "makeutusaineet"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "taaro",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "teff"
-    },
-    "tomato": {
-        "name": "tomaatti",
-        "plural_name": "tomatoes"
-    },
-    "trout": {
-        "name": "taimen"
-    },
-    "tubers": {
-        "name": "mukulat",
-        "plural_name": "tubers"
-    },
-    "tuna": {
-        "name": "tonnikala"
-    },
-    "turbanado-sugar": {
-        "name": "ruskea raakasokeri"
-    },
-    "turnip": {
-        "name": "nauris",
-        "plural_name": "turnips"
-    },
-    "unrefined-sugar": {
-        "name": "puhdistamaton sokeri"
-    },
-    "vanilla": {
-        "name": "vanilija"
-    },
-    "vegetables": {
-        "name": "vihannekset"
-    },
-    "watercress": {
-        "name": "vesikrassi"
-    },
-    "watermelon": {
-        "name": "vesimeloni",
-        "plural_name": "watermelons"
-    },
-    "white-mushroom": {
-        "name": "herkkusieni",
-        "plural_name": "white mushrooms"
-    },
-    "white-sugar": {
-        "name": "valkoinen sokeri"
-    },
-    "xanthan-gum": {
-        "name": "ksantaanikumi"
-    },
-    "yam": {
-        "name": "hillo",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "hiiva"
-    },
-    "zucchini": {
-        "name": "kesäkurpitsa",
-        "plural_name": "zucchinis"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "koristekurpitsa"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfaidut"
+            },
+            "anchovies": {
+                "name": "anjovikset"
+            },
+            "apples": {
+                "name": "omenat",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artisokka"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "parsa"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "pekoni"
+            },
+            "baking-powder": {
+                "name": "leivinjauhe"
+            },
+            "baking-soda": {
+                "name": "ruokasooda"
+            },
+            "baking-sugar": {
+                "name": "leivontasokeri"
+            },
+            "bar-sugar": {
+                "name": "sirosokeri"
+            },
+            "basil": {
+                "name": "basilika"
+            },
+            "beans": {
+                "name": "pavut"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "karhunvatukat"
+            },
+            "bok-choy": {
+                "name": "paksoi"
+            },
+            "brassicas": {
+                "name": "kaalit"
+            },
+            "bread": {
+                "name": "leipä"
+            },
+            "breadfruit": {
+                "name": "leipäpuun hedelmä"
+            },
+            "broccoflower": {
+                "name": "parsakukkakaali"
+            },
+            "broccoli": {
+                "name": "parsakaali"
+            },
+            "broccoli-rabe": {
+                "name": "varsiparsakaali"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "fariinisokeri"
+            },
+            "brussels-sprouts": {
+                "name": "ruusukaalit"
+            },
+            "butter": {
+                "name": "voi"
+            },
+            "butternut-pumpkin": {
+                "name": "myskikurpitsa"
+            },
+            "butternut-squash": {
+                "name": "myskikurpitsa"
+            },
+            "cabbage": {
+                "name": "kaali",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "kaktus, syötävä"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "ruokosokeri"
+            },
+            "cannabis": {
+                "name": "kannabis"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "kumina"
+            },
+            "carrot": {
+                "name": "porkkana",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "castersokeri"
+            },
+            "castor-sugar": {
+                "name": "castor sokeri"
+            },
+            "catfish": {
+                "name": "monni"
+            },
+            "cauliflower": {
+                "name": "kukkakaali",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne-pippuri"
+            },
+            "celeriac": {
+                "name": "juuriselleri"
+            },
+            "celery": {
+                "name": "selleri"
+            },
+            "cereal-grains": {
+                "name": "viljanjyvät"
+            },
+            "chard": {
+                "name": "mangoldi"
+            },
+            "cheese": {
+                "name": "juusto"
+            },
+            "chicory": {
+                "name": "sikuri"
+            },
+            "chilli-peppers": {
+                "name": "chilipaprikat",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "kiinankaali"
+            },
+            "chives": {
+                "name": "ruohosipuli"
+            },
+            "chocolate": {
+                "name": "suklaa"
+            },
+            "cilantro": {
+                "name": "korianteri"
+            },
+            "cinnamon": {
+                "name": "kaneli"
+            },
+            "clarified-butter": {
+                "name": "kirkastettu voi"
+            },
+            "coconut": {
+                "name": "kookospähkinä",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "kookosmaito"
+            },
+            "cod": {
+                "name": "turska"
+            },
+            "coffee": {
+                "name": "kahvi"
+            },
+            "collard-greens": {
+                "name": "lehtikaali"
+            },
+            "confectioners-sugar": {
+                "name": "tomusokeri"
+            },
+            "coriander": {
+                "name": "korianteri"
+            },
+            "corn": {
+                "name": "maissi",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "maissisiirappi"
+            },
+            "cottonseed-oil": {
+                "name": "pellavansiemenöljy"
+            },
+            "courgette": {
+                "name": "kesäkurpitsa"
+            },
+            "cream-of-tartar": {
+                "name": "viinikivi"
+            },
+            "cucumber": {
+                "name": "kurkku",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "kumina"
+            },
+            "daikon": {
+                "name": "japaninretikka",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "maitotuotteet ja maidonkorvikkeet"
+            },
+            "dandelion": {
+                "name": "voikukka"
+            },
+            "demerara-sugar": {
+                "name": "fariinisokeri"
+            },
+            "dough": {
+                "name": "taikina"
+            },
+            "edible-cactus": {
+                "name": "syötävä kaktus"
+            },
+            "eggplant": {
+                "name": "munakoiso",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "munat",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endiivit",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "rasvat"
+            },
+            "fava-beans": {
+                "name": "härkäpapu"
+            },
+            "fiddlehead": {
+                "name": "viulunkierukka"
+            },
+            "fiddlehead-fern": {
+                "name": "viulunkierukka",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "kala"
+            },
+            "five-spice-powder": {
+                "name": "viiden mausteen seos"
+            },
+            "flour": {
+                "name": "jauho"
+            },
+            "frisee": {
+                "name": "friseesalaatti"
+            },
+            "fructose": {
+                "name": "fruktoosi"
+            },
+            "fruit": {
+                "name": "hedelmä"
+            },
+            "fruit-sugar": {
+                "name": "hedelmäsokeri"
+            },
+            "ful": {
+                "name": "ful-pavut"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "valkosipuli",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "kurpitsa"
+            },
+            "ghee": {
+                "name": "ghee-voi"
+            },
+            "giblets": {
+                "name": "linnun sisäelimet"
+            },
+            "ginger": {
+                "name": "inkivääri"
+            },
+            "grains": {
+                "name": "viljat"
+            },
+            "granulated-sugar": {
+                "name": "taloussokeri"
+            },
+            "grape-seed-oil": {
+                "name": "viinirypäleiden siemenöljy"
+            },
+            "green-onion": {
+                "name": "vihreä sipuli",
+                "plural_name": "vihreää sipulia"
+            },
+            "heart-of-palm": {
+                "name": "palmun sydän",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hamppu"
+            },
+            "herbs": {
+                "name": "yrtit"
+            },
+            "honey": {
+                "name": "hunaja"
+            },
+            "isomalt": {
+                "name": "isomaltoosi"
+            },
+            "jackfruit": {
+                "name": "jakkihedelmä",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "raakasokeri"
+            },
+            "jams": {
+                "name": "jamssi"
+            },
+            "jellies": {
+                "name": "hyytelöt"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalemin artisokka"
+            },
+            "jicama": {
+                "name": "pikkujamssipapu"
+            },
+            "kale": {
+                "name": "lehtikaali"
+            },
+            "kohlrabi": {
+                "name": "kyssäkaali"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "nostatusaineet"
+            },
+            "leek": {
+                "name": "purjo",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "palkokasvit"
+            },
+            "lemongrass": {
+                "name": "sitruunaruoho"
+            },
+            "lentils": {
+                "name": "linssit"
+            },
+            "lettuce": {
+                "name": "lehtisalaatti"
+            },
+            "liver": {
+                "name": "maksa",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maissi"
+            },
+            "maple-syrup": {
+                "name": "vaahterasiirappi"
+            },
+            "meat": {
+                "name": "liha"
+            },
+            "milk": {
+                "name": "maito"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "sieni",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "sinisimpukka"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo -palasekoitus"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muskottipähkinä"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "hiivahiutaleet"
+            },
+            "nuts": {
+                "name": "pähkinät"
+            },
+            "octopuses": {
+                "name": "mustekalat",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "öljyt"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliivi"
+            },
+            "olive-oil": {
+                "name": "oliiviöljy"
+            },
+            "onion": {
+                "name": "sipuli"
+            },
+            "onion-family": {
+                "name": "sipulit"
+            },
+            "orange-blossom-water": {
+                "name": "appelsiininkukkavesi"
+            },
+            "oranges": {
+                "name": "appelsiinit",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "osterit"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persilja"
+            },
+            "parsnip": {
+                "name": "palsternakka",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "päärynä",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "herneet"
+            },
+            "pepper": {
+                "name": "pippuri",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananasta"
+            },
+            "plantain": {
+                "name": "keittobanaani",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "unikonsiemenet"
+            },
+            "potato": {
+                "name": "peruna",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "siipikarja"
+            },
+            "powdered-sugar": {
+                "name": "tomusokeri"
+            },
+            "pumpkin": {
+                "name": "kurpitsa",
+                "plural_name": "kurpitsaa"
+            },
+            "pumpkin-seeds": {
+                "name": "kurpitsansiemen"
+            },
+            "radish": {
+                "name": "retiisi",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raakasokeri"
+            },
+            "refined-sugar": {
+                "name": "puhdistamaton sokeri"
+            },
+            "rice": {
+                "name": "riisi"
+            },
+            "rice-flour": {
+                "name": "riisijauho"
+            },
+            "rock-sugar": {
+                "name": "kivisokeri"
+            },
+            "rum": {
+                "name": "rommi"
+            },
+            "salmon": {
+                "name": "lohi"
+            },
+            "salt": {
+                "name": "suola"
+            },
+            "salt-cod": {
+                "name": "suolaturska"
+            },
+            "scallion": {
+                "name": "vihersipuli",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "merenelävät"
+            },
+            "seeds": {
+                "name": "siemenet"
+            },
+            "sesame-seeds": {
+                "name": "seesaminsiemenet"
+            },
+            "shallot": {
+                "name": "salottisipuli",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate-kala"
+            },
+            "soda": {
+                "name": "virvoitusjuoma"
+            },
+            "soda-baking": {
+                "name": "ruokasooda"
+            },
+            "soybean": {
+                "name": "soijapapu"
+            },
+            "spaghetti-squash": {
+                "name": "spagettikurpitsa",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck-kinkku"
+            },
+            "spices": {
+                "name": "mausteet"
+            },
+            "spinach": {
+                "name": "pinaatti"
+            },
+            "spring-onion": {
+                "name": "kevätsipuli",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "kurpitsa",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "kurpitsat"
+            },
+            "stockfish": {
+                "name": "kuivakala"
+            },
+            "sugar": {
+                "name": "sokeri"
+            },
+            "sunchoke": {
+                "name": "maa-artisokka",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "auringonkukansiemenet"
+            },
+            "superfine-sugar": {
+                "name": "erikoishieno sokeri"
+            },
+            "sweet-potato": {
+                "name": "bataatti",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "maissi",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "makeutusaineet"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taaro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomaatti",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "taimen"
+            },
+            "tubers": {
+                "name": "mukulat",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tonnikala"
+            },
+            "turbanado-sugar": {
+                "name": "ruskea raakasokeri"
+            },
+            "turnip": {
+                "name": "nauris",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "puhdistamaton sokeri"
+            },
+            "vanilla": {
+                "name": "vanilija"
+            },
+            "vegetables": {
+                "name": "vihannekset"
+            },
+            "watercress": {
+                "name": "vesikrassi"
+            },
+            "watermelon": {
+                "name": "vesimeloni",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "herkkusieni",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "valkoinen sokeri"
+            },
+            "xanthan-gum": {
+                "name": "ksantaanikumi"
+            },
+            "yam": {
+                "name": "hillo",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "hiiva"
+            },
+            "zucchini": {
+                "name": "kesäkurpitsa",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Tuote": {
+        "foods": {}
+    },
+    "Vilja": {
+        "foods": {}
+    },
+    "Hedelmät": {
+        "foods": {}
+    },
+    "Vihannekset": {
+        "foods": {}
+    },
+    "Liha": {
+        "foods": {}
+    },
+    "Merenelävät": {
+        "foods": {}
+    },
+    "Juomat": {
+        "foods": {}
+    },
+    "Paistetut": {
+        "foods": {}
+    },
+    "Tölkitetyt": {
+        "foods": {}
+    },
+    "Mausteet": {
+        "foods": {}
+    },
+    "Makeiset": {
+        "foods": {}
+    },
+    "Maitotuotteet": {
+        "foods": {}
+    },
+    "Pakasteet": {
+        "foods": {}
+    },
+    "Terveelliset": {
+        "foods": {}
+    },
+    "Kotitaloudet": {
+        "foods": {}
+    },
+    "Lihatuotteet": {
+        "foods": {}
+    },
+    "Pienpurtavat": {
+        "foods": {}
+    },
+    "Alkoholi": {
+        "foods": {}
+    },
+    "Muu": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/fr-BE.json
+++ b/mealie/repos/seed/resources/foods/locales/fr-BE.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "courge poivrée"
-	},
-	"alfalfa-sprouts": {
-		"name": "luzerne"
-	},
-	"anchovies": {
-		"name": "anchois"
-	},
-	"apples": {
-		"name": "pommes",
-		"plural_name": "pommes"
-	},
-	"artichoke": {
-		"name": "artichaut"
-	},
-	"arugula": {
-		"name": "roquette"
-	},
-	"asparagus": {
-		"name": "asperge"
-	},
-	"avocado": {
-		"name": "avocat",
-		"plural_name": "avocats"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "levure chimique"
-	},
-	"baking-soda": {
-		"name": "bicarbonate de soude"
-	},
-	"baking-sugar": {
-		"name": "sucre de cuisson"
-	},
-	"bar-sugar": {
-		"name": "barre de sucre"
-	},
-	"basil": {
-		"name": "basilic"
-	},
-	"beans": {
-		"name": "haricots"
-	},
-	"bell-peppers": {
-		"name": "poivrons",
-		"plural_name": "poivrons"
-	},
-	"blackberries": {
-		"name": "mûres"
-	},
-	"bok-choy": {
-		"name": "pakchoï"
-	},
-	"brassicas": {
-		"name": "choux"
-	},
-	"bread": {
-		"name": "pain"
-	},
-	"breadfruit": {
-		"name": "fruit à pain"
-	},
-	"broccoflower": {
-		"name": "chou-fleur"
-	},
-	"broccoli": {
-		"name": "brocoli"
-	},
-	"broccoli-rabe": {
-		"name": "brocoli-rave"
-	},
-	"broccolini": {
-		"name": "brocolini"
-	},
-	"brown-sugar": {
-		"name": "cassonade"
-	},
-	"brussels-sprouts": {
-		"name": "choux de Bruxelles"
-	},
-	"butter": {
-		"name": "beurre"
-	},
-	"butternut-pumpkin": {
-		"name": "courge butternut"
-	},
-	"butternut-squash": {
-		"name": "courge butternut"
-	},
-	"cabbage": {
-		"name": "chou",
-		"plural_name": "choux"
-	},
-	"cactus-edible": {
-		"name": "cactus"
-	},
-	"calabrese": {
-		"name": "brocoli calabrese"
-	},
-	"cane-sugar": {
-		"name": "sucre de canne"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "poivron"
-	},
-	"caraway": {
-		"name": "cumin"
-	},
-	"carrot": {
-		"name": "carotte",
-		"plural_name": "carottes"
-	},
-	"caster-sugar": {
-		"name": "sucre semoule"
-	},
-	"castor-sugar": {
-		"name": "sucre en poudre"
-	},
-	"catfish": {
-		"name": "poisson-chat"
-	},
-	"cauliflower": {
-		"name": "chou-fleur",
-		"plural_name": "choux-fleur"
-	},
-	"cayenne-pepper": {
-		"name": "piment de cayenne"
-	},
-	"celeriac": {
-		"name": "céleri-rave"
-	},
-	"celery": {
-		"name": "céleri"
-	},
-	"cereal-grains": {
-		"name": "grains de céréales"
-	},
-	"chard": {
-		"name": "blette"
-	},
-	"cheese": {
-		"name": "fromage"
-	},
-	"chicory": {
-		"name": "chicorée"
-	},
-	"chilli-peppers": {
-		"name": "piment",
-		"plural_name": "piments"
-	},
-	"chinese-leaves": {
-		"name": "chou chinois"
-	},
-	"chives": {
-		"name": "ciboulette"
-	},
-	"chocolate": {
-		"name": "chocolat"
-	},
-	"cilantro": {
-		"name": "coriandre"
-	},
-	"cinnamon": {
-		"name": "cannelle"
-	},
-	"clarified-butter": {
-		"name": "beurre clarifié"
-	},
-	"coconut": {
-		"name": "noix de coco",
-		"plural_name": "noix de coco"
-	},
-	"coconut-milk": {
-		"name": "lait de coco"
-	},
-	"cod": {
-		"name": "morue"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "chou cavalier"
-	},
-	"confectioners-sugar": {
-		"name": "sucre des pâtissiers"
-	},
-	"coriander": {
-		"name": "coriandre"
-	},
-	"corn": {
-		"name": "maïs",
-		"plural_name": "maïs"
-	},
-	"corn-syrup": {
-		"name": "sirop de maïs"
-	},
-	"cottonseed-oil": {
-		"name": "huile de coton"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "crème de tartre"
-	},
-	"cucumber": {
-		"name": "concombre",
-		"plural_name": "concombres"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "radis blanc",
-		"plural_name": "radis blancs"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produits laitiers et substituts laitiers"
-	},
-	"dandelion": {
-		"name": "pissenlit"
-	},
-	"demerara-sugar": {
-		"name": "sucre demerara"
-	},
-	"dough": {
-		"name": "pâte"
-	},
-	"edible-cactus": {
-		"name": "cactus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "aubergines"
-	},
-	"eggs": {
-		"name": "œufs",
-		"plural_name": "œufs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "matières grasses"
-	},
-	"fava-beans": {
-		"name": "fèves"
-	},
-	"fiddlehead": {
-		"name": "crosse de fougère"
-	},
-	"fiddlehead-fern": {
-		"name": "crosse de fougère",
-		"plural_name": "crosses de fougères"
-	},
-	"fish": {
-		"name": "poisson"
-	},
-	"five-spice-powder": {
-		"name": "mélange 5 épices"
-	},
-	"flour": {
-		"name": "farine"
-	},
-	"frisee": {
-		"name": "frisée"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "sucre de fruits"
-	},
-	"ful": {
-		"name": "plein"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ail",
-		"plural_name": "gousses d'ails"
-	},
-	"gem-squash": {
-		"name": "courge gem squash"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "abats"
-	},
-	"ginger": {
-		"name": "gingembre"
-	},
-	"grains": {
-		"name": "céréales"
-	},
-	"granulated-sugar": {
-		"name": "sucre granulé"
-	},
-	"grape-seed-oil": {
-		"name": "huile de pépins de raisin"
-	},
-	"green-onion": {
-		"name": "oignon vert",
-		"plural_name": "oignons verts"
-	},
-	"heart-of-palm": {
-		"name": "cœur de palmier",
-		"plural_name": "cœurs de palmiers"
-	},
-	"hemp": {
-		"name": "chanvre"
-	},
-	"herbs": {
-		"name": "herbes"
-	},
-	"honey": {
-		"name": "miel"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "pomme jacque",
-		"plural_name": "pommes jaques"
-	},
-	"jaggery": {
-		"name": "gur"
-	},
-	"jams": {
-		"name": "confitures"
-	},
-	"jellies": {
-		"name": "gelées"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambour"
-	},
-	"jicama": {
-		"name": "igname"
-	},
-	"kale": {
-		"name": "chou frisé"
-	},
-	"kohlrabi": {
-		"name": "chou-rave"
-	},
-	"kumara": {
-		"name": "patate douce"
-	},
-	"leavening-agents": {
-		"name": "levure"
-	},
-	"leek": {
-		"name": "poireau",
-		"plural_name": "poireaux"
-	},
-	"legumes": {
-		"name": "légumineuses"
-	},
-	"lemongrass": {
-		"name": "citronnelle"
-	},
-	"lentils": {
-		"name": "lentilles"
-	},
-	"lettuce": {
-		"name": "laitue"
-	},
-	"liver": {
-		"name": "foie",
-		"plural_name": "foies"
-	},
-	"maize": {
-		"name": "maïs"
-	},
-	"maple-syrup": {
-		"name": "sirop d’érable"
-	},
-	"meat": {
-		"name": "viande"
-	},
-	"milk": {
-		"name": "lait"
-	},
-	"mortadella": {
-		"name": "mortadelle"
-	},
-	"mushroom": {
-		"name": "champignon",
-		"plural_name": "champignons"
-	},
-	"mussels": {
-		"name": "moules"
-	},
-	"nanaimo-bar-mix": {
-		"name": "mélange de barres nanaimo"
-	},
-	"nori": {
-		"name": "algue"
-	},
-	"nutmeg": {
-		"name": "noix de muscade"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "flocons de levure nutritionnelle"
-	},
-	"nuts": {
-		"name": "noix"
-	},
-	"octopuses": {
-		"name": "poulpe",
-		"plural_name": "poulpes"
-	},
-	"oils": {
-		"name": "huiles"
-	},
-	"okra": {
-		"name": "gombo"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "huile d’olive"
-	},
-	"onion": {
-		"name": "oignon"
-	},
-	"onion-family": {
-		"name": "oignons"
-	},
-	"orange-blossom-water": {
-		"name": "eau de fleur d’oranger"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "origan"
-	},
-	"oysters": {
-		"name": "huîtres"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persil"
-	},
-	"parsnip": {
-		"name": "panais",
-		"plural_name": "panais"
-	},
-	"pear": {
-		"name": "poire",
-		"plural_name": "poires"
-	},
-	"peas": {
-		"name": "pois"
-	},
-	"pepper": {
-		"name": "poivre",
-		"plural_name": "poivrons"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "banane plantain",
-		"plural_name": "bananes plantains"
-	},
-	"poppy-seeds": {
-		"name": "graines de pavot"
-	},
-	"potato": {
-		"name": "patate",
-		"plural_name": "pommes de terre"
-	},
-	"poultry": {
-		"name": "volaille"
-	},
-	"powdered-sugar": {
-		"name": "sucre en poudre"
-	},
-	"pumpkin": {
-		"name": "citrouille",
-		"plural_name": "citrouilles"
-	},
-	"pumpkin-seeds": {
-		"name": "graines de courge"
-	},
-	"radish": {
-		"name": "radis",
-		"plural_name": "radis"
-	},
-	"raw-sugar": {
-		"name": "sucre brut"
-	},
-	"refined-sugar": {
-		"name": "sucre raffiné"
-	},
-	"rice": {
-		"name": "riz"
-	},
-	"rice-flour": {
-		"name": "farine de riz"
-	},
-	"rock-sugar": {
-		"name": "sucre candi"
-	},
-	"rum": {
-		"name": "rhum"
-	},
-	"salmon": {
-		"name": "saumon"
-	},
-	"salt": {
-		"name": "sel"
-	},
-	"salt-cod": {
-		"name": "morue salée"
-	},
-	"scallion": {
-		"name": "échalote",
-		"plural_name": "cébettes"
-	},
-	"seafood": {
-		"name": "produits de la mer"
-	},
-	"seeds": {
-		"name": "graines"
-	},
-	"sesame-seeds": {
-		"name": "graines de sésame"
-	},
-	"shallot": {
-		"name": "échalote",
-		"plural_name": "échalotes"
-	},
-	"skate": {
-		"name": "raie"
-	},
-	"soda": {
-		"name": "bicarbonate de soude"
-	},
-	"soda-baking": {
-		"name": "bicarbonate de soude"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "courge spaghetti",
-		"plural_name": "courges spaghettis"
-	},
-	"speck": {
-		"name": "lard"
-	},
-	"spices": {
-		"name": "épices"
-	},
-	"spinach": {
-		"name": "épinard"
-	},
-	"spring-onion": {
-		"name": "oignons de printemps",
-		"plural_name": "oignons nouveaux"
-	},
-	"squash": {
-		"name": "courges",
-		"plural_name": "courges"
-	},
-	"squash-family": {
-		"name": "famille des courges"
-	},
-	"stockfish": {
-		"name": "cabillaud"
-	},
-	"sugar": {
-		"name": "sucre"
-	},
-	"sunchoke": {
-		"name": "topinambours",
-		"plural_name": "topinambours"
-	},
-	"sunflower-seeds": {
-		"name": "graines de tournesol"
-	},
-	"superfine-sugar": {
-		"name": "sucre superfin"
-	},
-	"sweet-potato": {
-		"name": "patate douce",
-		"plural_name": "patates douces"
-	},
-	"sweetcorn": {
-		"name": "maïs doux",
-		"plural_name": "maïs doux"
-	},
-	"sweeteners": {
-		"name": "édulcorant"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taros"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomates"
-	},
-	"trout": {
-		"name": "truite"
-	},
-	"tubers": {
-		"name": "tubercules",
-		"plural_name": "tubercules"
-	},
-	"tuna": {
-		"name": "thon"
-	},
-	"turbanado-sugar": {
-		"name": "sucre brun"
-	},
-	"turnip": {
-		"name": "navet",
-		"plural_name": "navets"
-	},
-	"unrefined-sugar": {
-		"name": "sucre non raffiné"
-	},
-	"vanilla": {
-		"name": "vanille"
-	},
-	"vegetables": {
-		"name": "légumes"
-	},
-	"watercress": {
-		"name": "cresson de fontaine"
-	},
-	"watermelon": {
-		"name": "pastèque",
-		"plural_name": "pastèques"
-	},
-	"white-mushroom": {
-		"name": "champignon blanc",
-		"plural_name": "champignons blancs"
-	},
-	"white-sugar": {
-		"name": "sucre blanc"
-	},
-	"xanthan-gum": {
-		"name": "gomme xanthane"
-	},
-	"yam": {
-		"name": "igname sauvage",
-		"plural_name": "ignames"
-	},
-	"yeast": {
-		"name": "levure"
-	},
-	"zucchini": {
-		"name": "courgette",
-		"plural_name": "courgettes"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "courge poivrée"
+            },
+            "alfalfa-sprouts": {
+                "name": "luzerne"
+            },
+            "anchovies": {
+                "name": "anchois"
+            },
+            "apples": {
+                "name": "pommes",
+                "plural_name": "pommes"
+            },
+            "artichoke": {
+                "name": "artichaut"
+            },
+            "arugula": {
+                "name": "roquette"
+            },
+            "asparagus": {
+                "name": "asperge"
+            },
+            "avocado": {
+                "name": "avocat",
+                "plural_name": "avocats"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "levure chimique"
+            },
+            "baking-soda": {
+                "name": "bicarbonate de soude"
+            },
+            "baking-sugar": {
+                "name": "sucre de cuisson"
+            },
+            "bar-sugar": {
+                "name": "barre de sucre"
+            },
+            "basil": {
+                "name": "basilic"
+            },
+            "beans": {
+                "name": "haricots"
+            },
+            "bell-peppers": {
+                "name": "poivrons",
+                "plural_name": "poivrons"
+            },
+            "blackberries": {
+                "name": "mûres"
+            },
+            "bok-choy": {
+                "name": "pakchoï"
+            },
+            "brassicas": {
+                "name": "choux"
+            },
+            "bread": {
+                "name": "pain"
+            },
+            "breadfruit": {
+                "name": "fruit à pain"
+            },
+            "broccoflower": {
+                "name": "chou-fleur"
+            },
+            "broccoli": {
+                "name": "brocoli"
+            },
+            "broccoli-rabe": {
+                "name": "brocoli-rave"
+            },
+            "broccolini": {
+                "name": "brocolini"
+            },
+            "brown-sugar": {
+                "name": "cassonade"
+            },
+            "brussels-sprouts": {
+                "name": "choux de Bruxelles"
+            },
+            "butter": {
+                "name": "beurre"
+            },
+            "butternut-pumpkin": {
+                "name": "courge butternut"
+            },
+            "butternut-squash": {
+                "name": "courge butternut"
+            },
+            "cabbage": {
+                "name": "chou",
+                "plural_name": "choux"
+            },
+            "cactus-edible": {
+                "name": "cactus"
+            },
+            "calabrese": {
+                "name": "brocoli calabrese"
+            },
+            "cane-sugar": {
+                "name": "sucre de canne"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "poivron"
+            },
+            "caraway": {
+                "name": "cumin"
+            },
+            "carrot": {
+                "name": "carotte",
+                "plural_name": "carottes"
+            },
+            "caster-sugar": {
+                "name": "sucre semoule"
+            },
+            "castor-sugar": {
+                "name": "sucre en poudre"
+            },
+            "catfish": {
+                "name": "poisson-chat"
+            },
+            "cauliflower": {
+                "name": "chou-fleur",
+                "plural_name": "choux-fleur"
+            },
+            "cayenne-pepper": {
+                "name": "piment de cayenne"
+            },
+            "celeriac": {
+                "name": "céleri-rave"
+            },
+            "celery": {
+                "name": "céleri"
+            },
+            "cereal-grains": {
+                "name": "grains de céréales"
+            },
+            "chard": {
+                "name": "blette"
+            },
+            "cheese": {
+                "name": "fromage"
+            },
+            "chicory": {
+                "name": "chicorée"
+            },
+            "chilli-peppers": {
+                "name": "piment",
+                "plural_name": "piments"
+            },
+            "chinese-leaves": {
+                "name": "chou chinois"
+            },
+            "chives": {
+                "name": "ciboulette"
+            },
+            "chocolate": {
+                "name": "chocolat"
+            },
+            "cilantro": {
+                "name": "coriandre"
+            },
+            "cinnamon": {
+                "name": "cannelle"
+            },
+            "clarified-butter": {
+                "name": "beurre clarifié"
+            },
+            "coconut": {
+                "name": "noix de coco",
+                "plural_name": "noix de coco"
+            },
+            "coconut-milk": {
+                "name": "lait de coco"
+            },
+            "cod": {
+                "name": "morue"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "chou cavalier"
+            },
+            "confectioners-sugar": {
+                "name": "sucre des pâtissiers"
+            },
+            "coriander": {
+                "name": "coriandre"
+            },
+            "corn": {
+                "name": "maïs",
+                "plural_name": "maïs"
+            },
+            "corn-syrup": {
+                "name": "sirop de maïs"
+            },
+            "cottonseed-oil": {
+                "name": "huile de coton"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "crème de tartre"
+            },
+            "cucumber": {
+                "name": "concombre",
+                "plural_name": "concombres"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "radis blanc",
+                "plural_name": "radis blancs"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produits laitiers et substituts laitiers"
+            },
+            "dandelion": {
+                "name": "pissenlit"
+            },
+            "demerara-sugar": {
+                "name": "sucre demerara"
+            },
+            "dough": {
+                "name": "pâte"
+            },
+            "edible-cactus": {
+                "name": "cactus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "aubergines"
+            },
+            "eggs": {
+                "name": "œufs",
+                "plural_name": "œufs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "matières grasses"
+            },
+            "fava-beans": {
+                "name": "fèves"
+            },
+            "fiddlehead": {
+                "name": "crosse de fougère"
+            },
+            "fiddlehead-fern": {
+                "name": "crosse de fougère",
+                "plural_name": "crosses de fougères"
+            },
+            "fish": {
+                "name": "poisson"
+            },
+            "five-spice-powder": {
+                "name": "mélange 5 épices"
+            },
+            "flour": {
+                "name": "farine"
+            },
+            "frisee": {
+                "name": "frisée"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "sucre de fruits"
+            },
+            "ful": {
+                "name": "plein"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ail",
+                "plural_name": "gousses d'ails"
+            },
+            "gem-squash": {
+                "name": "courge gem squash"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "abats"
+            },
+            "ginger": {
+                "name": "gingembre"
+            },
+            "grains": {
+                "name": "céréales"
+            },
+            "granulated-sugar": {
+                "name": "sucre granulé"
+            },
+            "grape-seed-oil": {
+                "name": "huile de pépins de raisin"
+            },
+            "green-onion": {
+                "name": "oignon vert",
+                "plural_name": "oignons verts"
+            },
+            "heart-of-palm": {
+                "name": "cœur de palmier",
+                "plural_name": "cœurs de palmiers"
+            },
+            "hemp": {
+                "name": "chanvre"
+            },
+            "herbs": {
+                "name": "herbes"
+            },
+            "honey": {
+                "name": "miel"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "pomme jacque",
+                "plural_name": "pommes jaques"
+            },
+            "jaggery": {
+                "name": "gur"
+            },
+            "jams": {
+                "name": "confitures"
+            },
+            "jellies": {
+                "name": "gelées"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambour"
+            },
+            "jicama": {
+                "name": "igname"
+            },
+            "kale": {
+                "name": "chou frisé"
+            },
+            "kohlrabi": {
+                "name": "chou-rave"
+            },
+            "kumara": {
+                "name": "patate douce"
+            },
+            "leavening-agents": {
+                "name": "levure"
+            },
+            "leek": {
+                "name": "poireau",
+                "plural_name": "poireaux"
+            },
+            "legumes": {
+                "name": "légumineuses"
+            },
+            "lemongrass": {
+                "name": "citronnelle"
+            },
+            "lentils": {
+                "name": "lentilles"
+            },
+            "lettuce": {
+                "name": "laitue"
+            },
+            "liver": {
+                "name": "foie",
+                "plural_name": "foies"
+            },
+            "maize": {
+                "name": "maïs"
+            },
+            "maple-syrup": {
+                "name": "sirop d’érable"
+            },
+            "meat": {
+                "name": "viande"
+            },
+            "milk": {
+                "name": "lait"
+            },
+            "mortadella": {
+                "name": "mortadelle"
+            },
+            "mushroom": {
+                "name": "champignon",
+                "plural_name": "champignons"
+            },
+            "mussels": {
+                "name": "moules"
+            },
+            "nanaimo-bar-mix": {
+                "name": "mélange de barres nanaimo"
+            },
+            "nori": {
+                "name": "algue"
+            },
+            "nutmeg": {
+                "name": "noix de muscade"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "flocons de levure nutritionnelle"
+            },
+            "nuts": {
+                "name": "noix"
+            },
+            "octopuses": {
+                "name": "poulpe",
+                "plural_name": "poulpes"
+            },
+            "oils": {
+                "name": "huiles"
+            },
+            "okra": {
+                "name": "gombo"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "huile d’olive"
+            },
+            "onion": {
+                "name": "oignon"
+            },
+            "onion-family": {
+                "name": "oignons"
+            },
+            "orange-blossom-water": {
+                "name": "eau de fleur d’oranger"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "origan"
+            },
+            "oysters": {
+                "name": "huîtres"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persil"
+            },
+            "parsnip": {
+                "name": "panais",
+                "plural_name": "panais"
+            },
+            "pear": {
+                "name": "poire",
+                "plural_name": "poires"
+            },
+            "peas": {
+                "name": "pois"
+            },
+            "pepper": {
+                "name": "poivre",
+                "plural_name": "poivrons"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "banane plantain",
+                "plural_name": "bananes plantains"
+            },
+            "poppy-seeds": {
+                "name": "graines de pavot"
+            },
+            "potato": {
+                "name": "patate",
+                "plural_name": "pommes de terre"
+            },
+            "poultry": {
+                "name": "volaille"
+            },
+            "powdered-sugar": {
+                "name": "sucre en poudre"
+            },
+            "pumpkin": {
+                "name": "citrouille",
+                "plural_name": "citrouilles"
+            },
+            "pumpkin-seeds": {
+                "name": "graines de courge"
+            },
+            "radish": {
+                "name": "radis",
+                "plural_name": "radis"
+            },
+            "raw-sugar": {
+                "name": "sucre brut"
+            },
+            "refined-sugar": {
+                "name": "sucre raffiné"
+            },
+            "rice": {
+                "name": "riz"
+            },
+            "rice-flour": {
+                "name": "farine de riz"
+            },
+            "rock-sugar": {
+                "name": "sucre candi"
+            },
+            "rum": {
+                "name": "rhum"
+            },
+            "salmon": {
+                "name": "saumon"
+            },
+            "salt": {
+                "name": "sel"
+            },
+            "salt-cod": {
+                "name": "morue salée"
+            },
+            "scallion": {
+                "name": "échalote",
+                "plural_name": "cébettes"
+            },
+            "seafood": {
+                "name": "produits de la mer"
+            },
+            "seeds": {
+                "name": "graines"
+            },
+            "sesame-seeds": {
+                "name": "graines de sésame"
+            },
+            "shallot": {
+                "name": "échalote",
+                "plural_name": "échalotes"
+            },
+            "skate": {
+                "name": "raie"
+            },
+            "soda": {
+                "name": "bicarbonate de soude"
+            },
+            "soda-baking": {
+                "name": "bicarbonate de soude"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "courge spaghetti",
+                "plural_name": "courges spaghettis"
+            },
+            "speck": {
+                "name": "lard"
+            },
+            "spices": {
+                "name": "épices"
+            },
+            "spinach": {
+                "name": "épinard"
+            },
+            "spring-onion": {
+                "name": "oignons de printemps",
+                "plural_name": "oignons nouveaux"
+            },
+            "squash": {
+                "name": "courges",
+                "plural_name": "courges"
+            },
+            "squash-family": {
+                "name": "famille des courges"
+            },
+            "stockfish": {
+                "name": "cabillaud"
+            },
+            "sugar": {
+                "name": "sucre"
+            },
+            "sunchoke": {
+                "name": "topinambours",
+                "plural_name": "topinambours"
+            },
+            "sunflower-seeds": {
+                "name": "graines de tournesol"
+            },
+            "superfine-sugar": {
+                "name": "sucre superfin"
+            },
+            "sweet-potato": {
+                "name": "patate douce",
+                "plural_name": "patates douces"
+            },
+            "sweetcorn": {
+                "name": "maïs doux",
+                "plural_name": "maïs doux"
+            },
+            "sweeteners": {
+                "name": "édulcorant"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taros"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomates"
+            },
+            "trout": {
+                "name": "truite"
+            },
+            "tubers": {
+                "name": "tubercules",
+                "plural_name": "tubercules"
+            },
+            "tuna": {
+                "name": "thon"
+            },
+            "turbanado-sugar": {
+                "name": "sucre brun"
+            },
+            "turnip": {
+                "name": "navet",
+                "plural_name": "navets"
+            },
+            "unrefined-sugar": {
+                "name": "sucre non raffiné"
+            },
+            "vanilla": {
+                "name": "vanille"
+            },
+            "vegetables": {
+                "name": "légumes"
+            },
+            "watercress": {
+                "name": "cresson de fontaine"
+            },
+            "watermelon": {
+                "name": "pastèque",
+                "plural_name": "pastèques"
+            },
+            "white-mushroom": {
+                "name": "champignon blanc",
+                "plural_name": "champignons blancs"
+            },
+            "white-sugar": {
+                "name": "sucre blanc"
+            },
+            "xanthan-gum": {
+                "name": "gomme xanthane"
+            },
+            "yam": {
+                "name": "igname sauvage",
+                "plural_name": "ignames"
+            },
+            "yeast": {
+                "name": "levure"
+            },
+            "zucchini": {
+                "name": "courgette",
+                "plural_name": "courgettes"
+            }
+        }
+    },
+    "Produits": {
+        "foods": {}
+    },
+    "Céréales": {
+        "foods": {}
+    },
+    "Fruits": {
+        "foods": {}
+    },
+    "Légumes": {
+        "foods": {}
+    },
+    "Viande": {
+        "foods": {}
+    },
+    "Produits de la mer": {
+        "foods": {}
+    },
+    "Boissons": {
+        "foods": {}
+    },
+    "Produits cuisinés": {
+        "foods": {}
+    },
+    "Conserves": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Confiseries": {
+        "foods": {}
+    },
+    "Produits laitiers": {
+        "foods": {}
+    },
+    "Produits surgelés": {
+        "foods": {}
+    },
+    "Produits healthy": {
+        "foods": {}
+    },
+    "Foyer": {
+        "foods": {}
+    },
+    "Viandes": {
+        "foods": {}
+    },
+    "Collations": {
+        "foods": {}
+    },
+    "Épices": {
+        "foods": {}
+    },
+    "Sucrerie": {
+        "foods": {}
+    },
+    "Alcool": {
+        "foods": {}
+    },
+    "Autre": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/fr-CA.json
+++ b/mealie/repos/seed/resources/foods/locales/fr-CA.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "courge poivrée"
-	},
-	"alfalfa-sprouts": {
-		"name": "germes de luzerne"
-	},
-	"anchovies": {
-		"name": "anchois"
-	},
-	"apples": {
-		"name": "pommes",
-		"plural_name": "pommes"
-	},
-	"artichoke": {
-		"name": "artichauts"
-	},
-	"arugula": {
-		"name": "roquette"
-	},
-	"asparagus": {
-		"name": "asperges"
-	},
-	"avocado": {
-		"name": "avocat",
-		"plural_name": "avocats"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "poudre à pâte"
-	},
-	"baking-soda": {
-		"name": "bicarbonate de soude"
-	},
-	"baking-sugar": {
-		"name": "sucre de canne"
-	},
-	"bar-sugar": {
-		"name": "barre de sucre"
-	},
-	"basil": {
-		"name": "basilic"
-	},
-	"beans": {
-		"name": "haricots"
-	},
-	"bell-peppers": {
-		"name": "poivrons",
-		"plural_name": "poivrons"
-	},
-	"blackberries": {
-		"name": "mûres"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "crucifères"
-	},
-	"bread": {
-		"name": "pain"
-	},
-	"breadfruit": {
-		"name": "fruits de pain"
-	},
-	"broccoflower": {
-		"name": "broco-fleur"
-	},
-	"broccoli": {
-		"name": "brocoli"
-	},
-	"broccoli-rabe": {
-		"name": "brocoli-rave"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "sucre brun"
-	},
-	"brussels-sprouts": {
-		"name": "choux de Bruxelles"
-	},
-	"butter": {
-		"name": "beurre"
-	},
-	"butternut-pumpkin": {
-		"name": "courge butternut"
-	},
-	"butternut-squash": {
-		"name": "courge butternut"
-	},
-	"cabbage": {
-		"name": "chou",
-		"plural_name": "choux"
-	},
-	"cactus-edible": {
-		"name": "cactus, comestible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "sucre de canne"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "poivron"
-	},
-	"caraway": {
-		"name": "carvi"
-	},
-	"carrot": {
-		"name": "carotte",
-		"plural_name": "carottes"
-	},
-	"caster-sugar": {
-		"name": "sucre semoule"
-	},
-	"castor-sugar": {
-		"name": "sucre en poudre"
-	},
-	"catfish": {
-		"name": "poisson-chat"
-	},
-	"cauliflower": {
-		"name": "chou-fleur",
-		"plural_name": "chou-fleurs"
-	},
-	"cayenne-pepper": {
-		"name": "poivre de cayenne"
-	},
-	"celeriac": {
-		"name": "céleri-rave"
-	},
-	"celery": {
-		"name": "céleri"
-	},
-	"cereal-grains": {
-		"name": "grains de céréales"
-	},
-	"chard": {
-		"name": "blette"
-	},
-	"cheese": {
-		"name": "fromage"
-	},
-	"chicory": {
-		"name": "chicorée"
-	},
-	"chilli-peppers": {
-		"name": "piment",
-		"plural_name": "piments"
-	},
-	"chinese-leaves": {
-		"name": "feuilles chinoises"
-	},
-	"chives": {
-		"name": "ciboulette"
-	},
-	"chocolate": {
-		"name": "chocolat"
-	},
-	"cilantro": {
-		"name": "coriandre"
-	},
-	"cinnamon": {
-		"name": "cannelle"
-	},
-	"clarified-butter": {
-		"name": "beurre clarifié"
-	},
-	"coconut": {
-		"name": "noix de coco",
-		"plural_name": "noix de coco"
-	},
-	"coconut-milk": {
-		"name": "lait de coco"
-	},
-	"cod": {
-		"name": "morue"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "chou vert"
-	},
-	"confectioners-sugar": {
-		"name": "sucre des pâtissiers"
-	},
-	"coriander": {
-		"name": "coriandre"
-	},
-	"corn": {
-		"name": "maïs",
-		"plural_name": "maïs"
-	},
-	"corn-syrup": {
-		"name": "sirop de maïs"
-	},
-	"cottonseed-oil": {
-		"name": "huile de coton"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "crème de tartre"
-	},
-	"cucumber": {
-		"name": "concombre",
-		"plural_name": "concombres"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "radis blanc",
-		"plural_name": "radis blancs"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produits laitiers et substituts laitiers"
-	},
-	"dandelion": {
-		"name": "pissenlit"
-	},
-	"demerara-sugar": {
-		"name": "sucre demerara"
-	},
-	"dough": {
-		"name": "pâte"
-	},
-	"edible-cactus": {
-		"name": "cactus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "aubergines"
-	},
-	"eggs": {
-		"name": "œufs",
-		"plural_name": "œufs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "matières grasses"
-	},
-	"fava-beans": {
-		"name": "fèves"
-	},
-	"fiddlehead": {
-		"name": "crosse de fougère"
-	},
-	"fiddlehead-fern": {
-		"name": "crosse de fougère",
-		"plural_name": "crosses de fougères"
-	},
-	"fish": {
-		"name": "poisson"
-	},
-	"five-spice-powder": {
-		"name": "mélange 5 épices"
-	},
-	"flour": {
-		"name": "farine"
-	},
-	"frisee": {
-		"name": "frisé(e)"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "sucre de fruits"
-	},
-	"ful": {
-		"name": "plein"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ail",
-		"plural_name": "ails"
-	},
-	"gem-squash": {
-		"name": "courge gem squash"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "abats"
-	},
-	"ginger": {
-		"name": "gingembre"
-	},
-	"grains": {
-		"name": "céréales"
-	},
-	"granulated-sugar": {
-		"name": "sucre granulé"
-	},
-	"grape-seed-oil": {
-		"name": "huile de pépins de raisin"
-	},
-	"green-onion": {
-		"name": "oignon vert",
-		"plural_name": "oignons verts"
-	},
-	"heart-of-palm": {
-		"name": "cœur de palmier",
-		"plural_name": "cœurs de palmiers"
-	},
-	"hemp": {
-		"name": "chanvre"
-	},
-	"herbs": {
-		"name": "herbes"
-	},
-	"honey": {
-		"name": "miel"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "pomme jacque",
-		"plural_name": "pommes jaques"
-	},
-	"jaggery": {
-		"name": "gur"
-	},
-	"jams": {
-		"name": "confitures"
-	},
-	"jellies": {
-		"name": "gelées"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambour"
-	},
-	"jicama": {
-		"name": "igname"
-	},
-	"kale": {
-		"name": "chou frisé"
-	},
-	"kohlrabi": {
-		"name": "chou-rave"
-	},
-	"kumara": {
-		"name": "patate douce"
-	},
-	"leavening-agents": {
-		"name": "levure"
-	},
-	"leek": {
-		"name": "poireau",
-		"plural_name": "poireaux"
-	},
-	"legumes": {
-		"name": "légumineuses"
-	},
-	"lemongrass": {
-		"name": "citronnelle"
-	},
-	"lentils": {
-		"name": "lentilles"
-	},
-	"lettuce": {
-		"name": "laitue"
-	},
-	"liver": {
-		"name": "foie",
-		"plural_name": "foies"
-	},
-	"maize": {
-		"name": "maïs"
-	},
-	"maple-syrup": {
-		"name": "sirop d'érable"
-	},
-	"meat": {
-		"name": "viande"
-	},
-	"milk": {
-		"name": "lait"
-	},
-	"mortadella": {
-		"name": "mortadelle"
-	},
-	"mushroom": {
-		"name": "champignon",
-		"plural_name": "champignons"
-	},
-	"mussels": {
-		"name": "moules"
-	},
-	"nanaimo-bar-mix": {
-		"name": "mélange de barres nanaimo"
-	},
-	"nori": {
-		"name": "algue"
-	},
-	"nutmeg": {
-		"name": "muscade"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "flocons de levure nutritionnelle"
-	},
-	"nuts": {
-		"name": "noix"
-	},
-	"octopuses": {
-		"name": "poulpe",
-		"plural_name": "poulpes"
-	},
-	"oils": {
-		"name": "huiles"
-	},
-	"okra": {
-		"name": "gombo"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "huile d'olive"
-	},
-	"onion": {
-		"name": "oignon"
-	},
-	"onion-family": {
-		"name": "oignons"
-	},
-	"orange-blossom-water": {
-		"name": "eau de fleur d'oranger"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "origan"
-	},
-	"oysters": {
-		"name": "huîtres"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persil"
-	},
-	"parsnip": {
-		"name": "panais",
-		"plural_name": "panais"
-	},
-	"pear": {
-		"name": "poire",
-		"plural_name": "poires"
-	},
-	"peas": {
-		"name": "pois"
-	},
-	"pepper": {
-		"name": "poivre",
-		"plural_name": "poivrons"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "banane plantain",
-		"plural_name": "bananes plantains"
-	},
-	"poppy-seeds": {
-		"name": "graines de pavot"
-	},
-	"potato": {
-		"name": "patate",
-		"plural_name": "pommes de terre"
-	},
-	"poultry": {
-		"name": "volaille"
-	},
-	"powdered-sugar": {
-		"name": "sucre en poudre"
-	},
-	"pumpkin": {
-		"name": "citrouille",
-		"plural_name": "citrouilles"
-	},
-	"pumpkin-seeds": {
-		"name": "graines de citrouille"
-	},
-	"radish": {
-		"name": "radis",
-		"plural_name": "radis"
-	},
-	"raw-sugar": {
-		"name": "sucre brut"
-	},
-	"refined-sugar": {
-		"name": "sucre raffiné"
-	},
-	"rice": {
-		"name": "riz"
-	},
-	"rice-flour": {
-		"name": "farine de riz"
-	},
-	"rock-sugar": {
-		"name": "sucre candi"
-	},
-	"rum": {
-		"name": "rhum"
-	},
-	"salmon": {
-		"name": "saumon"
-	},
-	"salt": {
-		"name": "sel"
-	},
-	"salt-cod": {
-		"name": "morue salée"
-	},
-	"scallion": {
-		"name": "oignon vert",
-		"plural_name": "oignons verts"
-	},
-	"seafood": {
-		"name": "produits de la mer"
-	},
-	"seeds": {
-		"name": "graines"
-	},
-	"sesame-seeds": {
-		"name": "graines de sésame"
-	},
-	"shallot": {
-		"name": "échalote",
-		"plural_name": "échalotes"
-	},
-	"skate": {
-		"name": "raie"
-	},
-	"soda": {
-		"name": "bicarbonate de soude"
-	},
-	"soda-baking": {
-		"name": "bicarbonate de soude"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "courge spaghetti",
-		"plural_name": "courges spaghettis"
-	},
-	"speck": {
-		"name": "lard"
-	},
-	"spices": {
-		"name": "épices"
-	},
-	"spinach": {
-		"name": "épinard"
-	},
-	"spring-onion": {
-		"name": "oignons de printemps",
-		"plural_name": "oignons nouveaux"
-	},
-	"squash": {
-		"name": "courges",
-		"plural_name": "courges"
-	},
-	"squash-family": {
-		"name": "famille des courges"
-	},
-	"stockfish": {
-		"name": "cabillaud"
-	},
-	"sugar": {
-		"name": "sucre"
-	},
-	"sunchoke": {
-		"name": "topinambours",
-		"plural_name": "topinambours"
-	},
-	"sunflower-seeds": {
-		"name": "graines de tournesol"
-	},
-	"superfine-sugar": {
-		"name": "sucre superfin"
-	},
-	"sweet-potato": {
-		"name": "patate douce",
-		"plural_name": "patates douces"
-	},
-	"sweetcorn": {
-		"name": "maïs doux",
-		"plural_name": "maïs doux"
-	},
-	"sweeteners": {
-		"name": "édulcorant"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taros"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomates"
-	},
-	"trout": {
-		"name": "truite"
-	},
-	"tubers": {
-		"name": "tubercules",
-		"plural_name": "tubercules"
-	},
-	"tuna": {
-		"name": "thon"
-	},
-	"turbanado-sugar": {
-		"name": "sucre brun"
-	},
-	"turnip": {
-		"name": "navet",
-		"plural_name": "navets"
-	},
-	"unrefined-sugar": {
-		"name": "sucre non raffiné"
-	},
-	"vanilla": {
-		"name": "vanille"
-	},
-	"vegetables": {
-		"name": "légumes"
-	},
-	"watercress": {
-		"name": "cresson de fontaine"
-	},
-	"watermelon": {
-		"name": "melon d'eau",
-		"plural_name": "melons d'eau"
-	},
-	"white-mushroom": {
-		"name": "champignon blanc",
-		"plural_name": "champignons blancs"
-	},
-	"white-sugar": {
-		"name": "sucre blanc"
-	},
-	"xanthan-gum": {
-		"name": "gomme xanthane"
-	},
-	"yam": {
-		"name": "igname sauvage",
-		"plural_name": "ignames"
-	},
-	"yeast": {
-		"name": "levure"
-	},
-	"zucchini": {
-		"name": "courgette",
-		"plural_name": "courgettes"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "courge poivrée"
+            },
+            "alfalfa-sprouts": {
+                "name": "germes de luzerne"
+            },
+            "anchovies": {
+                "name": "anchois"
+            },
+            "apples": {
+                "name": "pommes",
+                "plural_name": "pommes"
+            },
+            "artichoke": {
+                "name": "artichauts"
+            },
+            "arugula": {
+                "name": "roquette"
+            },
+            "asparagus": {
+                "name": "asperges"
+            },
+            "avocado": {
+                "name": "avocat",
+                "plural_name": "avocats"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "poudre à pâte"
+            },
+            "baking-soda": {
+                "name": "bicarbonate de soude"
+            },
+            "baking-sugar": {
+                "name": "sucre de canne"
+            },
+            "bar-sugar": {
+                "name": "barre de sucre"
+            },
+            "basil": {
+                "name": "basilic"
+            },
+            "beans": {
+                "name": "haricots"
+            },
+            "bell-peppers": {
+                "name": "poivrons",
+                "plural_name": "poivrons"
+            },
+            "blackberries": {
+                "name": "mûres"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "crucifères"
+            },
+            "bread": {
+                "name": "pain"
+            },
+            "breadfruit": {
+                "name": "fruits de pain"
+            },
+            "broccoflower": {
+                "name": "broco-fleur"
+            },
+            "broccoli": {
+                "name": "brocoli"
+            },
+            "broccoli-rabe": {
+                "name": "brocoli-rave"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "sucre brun"
+            },
+            "brussels-sprouts": {
+                "name": "choux de Bruxelles"
+            },
+            "butter": {
+                "name": "beurre"
+            },
+            "butternut-pumpkin": {
+                "name": "courge butternut"
+            },
+            "butternut-squash": {
+                "name": "courge butternut"
+            },
+            "cabbage": {
+                "name": "chou",
+                "plural_name": "choux"
+            },
+            "cactus-edible": {
+                "name": "cactus, comestible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "sucre de canne"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "poivron"
+            },
+            "caraway": {
+                "name": "carvi"
+            },
+            "carrot": {
+                "name": "carotte",
+                "plural_name": "carottes"
+            },
+            "caster-sugar": {
+                "name": "sucre semoule"
+            },
+            "castor-sugar": {
+                "name": "sucre en poudre"
+            },
+            "catfish": {
+                "name": "poisson-chat"
+            },
+            "cauliflower": {
+                "name": "chou-fleur",
+                "plural_name": "chou-fleurs"
+            },
+            "cayenne-pepper": {
+                "name": "poivre de cayenne"
+            },
+            "celeriac": {
+                "name": "céleri-rave"
+            },
+            "celery": {
+                "name": "céleri"
+            },
+            "cereal-grains": {
+                "name": "grains de céréales"
+            },
+            "chard": {
+                "name": "blette"
+            },
+            "cheese": {
+                "name": "fromage"
+            },
+            "chicory": {
+                "name": "chicorée"
+            },
+            "chilli-peppers": {
+                "name": "piment",
+                "plural_name": "piments"
+            },
+            "chinese-leaves": {
+                "name": "feuilles chinoises"
+            },
+            "chives": {
+                "name": "ciboulette"
+            },
+            "chocolate": {
+                "name": "chocolat"
+            },
+            "cilantro": {
+                "name": "coriandre"
+            },
+            "cinnamon": {
+                "name": "cannelle"
+            },
+            "clarified-butter": {
+                "name": "beurre clarifié"
+            },
+            "coconut": {
+                "name": "noix de coco",
+                "plural_name": "noix de coco"
+            },
+            "coconut-milk": {
+                "name": "lait de coco"
+            },
+            "cod": {
+                "name": "morue"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "chou vert"
+            },
+            "confectioners-sugar": {
+                "name": "sucre des pâtissiers"
+            },
+            "coriander": {
+                "name": "coriandre"
+            },
+            "corn": {
+                "name": "maïs",
+                "plural_name": "maïs"
+            },
+            "corn-syrup": {
+                "name": "sirop de maïs"
+            },
+            "cottonseed-oil": {
+                "name": "huile de coton"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "crème de tartre"
+            },
+            "cucumber": {
+                "name": "concombre",
+                "plural_name": "concombres"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "radis blanc",
+                "plural_name": "radis blancs"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produits laitiers et substituts laitiers"
+            },
+            "dandelion": {
+                "name": "pissenlit"
+            },
+            "demerara-sugar": {
+                "name": "sucre demerara"
+            },
+            "dough": {
+                "name": "pâte"
+            },
+            "edible-cactus": {
+                "name": "cactus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "aubergines"
+            },
+            "eggs": {
+                "name": "œufs",
+                "plural_name": "œufs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "matières grasses"
+            },
+            "fava-beans": {
+                "name": "fèves"
+            },
+            "fiddlehead": {
+                "name": "crosse de fougère"
+            },
+            "fiddlehead-fern": {
+                "name": "crosse de fougère",
+                "plural_name": "crosses de fougères"
+            },
+            "fish": {
+                "name": "poisson"
+            },
+            "five-spice-powder": {
+                "name": "mélange 5 épices"
+            },
+            "flour": {
+                "name": "farine"
+            },
+            "frisee": {
+                "name": "frisé(e)"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "sucre de fruits"
+            },
+            "ful": {
+                "name": "plein"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ail",
+                "plural_name": "ails"
+            },
+            "gem-squash": {
+                "name": "courge gem squash"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "abats"
+            },
+            "ginger": {
+                "name": "gingembre"
+            },
+            "grains": {
+                "name": "céréales"
+            },
+            "granulated-sugar": {
+                "name": "sucre granulé"
+            },
+            "grape-seed-oil": {
+                "name": "huile de pépins de raisin"
+            },
+            "green-onion": {
+                "name": "oignon vert",
+                "plural_name": "oignons verts"
+            },
+            "heart-of-palm": {
+                "name": "cœur de palmier",
+                "plural_name": "cœurs de palmiers"
+            },
+            "hemp": {
+                "name": "chanvre"
+            },
+            "herbs": {
+                "name": "herbes"
+            },
+            "honey": {
+                "name": "miel"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "pomme jacque",
+                "plural_name": "pommes jaques"
+            },
+            "jaggery": {
+                "name": "gur"
+            },
+            "jams": {
+                "name": "confitures"
+            },
+            "jellies": {
+                "name": "gelées"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambour"
+            },
+            "jicama": {
+                "name": "igname"
+            },
+            "kale": {
+                "name": "chou frisé"
+            },
+            "kohlrabi": {
+                "name": "chou-rave"
+            },
+            "kumara": {
+                "name": "patate douce"
+            },
+            "leavening-agents": {
+                "name": "levure"
+            },
+            "leek": {
+                "name": "poireau",
+                "plural_name": "poireaux"
+            },
+            "legumes": {
+                "name": "légumineuses"
+            },
+            "lemongrass": {
+                "name": "citronnelle"
+            },
+            "lentils": {
+                "name": "lentilles"
+            },
+            "lettuce": {
+                "name": "laitue"
+            },
+            "liver": {
+                "name": "foie",
+                "plural_name": "foies"
+            },
+            "maize": {
+                "name": "maïs"
+            },
+            "maple-syrup": {
+                "name": "sirop d'érable"
+            },
+            "meat": {
+                "name": "viande"
+            },
+            "milk": {
+                "name": "lait"
+            },
+            "mortadella": {
+                "name": "mortadelle"
+            },
+            "mushroom": {
+                "name": "champignon",
+                "plural_name": "champignons"
+            },
+            "mussels": {
+                "name": "moules"
+            },
+            "nanaimo-bar-mix": {
+                "name": "mélange de barres nanaimo"
+            },
+            "nori": {
+                "name": "algue"
+            },
+            "nutmeg": {
+                "name": "muscade"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "flocons de levure nutritionnelle"
+            },
+            "nuts": {
+                "name": "noix"
+            },
+            "octopuses": {
+                "name": "poulpe",
+                "plural_name": "poulpes"
+            },
+            "oils": {
+                "name": "huiles"
+            },
+            "okra": {
+                "name": "gombo"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "huile d'olive"
+            },
+            "onion": {
+                "name": "oignon"
+            },
+            "onion-family": {
+                "name": "oignons"
+            },
+            "orange-blossom-water": {
+                "name": "eau de fleur d'oranger"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "origan"
+            },
+            "oysters": {
+                "name": "huîtres"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persil"
+            },
+            "parsnip": {
+                "name": "panais",
+                "plural_name": "panais"
+            },
+            "pear": {
+                "name": "poire",
+                "plural_name": "poires"
+            },
+            "peas": {
+                "name": "pois"
+            },
+            "pepper": {
+                "name": "poivre",
+                "plural_name": "poivrons"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "banane plantain",
+                "plural_name": "bananes plantains"
+            },
+            "poppy-seeds": {
+                "name": "graines de pavot"
+            },
+            "potato": {
+                "name": "patate",
+                "plural_name": "pommes de terre"
+            },
+            "poultry": {
+                "name": "volaille"
+            },
+            "powdered-sugar": {
+                "name": "sucre en poudre"
+            },
+            "pumpkin": {
+                "name": "citrouille",
+                "plural_name": "citrouilles"
+            },
+            "pumpkin-seeds": {
+                "name": "graines de citrouille"
+            },
+            "radish": {
+                "name": "radis",
+                "plural_name": "radis"
+            },
+            "raw-sugar": {
+                "name": "sucre brut"
+            },
+            "refined-sugar": {
+                "name": "sucre raffiné"
+            },
+            "rice": {
+                "name": "riz"
+            },
+            "rice-flour": {
+                "name": "farine de riz"
+            },
+            "rock-sugar": {
+                "name": "sucre candi"
+            },
+            "rum": {
+                "name": "rhum"
+            },
+            "salmon": {
+                "name": "saumon"
+            },
+            "salt": {
+                "name": "sel"
+            },
+            "salt-cod": {
+                "name": "morue salée"
+            },
+            "scallion": {
+                "name": "oignon vert",
+                "plural_name": "oignons verts"
+            },
+            "seafood": {
+                "name": "produits de la mer"
+            },
+            "seeds": {
+                "name": "graines"
+            },
+            "sesame-seeds": {
+                "name": "graines de sésame"
+            },
+            "shallot": {
+                "name": "échalote",
+                "plural_name": "échalotes"
+            },
+            "skate": {
+                "name": "raie"
+            },
+            "soda": {
+                "name": "bicarbonate de soude"
+            },
+            "soda-baking": {
+                "name": "bicarbonate de soude"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "courge spaghetti",
+                "plural_name": "courges spaghettis"
+            },
+            "speck": {
+                "name": "lard"
+            },
+            "spices": {
+                "name": "épices"
+            },
+            "spinach": {
+                "name": "épinard"
+            },
+            "spring-onion": {
+                "name": "oignons de printemps",
+                "plural_name": "oignons nouveaux"
+            },
+            "squash": {
+                "name": "courges",
+                "plural_name": "courges"
+            },
+            "squash-family": {
+                "name": "famille des courges"
+            },
+            "stockfish": {
+                "name": "cabillaud"
+            },
+            "sugar": {
+                "name": "sucre"
+            },
+            "sunchoke": {
+                "name": "topinambours",
+                "plural_name": "topinambours"
+            },
+            "sunflower-seeds": {
+                "name": "graines de tournesol"
+            },
+            "superfine-sugar": {
+                "name": "sucre superfin"
+            },
+            "sweet-potato": {
+                "name": "patate douce",
+                "plural_name": "patates douces"
+            },
+            "sweetcorn": {
+                "name": "maïs doux",
+                "plural_name": "maïs doux"
+            },
+            "sweeteners": {
+                "name": "édulcorant"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taros"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomates"
+            },
+            "trout": {
+                "name": "truite"
+            },
+            "tubers": {
+                "name": "tubercules",
+                "plural_name": "tubercules"
+            },
+            "tuna": {
+                "name": "thon"
+            },
+            "turbanado-sugar": {
+                "name": "sucre brun"
+            },
+            "turnip": {
+                "name": "navet",
+                "plural_name": "navets"
+            },
+            "unrefined-sugar": {
+                "name": "sucre non raffiné"
+            },
+            "vanilla": {
+                "name": "vanille"
+            },
+            "vegetables": {
+                "name": "légumes"
+            },
+            "watercress": {
+                "name": "cresson de fontaine"
+            },
+            "watermelon": {
+                "name": "melon d'eau",
+                "plural_name": "melons d'eau"
+            },
+            "white-mushroom": {
+                "name": "champignon blanc",
+                "plural_name": "champignons blancs"
+            },
+            "white-sugar": {
+                "name": "sucre blanc"
+            },
+            "xanthan-gum": {
+                "name": "gomme xanthane"
+            },
+            "yam": {
+                "name": "igname sauvage",
+                "plural_name": "ignames"
+            },
+            "yeast": {
+                "name": "levure"
+            },
+            "zucchini": {
+                "name": "courgette",
+                "plural_name": "courgettes"
+            }
+        }
+    },
+    "Produits": {
+        "foods": {}
+    },
+    "Céréales": {
+        "foods": {}
+    },
+    "Fruits": {
+        "foods": {}
+    },
+    "Légumes": {
+        "foods": {}
+    },
+    "Viande": {
+        "foods": {}
+    },
+    "Fruits de mer": {
+        "foods": {}
+    },
+    "Boissons": {
+        "foods": {}
+    },
+    "Produits cuisinés": {
+        "foods": {}
+    },
+    "Conserves": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Confiseries": {
+        "foods": {}
+    },
+    "Produits laitiers": {
+        "foods": {}
+    },
+    "Aliments congelés": {
+        "foods": {}
+    },
+    "Aliments Santé": {
+        "foods": {}
+    },
+    "Foyer": {
+        "foods": {}
+    },
+    "Viandes": {
+        "foods": {}
+    },
+    "Collations": {
+        "foods": {}
+    },
+    "Épices": {
+        "foods": {}
+    },
+    "Sucrerie": {
+        "foods": {}
+    },
+    "Alcool": {
+        "foods": {}
+    },
+    "Autre": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/fr-FR.json
+++ b/mealie/repos/seed/resources/foods/locales/fr-FR.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "courgeron"
-	},
-	"alfalfa-sprouts": {
-		"name": "pousses de luzerne"
-	},
-	"anchovies": {
-		"name": "anchois"
-	},
-	"apples": {
-		"name": "pomme",
-		"plural_name": "pommes"
-	},
-	"artichoke": {
-		"name": "artichaut"
-	},
-	"arugula": {
-		"name": "roquette"
-	},
-	"asparagus": {
-		"name": "asperge"
-	},
-	"avocado": {
-		"name": "avocat",
-		"plural_name": "avocats"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "levure chimique"
-	},
-	"baking-soda": {
-		"name": "bicarbonate de soude"
-	},
-	"baking-sugar": {
-		"name": "sucre semoule"
-	},
-	"bar-sugar": {
-		"name": "barre de sucre"
-	},
-	"basil": {
-		"name": "basilic"
-	},
-	"beans": {
-		"name": "haricots"
-	},
-	"bell-peppers": {
-		"name": "poivron",
-		"plural_name": "poivrons"
-	},
-	"blackberries": {
-		"name": "mûres"
-	},
-	"bok-choy": {
-		"name": "pakchoï"
-	},
-	"brassicas": {
-		"name": "choux"
-	},
-	"bread": {
-		"name": "pain"
-	},
-	"breadfruit": {
-		"name": "fruit à pain"
-	},
-	"broccoflower": {
-		"name": "chou romanesco"
-	},
-	"broccoli": {
-		"name": "brocoli"
-	},
-	"broccoli-rabe": {
-		"name": "brocoli-rave"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "cassonade"
-	},
-	"brussels-sprouts": {
-		"name": "choux de Bruxelles"
-	},
-	"butter": {
-		"name": "beurre"
-	},
-	"butternut-pumpkin": {
-		"name": "courge butternut"
-	},
-	"butternut-squash": {
-		"name": "doubeurre"
-	},
-	"cabbage": {
-		"name": "chou",
-		"plural_name": "choux"
-	},
-	"cactus-edible": {
-		"name": "cactus, comestible"
-	},
-	"calabrese": {
-		"name": "brocoli calabrese"
-	},
-	"cane-sugar": {
-		"name": "sucre de canne"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "cumin"
-	},
-	"carrot": {
-		"name": "carotte",
-		"plural_name": "carottes"
-	},
-	"caster-sugar": {
-		"name": "sucre semoule"
-	},
-	"castor-sugar": {
-		"name": "sucre en poudre"
-	},
-	"catfish": {
-		"name": "poisson-chat"
-	},
-	"cauliflower": {
-		"name": "chou-fleur",
-		"plural_name": "choux-fleur"
-	},
-	"cayenne-pepper": {
-		"name": "piment de Cayenne"
-	},
-	"celeriac": {
-		"name": "céleri-rave"
-	},
-	"celery": {
-		"name": "céleri"
-	},
-	"cereal-grains": {
-		"name": "grains de céréales"
-	},
-	"chard": {
-		"name": "blette"
-	},
-	"cheese": {
-		"name": "fromage"
-	},
-	"chicory": {
-		"name": "chicorée"
-	},
-	"chilli-peppers": {
-		"name": "piment",
-		"plural_name": "piments"
-	},
-	"chinese-leaves": {
-		"name": "chou chinois"
-	},
-	"chives": {
-		"name": "ciboulette"
-	},
-	"chocolate": {
-		"name": "chocolat"
-	},
-	"cilantro": {
-		"name": "coriandre"
-	},
-	"cinnamon": {
-		"name": "cannelle"
-	},
-	"clarified-butter": {
-		"name": "beurre clarifié"
-	},
-	"coconut": {
-		"name": "noix de coco",
-		"plural_name": "noix de coco"
-	},
-	"coconut-milk": {
-		"name": "lait de coco"
-	},
-	"cod": {
-		"name": "morue"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "chou cavalier"
-	},
-	"confectioners-sugar": {
-		"name": "sucre glace"
-	},
-	"coriander": {
-		"name": "coriandre"
-	},
-	"corn": {
-		"name": "maïs",
-		"plural_name": "maïs"
-	},
-	"corn-syrup": {
-		"name": "sirop de maïs"
-	},
-	"cottonseed-oil": {
-		"name": "huile de coton"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "crème de tartre"
-	},
-	"cucumber": {
-		"name": "concombre",
-		"plural_name": "concombres"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "radis blanc",
-		"plural_name": "radis blancs"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produits laitiers et substituts laitiers"
-	},
-	"dandelion": {
-		"name": "pissenlit"
-	},
-	"demerara-sugar": {
-		"name": "sucre demerara"
-	},
-	"dough": {
-		"name": "pâte"
-	},
-	"edible-cactus": {
-		"name": "cactus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "aubergines"
-	},
-	"eggs": {
-		"name": "œufs",
-		"plural_name": "œufs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "matières grasses"
-	},
-	"fava-beans": {
-		"name": "fèves"
-	},
-	"fiddlehead": {
-		"name": "crosse de fougère"
-	},
-	"fiddlehead-fern": {
-		"name": "crosse de fougère",
-		"plural_name": "crosses de fougères"
-	},
-	"fish": {
-		"name": "poisson"
-	},
-	"five-spice-powder": {
-		"name": "mélange 5 épices"
-	},
-	"flour": {
-		"name": "farine"
-	},
-	"frisee": {
-		"name": "frisée"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "sucre de fruits"
-	},
-	"ful": {
-		"name": "plein"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ail",
-		"plural_name": "gousses d'ails"
-	},
-	"gem-squash": {
-		"name": "courge gem squash"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "abats"
-	},
-	"ginger": {
-		"name": "gingembre"
-	},
-	"grains": {
-		"name": "céréales"
-	},
-	"granulated-sugar": {
-		"name": "sucre granulé"
-	},
-	"grape-seed-oil": {
-		"name": "huile de pépins de raisin"
-	},
-	"green-onion": {
-		"name": "oignon vert",
-		"plural_name": "oignons verts"
-	},
-	"heart-of-palm": {
-		"name": "cœur de palmier",
-		"plural_name": "cœurs de palmiers"
-	},
-	"hemp": {
-		"name": "chanvre"
-	},
-	"herbs": {
-		"name": "herbes"
-	},
-	"honey": {
-		"name": "miel"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "pomme jacque",
-		"plural_name": "pommes jaques"
-	},
-	"jaggery": {
-		"name": "gur"
-	},
-	"jams": {
-		"name": "confitures"
-	},
-	"jellies": {
-		"name": "gelées"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambour"
-	},
-	"jicama": {
-		"name": "igname"
-	},
-	"kale": {
-		"name": "chou frisé"
-	},
-	"kohlrabi": {
-		"name": "chou-rave"
-	},
-	"kumara": {
-		"name": "patate douce"
-	},
-	"leavening-agents": {
-		"name": "levure"
-	},
-	"leek": {
-		"name": "poireau",
-		"plural_name": "poireaux"
-	},
-	"legumes": {
-		"name": "légumineuses"
-	},
-	"lemongrass": {
-		"name": "citronnelle"
-	},
-	"lentils": {
-		"name": "lentilles"
-	},
-	"lettuce": {
-		"name": "laitue"
-	},
-	"liver": {
-		"name": "foie",
-		"plural_name": "foies"
-	},
-	"maize": {
-		"name": "maïs"
-	},
-	"maple-syrup": {
-		"name": "sirop d’érable"
-	},
-	"meat": {
-		"name": "viande"
-	},
-	"milk": {
-		"name": "lait"
-	},
-	"mortadella": {
-		"name": "mortadelle"
-	},
-	"mushroom": {
-		"name": "champignon",
-		"plural_name": "champignons"
-	},
-	"mussels": {
-		"name": "moules"
-	},
-	"nanaimo-bar-mix": {
-		"name": "mélange de barres nanaimo"
-	},
-	"nori": {
-		"name": "algue"
-	},
-	"nutmeg": {
-		"name": "noix de muscade"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "flocons de levure nutritionnelle"
-	},
-	"nuts": {
-		"name": "noix"
-	},
-	"octopuses": {
-		"name": "poulpe",
-		"plural_name": "poulpes"
-	},
-	"oils": {
-		"name": "huiles"
-	},
-	"okra": {
-		"name": "gombo"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "huile d’olive"
-	},
-	"onion": {
-		"name": "oignon"
-	},
-	"onion-family": {
-		"name": "oignons"
-	},
-	"orange-blossom-water": {
-		"name": "eau de fleur d’oranger"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "origan"
-	},
-	"oysters": {
-		"name": "huîtres"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persil"
-	},
-	"parsnip": {
-		"name": "panais",
-		"plural_name": "panais"
-	},
-	"pear": {
-		"name": "poire",
-		"plural_name": "poires"
-	},
-	"peas": {
-		"name": "pois"
-	},
-	"pepper": {
-		"name": "poivre",
-		"plural_name": "poivrons"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "banane plantain",
-		"plural_name": "bananes plantains"
-	},
-	"poppy-seeds": {
-		"name": "graines de pavot"
-	},
-	"potato": {
-		"name": "patate",
-		"plural_name": "pommes de terre"
-	},
-	"poultry": {
-		"name": "volaille"
-	},
-	"powdered-sugar": {
-		"name": "sucre en poudre"
-	},
-	"pumpkin": {
-		"name": "citrouille",
-		"plural_name": "citrouilles"
-	},
-	"pumpkin-seeds": {
-		"name": "graines de courge"
-	},
-	"radish": {
-		"name": "radis",
-		"plural_name": "radis"
-	},
-	"raw-sugar": {
-		"name": "sucre brut"
-	},
-	"refined-sugar": {
-		"name": "sucre raffiné"
-	},
-	"rice": {
-		"name": "riz"
-	},
-	"rice-flour": {
-		"name": "farine de riz"
-	},
-	"rock-sugar": {
-		"name": "sucre candi"
-	},
-	"rum": {
-		"name": "rhum"
-	},
-	"salmon": {
-		"name": "saumon"
-	},
-	"salt": {
-		"name": "sel"
-	},
-	"salt-cod": {
-		"name": "morue salée"
-	},
-	"scallion": {
-		"name": "échalote",
-		"plural_name": "cébettes"
-	},
-	"seafood": {
-		"name": "produits de la mer"
-	},
-	"seeds": {
-		"name": "graines"
-	},
-	"sesame-seeds": {
-		"name": "graines de sésame"
-	},
-	"shallot": {
-		"name": "échalote",
-		"plural_name": "échalotes"
-	},
-	"skate": {
-		"name": "raie"
-	},
-	"soda": {
-		"name": "bicarbonate de soude"
-	},
-	"soda-baking": {
-		"name": "bicarbonate de soude"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "courge spaghetti",
-		"plural_name": "courges spaghettis"
-	},
-	"speck": {
-		"name": "lard"
-	},
-	"spices": {
-		"name": "épices"
-	},
-	"spinach": {
-		"name": "épinard"
-	},
-	"spring-onion": {
-		"name": "oignons de printemps",
-		"plural_name": "oignons nouveaux"
-	},
-	"squash": {
-		"name": "courges",
-		"plural_name": "courges"
-	},
-	"squash-family": {
-		"name": "famille des courges"
-	},
-	"stockfish": {
-		"name": "cabillaud"
-	},
-	"sugar": {
-		"name": "sucre"
-	},
-	"sunchoke": {
-		"name": "topinambours",
-		"plural_name": "topinambours"
-	},
-	"sunflower-seeds": {
-		"name": "graines de tournesol"
-	},
-	"superfine-sugar": {
-		"name": "sucre superfin"
-	},
-	"sweet-potato": {
-		"name": "patate douce",
-		"plural_name": "patates douces"
-	},
-	"sweetcorn": {
-		"name": "maïs doux",
-		"plural_name": "maïs doux"
-	},
-	"sweeteners": {
-		"name": "édulcorant"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taros"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomates"
-	},
-	"trout": {
-		"name": "truite"
-	},
-	"tubers": {
-		"name": "tubercules",
-		"plural_name": "tubercules"
-	},
-	"tuna": {
-		"name": "thon"
-	},
-	"turbanado-sugar": {
-		"name": "sucre brun"
-	},
-	"turnip": {
-		"name": "navet",
-		"plural_name": "navets"
-	},
-	"unrefined-sugar": {
-		"name": "sucre non raffiné"
-	},
-	"vanilla": {
-		"name": "vanille"
-	},
-	"vegetables": {
-		"name": "légumes"
-	},
-	"watercress": {
-		"name": "cresson de fontaine"
-	},
-	"watermelon": {
-		"name": "pastèque",
-		"plural_name": "pastèques"
-	},
-	"white-mushroom": {
-		"name": "champignon blanc",
-		"plural_name": "champignons blancs"
-	},
-	"white-sugar": {
-		"name": "sucre blanc"
-	},
-	"xanthan-gum": {
-		"name": "gomme xanthane"
-	},
-	"yam": {
-		"name": "igname sauvage",
-		"plural_name": "ignames"
-	},
-	"yeast": {
-		"name": "levure"
-	},
-	"zucchini": {
-		"name": "courgette",
-		"plural_name": "courgettes"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "courgeron"
+            },
+            "alfalfa-sprouts": {
+                "name": "pousses de luzerne"
+            },
+            "anchovies": {
+                "name": "anchois"
+            },
+            "apples": {
+                "name": "pomme",
+                "plural_name": "pommes"
+            },
+            "artichoke": {
+                "name": "artichaut"
+            },
+            "arugula": {
+                "name": "roquette"
+            },
+            "asparagus": {
+                "name": "asperge"
+            },
+            "avocado": {
+                "name": "avocat",
+                "plural_name": "avocats"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "levure chimique"
+            },
+            "baking-soda": {
+                "name": "bicarbonate de soude"
+            },
+            "baking-sugar": {
+                "name": "sucre semoule"
+            },
+            "bar-sugar": {
+                "name": "barre de sucre"
+            },
+            "basil": {
+                "name": "basilic"
+            },
+            "beans": {
+                "name": "haricots"
+            },
+            "bell-peppers": {
+                "name": "poivron",
+                "plural_name": "poivrons"
+            },
+            "blackberries": {
+                "name": "mûres"
+            },
+            "bok-choy": {
+                "name": "pakchoï"
+            },
+            "brassicas": {
+                "name": "choux"
+            },
+            "bread": {
+                "name": "pain"
+            },
+            "breadfruit": {
+                "name": "fruit à pain"
+            },
+            "broccoflower": {
+                "name": "chou romanesco"
+            },
+            "broccoli": {
+                "name": "brocoli"
+            },
+            "broccoli-rabe": {
+                "name": "brocoli-rave"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "cassonade"
+            },
+            "brussels-sprouts": {
+                "name": "choux de Bruxelles"
+            },
+            "butter": {
+                "name": "beurre"
+            },
+            "butternut-pumpkin": {
+                "name": "courge butternut"
+            },
+            "butternut-squash": {
+                "name": "doubeurre"
+            },
+            "cabbage": {
+                "name": "chou",
+                "plural_name": "choux"
+            },
+            "cactus-edible": {
+                "name": "cactus, comestible"
+            },
+            "calabrese": {
+                "name": "brocoli calabrese"
+            },
+            "cane-sugar": {
+                "name": "sucre de canne"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "cumin"
+            },
+            "carrot": {
+                "name": "carotte",
+                "plural_name": "carottes"
+            },
+            "caster-sugar": {
+                "name": "sucre semoule"
+            },
+            "castor-sugar": {
+                "name": "sucre en poudre"
+            },
+            "catfish": {
+                "name": "poisson-chat"
+            },
+            "cauliflower": {
+                "name": "chou-fleur",
+                "plural_name": "choux-fleur"
+            },
+            "cayenne-pepper": {
+                "name": "piment de Cayenne"
+            },
+            "celeriac": {
+                "name": "céleri-rave"
+            },
+            "celery": {
+                "name": "céleri"
+            },
+            "cereal-grains": {
+                "name": "grains de céréales"
+            },
+            "chard": {
+                "name": "blette"
+            },
+            "cheese": {
+                "name": "fromage"
+            },
+            "chicory": {
+                "name": "chicorée"
+            },
+            "chilli-peppers": {
+                "name": "piment",
+                "plural_name": "piments"
+            },
+            "chinese-leaves": {
+                "name": "chou chinois"
+            },
+            "chives": {
+                "name": "ciboulette"
+            },
+            "chocolate": {
+                "name": "chocolat"
+            },
+            "cilantro": {
+                "name": "coriandre"
+            },
+            "cinnamon": {
+                "name": "cannelle"
+            },
+            "clarified-butter": {
+                "name": "beurre clarifié"
+            },
+            "coconut": {
+                "name": "noix de coco",
+                "plural_name": "noix de coco"
+            },
+            "coconut-milk": {
+                "name": "lait de coco"
+            },
+            "cod": {
+                "name": "morue"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "chou cavalier"
+            },
+            "confectioners-sugar": {
+                "name": "sucre glace"
+            },
+            "coriander": {
+                "name": "coriandre"
+            },
+            "corn": {
+                "name": "maïs",
+                "plural_name": "maïs"
+            },
+            "corn-syrup": {
+                "name": "sirop de maïs"
+            },
+            "cottonseed-oil": {
+                "name": "huile de coton"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "crème de tartre"
+            },
+            "cucumber": {
+                "name": "concombre",
+                "plural_name": "concombres"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "radis blanc",
+                "plural_name": "radis blancs"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produits laitiers et substituts laitiers"
+            },
+            "dandelion": {
+                "name": "pissenlit"
+            },
+            "demerara-sugar": {
+                "name": "sucre demerara"
+            },
+            "dough": {
+                "name": "pâte"
+            },
+            "edible-cactus": {
+                "name": "cactus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "aubergines"
+            },
+            "eggs": {
+                "name": "œufs",
+                "plural_name": "œufs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "matières grasses"
+            },
+            "fava-beans": {
+                "name": "fèves"
+            },
+            "fiddlehead": {
+                "name": "crosse de fougère"
+            },
+            "fiddlehead-fern": {
+                "name": "crosse de fougère",
+                "plural_name": "crosses de fougères"
+            },
+            "fish": {
+                "name": "poisson"
+            },
+            "five-spice-powder": {
+                "name": "mélange 5 épices"
+            },
+            "flour": {
+                "name": "farine"
+            },
+            "frisee": {
+                "name": "frisée"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "sucre de fruits"
+            },
+            "ful": {
+                "name": "plein"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ail",
+                "plural_name": "gousses d'ails"
+            },
+            "gem-squash": {
+                "name": "courge gem squash"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "abats"
+            },
+            "ginger": {
+                "name": "gingembre"
+            },
+            "grains": {
+                "name": "céréales"
+            },
+            "granulated-sugar": {
+                "name": "sucre granulé"
+            },
+            "grape-seed-oil": {
+                "name": "huile de pépins de raisin"
+            },
+            "green-onion": {
+                "name": "oignon vert",
+                "plural_name": "oignons verts"
+            },
+            "heart-of-palm": {
+                "name": "cœur de palmier",
+                "plural_name": "cœurs de palmiers"
+            },
+            "hemp": {
+                "name": "chanvre"
+            },
+            "herbs": {
+                "name": "herbes"
+            },
+            "honey": {
+                "name": "miel"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "pomme jacque",
+                "plural_name": "pommes jaques"
+            },
+            "jaggery": {
+                "name": "gur"
+            },
+            "jams": {
+                "name": "confitures"
+            },
+            "jellies": {
+                "name": "gelées"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambour"
+            },
+            "jicama": {
+                "name": "igname"
+            },
+            "kale": {
+                "name": "chou frisé"
+            },
+            "kohlrabi": {
+                "name": "chou-rave"
+            },
+            "kumara": {
+                "name": "patate douce"
+            },
+            "leavening-agents": {
+                "name": "levure"
+            },
+            "leek": {
+                "name": "poireau",
+                "plural_name": "poireaux"
+            },
+            "legumes": {
+                "name": "légumineuses"
+            },
+            "lemongrass": {
+                "name": "citronnelle"
+            },
+            "lentils": {
+                "name": "lentilles"
+            },
+            "lettuce": {
+                "name": "laitue"
+            },
+            "liver": {
+                "name": "foie",
+                "plural_name": "foies"
+            },
+            "maize": {
+                "name": "maïs"
+            },
+            "maple-syrup": {
+                "name": "sirop d’érable"
+            },
+            "meat": {
+                "name": "viande"
+            },
+            "milk": {
+                "name": "lait"
+            },
+            "mortadella": {
+                "name": "mortadelle"
+            },
+            "mushroom": {
+                "name": "champignon",
+                "plural_name": "champignons"
+            },
+            "mussels": {
+                "name": "moules"
+            },
+            "nanaimo-bar-mix": {
+                "name": "mélange de barres nanaimo"
+            },
+            "nori": {
+                "name": "algue"
+            },
+            "nutmeg": {
+                "name": "noix de muscade"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "flocons de levure nutritionnelle"
+            },
+            "nuts": {
+                "name": "noix"
+            },
+            "octopuses": {
+                "name": "poulpe",
+                "plural_name": "poulpes"
+            },
+            "oils": {
+                "name": "huiles"
+            },
+            "okra": {
+                "name": "gombo"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "huile d’olive"
+            },
+            "onion": {
+                "name": "oignon"
+            },
+            "onion-family": {
+                "name": "oignons"
+            },
+            "orange-blossom-water": {
+                "name": "eau de fleur d’oranger"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "origan"
+            },
+            "oysters": {
+                "name": "huîtres"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persil"
+            },
+            "parsnip": {
+                "name": "panais",
+                "plural_name": "panais"
+            },
+            "pear": {
+                "name": "poire",
+                "plural_name": "poires"
+            },
+            "peas": {
+                "name": "pois"
+            },
+            "pepper": {
+                "name": "poivre",
+                "plural_name": "poivrons"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "banane plantain",
+                "plural_name": "bananes plantains"
+            },
+            "poppy-seeds": {
+                "name": "graines de pavot"
+            },
+            "potato": {
+                "name": "patate",
+                "plural_name": "pommes de terre"
+            },
+            "poultry": {
+                "name": "volaille"
+            },
+            "powdered-sugar": {
+                "name": "sucre en poudre"
+            },
+            "pumpkin": {
+                "name": "citrouille",
+                "plural_name": "citrouilles"
+            },
+            "pumpkin-seeds": {
+                "name": "graines de courge"
+            },
+            "radish": {
+                "name": "radis",
+                "plural_name": "radis"
+            },
+            "raw-sugar": {
+                "name": "sucre brut"
+            },
+            "refined-sugar": {
+                "name": "sucre raffiné"
+            },
+            "rice": {
+                "name": "riz"
+            },
+            "rice-flour": {
+                "name": "farine de riz"
+            },
+            "rock-sugar": {
+                "name": "sucre candi"
+            },
+            "rum": {
+                "name": "rhum"
+            },
+            "salmon": {
+                "name": "saumon"
+            },
+            "salt": {
+                "name": "sel"
+            },
+            "salt-cod": {
+                "name": "morue salée"
+            },
+            "scallion": {
+                "name": "échalote",
+                "plural_name": "cébettes"
+            },
+            "seafood": {
+                "name": "produits de la mer"
+            },
+            "seeds": {
+                "name": "graines"
+            },
+            "sesame-seeds": {
+                "name": "graines de sésame"
+            },
+            "shallot": {
+                "name": "échalote",
+                "plural_name": "échalotes"
+            },
+            "skate": {
+                "name": "raie"
+            },
+            "soda": {
+                "name": "bicarbonate de soude"
+            },
+            "soda-baking": {
+                "name": "bicarbonate de soude"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "courge spaghetti",
+                "plural_name": "courges spaghettis"
+            },
+            "speck": {
+                "name": "lard"
+            },
+            "spices": {
+                "name": "épices"
+            },
+            "spinach": {
+                "name": "épinard"
+            },
+            "spring-onion": {
+                "name": "oignons de printemps",
+                "plural_name": "oignons nouveaux"
+            },
+            "squash": {
+                "name": "courges",
+                "plural_name": "courges"
+            },
+            "squash-family": {
+                "name": "famille des courges"
+            },
+            "stockfish": {
+                "name": "cabillaud"
+            },
+            "sugar": {
+                "name": "sucre"
+            },
+            "sunchoke": {
+                "name": "topinambours",
+                "plural_name": "topinambours"
+            },
+            "sunflower-seeds": {
+                "name": "graines de tournesol"
+            },
+            "superfine-sugar": {
+                "name": "sucre superfin"
+            },
+            "sweet-potato": {
+                "name": "patate douce",
+                "plural_name": "patates douces"
+            },
+            "sweetcorn": {
+                "name": "maïs doux",
+                "plural_name": "maïs doux"
+            },
+            "sweeteners": {
+                "name": "édulcorant"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taros"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomates"
+            },
+            "trout": {
+                "name": "truite"
+            },
+            "tubers": {
+                "name": "tubercules",
+                "plural_name": "tubercules"
+            },
+            "tuna": {
+                "name": "thon"
+            },
+            "turbanado-sugar": {
+                "name": "sucre brun"
+            },
+            "turnip": {
+                "name": "navet",
+                "plural_name": "navets"
+            },
+            "unrefined-sugar": {
+                "name": "sucre non raffiné"
+            },
+            "vanilla": {
+                "name": "vanille"
+            },
+            "vegetables": {
+                "name": "légumes"
+            },
+            "watercress": {
+                "name": "cresson de fontaine"
+            },
+            "watermelon": {
+                "name": "pastèque",
+                "plural_name": "pastèques"
+            },
+            "white-mushroom": {
+                "name": "champignon blanc",
+                "plural_name": "champignons blancs"
+            },
+            "white-sugar": {
+                "name": "sucre blanc"
+            },
+            "xanthan-gum": {
+                "name": "gomme xanthane"
+            },
+            "yam": {
+                "name": "igname sauvage",
+                "plural_name": "ignames"
+            },
+            "yeast": {
+                "name": "levure"
+            },
+            "zucchini": {
+                "name": "courgette",
+                "plural_name": "courgettes"
+            }
+        }
+    },
+    "Produits": {
+        "foods": {}
+    },
+    "Céréales": {
+        "foods": {}
+    },
+    "Fruits": {
+        "foods": {}
+    },
+    "Légumes": {
+        "foods": {}
+    },
+    "Viande": {
+        "foods": {}
+    },
+    "Produits de la mer": {
+        "foods": {}
+    },
+    "Boissons": {
+        "foods": {}
+    },
+    "Produits cuisinés": {
+        "foods": {}
+    },
+    "Conserves": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Confiseries": {
+        "foods": {}
+    },
+    "Produits laitiers": {
+        "foods": {}
+    },
+    "Produits surgelés": {
+        "foods": {}
+    },
+    "Produits sains": {
+        "foods": {}
+    },
+    "Foyer": {
+        "foods": {}
+    },
+    "Viandes": {
+        "foods": {}
+    },
+    "Collations": {
+        "foods": {}
+    },
+    "Épices": {
+        "foods": {}
+    },
+    "Sucrerie": {
+        "foods": {}
+    },
+    "Alcool": {
+        "foods": {}
+    },
+    "Autre": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/gl-ES.json
+++ b/mealie/repos/seed/resources/foods/locales/gl-ES.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "queixo"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "coandro"
-	},
-	"cinnamon": {
-		"name": "canela"
-	},
-	"clarified-butter": {
-		"name": "manteiga clarificada"
-	},
-	"coconut": {
-		"name": "coco",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "leite de coco"
-	},
-	"cod": {
-		"name": "bacallau"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "millo",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "xarope de millo"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "pepino",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dente de león"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "masa"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "berenxena",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "ovos",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "graxas"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "peixe"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "fariña"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "frutosa"
-	},
-	"fruit": {
-		"name": "froita"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "leite"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "laranxas",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pera",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "arroz"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmón"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "bacallau en salgadura"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "troita"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "bonito"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "baking soda"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell peppers",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "blackberries"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "bread"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brown sugar"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "butter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "queixo"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "coandro"
+            },
+            "cinnamon": {
+                "name": "canela"
+            },
+            "clarified-butter": {
+                "name": "manteiga clarificada"
+            },
+            "coconut": {
+                "name": "coco",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "leite de coco"
+            },
+            "cod": {
+                "name": "bacallau"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "millo",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "xarope de millo"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "pepino",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dente de león"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "masa"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "berenxena",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "ovos",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "graxas"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "peixe"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "fariña"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "frutosa"
+            },
+            "fruit": {
+                "name": "froita"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "leite"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "laranxas",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pera",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "arroz"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmón"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "bacallau en salgadura"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "troita"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "bonito"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Froitas e verduras": {
+        "foods": {}
+    },
+    "Grans": {
+        "foods": {}
+    },
+    "Froitas": {
+        "foods": {}
+    },
+    "Vexetais": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Marisco": {
+        "foods": {}
+    },
+    "Bebidas": {
+        "foods": {}
+    },
+    "Padaría": {
+        "foods": {}
+    },
+    "Latas": {
+        "foods": {}
+    },
+    "Condimentos": {
+        "foods": {}
+    },
+    "Repostería": {
+        "foods": {}
+    },
+    "Lácteos": {
+        "foods": {}
+    },
+    "Conxelados": {
+        "foods": {}
+    },
+    "Alimentos saudables": {
+        "foods": {}
+    },
+    "Fogar": {
+        "foods": {}
+    },
+    "Produtos cárnicos": {
+        "foods": {}
+    },
+    "Petiscos": {
+        "foods": {}
+    },
+    "Especias": {
+        "foods": {}
+    },
+    "Doces": {
+        "foods": {}
+    },
+    "Alcol": {
+        "foods": {}
+    },
+    "Outros": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/he-IL.json
+++ b/mealie/repos/seed/resources/foods/locales/he-IL.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "דלעת ערמונים"
-	},
-	"alfalfa-sprouts": {
-		"name": "נבטי אלפלפא"
-	},
-	"anchovies": {
-		"name": "אנשובי"
-	},
-	"apples": {
-		"name": "תפוחים",
-		"plural_name": "תפוחים"
-	},
-	"artichoke": {
-		"name": "ארטישוק"
-	},
-	"arugula": {
-		"name": "אורוגולה"
-	},
-	"asparagus": {
-		"name": "אספרגוס"
-	},
-	"avocado": {
-		"name": "אבוקדו",
-		"plural_name": "אבוקדו"
-	},
-	"bacon": {
-		"name": "בייקון"
-	},
-	"baking-powder": {
-		"name": "אבקת אפייה"
-	},
-	"baking-soda": {
-		"name": "סודה לשתייה"
-	},
-	"baking-sugar": {
-		"name": "סוכר לאפייה"
-	},
-	"bar-sugar": {
-		"name": "סוכר דק"
-	},
-	"basil": {
-		"name": "בזיליקום"
-	},
-	"beans": {
-		"name": "שעועית"
-	},
-	"bell-peppers": {
-		"name": "פלפל מתוק",
-		"plural_name": "פלפלים"
-	},
-	"blackberries": {
-		"name": "אוכמניות"
-	},
-	"bok-choy": {
-		"name": "באק צ'וי"
-	},
-	"brassicas": {
-		"name": "כרוב"
-	},
-	"bread": {
-		"name": "לחם"
-	},
-	"breadfruit": {
-		"name": "פרי הלחם"
-	},
-	"broccoflower": {
-		"name": "פריחת ברוקולי"
-	},
-	"broccoli": {
-		"name": "ברוקולי"
-	},
-	"broccoli-rabe": {
-		"name": "ברוקולי"
-	},
-	"broccolini": {
-		"name": "ברוקוליני"
-	},
-	"brown-sugar": {
-		"name": "סוכר חום"
-	},
-	"brussels-sprouts": {
-		"name": "כרוב ניצנים"
-	},
-	"butter": {
-		"name": "חמאה"
-	},
-	"butternut-pumpkin": {
-		"name": "דלורית"
-	},
-	"butternut-squash": {
-		"name": "דלורית"
-	},
-	"cabbage": {
-		"name": "כרוב",
-		"plural_name": "כרובים"
-	},
-	"cactus-edible": {
-		"name": "סברס"
-	},
-	"calabrese": {
-		"name": "ברוקולי"
-	},
-	"cane-sugar": {
-		"name": "סוכר קנים"
-	},
-	"cannabis": {
-		"name": "קנאביס"
-	},
-	"capsicum": {
-		"name": "גמבה"
-	},
-	"caraway": {
-		"name": "קימל"
-	},
-	"carrot": {
-		"name": "גזר",
-		"plural_name": "גזרים"
-	},
-	"caster-sugar": {
-		"name": "סוכר דק"
-	},
-	"castor-sugar": {
-		"name": "סוכר קיק"
-	},
-	"catfish": {
-		"name": "שפמנון"
-	},
-	"cauliflower": {
-		"name": "כרובית",
-		"plural_name": "כרוביות"
-	},
-	"cayenne-pepper": {
-		"name": "פלפל קאיין"
-	},
-	"celeriac": {
-		"name": "סלרי"
-	},
-	"celery": {
-		"name": "סלרי"
-	},
-	"cereal-grains": {
-		"name": "דגני בוקר"
-	},
-	"chard": {
-		"name": "מנגולד"
-	},
-	"cheese": {
-		"name": "גבינה"
-	},
-	"chicory": {
-		"name": "עולש"
-	},
-	"chilli-peppers": {
-		"name": "צ'ילי",
-		"plural_name": "פלפלים חריפים"
-	},
-	"chinese-leaves": {
-		"name": "עלים סינים"
-	},
-	"chives": {
-		"name": "עירית"
-	},
-	"chocolate": {
-		"name": "שוקולד"
-	},
-	"cilantro": {
-		"name": "כוסברה"
-	},
-	"cinnamon": {
-		"name": "קינמון"
-	},
-	"clarified-butter": {
-		"name": "חמאה מזוקקת"
-	},
-	"coconut": {
-		"name": "קוקוס",
-		"plural_name": "אגוזי קוקוס"
-	},
-	"coconut-milk": {
-		"name": "חלב קוקוס"
-	},
-	"cod": {
-		"name": "בקלה"
-	},
-	"coffee": {
-		"name": "קפה"
-	},
-	"collard-greens": {
-		"name": "כרוב ירוק"
-	},
-	"confectioners-sugar": {
-		"name": "אבקת סוכר"
-	},
-	"coriander": {
-		"name": "כוסברה"
-	},
-	"corn": {
-		"name": "תירס",
-		"plural_name": "תירס"
-	},
-	"corn-syrup": {
-		"name": "סירופ תירס"
-	},
-	"cottonseed-oil": {
-		"name": "שמן כותנה"
-	},
-	"courgette": {
-		"name": "קישוא"
-	},
-	"cream-of-tartar": {
-		"name": "קרם טרטר"
-	},
-	"cucumber": {
-		"name": "מלפפון",
-		"plural_name": "מלפפונים"
-	},
-	"cumin": {
-		"name": "כמון"
-	},
-	"daikon": {
-		"name": "צנון דייקון",
-		"plural_name": "צנוני דייקון"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "מוצרי חלב ותחליפי חלב"
-	},
-	"dandelion": {
-		"name": "שן הארי"
-	},
-	"demerara-sugar": {
-		"name": "סוכר דמררה"
-	},
-	"dough": {
-		"name": "בצק"
-	},
-	"edible-cactus": {
-		"name": "קקטוס אכיל (סברס)"
-	},
-	"eggplant": {
-		"name": "חציל",
-		"plural_name": "חצילים"
-	},
-	"eggs": {
-		"name": "ביצים",
-		"plural_name": "ביצים"
-	},
-	"endive": {
-		"name": "אנדיב",
-		"plural_name": "אנדיבים"
-	},
-	"fats": {
-		"name": "שומנים"
-	},
-	"fava-beans": {
-		"name": "פול מצרי"
-	},
-	"fiddlehead": {
-		"name": "שרך ראש הכינור"
-	},
-	"fiddlehead-fern": {
-		"name": "שרך ראש הכינור",
-		"plural_name": "שרכי ראש הכינור"
-	},
-	"fish": {
-		"name": "דג"
-	},
-	"five-spice-powder": {
-		"name": "אבקת 5 תבלינים"
-	},
-	"flour": {
-		"name": "קמח"
-	},
-	"frisee": {
-		"name": "פריזה"
-	},
-	"fructose": {
-		"name": "פרוקטוז"
-	},
-	"fruit": {
-		"name": "פרי"
-	},
-	"fruit-sugar": {
-		"name": "סוכר פירות"
-	},
-	"ful": {
-		"name": "פול"
-	},
-	"garam-masala": {
-		"name": "גראם מסאלה"
-	},
-	"garlic": {
-		"name": "שום",
-		"plural_name": "שום"
-	},
-	"gem-squash": {
-		"name": "דלעת פנינה"
-	},
-	"ghee": {
-		"name": "גהי"
-	},
-	"giblets": {
-		"name": "קרביים"
-	},
-	"ginger": {
-		"name": "ג'ינג'ר"
-	},
-	"grains": {
-		"name": "דגנים"
-	},
-	"granulated-sugar": {
-		"name": "סוכר לבן"
-	},
-	"grape-seed-oil": {
-		"name": "שמן זרעי ענבים"
-	},
-	"green-onion": {
-		"name": "בצל ירוק",
-		"plural_name": "בצלים ירוקים"
-	},
-	"heart-of-palm": {
-		"name": "לב דקל",
-		"plural_name": "לבבות דקל"
-	},
-	"hemp": {
-		"name": "האמפ"
-	},
-	"herbs": {
-		"name": "עשבים"
-	},
-	"honey": {
-		"name": "דבש"
-	},
-	"isomalt": {
-		"name": "איזומלט"
-	},
-	"jackfruit": {
-		"name": "ג׳קפרוט",
-		"plural_name": "ג'קפרוטים"
-	},
-	"jaggery": {
-		"name": "ג’אגרי"
-	},
-	"jams": {
-		"name": "ריבות"
-	},
-	"jellies": {
-		"name": "ג׳לים"
-	},
-	"jerusalem-artichoke": {
-		"name": "ארטישוק ירושלמי"
-	},
-	"jicama": {
-		"name": "חיקמה"
-	},
-	"kale": {
-		"name": "קייל"
-	},
-	"kohlrabi": {
-		"name": "קולורבי"
-	},
-	"kumara": {
-		"name": "בטטה"
-	},
-	"leavening-agents": {
-		"name": "חומר התפחה"
-	},
-	"leek": {
-		"name": "כרישה",
-		"plural_name": "כרישה"
-	},
-	"legumes": {
-		"name": "קטניות"
-	},
-	"lemongrass": {
-		"name": "לימונית"
-	},
-	"lentils": {
-		"name": "עדשים"
-	},
-	"lettuce": {
-		"name": "חסה"
-	},
-	"liver": {
-		"name": "כבד",
-		"plural_name": "כבדים"
-	},
-	"maize": {
-		"name": "תירס"
-	},
-	"maple-syrup": {
-		"name": "סירופ מייפל"
-	},
-	"meat": {
-		"name": "בשר"
-	},
-	"milk": {
-		"name": "חלב"
-	},
-	"mortadella": {
-		"name": "מורטדלה"
-	},
-	"mushroom": {
-		"name": "פטריה",
-		"plural_name": "פטריות"
-	},
-	"mussels": {
-		"name": "צדפות"
-	},
-	"nanaimo-bar-mix": {
-		"name": "תערובת נאנאימו"
-	},
-	"nori": {
-		"name": "נורי"
-	},
-	"nutmeg": {
-		"name": "אגוז מוסקט"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "שבבי שמרים תזונתיים"
-	},
-	"nuts": {
-		"name": "אגוזים"
-	},
-	"octopuses": {
-		"name": "תמנונים",
-		"plural_name": "תמנונים"
-	},
-	"oils": {
-		"name": "שמנים"
-	},
-	"okra": {
-		"name": "אוקרה"
-	},
-	"olive": {
-		"name": "זית"
-	},
-	"olive-oil": {
-		"name": "שמן זית"
-	},
-	"onion": {
-		"name": "בצל"
-	},
-	"onion-family": {
-		"name": "משפחת הבצלים"
-	},
-	"orange-blossom-water": {
-		"name": "מי פריחת הדרים"
-	},
-	"oranges": {
-		"name": "תפוזים",
-		"plural_name": "תפוזים"
-	},
-	"oregano": {
-		"name": "אורגנו"
-	},
-	"oysters": {
-		"name": "צדפות"
-	},
-	"panch-puran": {
-		"name": "פאנץ' פורן (תערובת תבלינים הודית)"
-	},
-	"paprika": {
-		"name": "פפריקה"
-	},
-	"parsley": {
-		"name": "פטרוזיליה"
-	},
-	"parsnip": {
-		"name": "גזר לבן",
-		"plural_name": "גזרים לבנים"
-	},
-	"pear": {
-		"name": "אגס",
-		"plural_name": "אגסים"
-	},
-	"peas": {
-		"name": "אפונה"
-	},
-	"pepper": {
-		"name": "פלפל",
-		"plural_name": "פלפלים"
-	},
-	"pineapple": {
-		"name": "אננס",
-		"plural_name": "אננסים"
-	},
-	"plantain": {
-		"name": "פלנטיין",
-		"plural_name": "פלנטיינים"
-	},
-	"poppy-seeds": {
-		"name": "פרג"
-	},
-	"potato": {
-		"name": "תפוח אדמה",
-		"plural_name": "תפוחי אדמה"
-	},
-	"poultry": {
-		"name": "עוף"
-	},
-	"powdered-sugar": {
-		"name": "אבקת סוכר"
-	},
-	"pumpkin": {
-		"name": "דלעת",
-		"plural_name": "דלעות"
-	},
-	"pumpkin-seeds": {
-		"name": "זרעי דלעת"
-	},
-	"radish": {
-		"name": "צנון",
-		"plural_name": "צנוניות"
-	},
-	"raw-sugar": {
-		"name": "סוכר גולמי"
-	},
-	"refined-sugar": {
-		"name": "סוכר מנופה"
-	},
-	"rice": {
-		"name": "אורז"
-	},
-	"rice-flour": {
-		"name": "קמח אורז"
-	},
-	"rock-sugar": {
-		"name": "גבישי סוכר"
-	},
-	"rum": {
-		"name": "רום"
-	},
-	"salmon": {
-		"name": "סלמון"
-	},
-	"salt": {
-		"name": "מלח"
-	},
-	"salt-cod": {
-		"name": "בקלה ממולח"
-	},
-	"scallion": {
-		"name": "בצל ירוק",
-		"plural_name": "בצלים ירוקים"
-	},
-	"seafood": {
-		"name": "מאכלי ים"
-	},
-	"seeds": {
-		"name": "זרעים"
-	},
-	"sesame-seeds": {
-		"name": "שומשום"
-	},
-	"shallot": {
-		"name": "בצל שאלוט",
-		"plural_name": "בצלצלי שאלוט"
-	},
-	"skate": {
-		"name": "דג תריסנית"
-	},
-	"soda": {
-		"name": "סודה"
-	},
-	"soda-baking": {
-		"name": "סודה לשתייה"
-	},
-	"soybean": {
-		"name": "פולי סויה"
-	},
-	"spaghetti-squash": {
-		"name": "דלעת ספגטי",
-		"plural_name": "דלעות ספגטי"
-	},
-	"speck": {
-		"name": "גרגר"
-	},
-	"spices": {
-		"name": "תבלינים"
-	},
-	"spinach": {
-		"name": "תרד"
-	},
-	"spring-onion": {
-		"name": "בצל אביב",
-		"plural_name": "בצלי אביב"
-	},
-	"squash": {
-		"name": "דלעת",
-		"plural_name": "דלעות"
-	},
-	"squash-family": {
-		"name": "משפחת הדלועים"
-	},
-	"stockfish": {
-		"name": "דג מיובש"
-	},
-	"sugar": {
-		"name": "סוכר"
-	},
-	"sunchoke": {
-		"name": "ארטישוק ירושלמי",
-		"plural_name": "ארטישוק ירושלמי"
-	},
-	"sunflower-seeds": {
-		"name": "זרעי חמניה"
-	},
-	"superfine-sugar": {
-		"name": "אבקת סוכר"
-	},
-	"sweet-potato": {
-		"name": "בטטה",
-		"plural_name": "בטטות"
-	},
-	"sweetcorn": {
-		"name": "תירס מתוק",
-		"plural_name": "תירס מתוק"
-	},
-	"sweeteners": {
-		"name": "ממתיקים"
-	},
-	"tahini": {
-		"name": "טחינה"
-	},
-	"taro": {
-		"name": "טארו",
-		"plural_name": "טארואים"
-	},
-	"teff": {
-		"name": "טף"
-	},
-	"tomato": {
-		"name": "עגבנייה",
-		"plural_name": "עגבניות"
-	},
-	"trout": {
-		"name": "טרוטה"
-	},
-	"tubers": {
-		"name": "שורשיים",
-		"plural_name": "שורשיים"
-	},
-	"tuna": {
-		"name": "טונה"
-	},
-	"turbanado-sugar": {
-		"name": "סוכר גולמי"
-	},
-	"turnip": {
-		"name": "לפת",
-		"plural_name": "לפתות"
-	},
-	"unrefined-sugar": {
-		"name": "סוכר לא מנופה"
-	},
-	"vanilla": {
-		"name": "וניל"
-	},
-	"vegetables": {
-		"name": "ירקות"
-	},
-	"watercress": {
-		"name": "גרגיר הנחלים"
-	},
-	"watermelon": {
-		"name": "אבטיח",
-		"plural_name": "אבטיחים"
-	},
-	"white-mushroom": {
-		"name": "פטריה לבנה",
-		"plural_name": "פטריות לבנות"
-	},
-	"white-sugar": {
-		"name": "סוכר לבן"
-	},
-	"xanthan-gum": {
-		"name": "קסנטן גאם"
-	},
-	"yam": {
-		"name": "בטטה",
-		"plural_name": "בטטות"
-	},
-	"yeast": {
-		"name": "שמרים"
-	},
-	"zucchini": {
-		"name": "זוקיני",
-		"plural_name": "זוקיני"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "דלעת ערמונים"
+            },
+            "alfalfa-sprouts": {
+                "name": "נבטי אלפלפא"
+            },
+            "anchovies": {
+                "name": "אנשובי"
+            },
+            "apples": {
+                "name": "תפוחים",
+                "plural_name": "תפוחים"
+            },
+            "artichoke": {
+                "name": "ארטישוק"
+            },
+            "arugula": {
+                "name": "אורוגולה"
+            },
+            "asparagus": {
+                "name": "אספרגוס"
+            },
+            "avocado": {
+                "name": "אבוקדו",
+                "plural_name": "אבוקדו"
+            },
+            "bacon": {
+                "name": "בייקון"
+            },
+            "baking-powder": {
+                "name": "אבקת אפייה"
+            },
+            "baking-soda": {
+                "name": "סודה לשתייה"
+            },
+            "baking-sugar": {
+                "name": "סוכר לאפייה"
+            },
+            "bar-sugar": {
+                "name": "סוכר דק"
+            },
+            "basil": {
+                "name": "בזיליקום"
+            },
+            "beans": {
+                "name": "שעועית"
+            },
+            "bell-peppers": {
+                "name": "פלפל מתוק",
+                "plural_name": "פלפלים"
+            },
+            "blackberries": {
+                "name": "אוכמניות"
+            },
+            "bok-choy": {
+                "name": "באק צ'וי"
+            },
+            "brassicas": {
+                "name": "כרוב"
+            },
+            "bread": {
+                "name": "לחם"
+            },
+            "breadfruit": {
+                "name": "פרי הלחם"
+            },
+            "broccoflower": {
+                "name": "פריחת ברוקולי"
+            },
+            "broccoli": {
+                "name": "ברוקולי"
+            },
+            "broccoli-rabe": {
+                "name": "ברוקולי"
+            },
+            "broccolini": {
+                "name": "ברוקוליני"
+            },
+            "brown-sugar": {
+                "name": "סוכר חום"
+            },
+            "brussels-sprouts": {
+                "name": "כרוב ניצנים"
+            },
+            "butter": {
+                "name": "חמאה"
+            },
+            "butternut-pumpkin": {
+                "name": "דלורית"
+            },
+            "butternut-squash": {
+                "name": "דלורית"
+            },
+            "cabbage": {
+                "name": "כרוב",
+                "plural_name": "כרובים"
+            },
+            "cactus-edible": {
+                "name": "סברס"
+            },
+            "calabrese": {
+                "name": "ברוקולי"
+            },
+            "cane-sugar": {
+                "name": "סוכר קנים"
+            },
+            "cannabis": {
+                "name": "קנאביס"
+            },
+            "capsicum": {
+                "name": "גמבה"
+            },
+            "caraway": {
+                "name": "קימל"
+            },
+            "carrot": {
+                "name": "גזר",
+                "plural_name": "גזרים"
+            },
+            "caster-sugar": {
+                "name": "סוכר דק"
+            },
+            "castor-sugar": {
+                "name": "סוכר קיק"
+            },
+            "catfish": {
+                "name": "שפמנון"
+            },
+            "cauliflower": {
+                "name": "כרובית",
+                "plural_name": "כרוביות"
+            },
+            "cayenne-pepper": {
+                "name": "פלפל קאיין"
+            },
+            "celeriac": {
+                "name": "סלרי"
+            },
+            "celery": {
+                "name": "סלרי"
+            },
+            "cereal-grains": {
+                "name": "דגני בוקר"
+            },
+            "chard": {
+                "name": "מנגולד"
+            },
+            "cheese": {
+                "name": "גבינה"
+            },
+            "chicory": {
+                "name": "עולש"
+            },
+            "chilli-peppers": {
+                "name": "צ'ילי",
+                "plural_name": "פלפלים חריפים"
+            },
+            "chinese-leaves": {
+                "name": "עלים סינים"
+            },
+            "chives": {
+                "name": "עירית"
+            },
+            "chocolate": {
+                "name": "שוקולד"
+            },
+            "cilantro": {
+                "name": "כוסברה"
+            },
+            "cinnamon": {
+                "name": "קינמון"
+            },
+            "clarified-butter": {
+                "name": "חמאה מזוקקת"
+            },
+            "coconut": {
+                "name": "קוקוס",
+                "plural_name": "אגוזי קוקוס"
+            },
+            "coconut-milk": {
+                "name": "חלב קוקוס"
+            },
+            "cod": {
+                "name": "בקלה"
+            },
+            "coffee": {
+                "name": "קפה"
+            },
+            "collard-greens": {
+                "name": "כרוב ירוק"
+            },
+            "confectioners-sugar": {
+                "name": "אבקת סוכר"
+            },
+            "coriander": {
+                "name": "כוסברה"
+            },
+            "corn": {
+                "name": "תירס",
+                "plural_name": "תירס"
+            },
+            "corn-syrup": {
+                "name": "סירופ תירס"
+            },
+            "cottonseed-oil": {
+                "name": "שמן כותנה"
+            },
+            "courgette": {
+                "name": "קישוא"
+            },
+            "cream-of-tartar": {
+                "name": "קרם טרטר"
+            },
+            "cucumber": {
+                "name": "מלפפון",
+                "plural_name": "מלפפונים"
+            },
+            "cumin": {
+                "name": "כמון"
+            },
+            "daikon": {
+                "name": "צנון דייקון",
+                "plural_name": "צנוני דייקון"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "מוצרי חלב ותחליפי חלב"
+            },
+            "dandelion": {
+                "name": "שן הארי"
+            },
+            "demerara-sugar": {
+                "name": "סוכר דמררה"
+            },
+            "dough": {
+                "name": "בצק"
+            },
+            "edible-cactus": {
+                "name": "קקטוס אכיל (סברס)"
+            },
+            "eggplant": {
+                "name": "חציל",
+                "plural_name": "חצילים"
+            },
+            "eggs": {
+                "name": "ביצים",
+                "plural_name": "ביצים"
+            },
+            "endive": {
+                "name": "אנדיב",
+                "plural_name": "אנדיבים"
+            },
+            "fats": {
+                "name": "שומנים"
+            },
+            "fava-beans": {
+                "name": "פול מצרי"
+            },
+            "fiddlehead": {
+                "name": "שרך ראש הכינור"
+            },
+            "fiddlehead-fern": {
+                "name": "שרך ראש הכינור",
+                "plural_name": "שרכי ראש הכינור"
+            },
+            "fish": {
+                "name": "דג"
+            },
+            "five-spice-powder": {
+                "name": "אבקת 5 תבלינים"
+            },
+            "flour": {
+                "name": "קמח"
+            },
+            "frisee": {
+                "name": "פריזה"
+            },
+            "fructose": {
+                "name": "פרוקטוז"
+            },
+            "fruit": {
+                "name": "פרי"
+            },
+            "fruit-sugar": {
+                "name": "סוכר פירות"
+            },
+            "ful": {
+                "name": "פול"
+            },
+            "garam-masala": {
+                "name": "גראם מסאלה"
+            },
+            "garlic": {
+                "name": "שום",
+                "plural_name": "שום"
+            },
+            "gem-squash": {
+                "name": "דלעת פנינה"
+            },
+            "ghee": {
+                "name": "גהי"
+            },
+            "giblets": {
+                "name": "קרביים"
+            },
+            "ginger": {
+                "name": "ג'ינג'ר"
+            },
+            "grains": {
+                "name": "דגנים"
+            },
+            "granulated-sugar": {
+                "name": "סוכר לבן"
+            },
+            "grape-seed-oil": {
+                "name": "שמן זרעי ענבים"
+            },
+            "green-onion": {
+                "name": "בצל ירוק",
+                "plural_name": "בצלים ירוקים"
+            },
+            "heart-of-palm": {
+                "name": "לב דקל",
+                "plural_name": "לבבות דקל"
+            },
+            "hemp": {
+                "name": "האמפ"
+            },
+            "herbs": {
+                "name": "עשבים"
+            },
+            "honey": {
+                "name": "דבש"
+            },
+            "isomalt": {
+                "name": "איזומלט"
+            },
+            "jackfruit": {
+                "name": "ג׳קפרוט",
+                "plural_name": "ג'קפרוטים"
+            },
+            "jaggery": {
+                "name": "ג’אגרי"
+            },
+            "jams": {
+                "name": "ריבות"
+            },
+            "jellies": {
+                "name": "ג׳לים"
+            },
+            "jerusalem-artichoke": {
+                "name": "ארטישוק ירושלמי"
+            },
+            "jicama": {
+                "name": "חיקמה"
+            },
+            "kale": {
+                "name": "קייל"
+            },
+            "kohlrabi": {
+                "name": "קולורבי"
+            },
+            "kumara": {
+                "name": "בטטה"
+            },
+            "leavening-agents": {
+                "name": "חומר התפחה"
+            },
+            "leek": {
+                "name": "כרישה",
+                "plural_name": "כרישה"
+            },
+            "legumes": {
+                "name": "קטניות"
+            },
+            "lemongrass": {
+                "name": "לימונית"
+            },
+            "lentils": {
+                "name": "עדשים"
+            },
+            "lettuce": {
+                "name": "חסה"
+            },
+            "liver": {
+                "name": "כבד",
+                "plural_name": "כבדים"
+            },
+            "maize": {
+                "name": "תירס"
+            },
+            "maple-syrup": {
+                "name": "סירופ מייפל"
+            },
+            "meat": {
+                "name": "בשר"
+            },
+            "milk": {
+                "name": "חלב"
+            },
+            "mortadella": {
+                "name": "מורטדלה"
+            },
+            "mushroom": {
+                "name": "פטריה",
+                "plural_name": "פטריות"
+            },
+            "mussels": {
+                "name": "צדפות"
+            },
+            "nanaimo-bar-mix": {
+                "name": "תערובת נאנאימו"
+            },
+            "nori": {
+                "name": "נורי"
+            },
+            "nutmeg": {
+                "name": "אגוז מוסקט"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "שבבי שמרים תזונתיים"
+            },
+            "nuts": {
+                "name": "אגוזים"
+            },
+            "octopuses": {
+                "name": "תמנונים",
+                "plural_name": "תמנונים"
+            },
+            "oils": {
+                "name": "שמנים"
+            },
+            "okra": {
+                "name": "אוקרה"
+            },
+            "olive": {
+                "name": "זית"
+            },
+            "olive-oil": {
+                "name": "שמן זית"
+            },
+            "onion": {
+                "name": "בצל"
+            },
+            "onion-family": {
+                "name": "משפחת הבצלים"
+            },
+            "orange-blossom-water": {
+                "name": "מי פריחת הדרים"
+            },
+            "oranges": {
+                "name": "תפוזים",
+                "plural_name": "תפוזים"
+            },
+            "oregano": {
+                "name": "אורגנו"
+            },
+            "oysters": {
+                "name": "צדפות"
+            },
+            "panch-puran": {
+                "name": "פאנץ' פורן (תערובת תבלינים הודית)"
+            },
+            "paprika": {
+                "name": "פפריקה"
+            },
+            "parsley": {
+                "name": "פטרוזיליה"
+            },
+            "parsnip": {
+                "name": "גזר לבן",
+                "plural_name": "גזרים לבנים"
+            },
+            "pear": {
+                "name": "אגס",
+                "plural_name": "אגסים"
+            },
+            "peas": {
+                "name": "אפונה"
+            },
+            "pepper": {
+                "name": "פלפל",
+                "plural_name": "פלפלים"
+            },
+            "pineapple": {
+                "name": "אננס",
+                "plural_name": "אננסים"
+            },
+            "plantain": {
+                "name": "פלנטיין",
+                "plural_name": "פלנטיינים"
+            },
+            "poppy-seeds": {
+                "name": "פרג"
+            },
+            "potato": {
+                "name": "תפוח אדמה",
+                "plural_name": "תפוחי אדמה"
+            },
+            "poultry": {
+                "name": "עוף"
+            },
+            "powdered-sugar": {
+                "name": "אבקת סוכר"
+            },
+            "pumpkin": {
+                "name": "דלעת",
+                "plural_name": "דלעות"
+            },
+            "pumpkin-seeds": {
+                "name": "זרעי דלעת"
+            },
+            "radish": {
+                "name": "צנון",
+                "plural_name": "צנוניות"
+            },
+            "raw-sugar": {
+                "name": "סוכר גולמי"
+            },
+            "refined-sugar": {
+                "name": "סוכר מנופה"
+            },
+            "rice": {
+                "name": "אורז"
+            },
+            "rice-flour": {
+                "name": "קמח אורז"
+            },
+            "rock-sugar": {
+                "name": "גבישי סוכר"
+            },
+            "rum": {
+                "name": "רום"
+            },
+            "salmon": {
+                "name": "סלמון"
+            },
+            "salt": {
+                "name": "מלח"
+            },
+            "salt-cod": {
+                "name": "בקלה ממולח"
+            },
+            "scallion": {
+                "name": "בצל ירוק",
+                "plural_name": "בצלים ירוקים"
+            },
+            "seafood": {
+                "name": "מאכלי ים"
+            },
+            "seeds": {
+                "name": "זרעים"
+            },
+            "sesame-seeds": {
+                "name": "שומשום"
+            },
+            "shallot": {
+                "name": "בצל שאלוט",
+                "plural_name": "בצלצלי שאלוט"
+            },
+            "skate": {
+                "name": "דג תריסנית"
+            },
+            "soda": {
+                "name": "סודה"
+            },
+            "soda-baking": {
+                "name": "סודה לשתייה"
+            },
+            "soybean": {
+                "name": "פולי סויה"
+            },
+            "spaghetti-squash": {
+                "name": "דלעת ספגטי",
+                "plural_name": "דלעות ספגטי"
+            },
+            "speck": {
+                "name": "גרגר"
+            },
+            "spices": {
+                "name": "תבלינים"
+            },
+            "spinach": {
+                "name": "תרד"
+            },
+            "spring-onion": {
+                "name": "בצל אביב",
+                "plural_name": "בצלי אביב"
+            },
+            "squash": {
+                "name": "דלעת",
+                "plural_name": "דלעות"
+            },
+            "squash-family": {
+                "name": "משפחת הדלועים"
+            },
+            "stockfish": {
+                "name": "דג מיובש"
+            },
+            "sugar": {
+                "name": "סוכר"
+            },
+            "sunchoke": {
+                "name": "ארטישוק ירושלמי",
+                "plural_name": "ארטישוק ירושלמי"
+            },
+            "sunflower-seeds": {
+                "name": "זרעי חמניה"
+            },
+            "superfine-sugar": {
+                "name": "אבקת סוכר"
+            },
+            "sweet-potato": {
+                "name": "בטטה",
+                "plural_name": "בטטות"
+            },
+            "sweetcorn": {
+                "name": "תירס מתוק",
+                "plural_name": "תירס מתוק"
+            },
+            "sweeteners": {
+                "name": "ממתיקים"
+            },
+            "tahini": {
+                "name": "טחינה"
+            },
+            "taro": {
+                "name": "טארו",
+                "plural_name": "טארואים"
+            },
+            "teff": {
+                "name": "טף"
+            },
+            "tomato": {
+                "name": "עגבנייה",
+                "plural_name": "עגבניות"
+            },
+            "trout": {
+                "name": "טרוטה"
+            },
+            "tubers": {
+                "name": "שורשיים",
+                "plural_name": "שורשיים"
+            },
+            "tuna": {
+                "name": "טונה"
+            },
+            "turbanado-sugar": {
+                "name": "סוכר גולמי"
+            },
+            "turnip": {
+                "name": "לפת",
+                "plural_name": "לפתות"
+            },
+            "unrefined-sugar": {
+                "name": "סוכר לא מנופה"
+            },
+            "vanilla": {
+                "name": "וניל"
+            },
+            "vegetables": {
+                "name": "ירקות"
+            },
+            "watercress": {
+                "name": "גרגיר הנחלים"
+            },
+            "watermelon": {
+                "name": "אבטיח",
+                "plural_name": "אבטיחים"
+            },
+            "white-mushroom": {
+                "name": "פטריה לבנה",
+                "plural_name": "פטריות לבנות"
+            },
+            "white-sugar": {
+                "name": "סוכר לבן"
+            },
+            "xanthan-gum": {
+                "name": "קסנטן גאם"
+            },
+            "yam": {
+                "name": "בטטה",
+                "plural_name": "בטטות"
+            },
+            "yeast": {
+                "name": "שמרים"
+            },
+            "zucchini": {
+                "name": "זוקיני",
+                "plural_name": "זוקיני"
+            }
+        }
+    },
+    "מוצר": {
+        "foods": {}
+    },
+    "דגנים": {
+        "foods": {}
+    },
+    "פירות": {
+        "foods": {}
+    },
+    "ירקות": {
+        "foods": {}
+    },
+    "בשר": {
+        "foods": {}
+    },
+    "מאכלי ים": {
+        "foods": {}
+    },
+    "משקאות": {
+        "foods": {}
+    },
+    "מאפים": {
+        "foods": {}
+    },
+    "פחיות שימורים": {
+        "foods": {}
+    },
+    "רטבים": {
+        "foods": {}
+    },
+    "מתוקים": {
+        "foods": {}
+    },
+    "מוצרי חלב": {
+        "foods": {}
+    },
+    "אוכל קפוא": {
+        "foods": {}
+    },
+    "אוכל בריאותי": {
+        "foods": {}
+    },
+    "משק בית": {
+        "foods": {}
+    },
+    "מוצרי בשר": {
+        "foods": {}
+    },
+    "חטיפים": {
+        "foods": {}
+    },
+    "תבלינים": {
+        "foods": {}
+    },
+    "ממתקים": {
+        "foods": {}
+    },
+    "אלכוהול": {
+        "foods": {}
+    },
+    "אחר": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/hr-HR.json
+++ b/mealie/repos/seed/resources/foods/locales/hr-HR.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "kupusnjača"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa klice"
-	},
-	"anchovies": {
-		"name": "inćuni"
-	},
-	"apples": {
-		"name": "jabuke",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artičoka"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "šparoga"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "slanina"
-	},
-	"baking-powder": {
-		"name": "prašak za pecivo"
-	},
-	"baking-soda": {
-		"name": "soda bikarbona"
-	},
-	"baking-sugar": {
-		"name": "šećer za pečenje"
-	},
-	"bar-sugar": {
-		"name": "šećer u štapićima"
-	},
-	"basil": {
-		"name": "bosiljak"
-	},
-	"beans": {
-		"name": "grah"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "kupina"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "kupusnjača"
-	},
-	"bread": {
-		"name": "kruh"
-	},
-	"breadfruit": {
-		"name": "kruška kruhovka"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "brokula"
-	},
-	"broccoli-rabe": {
-		"name": "brokula pupčar"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "smeđi šećer"
-	},
-	"brussels-sprouts": {
-		"name": "prokulice"
-	},
-	"butter": {
-		"name": "maslac"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut bundeva"
-	},
-	"butternut-squash": {
-		"name": "tikvica butternut"
-	},
-	"cabbage": {
-		"name": "kupus",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "kaktus, jestivi"
-	},
-	"calabrese": {
-		"name": "kalabarski cvjetača"
-	},
-	"cane-sugar": {
-		"name": "šećer od trske"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "kumin"
-	},
-	"carrot": {
-		"name": "mrkva",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "šećer za posipanje"
-	},
-	"castor-sugar": {
-		"name": "šećer u prahu"
-	},
-	"catfish": {
-		"name": "som"
-	},
-	"cauliflower": {
-		"name": "cvjetača",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne paprika"
-	},
-	"celeriac": {
-		"name": "korjen celera"
-	},
-	"celery": {
-		"name": "celer"
-	},
-	"cereal-grains": {
-		"name": "žitarice"
-	},
-	"chard": {
-		"name": "blitva"
-	},
-	"cheese": {
-		"name": "sir"
-	},
-	"chicory": {
-		"name": "cikorija"
-	},
-	"chilli-peppers": {
-		"name": "chilli paprika",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "kineski kupus"
-	},
-	"chives": {
-		"name": "vlasac"
-	},
-	"chocolate": {
-		"name": "čokolada"
-	},
-	"cilantro": {
-		"name": "korijander (listovi)"
-	},
-	"cinnamon": {
-		"name": "cimet"
-	},
-	"clarified-butter": {
-		"name": "pročišćeni maslac"
-	},
-	"coconut": {
-		"name": "kokos",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "kokosovo mlijeko"
-	},
-	"cod": {
-		"name": "bakalar"
-	},
-	"coffee": {
-		"name": "kava"
-	},
-	"collard-greens": {
-		"name": "raštika"
-	},
-	"confectioners-sugar": {
-		"name": "šećer u prahu"
-	},
-	"coriander": {
-		"name": "korijander"
-	},
-	"corn": {
-		"name": "kukuruz",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "kukuruzni sirup"
-	},
-	"cottonseed-oil": {
-		"name": "ulje pamuka"
-	},
-	"courgette": {
-		"name": "tikvica"
-	},
-	"cream-of-tartar": {
-		"name": "vinski prašak za pecivo"
-	},
-	"cucumber": {
-		"name": "svježi krastavac",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "kim"
-	},
-	"daikon": {
-		"name": "daikon rotkvica",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mliječni proizvodi i zamjene za mliječne proizvode"
-	},
-	"dandelion": {
-		"name": "maslačak"
-	},
-	"demerara-sugar": {
-		"name": "demerara šećer"
-	},
-	"dough": {
-		"name": "tijesto"
-	},
-	"edible-cactus": {
-		"name": "jestivi kaktus"
-	},
-	"eggplant": {
-		"name": "patlidžan",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "jaja",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endivija",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "masti"
-	},
-	"fava-beans": {
-		"name": "slanutak"
-	},
-	"fiddlehead": {
-		"name": "mladi izdanci paprati"
-	},
-	"fiddlehead-fern": {
-		"name": "mladi listovi paprati",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "riba"
-	},
-	"five-spice-powder": {
-		"name": "pet začina u prahu"
-	},
-	"flour": {
-		"name": "brašno"
-	},
-	"frisee": {
-		"name": "frizola"
-	},
-	"fructose": {
-		"name": "fruktoza"
-	},
-	"fruit": {
-		"name": "voće"
-	},
-	"fruit-sugar": {
-		"name": "voćni šećer"
-	},
-	"ful": {
-		"name": "taro"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "češnjak",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem tikva"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "peradske iznutrice"
-	},
-	"ginger": {
-		"name": "đumbir"
-	},
-	"grains": {
-		"name": "žitarice"
-	},
-	"granulated-sugar": {
-		"name": "granulirani šećer"
-	},
-	"grape-seed-oil": {
-		"name": "ulje sjemenki grožđa"
-	},
-	"green-onion": {
-		"name": "mladi luk",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "srce palme",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "konoplja"
-	},
-	"herbs": {
-		"name": "začinsko bilje"
-	},
-	"honey": {
-		"name": "med"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "šećer od trske"
-	},
-	"jams": {
-		"name": "pekmez"
-	},
-	"jellies": {
-		"name": "žele"
-	},
-	"jerusalem-artichoke": {
-		"name": "jeruzalemska artičoka"
-	},
-	"jicama": {
-		"name": "jikama"
-	},
-	"kale": {
-		"name": "kelj"
-	},
-	"kohlrabi": {
-		"name": "koraba"
-	},
-	"kumara": {
-		"name": "krastavac"
-	},
-	"leavening-agents": {
-		"name": "sredstva za dizanje tijesta"
-	},
-	"leek": {
-		"name": "poriluk",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "mahunarke"
-	},
-	"lemongrass": {
-		"name": "limunska trava"
-	},
-	"lentils": {
-		"name": "leća"
-	},
-	"lettuce": {
-		"name": "zelena salata"
-	},
-	"liver": {
-		"name": "jetra",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "kukuruz"
-	},
-	"maple-syrup": {
-		"name": "javorov sirup"
-	},
-	"meat": {
-		"name": "meso"
-	},
-	"milk": {
-		"name": "mlijeko"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "gljiva",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "musle"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori alga"
-	},
-	"nutmeg": {
-		"name": "muškatni oraščić"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "pahuljice od prehrambenog kvasca"
-	},
-	"nuts": {
-		"name": "orašasti plodovi"
-	},
-	"octopuses": {
-		"name": "hobotnica",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "ulja"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "maslina"
-	},
-	"olive-oil": {
-		"name": "maslinovo ulje"
-	},
-	"onion": {
-		"name": "luk"
-	},
-	"onion-family": {
-		"name": "iz familije luka"
-	},
-	"orange-blossom-water": {
-		"name": "voda od cvijeta naranče"
-	},
-	"oranges": {
-		"name": "naranča",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "origano"
-	},
-	"oysters": {
-		"name": "kamenica"
-	},
-	"panch-puran": {
-		"name": "panch puran - mješavina indijskih začina"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "peršin"
-	},
-	"parsnip": {
-		"name": "pastrnjak",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "kruška",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "grašak"
-	},
-	"pepper": {
-		"name": "papar",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "makovo sjeme"
-	},
-	"potato": {
-		"name": "krumpir",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "perad"
-	},
-	"powdered-sugar": {
-		"name": "šećer u prahu"
-	},
-	"pumpkin": {
-		"name": "bundeva",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "sjemenke bundeve"
-	},
-	"radish": {
-		"name": "rotkvica",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "sirovi šećer"
-	},
-	"refined-sugar": {
-		"name": "rafinirani šećer"
-	},
-	"rice": {
-		"name": "riža"
-	},
-	"rice-flour": {
-		"name": "rižino brašno"
-	},
-	"rock-sugar": {
-		"name": "kameni šećer"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "losos"
-	},
-	"salt": {
-		"name": "sol"
-	},
-	"salt-cod": {
-		"name": "slani bakalar"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "plodovi mora"
-	},
-	"seeds": {
-		"name": "sjemenke"
-	},
-	"sesame-seeds": {
-		"name": "sjemenke sezama"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate (riba)"
-	},
-	"soda": {
-		"name": "gazirani sok"
-	},
-	"soda-baking": {
-		"name": "soda bikarbona"
-	},
-	"soybean": {
-		"name": "sojino zrno"
-	},
-	"spaghetti-squash": {
-		"name": "spageti tikva",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "spek (slanina)"
-	},
-	"spices": {
-		"name": "začini"
-	},
-	"spinach": {
-		"name": "špinat"
-	},
-	"spring-onion": {
-		"name": "proljetni luk - mladi luk",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "tikva",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "obitelj tikvi"
-	},
-	"stockfish": {
-		"name": "stockfish (sušena riba)"
-	},
-	"sugar": {
-		"name": "šećer"
-	},
-	"sunchoke": {
-		"name": "repa",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sjemenke suncokreta"
-	},
-	"superfine-sugar": {
-		"name": "super-fini šećer"
-	},
-	"sweet-potato": {
-		"name": "batat",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "slatki kukuruz",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "zaslađivač"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "rajčica",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "pastrva"
-	},
-	"tubers": {
-		"name": "gomolji",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "šećer od trske"
-	},
-	"turnip": {
-		"name": "repa",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "nerefinirani šećer"
-	},
-	"vanilla": {
-		"name": "vanilija"
-	},
-	"vegetables": {
-		"name": "povrće"
-	},
-	"watercress": {
-		"name": "ljekovita potočarka"
-	},
-	"watermelon": {
-		"name": "lubenica",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "bijela gljiva",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "bijeli šećer"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "jam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "kvasac"
-	},
-	"zucchini": {
-		"name": "tikvica",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "kupusnjača"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa klice"
+            },
+            "anchovies": {
+                "name": "inćuni"
+            },
+            "apples": {
+                "name": "jabuke",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artičoka"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "šparoga"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "slanina"
+            },
+            "baking-powder": {
+                "name": "prašak za pecivo"
+            },
+            "baking-soda": {
+                "name": "soda bikarbona"
+            },
+            "baking-sugar": {
+                "name": "šećer za pečenje"
+            },
+            "bar-sugar": {
+                "name": "šećer u štapićima"
+            },
+            "basil": {
+                "name": "bosiljak"
+            },
+            "beans": {
+                "name": "grah"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "kupina"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "kupusnjača"
+            },
+            "bread": {
+                "name": "kruh"
+            },
+            "breadfruit": {
+                "name": "kruška kruhovka"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "brokula"
+            },
+            "broccoli-rabe": {
+                "name": "brokula pupčar"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "smeđi šećer"
+            },
+            "brussels-sprouts": {
+                "name": "prokulice"
+            },
+            "butter": {
+                "name": "maslac"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut bundeva"
+            },
+            "butternut-squash": {
+                "name": "tikvica butternut"
+            },
+            "cabbage": {
+                "name": "kupus",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "kaktus, jestivi"
+            },
+            "calabrese": {
+                "name": "kalabarski cvjetača"
+            },
+            "cane-sugar": {
+                "name": "šećer od trske"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "kumin"
+            },
+            "carrot": {
+                "name": "mrkva",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "šećer za posipanje"
+            },
+            "castor-sugar": {
+                "name": "šećer u prahu"
+            },
+            "catfish": {
+                "name": "som"
+            },
+            "cauliflower": {
+                "name": "cvjetača",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne paprika"
+            },
+            "celeriac": {
+                "name": "korjen celera"
+            },
+            "celery": {
+                "name": "celer"
+            },
+            "cereal-grains": {
+                "name": "žitarice"
+            },
+            "chard": {
+                "name": "blitva"
+            },
+            "cheese": {
+                "name": "sir"
+            },
+            "chicory": {
+                "name": "cikorija"
+            },
+            "chilli-peppers": {
+                "name": "chilli paprika",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "kineski kupus"
+            },
+            "chives": {
+                "name": "vlasac"
+            },
+            "chocolate": {
+                "name": "čokolada"
+            },
+            "cilantro": {
+                "name": "korijander (listovi)"
+            },
+            "cinnamon": {
+                "name": "cimet"
+            },
+            "clarified-butter": {
+                "name": "pročišćeni maslac"
+            },
+            "coconut": {
+                "name": "kokos",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "kokosovo mlijeko"
+            },
+            "cod": {
+                "name": "bakalar"
+            },
+            "coffee": {
+                "name": "kava"
+            },
+            "collard-greens": {
+                "name": "raštika"
+            },
+            "confectioners-sugar": {
+                "name": "šećer u prahu"
+            },
+            "coriander": {
+                "name": "korijander"
+            },
+            "corn": {
+                "name": "kukuruz",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "kukuruzni sirup"
+            },
+            "cottonseed-oil": {
+                "name": "ulje pamuka"
+            },
+            "courgette": {
+                "name": "tikvica"
+            },
+            "cream-of-tartar": {
+                "name": "vinski prašak za pecivo"
+            },
+            "cucumber": {
+                "name": "svježi krastavac",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "kim"
+            },
+            "daikon": {
+                "name": "daikon rotkvica",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mliječni proizvodi i zamjene za mliječne proizvode"
+            },
+            "dandelion": {
+                "name": "maslačak"
+            },
+            "demerara-sugar": {
+                "name": "demerara šećer"
+            },
+            "dough": {
+                "name": "tijesto"
+            },
+            "edible-cactus": {
+                "name": "jestivi kaktus"
+            },
+            "eggplant": {
+                "name": "patlidžan",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "jaja",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endivija",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "masti"
+            },
+            "fava-beans": {
+                "name": "slanutak"
+            },
+            "fiddlehead": {
+                "name": "mladi izdanci paprati"
+            },
+            "fiddlehead-fern": {
+                "name": "mladi listovi paprati",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "riba"
+            },
+            "five-spice-powder": {
+                "name": "pet začina u prahu"
+            },
+            "flour": {
+                "name": "brašno"
+            },
+            "frisee": {
+                "name": "frizola"
+            },
+            "fructose": {
+                "name": "fruktoza"
+            },
+            "fruit": {
+                "name": "voće"
+            },
+            "fruit-sugar": {
+                "name": "voćni šećer"
+            },
+            "ful": {
+                "name": "taro"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "češnjak",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem tikva"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "peradske iznutrice"
+            },
+            "ginger": {
+                "name": "đumbir"
+            },
+            "grains": {
+                "name": "žitarice"
+            },
+            "granulated-sugar": {
+                "name": "granulirani šećer"
+            },
+            "grape-seed-oil": {
+                "name": "ulje sjemenki grožđa"
+            },
+            "green-onion": {
+                "name": "mladi luk",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "srce palme",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "konoplja"
+            },
+            "herbs": {
+                "name": "začinsko bilje"
+            },
+            "honey": {
+                "name": "med"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "šećer od trske"
+            },
+            "jams": {
+                "name": "pekmez"
+            },
+            "jellies": {
+                "name": "žele"
+            },
+            "jerusalem-artichoke": {
+                "name": "jeruzalemska artičoka"
+            },
+            "jicama": {
+                "name": "jikama"
+            },
+            "kale": {
+                "name": "kelj"
+            },
+            "kohlrabi": {
+                "name": "koraba"
+            },
+            "kumara": {
+                "name": "krastavac"
+            },
+            "leavening-agents": {
+                "name": "sredstva za dizanje tijesta"
+            },
+            "leek": {
+                "name": "poriluk",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "mahunarke"
+            },
+            "lemongrass": {
+                "name": "limunska trava"
+            },
+            "lentils": {
+                "name": "leća"
+            },
+            "lettuce": {
+                "name": "zelena salata"
+            },
+            "liver": {
+                "name": "jetra",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "kukuruz"
+            },
+            "maple-syrup": {
+                "name": "javorov sirup"
+            },
+            "meat": {
+                "name": "meso"
+            },
+            "milk": {
+                "name": "mlijeko"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "gljiva",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "musle"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori alga"
+            },
+            "nutmeg": {
+                "name": "muškatni oraščić"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "pahuljice od prehrambenog kvasca"
+            },
+            "nuts": {
+                "name": "orašasti plodovi"
+            },
+            "octopuses": {
+                "name": "hobotnica",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "ulja"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "maslina"
+            },
+            "olive-oil": {
+                "name": "maslinovo ulje"
+            },
+            "onion": {
+                "name": "luk"
+            },
+            "onion-family": {
+                "name": "iz familije luka"
+            },
+            "orange-blossom-water": {
+                "name": "voda od cvijeta naranče"
+            },
+            "oranges": {
+                "name": "naranča",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "origano"
+            },
+            "oysters": {
+                "name": "kamenica"
+            },
+            "panch-puran": {
+                "name": "panch puran - mješavina indijskih začina"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "peršin"
+            },
+            "parsnip": {
+                "name": "pastrnjak",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "kruška",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "grašak"
+            },
+            "pepper": {
+                "name": "papar",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "makovo sjeme"
+            },
+            "potato": {
+                "name": "krumpir",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "perad"
+            },
+            "powdered-sugar": {
+                "name": "šećer u prahu"
+            },
+            "pumpkin": {
+                "name": "bundeva",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "sjemenke bundeve"
+            },
+            "radish": {
+                "name": "rotkvica",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "sirovi šećer"
+            },
+            "refined-sugar": {
+                "name": "rafinirani šećer"
+            },
+            "rice": {
+                "name": "riža"
+            },
+            "rice-flour": {
+                "name": "rižino brašno"
+            },
+            "rock-sugar": {
+                "name": "kameni šećer"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "losos"
+            },
+            "salt": {
+                "name": "sol"
+            },
+            "salt-cod": {
+                "name": "slani bakalar"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "plodovi mora"
+            },
+            "seeds": {
+                "name": "sjemenke"
+            },
+            "sesame-seeds": {
+                "name": "sjemenke sezama"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate (riba)"
+            },
+            "soda": {
+                "name": "gazirani sok"
+            },
+            "soda-baking": {
+                "name": "soda bikarbona"
+            },
+            "soybean": {
+                "name": "sojino zrno"
+            },
+            "spaghetti-squash": {
+                "name": "spageti tikva",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "spek (slanina)"
+            },
+            "spices": {
+                "name": "začini"
+            },
+            "spinach": {
+                "name": "špinat"
+            },
+            "spring-onion": {
+                "name": "proljetni luk - mladi luk",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "tikva",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "obitelj tikvi"
+            },
+            "stockfish": {
+                "name": "stockfish (sušena riba)"
+            },
+            "sugar": {
+                "name": "šećer"
+            },
+            "sunchoke": {
+                "name": "repa",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sjemenke suncokreta"
+            },
+            "superfine-sugar": {
+                "name": "super-fini šećer"
+            },
+            "sweet-potato": {
+                "name": "batat",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "slatki kukuruz",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "zaslađivač"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "rajčica",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "pastrva"
+            },
+            "tubers": {
+                "name": "gomolji",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "šećer od trske"
+            },
+            "turnip": {
+                "name": "repa",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "nerefinirani šećer"
+            },
+            "vanilla": {
+                "name": "vanilija"
+            },
+            "vegetables": {
+                "name": "povrće"
+            },
+            "watercress": {
+                "name": "ljekovita potočarka"
+            },
+            "watermelon": {
+                "name": "lubenica",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "bijela gljiva",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "bijeli šećer"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "jam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "kvasac"
+            },
+            "zucchini": {
+                "name": "tikvica",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Svježe namirnice": {
+        "foods": {}
+    },
+    "Žitarice": {
+        "foods": {}
+    },
+    "Voće": {
+        "foods": {}
+    },
+    "Povrće": {
+        "foods": {}
+    },
+    "Meso": {
+        "foods": {}
+    },
+    "Plodovi mora": {
+        "foods": {}
+    },
+    "Piće": {
+        "foods": {}
+    },
+    "Pečeni proizvodi": {
+        "foods": {}
+    },
+    "Konzervirani proizvodi": {
+        "foods": {}
+    },
+    "Začini": {
+        "foods": {}
+    },
+    "Konditorski proizvodi": {
+        "foods": {}
+    },
+    "Mliječni proizvod": {
+        "foods": {}
+    },
+    "Smrznuta hrana": {
+        "foods": {}
+    },
+    "Zdrava Hrana": {
+        "foods": {}
+    },
+    "Kućanstvo": {
+        "foods": {}
+    },
+    "Mesni proizvodi": {
+        "foods": {}
+    },
+    "Grickalice": {
+        "foods": {}
+    },
+    "Slatkiši": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Ostalo": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/hu-HU.json
+++ b/mealie/repos/seed/resources/foods/locales/hu-HU.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "makktök"
-	},
-	"alfalfa-sprouts": {
-		"name": "lucernacsíra"
-	},
-	"anchovies": {
-		"name": "szardella"
-	},
-	"apples": {
-		"name": "alma",
-		"plural_name": "alma"
-	},
-	"artichoke": {
-		"name": "articsóka"
-	},
-	"arugula": {
-		"name": "rukkola"
-	},
-	"asparagus": {
-		"name": "spárga"
-	},
-	"avocado": {
-		"name": "avokádó",
-		"plural_name": "avokádó"
-	},
-	"bacon": {
-		"name": "szalonna"
-	},
-	"baking-powder": {
-		"name": "sütőpor"
-	},
-	"baking-soda": {
-		"name": "szódabikarbóna"
-	},
-	"baking-sugar": {
-		"name": "sütőcukor"
-	},
-	"bar-sugar": {
-		"name": "cukorrúd"
-	},
-	"basil": {
-		"name": "bazsalikom"
-	},
-	"beans": {
-		"name": "bab"
-	},
-	"bell-peppers": {
-		"name": "kaliforniai paprika",
-		"plural_name": "kaliforniai paprika"
-	},
-	"blackberries": {
-		"name": "szeder"
-	},
-	"bok-choy": {
-		"name": "bordáskel"
-	},
-	"brassicas": {
-		"name": "káposzta"
-	},
-	"bread": {
-		"name": "kenyér"
-	},
-	"breadfruit": {
-		"name": "kenyérfa"
-	},
-	"broccoflower": {
-		"name": "zöld karfiol"
-	},
-	"broccoli": {
-		"name": "brokkoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "brokkolini"
-	},
-	"brown-sugar": {
-		"name": "barna cukor"
-	},
-	"brussels-sprouts": {
-		"name": "kelbimbó"
-	},
-	"butter": {
-		"name": "vaj"
-	},
-	"butternut-pumpkin": {
-		"name": "pézsmatök"
-	},
-	"butternut-squash": {
-		"name": "vajtök"
-	},
-	"cabbage": {
-		"name": "káposzta",
-		"plural_name": "káposzta"
-	},
-	"cactus-edible": {
-		"name": "kaktusz"
-	},
-	"calabrese": {
-		"name": "brokkoli"
-	},
-	"cane-sugar": {
-		"name": "nádcukor"
-	},
-	"cannabis": {
-		"name": "kannabisz"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "fűszerkömény"
-	},
-	"carrot": {
-		"name": "sárgarépa",
-		"plural_name": "sárgarépa"
-	},
-	"caster-sugar": {
-		"name": "porcukor"
-	},
-	"castor-sugar": {
-		"name": "porcukor"
-	},
-	"catfish": {
-		"name": "harcsa"
-	},
-	"cauliflower": {
-		"name": "karfiol",
-		"plural_name": "karfiol"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne-bors"
-	},
-	"celeriac": {
-		"name": "zeller"
-	},
-	"celery": {
-		"name": "zeller"
-	},
-	"cereal-grains": {
-		"name": "gabonafélék"
-	},
-	"chard": {
-		"name": "mángold"
-	},
-	"cheese": {
-		"name": "sajt"
-	},
-	"chicory": {
-		"name": "cikória"
-	},
-	"chilli-peppers": {
-		"name": "csili paprika",
-		"plural_name": "csili paprika"
-	},
-	"chinese-leaves": {
-		"name": "kínai kel"
-	},
-	"chives": {
-		"name": "metélőhagyma"
-	},
-	"chocolate": {
-		"name": "csokoládé"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "fahéj"
-	},
-	"clarified-butter": {
-		"name": "tisztított vaj"
-	},
-	"coconut": {
-		"name": "kókuszdió",
-		"plural_name": "kókuszdió"
-	},
-	"coconut-milk": {
-		"name": "kókusztej"
-	},
-	"cod": {
-		"name": "tőkehal"
-	},
-	"coffee": {
-		"name": "kávé"
-	},
-	"collard-greens": {
-		"name": "káposztalevél"
-	},
-	"confectioners-sugar": {
-		"name": "porcukor"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "kukorica",
-		"plural_name": "kukorica"
-	},
-	"corn-syrup": {
-		"name": "kukoricaszirup"
-	},
-	"cottonseed-oil": {
-		"name": "gyapotmagolaj"
-	},
-	"courgette": {
-		"name": "cukkini"
-	},
-	"cream-of-tartar": {
-		"name": "tartárkrém"
-	},
-	"cucumber": {
-		"name": "uborka",
-		"plural_name": "uborka"
-	},
-	"cumin": {
-		"name": "kömény"
-	},
-	"daikon": {
-		"name": "jégcsapretek",
-		"plural_name": "jégcsapretek"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "tejtermékek és helyetesítők"
-	},
-	"dandelion": {
-		"name": "pitypang"
-	},
-	"demerara-sugar": {
-		"name": "barna cukor"
-	},
-	"dough": {
-		"name": "tészta"
-	},
-	"edible-cactus": {
-		"name": "kaktusz"
-	},
-	"eggplant": {
-		"name": "padlizsán",
-		"plural_name": "padlizsán"
-	},
-	"eggs": {
-		"name": "tojás",
-		"plural_name": "tojás"
-	},
-	"endive": {
-		"name": "endívia",
-		"plural_name": "endívia"
-	},
-	"fats": {
-		"name": "zsírok"
-	},
-	"fava-beans": {
-		"name": "lóbab"
-	},
-	"fiddlehead": {
-		"name": "hegedűfej"
-	},
-	"fiddlehead-fern": {
-		"name": "hegedűfej páfrány",
-		"plural_name": "hegedűfej páfrányok"
-	},
-	"fish": {
-		"name": "hal"
-	},
-	"five-spice-powder": {
-		"name": "ötfűszer keverék"
-	},
-	"flour": {
-		"name": "liszt"
-	},
-	"frisee": {
-		"name": "fríz saláta"
-	},
-	"fructose": {
-		"name": "fruktóz"
-	},
-	"fruit": {
-		"name": "gyümölcs"
-	},
-	"fruit-sugar": {
-		"name": "gyümölcscukor"
-	},
-	"ful": {
-		"name": "fúl medames"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "fokhagyma",
-		"plural_name": "fokhagyma"
-	},
-	"gem-squash": {
-		"name": "drágakő tök"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "szárnyas aprólék"
-	},
-	"ginger": {
-		"name": "gyömbér"
-	},
-	"grains": {
-		"name": "gabonafélék"
-	},
-	"granulated-sugar": {
-		"name": "cukor"
-	},
-	"grape-seed-oil": {
-		"name": "szőlőmagolaj"
-	},
-	"green-onion": {
-		"name": "zöld hagyma",
-		"plural_name": "zöld hagyma"
-	},
-	"heart-of-palm": {
-		"name": "pálma szíve",
-		"plural_name": "pálmák szívei"
-	},
-	"hemp": {
-		"name": "kender"
-	},
-	"herbs": {
-		"name": "gyógynövények"
-	},
-	"honey": {
-		"name": "méz"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "jákafa",
-		"plural_name": "jákafák"
-	},
-	"jaggery": {
-		"name": "nádcukor"
-	},
-	"jams": {
-		"name": "lekvár"
-	},
-	"jellies": {
-		"name": "zselé"
-	},
-	"jerusalem-artichoke": {
-		"name": "csicsóka"
-	},
-	"jicama": {
-		"name": "jícama"
-	},
-	"kale": {
-		"name": "kelkáposzta"
-	},
-	"kohlrabi": {
-		"name": "karalábé"
-	},
-	"kumara": {
-		"name": "édesburgonya"
-	},
-	"leavening-agents": {
-		"name": "lazító anyag"
-	},
-	"leek": {
-		"name": "póréhagyma",
-		"plural_name": "póréhagyma"
-	},
-	"legumes": {
-		"name": "hüvelyesek"
-	},
-	"lemongrass": {
-		"name": "citromfű"
-	},
-	"lentils": {
-		"name": "lencse"
-	},
-	"lettuce": {
-		"name": "saláta"
-	},
-	"liver": {
-		"name": "máj",
-		"plural_name": "máj"
-	},
-	"maize": {
-		"name": "csemegekukorica"
-	},
-	"maple-syrup": {
-		"name": "juharszirup"
-	},
-	"meat": {
-		"name": "hús"
-	},
-	"milk": {
-		"name": "tej"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "gomba",
-		"plural_name": "gomba"
-	},
-	"mussels": {
-		"name": "kagyló"
-	},
-	"nanaimo-bar-mix": {
-		"name": "eszkimó szelet keverék"
-	},
-	"nori": {
-		"name": "nori alga"
-	},
-	"nutmeg": {
-		"name": "szerecsendió"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "inaktív élesztő"
-	},
-	"nuts": {
-		"name": "diófélék"
-	},
-	"octopuses": {
-		"name": "polip",
-		"plural_name": "polip"
-	},
-	"oils": {
-		"name": "olajok"
-	},
-	"okra": {
-		"name": "bámia"
-	},
-	"olive": {
-		"name": "olívabogyó"
-	},
-	"olive-oil": {
-		"name": "olivaolaj"
-	},
-	"onion": {
-		"name": "hagyma"
-	},
-	"onion-family": {
-		"name": "hagymafélék"
-	},
-	"orange-blossom-water": {
-		"name": "narancsvirág víz"
-	},
-	"oranges": {
-		"name": "narancs",
-		"plural_name": "narancs"
-	},
-	"oregano": {
-		"name": "oregánó"
-	},
-	"oysters": {
-		"name": "osztriga"
-	},
-	"panch-puran": {
-		"name": "indiai ötfűszer keverék"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "petrezselyem"
-	},
-	"parsnip": {
-		"name": "paszternák",
-		"plural_name": "paszternák"
-	},
-	"pear": {
-		"name": "körte",
-		"plural_name": "körte"
-	},
-	"peas": {
-		"name": "borsó"
-	},
-	"pepper": {
-		"name": "bors",
-		"plural_name": "bors"
-	},
-	"pineapple": {
-		"name": "ananász",
-		"plural_name": "ananász"
-	},
-	"plantain": {
-		"name": "főzőbanán",
-		"plural_name": "főzőbanán"
-	},
-	"poppy-seeds": {
-		"name": "mák"
-	},
-	"potato": {
-		"name": "burgonya",
-		"plural_name": "burgonyák"
-	},
-	"poultry": {
-		"name": "baromfi"
-	},
-	"powdered-sugar": {
-		"name": "porcukor"
-	},
-	"pumpkin": {
-		"name": "tök",
-		"plural_name": "tök"
-	},
-	"pumpkin-seeds": {
-		"name": "tökmag"
-	},
-	"radish": {
-		"name": "retek",
-		"plural_name": "retek"
-	},
-	"raw-sugar": {
-		"name": "barna cukor"
-	},
-	"refined-sugar": {
-		"name": "finomitott cukor"
-	},
-	"rice": {
-		"name": "rizs"
-	},
-	"rice-flour": {
-		"name": "rízsliszt"
-	},
-	"rock-sugar": {
-		"name": "kandiscukor"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "lazac"
-	},
-	"salt": {
-		"name": "só"
-	},
-	"salt-cod": {
-		"name": "sózott tőkehal"
-	},
-	"scallion": {
-		"name": "zöldhagyma",
-		"plural_name": "zöldhagymák"
-	},
-	"seafood": {
-		"name": "tenger gyümölcsei"
-	},
-	"seeds": {
-		"name": "magvak"
-	},
-	"sesame-seeds": {
-		"name": "szezámmag"
-	},
-	"shallot": {
-		"name": "mogyoróhagyma",
-		"plural_name": "mogyoróhagyma"
-	},
-	"skate": {
-		"name": "rája"
-	},
-	"soda": {
-		"name": "szóda"
-	},
-	"soda-baking": {
-		"name": "szódabikarbóna"
-	},
-	"soybean": {
-		"name": "szójabab"
-	},
-	"spaghetti-squash": {
-		"name": "spárgatök",
-		"plural_name": "spárgatök"
-	},
-	"speck": {
-		"name": "speck sonka"
-	},
-	"spices": {
-		"name": "fűszerek"
-	},
-	"spinach": {
-		"name": "spenót"
-	},
-	"spring-onion": {
-		"name": "újhagyma",
-		"plural_name": "újhagyma"
-	},
-	"squash": {
-		"name": "tök",
-		"plural_name": "tökök"
-	},
-	"squash-family": {
-		"name": "tökfélék"
-	},
-	"stockfish": {
-		"name": "szárított hal"
-	},
-	"sugar": {
-		"name": "cukor"
-	},
-	"sunchoke": {
-		"name": "csicsóka",
-		"plural_name": "csicsókák"
-	},
-	"sunflower-seeds": {
-		"name": "napraforgómag"
-	},
-	"superfine-sugar": {
-		"name": "finom szemcsés cukor"
-	},
-	"sweet-potato": {
-		"name": "édesburgonya",
-		"plural_name": "édesburgonya"
-	},
-	"sweetcorn": {
-		"name": "csemegekukorica",
-		"plural_name": "csemegekukorica"
-	},
-	"sweeteners": {
-		"name": "édesítőszerek"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taró",
-		"plural_name": "tarók"
-	},
-	"teff": {
-		"name": "egynyári fürtfű"
-	},
-	"tomato": {
-		"name": "paradicsom",
-		"plural_name": "paradicsom"
-	},
-	"trout": {
-		"name": "pisztráng"
-	},
-	"tubers": {
-		"name": "gumók",
-		"plural_name": "gumók"
-	},
-	"tuna": {
-		"name": "tonhal"
-	},
-	"turbanado-sugar": {
-		"name": "barna cukor"
-	},
-	"turnip": {
-		"name": "fehér répa",
-		"plural_name": "fehérrépa"
-	},
-	"unrefined-sugar": {
-		"name": "finomitatlan cukor"
-	},
-	"vanilla": {
-		"name": "vanília"
-	},
-	"vegetables": {
-		"name": "zöldségek"
-	},
-	"watercress": {
-		"name": "vízitorma"
-	},
-	"watermelon": {
-		"name": "görögdinnye",
-		"plural_name": "görögdinnye"
-	},
-	"white-mushroom": {
-		"name": "fehér gomba",
-		"plural_name": "fehér gomba"
-	},
-	"white-sugar": {
-		"name": "fehér cukor"
-	},
-	"xanthan-gum": {
-		"name": "xantángumi"
-	},
-	"yam": {
-		"name": "jamgyökér",
-		"plural_name": "jamgyökér"
-	},
-	"yeast": {
-		"name": "élesztő"
-	},
-	"zucchini": {
-		"name": "cukkini",
-		"plural_name": "cukkini"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "makktök"
+            },
+            "alfalfa-sprouts": {
+                "name": "lucernacsíra"
+            },
+            "anchovies": {
+                "name": "szardella"
+            },
+            "apples": {
+                "name": "alma",
+                "plural_name": "alma"
+            },
+            "artichoke": {
+                "name": "articsóka"
+            },
+            "arugula": {
+                "name": "rukkola"
+            },
+            "asparagus": {
+                "name": "spárga"
+            },
+            "avocado": {
+                "name": "avokádó",
+                "plural_name": "avokádó"
+            },
+            "bacon": {
+                "name": "szalonna"
+            },
+            "baking-powder": {
+                "name": "sütőpor"
+            },
+            "baking-soda": {
+                "name": "szódabikarbóna"
+            },
+            "baking-sugar": {
+                "name": "sütőcukor"
+            },
+            "bar-sugar": {
+                "name": "cukorrúd"
+            },
+            "basil": {
+                "name": "bazsalikom"
+            },
+            "beans": {
+                "name": "bab"
+            },
+            "bell-peppers": {
+                "name": "kaliforniai paprika",
+                "plural_name": "kaliforniai paprika"
+            },
+            "blackberries": {
+                "name": "szeder"
+            },
+            "bok-choy": {
+                "name": "bordáskel"
+            },
+            "brassicas": {
+                "name": "káposzta"
+            },
+            "bread": {
+                "name": "kenyér"
+            },
+            "breadfruit": {
+                "name": "kenyérfa"
+            },
+            "broccoflower": {
+                "name": "zöld karfiol"
+            },
+            "broccoli": {
+                "name": "brokkoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "brokkolini"
+            },
+            "brown-sugar": {
+                "name": "barna cukor"
+            },
+            "brussels-sprouts": {
+                "name": "kelbimbó"
+            },
+            "butter": {
+                "name": "vaj"
+            },
+            "butternut-pumpkin": {
+                "name": "pézsmatök"
+            },
+            "butternut-squash": {
+                "name": "vajtök"
+            },
+            "cabbage": {
+                "name": "káposzta",
+                "plural_name": "káposzta"
+            },
+            "cactus-edible": {
+                "name": "kaktusz"
+            },
+            "calabrese": {
+                "name": "brokkoli"
+            },
+            "cane-sugar": {
+                "name": "nádcukor"
+            },
+            "cannabis": {
+                "name": "kannabisz"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "fűszerkömény"
+            },
+            "carrot": {
+                "name": "sárgarépa",
+                "plural_name": "sárgarépa"
+            },
+            "caster-sugar": {
+                "name": "porcukor"
+            },
+            "castor-sugar": {
+                "name": "porcukor"
+            },
+            "catfish": {
+                "name": "harcsa"
+            },
+            "cauliflower": {
+                "name": "karfiol",
+                "plural_name": "karfiol"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne-bors"
+            },
+            "celeriac": {
+                "name": "zeller"
+            },
+            "celery": {
+                "name": "zeller"
+            },
+            "cereal-grains": {
+                "name": "gabonafélék"
+            },
+            "chard": {
+                "name": "mángold"
+            },
+            "cheese": {
+                "name": "sajt"
+            },
+            "chicory": {
+                "name": "cikória"
+            },
+            "chilli-peppers": {
+                "name": "csili paprika",
+                "plural_name": "csili paprika"
+            },
+            "chinese-leaves": {
+                "name": "kínai kel"
+            },
+            "chives": {
+                "name": "metélőhagyma"
+            },
+            "chocolate": {
+                "name": "csokoládé"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "fahéj"
+            },
+            "clarified-butter": {
+                "name": "tisztított vaj"
+            },
+            "coconut": {
+                "name": "kókuszdió",
+                "plural_name": "kókuszdió"
+            },
+            "coconut-milk": {
+                "name": "kókusztej"
+            },
+            "cod": {
+                "name": "tőkehal"
+            },
+            "coffee": {
+                "name": "kávé"
+            },
+            "collard-greens": {
+                "name": "káposztalevél"
+            },
+            "confectioners-sugar": {
+                "name": "porcukor"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "kukorica",
+                "plural_name": "kukorica"
+            },
+            "corn-syrup": {
+                "name": "kukoricaszirup"
+            },
+            "cottonseed-oil": {
+                "name": "gyapotmagolaj"
+            },
+            "courgette": {
+                "name": "cukkini"
+            },
+            "cream-of-tartar": {
+                "name": "tartárkrém"
+            },
+            "cucumber": {
+                "name": "uborka",
+                "plural_name": "uborka"
+            },
+            "cumin": {
+                "name": "kömény"
+            },
+            "daikon": {
+                "name": "jégcsapretek",
+                "plural_name": "jégcsapretek"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "tejtermékek és helyetesítők"
+            },
+            "dandelion": {
+                "name": "pitypang"
+            },
+            "demerara-sugar": {
+                "name": "barna cukor"
+            },
+            "dough": {
+                "name": "tészta"
+            },
+            "edible-cactus": {
+                "name": "kaktusz"
+            },
+            "eggplant": {
+                "name": "padlizsán",
+                "plural_name": "padlizsán"
+            },
+            "eggs": {
+                "name": "tojás",
+                "plural_name": "tojás"
+            },
+            "endive": {
+                "name": "endívia",
+                "plural_name": "endívia"
+            },
+            "fats": {
+                "name": "zsírok"
+            },
+            "fava-beans": {
+                "name": "lóbab"
+            },
+            "fiddlehead": {
+                "name": "hegedűfej"
+            },
+            "fiddlehead-fern": {
+                "name": "hegedűfej páfrány",
+                "plural_name": "hegedűfej páfrányok"
+            },
+            "fish": {
+                "name": "hal"
+            },
+            "five-spice-powder": {
+                "name": "ötfűszer keverék"
+            },
+            "flour": {
+                "name": "liszt"
+            },
+            "frisee": {
+                "name": "fríz saláta"
+            },
+            "fructose": {
+                "name": "fruktóz"
+            },
+            "fruit": {
+                "name": "gyümölcs"
+            },
+            "fruit-sugar": {
+                "name": "gyümölcscukor"
+            },
+            "ful": {
+                "name": "fúl medames"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "fokhagyma",
+                "plural_name": "fokhagyma"
+            },
+            "gem-squash": {
+                "name": "drágakő tök"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "szárnyas aprólék"
+            },
+            "ginger": {
+                "name": "gyömbér"
+            },
+            "grains": {
+                "name": "gabonafélék"
+            },
+            "granulated-sugar": {
+                "name": "cukor"
+            },
+            "grape-seed-oil": {
+                "name": "szőlőmagolaj"
+            },
+            "green-onion": {
+                "name": "zöld hagyma",
+                "plural_name": "zöld hagyma"
+            },
+            "heart-of-palm": {
+                "name": "pálma szíve",
+                "plural_name": "pálmák szívei"
+            },
+            "hemp": {
+                "name": "kender"
+            },
+            "herbs": {
+                "name": "gyógynövények"
+            },
+            "honey": {
+                "name": "méz"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "jákafa",
+                "plural_name": "jákafák"
+            },
+            "jaggery": {
+                "name": "nádcukor"
+            },
+            "jams": {
+                "name": "lekvár"
+            },
+            "jellies": {
+                "name": "zselé"
+            },
+            "jerusalem-artichoke": {
+                "name": "csicsóka"
+            },
+            "jicama": {
+                "name": "jícama"
+            },
+            "kale": {
+                "name": "kelkáposzta"
+            },
+            "kohlrabi": {
+                "name": "karalábé"
+            },
+            "kumara": {
+                "name": "édesburgonya"
+            },
+            "leavening-agents": {
+                "name": "lazító anyag"
+            },
+            "leek": {
+                "name": "póréhagyma",
+                "plural_name": "póréhagyma"
+            },
+            "legumes": {
+                "name": "hüvelyesek"
+            },
+            "lemongrass": {
+                "name": "citromfű"
+            },
+            "lentils": {
+                "name": "lencse"
+            },
+            "lettuce": {
+                "name": "saláta"
+            },
+            "liver": {
+                "name": "máj",
+                "plural_name": "máj"
+            },
+            "maize": {
+                "name": "csemegekukorica"
+            },
+            "maple-syrup": {
+                "name": "juharszirup"
+            },
+            "meat": {
+                "name": "hús"
+            },
+            "milk": {
+                "name": "tej"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "gomba",
+                "plural_name": "gomba"
+            },
+            "mussels": {
+                "name": "kagyló"
+            },
+            "nanaimo-bar-mix": {
+                "name": "eszkimó szelet keverék"
+            },
+            "nori": {
+                "name": "nori alga"
+            },
+            "nutmeg": {
+                "name": "szerecsendió"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "inaktív élesztő"
+            },
+            "nuts": {
+                "name": "diófélék"
+            },
+            "octopuses": {
+                "name": "polip",
+                "plural_name": "polip"
+            },
+            "oils": {
+                "name": "olajok"
+            },
+            "okra": {
+                "name": "bámia"
+            },
+            "olive": {
+                "name": "olívabogyó"
+            },
+            "olive-oil": {
+                "name": "olivaolaj"
+            },
+            "onion": {
+                "name": "hagyma"
+            },
+            "onion-family": {
+                "name": "hagymafélék"
+            },
+            "orange-blossom-water": {
+                "name": "narancsvirág víz"
+            },
+            "oranges": {
+                "name": "narancs",
+                "plural_name": "narancs"
+            },
+            "oregano": {
+                "name": "oregánó"
+            },
+            "oysters": {
+                "name": "osztriga"
+            },
+            "panch-puran": {
+                "name": "indiai ötfűszer keverék"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "petrezselyem"
+            },
+            "parsnip": {
+                "name": "paszternák",
+                "plural_name": "paszternák"
+            },
+            "pear": {
+                "name": "körte",
+                "plural_name": "körte"
+            },
+            "peas": {
+                "name": "borsó"
+            },
+            "pepper": {
+                "name": "bors",
+                "plural_name": "bors"
+            },
+            "pineapple": {
+                "name": "ananász",
+                "plural_name": "ananász"
+            },
+            "plantain": {
+                "name": "főzőbanán",
+                "plural_name": "főzőbanán"
+            },
+            "poppy-seeds": {
+                "name": "mák"
+            },
+            "potato": {
+                "name": "burgonya",
+                "plural_name": "burgonyák"
+            },
+            "poultry": {
+                "name": "baromfi"
+            },
+            "powdered-sugar": {
+                "name": "porcukor"
+            },
+            "pumpkin": {
+                "name": "tök",
+                "plural_name": "tök"
+            },
+            "pumpkin-seeds": {
+                "name": "tökmag"
+            },
+            "radish": {
+                "name": "retek",
+                "plural_name": "retek"
+            },
+            "raw-sugar": {
+                "name": "barna cukor"
+            },
+            "refined-sugar": {
+                "name": "finomitott cukor"
+            },
+            "rice": {
+                "name": "rizs"
+            },
+            "rice-flour": {
+                "name": "rízsliszt"
+            },
+            "rock-sugar": {
+                "name": "kandiscukor"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "lazac"
+            },
+            "salt": {
+                "name": "só"
+            },
+            "salt-cod": {
+                "name": "sózott tőkehal"
+            },
+            "scallion": {
+                "name": "zöldhagyma",
+                "plural_name": "zöldhagymák"
+            },
+            "seafood": {
+                "name": "tenger gyümölcsei"
+            },
+            "seeds": {
+                "name": "magvak"
+            },
+            "sesame-seeds": {
+                "name": "szezámmag"
+            },
+            "shallot": {
+                "name": "mogyoróhagyma",
+                "plural_name": "mogyoróhagyma"
+            },
+            "skate": {
+                "name": "rája"
+            },
+            "soda": {
+                "name": "szóda"
+            },
+            "soda-baking": {
+                "name": "szódabikarbóna"
+            },
+            "soybean": {
+                "name": "szójabab"
+            },
+            "spaghetti-squash": {
+                "name": "spárgatök",
+                "plural_name": "spárgatök"
+            },
+            "speck": {
+                "name": "speck sonka"
+            },
+            "spices": {
+                "name": "fűszerek"
+            },
+            "spinach": {
+                "name": "spenót"
+            },
+            "spring-onion": {
+                "name": "újhagyma",
+                "plural_name": "újhagyma"
+            },
+            "squash": {
+                "name": "tök",
+                "plural_name": "tökök"
+            },
+            "squash-family": {
+                "name": "tökfélék"
+            },
+            "stockfish": {
+                "name": "szárított hal"
+            },
+            "sugar": {
+                "name": "cukor"
+            },
+            "sunchoke": {
+                "name": "csicsóka",
+                "plural_name": "csicsókák"
+            },
+            "sunflower-seeds": {
+                "name": "napraforgómag"
+            },
+            "superfine-sugar": {
+                "name": "finom szemcsés cukor"
+            },
+            "sweet-potato": {
+                "name": "édesburgonya",
+                "plural_name": "édesburgonya"
+            },
+            "sweetcorn": {
+                "name": "csemegekukorica",
+                "plural_name": "csemegekukorica"
+            },
+            "sweeteners": {
+                "name": "édesítőszerek"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taró",
+                "plural_name": "tarók"
+            },
+            "teff": {
+                "name": "egynyári fürtfű"
+            },
+            "tomato": {
+                "name": "paradicsom",
+                "plural_name": "paradicsom"
+            },
+            "trout": {
+                "name": "pisztráng"
+            },
+            "tubers": {
+                "name": "gumók",
+                "plural_name": "gumók"
+            },
+            "tuna": {
+                "name": "tonhal"
+            },
+            "turbanado-sugar": {
+                "name": "barna cukor"
+            },
+            "turnip": {
+                "name": "fehér répa",
+                "plural_name": "fehérrépa"
+            },
+            "unrefined-sugar": {
+                "name": "finomitatlan cukor"
+            },
+            "vanilla": {
+                "name": "vanília"
+            },
+            "vegetables": {
+                "name": "zöldségek"
+            },
+            "watercress": {
+                "name": "vízitorma"
+            },
+            "watermelon": {
+                "name": "görögdinnye",
+                "plural_name": "görögdinnye"
+            },
+            "white-mushroom": {
+                "name": "fehér gomba",
+                "plural_name": "fehér gomba"
+            },
+            "white-sugar": {
+                "name": "fehér cukor"
+            },
+            "xanthan-gum": {
+                "name": "xantángumi"
+            },
+            "yam": {
+                "name": "jamgyökér",
+                "plural_name": "jamgyökér"
+            },
+            "yeast": {
+                "name": "élesztő"
+            },
+            "zucchini": {
+                "name": "cukkini",
+                "plural_name": "cukkini"
+            }
+        }
+    },
+    "Termesztett növények": {
+        "foods": {}
+    },
+    "Gabonafélék": {
+        "foods": {}
+    },
+    "Gyümölcsök": {
+        "foods": {}
+    },
+    "Zöldségek": {
+        "foods": {}
+    },
+    "Hús": {
+        "foods": {}
+    },
+    "Tenger gyümölcsei": {
+        "foods": {}
+    },
+    "Italok": {
+        "foods": {}
+    },
+    "Péksütemény": {
+        "foods": {}
+    },
+    "Konzervek": {
+        "foods": {}
+    },
+    "Ételízesítők": {
+        "foods": {}
+    },
+    "Cukrászat": {
+        "foods": {}
+    },
+    "Tejtermékek": {
+        "foods": {}
+    },
+    "Fagyasztott Ételek": {
+        "foods": {}
+    },
+    "Egészséges Ételek": {
+        "foods": {}
+    },
+    "Háztartás": {
+        "foods": {}
+    },
+    "Húskészítmények": {
+        "foods": {}
+    },
+    "Nassolnivalók": {
+        "foods": {}
+    },
+    "Fűszerek": {
+        "foods": {}
+    },
+    "Édességek": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Egyéb": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/is-IS.json
+++ b/mealie/repos/seed/resources/foods/locales/is-IS.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "baking soda"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell peppers",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "blackberries"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "bread"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brown sugar"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "butter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "cheese"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rice"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Produce": {
+        "foods": {}
+    },
+    "Grains": {
+        "foods": {}
+    },
+    "Fruits": {
+        "foods": {}
+    },
+    "Vegetables": {
+        "foods": {}
+    },
+    "Meat": {
+        "foods": {}
+    },
+    "Seafood": {
+        "foods": {}
+    },
+    "Beverages": {
+        "foods": {}
+    },
+    "Baked Goods": {
+        "foods": {}
+    },
+    "Canned Goods": {
+        "foods": {}
+    },
+    "Condiments": {
+        "foods": {}
+    },
+    "Confectionary": {
+        "foods": {}
+    },
+    "Dairy Products": {
+        "foods": {}
+    },
+    "Frozen Foods": {
+        "foods": {}
+    },
+    "Health Foods": {
+        "foods": {}
+    },
+    "Household": {
+        "foods": {}
+    },
+    "Meat Products": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Spices": {
+        "foods": {}
+    },
+    "Sweets": {
+        "foods": {}
+    },
+    "Alcohol": {
+        "foods": {}
+    },
+    "Other": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/it-IT.json
+++ b/mealie/repos/seed/resources/foods/locales/it-IT.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "zucca di ghianda"
-	},
-	"alfalfa-sprouts": {
-		"name": "germogli di erba medica"
-	},
-	"anchovies": {
-		"name": "acciughe"
-	},
-	"apples": {
-		"name": "mele",
-		"plural_name": "mele"
-	},
-	"artichoke": {
-		"name": "carciofo"
-	},
-	"arugula": {
-		"name": "rucola"
-	},
-	"asparagus": {
-		"name": "asparago"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "pancetta"
-	},
-	"baking-powder": {
-		"name": "lievito in polvere"
-	},
-	"baking-soda": {
-		"name": "bicarbonato di sodio"
-	},
-	"baking-sugar": {
-		"name": "zucchero fino"
-	},
-	"bar-sugar": {
-		"name": "zucchero di canna"
-	},
-	"basil": {
-		"name": "basilico"
-	},
-	"beans": {
-		"name": "faglioli"
-	},
-	"bell-peppers": {
-		"name": "peperoni",
-		"plural_name": "peperoni"
-	},
-	"blackberries": {
-		"name": "more"
-	},
-	"bok-choy": {
-		"name": "cavolo cinese"
-	},
-	"brassicas": {
-		"name": "brassica"
-	},
-	"bread": {
-		"name": "pane"
-	},
-	"breadfruit": {
-		"name": "frutto del pane"
-	},
-	"broccoflower": {
-		"name": "cavolfiore verde"
-	},
-	"broccoli": {
-		"name": "broccolo"
-	},
-	"broccoli-rabe": {
-		"name": "friarielli"
-	},
-	"broccolini": {
-		"name": "broccoletto"
-	},
-	"brown-sugar": {
-		"name": "zucchero bruno"
-	},
-	"brussels-sprouts": {
-		"name": "cavoletti di Bruxelles"
-	},
-	"butter": {
-		"name": "burro"
-	},
-	"butternut-pumpkin": {
-		"name": "zucca violina"
-	},
-	"butternut-squash": {
-		"name": "zucca violina"
-	},
-	"cabbage": {
-		"name": "cavolo",
-		"plural_name": "cavoli"
-	},
-	"cactus-edible": {
-		"name": "cactus, commestibile"
-	},
-	"calabrese": {
-		"name": "broccolo calabrese"
-	},
-	"cane-sugar": {
-		"name": "zucchero di canna"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "peperoncino"
-	},
-	"caraway": {
-		"name": "cumino dei prati"
-	},
-	"carrot": {
-		"name": "carota",
-		"plural_name": "carote"
-	},
-	"caster-sugar": {
-		"name": "zucchero semolato"
-	},
-	"castor-sugar": {
-		"name": "zucchero semolato"
-	},
-	"catfish": {
-		"name": "pesce gatto"
-	},
-	"cauliflower": {
-		"name": "cavolfiore",
-		"plural_name": "cavolfiori"
-	},
-	"cayenne-pepper": {
-		"name": "pepe di cayenne"
-	},
-	"celeriac": {
-		"name": "sedano rapa"
-	},
-	"celery": {
-		"name": "sedano"
-	},
-	"cereal-grains": {
-		"name": "cereali"
-	},
-	"chard": {
-		"name": "bietola"
-	},
-	"cheese": {
-		"name": "formaggio"
-	},
-	"chicory": {
-		"name": "cicoria"
-	},
-	"chilli-peppers": {
-		"name": "peperoncino",
-		"plural_name": "peperoncino"
-	},
-	"chinese-leaves": {
-		"name": "cavolo di pechino"
-	},
-	"chives": {
-		"name": "erba cipollina"
-	},
-	"chocolate": {
-		"name": "cioccolato"
-	},
-	"cilantro": {
-		"name": "coriandolo"
-	},
-	"cinnamon": {
-		"name": "cannella"
-	},
-	"clarified-butter": {
-		"name": "burro chiarificato"
-	},
-	"coconut": {
-		"name": "cocco",
-		"plural_name": "noci di cocco"
-	},
-	"coconut-milk": {
-		"name": "latte di cocco"
-	},
-	"cod": {
-		"name": "merluzzo"
-	},
-	"coffee": {
-		"name": "caffè"
-	},
-	"collard-greens": {
-		"name": "cavolo nero"
-	},
-	"confectioners-sugar": {
-		"name": "zucchero a velo"
-	},
-	"coriander": {
-		"name": "coriandolo"
-	},
-	"corn": {
-		"name": "granoturco",
-		"plural_name": "mais"
-	},
-	"corn-syrup": {
-		"name": "sciroppo di mais"
-	},
-	"cottonseed-oil": {
-		"name": "olio di semi di cotone"
-	},
-	"courgette": {
-		"name": "zucchine"
-	},
-	"cream-of-tartar": {
-		"name": "cremor tartaro"
-	},
-	"cucumber": {
-		"name": "cetriolo",
-		"plural_name": "cetrioli"
-	},
-	"cumin": {
-		"name": "cumino"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikon"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "latticini e sostituti dei latticini"
-	},
-	"dandelion": {
-		"name": "tarassaco"
-	},
-	"demerara-sugar": {
-		"name": "zucchero grezzo di canna"
-	},
-	"dough": {
-		"name": "impasto"
-	},
-	"edible-cactus": {
-		"name": "cactus edibile"
-	},
-	"eggplant": {
-		"name": "melanzana",
-		"plural_name": "melanzane"
-	},
-	"eggs": {
-		"name": "uova",
-		"plural_name": "uova"
-	},
-	"endive": {
-		"name": "cicoria",
-		"plural_name": "indivia"
-	},
-	"fats": {
-		"name": "grassi"
-	},
-	"fava-beans": {
-		"name": "fave"
-	},
-	"fiddlehead": {
-		"name": "cime di felce"
-	},
-	"fiddlehead-fern": {
-		"name": "germogli di felce",
-		"plural_name": "germogli di felce"
-	},
-	"fish": {
-		"name": "pesce"
-	},
-	"five-spice-powder": {
-		"name": "polvere cinque spezie"
-	},
-	"flour": {
-		"name": "farina"
-	},
-	"frisee": {
-		"name": "indivia riccia"
-	},
-	"fructose": {
-		"name": "fruttosio"
-	},
-	"fruit": {
-		"name": "frutta"
-	},
-	"fruit-sugar": {
-		"name": "fruttosio"
-	},
-	"ful": {
-		"name": "ful medames"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "aglio",
-		"plural_name": "agli"
-	},
-	"gem-squash": {
-		"name": "zucca gemma"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "frattaglie"
-	},
-	"ginger": {
-		"name": "zenzero"
-	},
-	"grains": {
-		"name": "cereali"
-	},
-	"granulated-sugar": {
-		"name": "zucchero granulato"
-	},
-	"grape-seed-oil": {
-		"name": "olio di semi di uva"
-	},
-	"green-onion": {
-		"name": "cipolla verde",
-		"plural_name": "cipolle verdi"
-	},
-	"heart-of-palm": {
-		"name": "cuore di palma",
-		"plural_name": "cuori di palma"
-	},
-	"hemp": {
-		"name": "canapa"
-	},
-	"herbs": {
-		"name": "erbe aromatiche"
-	},
-	"honey": {
-		"name": "miele"
-	},
-	"isomalt": {
-		"name": "isomaltosio"
-	},
-	"jackfruit": {
-		"name": "iaca",
-		"plural_name": "jackfruit"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "marmellate"
-	},
-	"jellies": {
-		"name": "gelatine"
-	},
-	"jerusalem-artichoke": {
-		"name": "carciofo di Gerusalemme"
-	},
-	"jicama": {
-		"name": "patata messicana"
-	},
-	"kale": {
-		"name": "cavolo da foglia"
-	},
-	"kohlrabi": {
-		"name": "cavolo rapa"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "agenti lievitanti"
-	},
-	"leek": {
-		"name": "porro",
-		"plural_name": "porri"
-	},
-	"legumes": {
-		"name": "legumi"
-	},
-	"lemongrass": {
-		"name": "citronella"
-	},
-	"lentils": {
-		"name": "lenticchie"
-	},
-	"lettuce": {
-		"name": "lattuga"
-	},
-	"liver": {
-		"name": "fegato",
-		"plural_name": "fegatini"
-	},
-	"maize": {
-		"name": "mais"
-	},
-	"maple-syrup": {
-		"name": "sciroppo d'acero"
-	},
-	"meat": {
-		"name": "carne"
-	},
-	"milk": {
-		"name": "latte"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "fungo",
-		"plural_name": "funghi"
-	},
-	"mussels": {
-		"name": "cozze"
-	},
-	"nanaimo-bar-mix": {
-		"name": "miscela per barrette nanaimo"
-	},
-	"nori": {
-		"name": "alga nori"
-	},
-	"nutmeg": {
-		"name": "noce moscata"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "lievito alimentare in scaglie"
-	},
-	"nuts": {
-		"name": "frutta a guscio"
-	},
-	"octopuses": {
-		"name": "polpi",
-		"plural_name": "polpi"
-	},
-	"oils": {
-		"name": "oli"
-	},
-	"okra": {
-		"name": "ocra"
-	},
-	"olive": {
-		"name": "oliva"
-	},
-	"olive-oil": {
-		"name": "olio d'oliva"
-	},
-	"onion": {
-		"name": "cipolla"
-	},
-	"onion-family": {
-		"name": "famiglia delle cipolle"
-	},
-	"orange-blossom-water": {
-		"name": "acqua di fiori d'arancio"
-	},
-	"oranges": {
-		"name": "arance",
-		"plural_name": "arance"
-	},
-	"oregano": {
-		"name": "origano"
-	},
-	"oysters": {
-		"name": "ostriche"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "prezzemolo"
-	},
-	"parsnip": {
-		"name": "pastinaca",
-		"plural_name": "pastinache"
-	},
-	"pear": {
-		"name": "pera",
-		"plural_name": "pere"
-	},
-	"peas": {
-		"name": "piselli"
-	},
-	"pepper": {
-		"name": "pepe",
-		"plural_name": "peperoni"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "platano",
-		"plural_name": "platani"
-	},
-	"poppy-seeds": {
-		"name": "semi di papavero"
-	},
-	"potato": {
-		"name": "patata",
-		"plural_name": "patate"
-	},
-	"poultry": {
-		"name": "pollame"
-	},
-	"powdered-sugar": {
-		"name": "zucchero in polvere"
-	},
-	"pumpkin": {
-		"name": "zucca",
-		"plural_name": "zucca"
-	},
-	"pumpkin-seeds": {
-		"name": "semi di zucca"
-	},
-	"radish": {
-		"name": "ravanello",
-		"plural_name": "ravanelli"
-	},
-	"raw-sugar": {
-		"name": "zucchero grezzo"
-	},
-	"refined-sugar": {
-		"name": "zucchero raffinato"
-	},
-	"rice": {
-		"name": "riso"
-	},
-	"rice-flour": {
-		"name": "farina di riso"
-	},
-	"rock-sugar": {
-		"name": "cristalli di zucchero"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmone"
-	},
-	"salt": {
-		"name": "sale"
-	},
-	"salt-cod": {
-		"name": "baccalà"
-	},
-	"scallion": {
-		"name": "scalogno",
-		"plural_name": "scalogno"
-	},
-	"seafood": {
-		"name": "frutti di mare"
-	},
-	"seeds": {
-		"name": "semi"
-	},
-	"sesame-seeds": {
-		"name": "semi di sesamo"
-	},
-	"shallot": {
-		"name": "scalogno",
-		"plural_name": "scalogni"
-	},
-	"skate": {
-		"name": "razza"
-	},
-	"soda": {
-		"name": "bicarbonato di sodio"
-	},
-	"soda-baking": {
-		"name": "bicarbonato di sodio"
-	},
-	"soybean": {
-		"name": "soia"
-	},
-	"spaghetti-squash": {
-		"name": "zucca spaghetti",
-		"plural_name": "zucche spaghetti"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spezie"
-	},
-	"spinach": {
-		"name": "spinacio"
-	},
-	"spring-onion": {
-		"name": "cipolla verde",
-		"plural_name": "cipollotti"
-	},
-	"squash": {
-		"name": "zucca",
-		"plural_name": "zucche"
-	},
-	"squash-family": {
-		"name": "cucurbitaceae"
-	},
-	"stockfish": {
-		"name": "stoccafisso"
-	},
-	"sugar": {
-		"name": "zucchero"
-	},
-	"sunchoke": {
-		"name": "topinambur",
-		"plural_name": "topinambur"
-	},
-	"sunflower-seeds": {
-		"name": "semi di girasole"
-	},
-	"superfine-sugar": {
-		"name": "zucchero superfine"
-	},
-	"sweet-potato": {
-		"name": "patata dolce",
-		"plural_name": "patate dolci"
-	},
-	"sweetcorn": {
-		"name": "mais dolce",
-		"plural_name": "mais dolce"
-	},
-	"sweeteners": {
-		"name": "dolcificanti"
-	},
-	"tahini": {
-		"name": "tahina"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "tari"
-	},
-	"teff": {
-		"name": "tef"
-	},
-	"tomato": {
-		"name": "pomodoro",
-		"plural_name": "pomodori"
-	},
-	"trout": {
-		"name": "trota"
-	},
-	"tubers": {
-		"name": "tuberi",
-		"plural_name": "tuberi"
-	},
-	"tuna": {
-		"name": "tonno"
-	},
-	"turbanado-sugar": {
-		"name": "zucchero bruno"
-	},
-	"turnip": {
-		"name": "rapa",
-		"plural_name": "rape"
-	},
-	"unrefined-sugar": {
-		"name": "zucchero non raffinato"
-	},
-	"vanilla": {
-		"name": "vaniglia"
-	},
-	"vegetables": {
-		"name": "verdure"
-	},
-	"watercress": {
-		"name": "crescione"
-	},
-	"watermelon": {
-		"name": "anguria",
-		"plural_name": "angurie"
-	},
-	"white-mushroom": {
-		"name": "fungo bianco",
-		"plural_name": "funghi bianchi"
-	},
-	"white-sugar": {
-		"name": "zucchero bianco"
-	},
-	"xanthan-gum": {
-		"name": "gomma di xantano"
-	},
-	"yam": {
-		"name": "igname",
-		"plural_name": "patate dolci"
-	},
-	"yeast": {
-		"name": "lievito"
-	},
-	"zucchini": {
-		"name": "zucchine",
-		"plural_name": "zucchine"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "zucca di ghianda"
+            },
+            "alfalfa-sprouts": {
+                "name": "germogli di erba medica"
+            },
+            "anchovies": {
+                "name": "acciughe"
+            },
+            "apples": {
+                "name": "mele",
+                "plural_name": "mele"
+            },
+            "artichoke": {
+                "name": "carciofo"
+            },
+            "arugula": {
+                "name": "rucola"
+            },
+            "asparagus": {
+                "name": "asparago"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "pancetta"
+            },
+            "baking-powder": {
+                "name": "lievito in polvere"
+            },
+            "baking-soda": {
+                "name": "bicarbonato di sodio"
+            },
+            "baking-sugar": {
+                "name": "zucchero fino"
+            },
+            "bar-sugar": {
+                "name": "zucchero di canna"
+            },
+            "basil": {
+                "name": "basilico"
+            },
+            "beans": {
+                "name": "faglioli"
+            },
+            "bell-peppers": {
+                "name": "peperoni",
+                "plural_name": "peperoni"
+            },
+            "blackberries": {
+                "name": "more"
+            },
+            "bok-choy": {
+                "name": "cavolo cinese"
+            },
+            "brassicas": {
+                "name": "brassica"
+            },
+            "bread": {
+                "name": "pane"
+            },
+            "breadfruit": {
+                "name": "frutto del pane"
+            },
+            "broccoflower": {
+                "name": "cavolfiore verde"
+            },
+            "broccoli": {
+                "name": "broccolo"
+            },
+            "broccoli-rabe": {
+                "name": "friarielli"
+            },
+            "broccolini": {
+                "name": "broccoletto"
+            },
+            "brown-sugar": {
+                "name": "zucchero bruno"
+            },
+            "brussels-sprouts": {
+                "name": "cavoletti di Bruxelles"
+            },
+            "butter": {
+                "name": "burro"
+            },
+            "butternut-pumpkin": {
+                "name": "zucca violina"
+            },
+            "butternut-squash": {
+                "name": "zucca violina"
+            },
+            "cabbage": {
+                "name": "cavolo",
+                "plural_name": "cavoli"
+            },
+            "cactus-edible": {
+                "name": "cactus, commestibile"
+            },
+            "calabrese": {
+                "name": "broccolo calabrese"
+            },
+            "cane-sugar": {
+                "name": "zucchero di canna"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "peperoncino"
+            },
+            "caraway": {
+                "name": "cumino dei prati"
+            },
+            "carrot": {
+                "name": "carota",
+                "plural_name": "carote"
+            },
+            "caster-sugar": {
+                "name": "zucchero semolato"
+            },
+            "castor-sugar": {
+                "name": "zucchero semolato"
+            },
+            "catfish": {
+                "name": "pesce gatto"
+            },
+            "cauliflower": {
+                "name": "cavolfiore",
+                "plural_name": "cavolfiori"
+            },
+            "cayenne-pepper": {
+                "name": "pepe di cayenne"
+            },
+            "celeriac": {
+                "name": "sedano rapa"
+            },
+            "celery": {
+                "name": "sedano"
+            },
+            "cereal-grains": {
+                "name": "cereali"
+            },
+            "chard": {
+                "name": "bietola"
+            },
+            "cheese": {
+                "name": "formaggio"
+            },
+            "chicory": {
+                "name": "cicoria"
+            },
+            "chilli-peppers": {
+                "name": "peperoncino",
+                "plural_name": "peperoncino"
+            },
+            "chinese-leaves": {
+                "name": "cavolo di pechino"
+            },
+            "chives": {
+                "name": "erba cipollina"
+            },
+            "chocolate": {
+                "name": "cioccolato"
+            },
+            "cilantro": {
+                "name": "coriandolo"
+            },
+            "cinnamon": {
+                "name": "cannella"
+            },
+            "clarified-butter": {
+                "name": "burro chiarificato"
+            },
+            "coconut": {
+                "name": "cocco",
+                "plural_name": "noci di cocco"
+            },
+            "coconut-milk": {
+                "name": "latte di cocco"
+            },
+            "cod": {
+                "name": "merluzzo"
+            },
+            "coffee": {
+                "name": "caffè"
+            },
+            "collard-greens": {
+                "name": "cavolo nero"
+            },
+            "confectioners-sugar": {
+                "name": "zucchero a velo"
+            },
+            "coriander": {
+                "name": "coriandolo"
+            },
+            "corn": {
+                "name": "granoturco",
+                "plural_name": "mais"
+            },
+            "corn-syrup": {
+                "name": "sciroppo di mais"
+            },
+            "cottonseed-oil": {
+                "name": "olio di semi di cotone"
+            },
+            "courgette": {
+                "name": "zucchine"
+            },
+            "cream-of-tartar": {
+                "name": "cremor tartaro"
+            },
+            "cucumber": {
+                "name": "cetriolo",
+                "plural_name": "cetrioli"
+            },
+            "cumin": {
+                "name": "cumino"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikon"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "latticini e sostituti dei latticini"
+            },
+            "dandelion": {
+                "name": "tarassaco"
+            },
+            "demerara-sugar": {
+                "name": "zucchero grezzo di canna"
+            },
+            "dough": {
+                "name": "impasto"
+            },
+            "edible-cactus": {
+                "name": "cactus edibile"
+            },
+            "eggplant": {
+                "name": "melanzana",
+                "plural_name": "melanzane"
+            },
+            "eggs": {
+                "name": "uova",
+                "plural_name": "uova"
+            },
+            "endive": {
+                "name": "cicoria",
+                "plural_name": "indivia"
+            },
+            "fats": {
+                "name": "grassi"
+            },
+            "fava-beans": {
+                "name": "fave"
+            },
+            "fiddlehead": {
+                "name": "cime di felce"
+            },
+            "fiddlehead-fern": {
+                "name": "germogli di felce",
+                "plural_name": "germogli di felce"
+            },
+            "fish": {
+                "name": "pesce"
+            },
+            "five-spice-powder": {
+                "name": "polvere cinque spezie"
+            },
+            "flour": {
+                "name": "farina"
+            },
+            "frisee": {
+                "name": "indivia riccia"
+            },
+            "fructose": {
+                "name": "fruttosio"
+            },
+            "fruit": {
+                "name": "frutta"
+            },
+            "fruit-sugar": {
+                "name": "fruttosio"
+            },
+            "ful": {
+                "name": "ful medames"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "aglio",
+                "plural_name": "agli"
+            },
+            "gem-squash": {
+                "name": "zucca gemma"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "frattaglie"
+            },
+            "ginger": {
+                "name": "zenzero"
+            },
+            "grains": {
+                "name": "cereali"
+            },
+            "granulated-sugar": {
+                "name": "zucchero granulato"
+            },
+            "grape-seed-oil": {
+                "name": "olio di semi di uva"
+            },
+            "green-onion": {
+                "name": "cipolla verde",
+                "plural_name": "cipolle verdi"
+            },
+            "heart-of-palm": {
+                "name": "cuore di palma",
+                "plural_name": "cuori di palma"
+            },
+            "hemp": {
+                "name": "canapa"
+            },
+            "herbs": {
+                "name": "erbe aromatiche"
+            },
+            "honey": {
+                "name": "miele"
+            },
+            "isomalt": {
+                "name": "isomaltosio"
+            },
+            "jackfruit": {
+                "name": "iaca",
+                "plural_name": "jackfruit"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "marmellate"
+            },
+            "jellies": {
+                "name": "gelatine"
+            },
+            "jerusalem-artichoke": {
+                "name": "carciofo di Gerusalemme"
+            },
+            "jicama": {
+                "name": "patata messicana"
+            },
+            "kale": {
+                "name": "cavolo da foglia"
+            },
+            "kohlrabi": {
+                "name": "cavolo rapa"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "agenti lievitanti"
+            },
+            "leek": {
+                "name": "porro",
+                "plural_name": "porri"
+            },
+            "legumes": {
+                "name": "legumi"
+            },
+            "lemongrass": {
+                "name": "citronella"
+            },
+            "lentils": {
+                "name": "lenticchie"
+            },
+            "lettuce": {
+                "name": "lattuga"
+            },
+            "liver": {
+                "name": "fegato",
+                "plural_name": "fegatini"
+            },
+            "maize": {
+                "name": "mais"
+            },
+            "maple-syrup": {
+                "name": "sciroppo d'acero"
+            },
+            "meat": {
+                "name": "carne"
+            },
+            "milk": {
+                "name": "latte"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "fungo",
+                "plural_name": "funghi"
+            },
+            "mussels": {
+                "name": "cozze"
+            },
+            "nanaimo-bar-mix": {
+                "name": "miscela per barrette nanaimo"
+            },
+            "nori": {
+                "name": "alga nori"
+            },
+            "nutmeg": {
+                "name": "noce moscata"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "lievito alimentare in scaglie"
+            },
+            "nuts": {
+                "name": "frutta a guscio"
+            },
+            "octopuses": {
+                "name": "polpi",
+                "plural_name": "polpi"
+            },
+            "oils": {
+                "name": "oli"
+            },
+            "okra": {
+                "name": "ocra"
+            },
+            "olive": {
+                "name": "oliva"
+            },
+            "olive-oil": {
+                "name": "olio d'oliva"
+            },
+            "onion": {
+                "name": "cipolla"
+            },
+            "onion-family": {
+                "name": "famiglia delle cipolle"
+            },
+            "orange-blossom-water": {
+                "name": "acqua di fiori d'arancio"
+            },
+            "oranges": {
+                "name": "arance",
+                "plural_name": "arance"
+            },
+            "oregano": {
+                "name": "origano"
+            },
+            "oysters": {
+                "name": "ostriche"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "prezzemolo"
+            },
+            "parsnip": {
+                "name": "pastinaca",
+                "plural_name": "pastinache"
+            },
+            "pear": {
+                "name": "pera",
+                "plural_name": "pere"
+            },
+            "peas": {
+                "name": "piselli"
+            },
+            "pepper": {
+                "name": "pepe",
+                "plural_name": "peperoni"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "platano",
+                "plural_name": "platani"
+            },
+            "poppy-seeds": {
+                "name": "semi di papavero"
+            },
+            "potato": {
+                "name": "patata",
+                "plural_name": "patate"
+            },
+            "poultry": {
+                "name": "pollame"
+            },
+            "powdered-sugar": {
+                "name": "zucchero in polvere"
+            },
+            "pumpkin": {
+                "name": "zucca",
+                "plural_name": "zucca"
+            },
+            "pumpkin-seeds": {
+                "name": "semi di zucca"
+            },
+            "radish": {
+                "name": "ravanello",
+                "plural_name": "ravanelli"
+            },
+            "raw-sugar": {
+                "name": "zucchero grezzo"
+            },
+            "refined-sugar": {
+                "name": "zucchero raffinato"
+            },
+            "rice": {
+                "name": "riso"
+            },
+            "rice-flour": {
+                "name": "farina di riso"
+            },
+            "rock-sugar": {
+                "name": "cristalli di zucchero"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmone"
+            },
+            "salt": {
+                "name": "sale"
+            },
+            "salt-cod": {
+                "name": "baccalà"
+            },
+            "scallion": {
+                "name": "scalogno",
+                "plural_name": "scalogno"
+            },
+            "seafood": {
+                "name": "frutti di mare"
+            },
+            "seeds": {
+                "name": "semi"
+            },
+            "sesame-seeds": {
+                "name": "semi di sesamo"
+            },
+            "shallot": {
+                "name": "scalogno",
+                "plural_name": "scalogni"
+            },
+            "skate": {
+                "name": "razza"
+            },
+            "soda": {
+                "name": "bicarbonato di sodio"
+            },
+            "soda-baking": {
+                "name": "bicarbonato di sodio"
+            },
+            "soybean": {
+                "name": "soia"
+            },
+            "spaghetti-squash": {
+                "name": "zucca spaghetti",
+                "plural_name": "zucche spaghetti"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spezie"
+            },
+            "spinach": {
+                "name": "spinacio"
+            },
+            "spring-onion": {
+                "name": "cipolla verde",
+                "plural_name": "cipollotti"
+            },
+            "squash": {
+                "name": "zucca",
+                "plural_name": "zucche"
+            },
+            "squash-family": {
+                "name": "cucurbitaceae"
+            },
+            "stockfish": {
+                "name": "stoccafisso"
+            },
+            "sugar": {
+                "name": "zucchero"
+            },
+            "sunchoke": {
+                "name": "topinambur",
+                "plural_name": "topinambur"
+            },
+            "sunflower-seeds": {
+                "name": "semi di girasole"
+            },
+            "superfine-sugar": {
+                "name": "zucchero superfine"
+            },
+            "sweet-potato": {
+                "name": "patata dolce",
+                "plural_name": "patate dolci"
+            },
+            "sweetcorn": {
+                "name": "mais dolce",
+                "plural_name": "mais dolce"
+            },
+            "sweeteners": {
+                "name": "dolcificanti"
+            },
+            "tahini": {
+                "name": "tahina"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "tari"
+            },
+            "teff": {
+                "name": "tef"
+            },
+            "tomato": {
+                "name": "pomodoro",
+                "plural_name": "pomodori"
+            },
+            "trout": {
+                "name": "trota"
+            },
+            "tubers": {
+                "name": "tuberi",
+                "plural_name": "tuberi"
+            },
+            "tuna": {
+                "name": "tonno"
+            },
+            "turbanado-sugar": {
+                "name": "zucchero bruno"
+            },
+            "turnip": {
+                "name": "rapa",
+                "plural_name": "rape"
+            },
+            "unrefined-sugar": {
+                "name": "zucchero non raffinato"
+            },
+            "vanilla": {
+                "name": "vaniglia"
+            },
+            "vegetables": {
+                "name": "verdure"
+            },
+            "watercress": {
+                "name": "crescione"
+            },
+            "watermelon": {
+                "name": "anguria",
+                "plural_name": "angurie"
+            },
+            "white-mushroom": {
+                "name": "fungo bianco",
+                "plural_name": "funghi bianchi"
+            },
+            "white-sugar": {
+                "name": "zucchero bianco"
+            },
+            "xanthan-gum": {
+                "name": "gomma di xantano"
+            },
+            "yam": {
+                "name": "igname",
+                "plural_name": "patate dolci"
+            },
+            "yeast": {
+                "name": "lievito"
+            },
+            "zucchini": {
+                "name": "zucchine",
+                "plural_name": "zucchine"
+            }
+        }
+    },
+    "Prodotti": {
+        "foods": {}
+    },
+    "Cereali": {
+        "foods": {}
+    },
+    "Frutta": {
+        "foods": {}
+    },
+    "Verdure": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Frutti di Mare": {
+        "foods": {}
+    },
+    "Bevande": {
+        "foods": {}
+    },
+    "Prodotti da Forno": {
+        "foods": {}
+    },
+    "Cibi in Scatola": {
+        "foods": {}
+    },
+    "Condimenti": {
+        "foods": {}
+    },
+    "Pasticceria": {
+        "foods": {}
+    },
+    "Latticini": {
+        "foods": {}
+    },
+    "Alimenti Congelati": {
+        "foods": {}
+    },
+    "Alimenti Per La Salute": {
+        "foods": {}
+    },
+    "Prodotti per la Casa": {
+        "foods": {}
+    },
+    "Prodotti Di Carne": {
+        "foods": {}
+    },
+    "Spuntini": {
+        "foods": {}
+    },
+    "Spezie": {
+        "foods": {}
+    },
+    "Dolci": {
+        "foods": {}
+    },
+    "Alcol": {
+        "foods": {}
+    },
+    "Altro": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ja-JP.json
+++ b/mealie/repos/seed/resources/foods/locales/ja-JP.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "どんぐりかぼちゃ"
-	},
-	"alfalfa-sprouts": {
-		"name": "アルファルファもやし"
-	},
-	"anchovies": {
-		"name": "アンチョビ"
-	},
-	"apples": {
-		"name": "りんご",
-		"plural_name": "りんご"
-	},
-	"artichoke": {
-		"name": "アーティチョーク"
-	},
-	"arugula": {
-		"name": "ルッコラ"
-	},
-	"asparagus": {
-		"name": "アスパラガス"
-	},
-	"avocado": {
-		"name": "アボカド",
-		"plural_name": "アボカド"
-	},
-	"bacon": {
-		"name": "ベーコン"
-	},
-	"baking-powder": {
-		"name": "ベーキングパウダー"
-	},
-	"baking-soda": {
-		"name": "重曹"
-	},
-	"baking-sugar": {
-		"name": "ベーキングシュガー"
-	},
-	"bar-sugar": {
-		"name": "棒砂糖"
-	},
-	"basil": {
-		"name": "バジル"
-	},
-	"beans": {
-		"name": "豆"
-	},
-	"bell-peppers": {
-		"name": "ピーマン",
-		"plural_name": "ピーマン"
-	},
-	"blackberries": {
-		"name": "ブラックベリー"
-	},
-	"bok-choy": {
-		"name": "チンゲンサイ"
-	},
-	"brassicas": {
-		"name": "アブラナ属"
-	},
-	"bread": {
-		"name": "パン"
-	},
-	"breadfruit": {
-		"name": "パンノキ"
-	},
-	"broccoflower": {
-		"name": "ブロッコフラワー"
-	},
-	"broccoli": {
-		"name": "ブロッコリー"
-	},
-	"broccoli-rabe": {
-		"name": "ブロッコリーラーブ"
-	},
-	"broccolini": {
-		"name": "スティックセニョール"
-	},
-	"brown-sugar": {
-		"name": "黒砂糖"
-	},
-	"brussels-sprouts": {
-		"name": "芽キャベツ"
-	},
-	"butter": {
-		"name": "バター"
-	},
-	"butternut-pumpkin": {
-		"name": "バターナッツ・スクワッシュ"
-	},
-	"butternut-squash": {
-		"name": "バターナッツ・スクワッシュ"
-	},
-	"cabbage": {
-		"name": "キャベツ",
-		"plural_name": "キャベツ"
-	},
-	"cactus-edible": {
-		"name": "食用サボテン"
-	},
-	"calabrese": {
-		"name": "カラブレーゼ"
-	},
-	"cane-sugar": {
-		"name": "甘庶糖"
-	},
-	"cannabis": {
-		"name": "大麻"
-	},
-	"capsicum": {
-		"name": "トウガラシ"
-	},
-	"caraway": {
-		"name": "キャラウェイ"
-	},
-	"carrot": {
-		"name": "人参",
-		"plural_name": "人参"
-	},
-	"caster-sugar": {
-		"name": "微粒子グラニュー糖"
-	},
-	"castor-sugar": {
-		"name": "微粒子グラニュー糖"
-	},
-	"catfish": {
-		"name": "ナマズ"
-	},
-	"cauliflower": {
-		"name": "カリフラワー",
-		"plural_name": "カリフラワー"
-	},
-	"cayenne-pepper": {
-		"name": "カイエンペッパー"
-	},
-	"celeriac": {
-		"name": "セルリアック"
-	},
-	"celery": {
-		"name": "セロリ"
-	},
-	"cereal-grains": {
-		"name": "穀物"
-	},
-	"chard": {
-		"name": "フダンソウ"
-	},
-	"cheese": {
-		"name": "チーズ"
-	},
-	"chicory": {
-		"name": "チコリー"
-	},
-	"chilli-peppers": {
-		"name": "チリペッパー",
-		"plural_name": "唐辛子"
-	},
-	"chinese-leaves": {
-		"name": "白菜"
-	},
-	"chives": {
-		"name": "浅葱"
-	},
-	"chocolate": {
-		"name": "チョコレート"
-	},
-	"cilantro": {
-		"name": "コリアンダー"
-	},
-	"cinnamon": {
-		"name": "シナモン"
-	},
-	"clarified-butter": {
-		"name": "澄ましバター"
-	},
-	"coconut": {
-		"name": "ココナッツ",
-		"plural_name": "ココナッツ"
-	},
-	"coconut-milk": {
-		"name": "ココナッツミルク"
-	},
-	"cod": {
-		"name": "タラ"
-	},
-	"coffee": {
-		"name": "コーヒー"
-	},
-	"collard-greens": {
-		"name": "カラードグリーン"
-	},
-	"confectioners-sugar": {
-		"name": "粉糖"
-	},
-	"coriander": {
-		"name": "コリアンダー"
-	},
-	"corn": {
-		"name": "トウモロコシ",
-		"plural_name": "トウモロコシ"
-	},
-	"corn-syrup": {
-		"name": "コーンシロップ"
-	},
-	"cottonseed-oil": {
-		"name": "綿実油"
-	},
-	"courgette": {
-		"name": "ズッキーニ"
-	},
-	"cream-of-tartar": {
-		"name": "ケレモル"
-	},
-	"cucumber": {
-		"name": "きゅうり",
-		"plural_name": "きゅうり"
-	},
-	"cumin": {
-		"name": "クミン"
-	},
-	"daikon": {
-		"name": "大根",
-		"plural_name": "大根"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "乳製品および乳製品代替品"
-	},
-	"dandelion": {
-		"name": "タンポポ"
-	},
-	"demerara-sugar": {
-		"name": "デメララ砂糖"
-	},
-	"dough": {
-		"name": "生地"
-	},
-	"edible-cactus": {
-		"name": "食用サボテン"
-	},
-	"eggplant": {
-		"name": "茄子",
-		"plural_name": "茄子"
-	},
-	"eggs": {
-		"name": "卵",
-		"plural_name": "卵"
-	},
-	"endive": {
-		"name": "エンダイブ",
-		"plural_name": "エンダイブ"
-	},
-	"fats": {
-		"name": "脂質"
-	},
-	"fava-beans": {
-		"name": "そら豆"
-	},
-	"fiddlehead": {
-		"name": "ワラビ"
-	},
-	"fiddlehead-fern": {
-		"name": "ゼンマイ",
-		"plural_name": "フィドルヘッド"
-	},
-	"fish": {
-		"name": "魚"
-	},
-	"five-spice-powder": {
-		"name": "五香粉"
-	},
-	"flour": {
-		"name": "小麦粉"
-	},
-	"frisee": {
-		"name": "エンダイブ"
-	},
-	"fructose": {
-		"name": "果糖"
-	},
-	"fruit": {
-		"name": "果物"
-	},
-	"fruit-sugar": {
-		"name": "果糖"
-	},
-	"ful": {
-		"name": "そら豆"
-	},
-	"garam-masala": {
-		"name": "ガラムマサラ"
-	},
-	"garlic": {
-		"name": "ニンニク",
-		"plural_name": "ニンニク"
-	},
-	"gem-squash": {
-		"name": "ジェムスカッシュ"
-	},
-	"ghee": {
-		"name": "ギー"
-	},
-	"giblets": {
-		"name": "ジブレッツ"
-	},
-	"ginger": {
-		"name": "ショウガ"
-	},
-	"grains": {
-		"name": "穀物"
-	},
-	"granulated-sugar": {
-		"name": "グラニュー糖"
-	},
-	"grape-seed-oil": {
-		"name": "グレープシードオイル"
-	},
-	"green-onion": {
-		"name": "ネギ",
-		"plural_name": "ネギ"
-	},
-	"heart-of-palm": {
-		"name": "ハート・オブ・パーム",
-		"plural_name": "ハート・オブ・パーム"
-	},
-	"hemp": {
-		"name": "ヘンプ"
-	},
-	"herbs": {
-		"name": "ハーブ"
-	},
-	"honey": {
-		"name": "蜂蜜"
-	},
-	"isomalt": {
-		"name": "イソマルト"
-	},
-	"jackfruit": {
-		"name": "パラミツ",
-		"plural_name": "パラミツ"
-	},
-	"jaggery": {
-		"name": "ジャグリー"
-	},
-	"jams": {
-		"name": "ジャム"
-	},
-	"jellies": {
-		"name": "ジェリー"
-	},
-	"jerusalem-artichoke": {
-		"name": "キクイモ"
-	},
-	"jicama": {
-		"name": "ヒカマ"
-	},
-	"kale": {
-		"name": "ケール"
-	},
-	"kohlrabi": {
-		"name": "コールラビ"
-	},
-	"kumara": {
-		"name": "サツマイモ"
-	},
-	"leavening-agents": {
-		"name": "膨張剤"
-	},
-	"leek": {
-		"name": "ねぎ",
-		"plural_name": "セイヨウネギ"
-	},
-	"legumes": {
-		"name": "マメ"
-	},
-	"lemongrass": {
-		"name": "レモングラス"
-	},
-	"lentils": {
-		"name": "レンズ豆"
-	},
-	"lettuce": {
-		"name": "レタス"
-	},
-	"liver": {
-		"name": "レバー",
-		"plural_name": "レバー"
-	},
-	"maize": {
-		"name": "トウモロコシ"
-	},
-	"maple-syrup": {
-		"name": "メープルシロップ"
-	},
-	"meat": {
-		"name": "肉"
-	},
-	"milk": {
-		"name": "牛乳"
-	},
-	"mortadella": {
-		"name": "モルタデッラ"
-	},
-	"mushroom": {
-		"name": "キノコ",
-		"plural_name": "キノコ"
-	},
-	"mussels": {
-		"name": "ムール貝"
-	},
-	"nanaimo-bar-mix": {
-		"name": "ナナイモ・バー・ミックス"
-	},
-	"nori": {
-		"name": "のり"
-	},
-	"nutmeg": {
-		"name": "ナツメグ"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "ナショナルイーストフレーク"
-	},
-	"nuts": {
-		"name": "ナッツ"
-	},
-	"octopuses": {
-		"name": "タコ",
-		"plural_name": "タコ"
-	},
-	"oils": {
-		"name": "油"
-	},
-	"okra": {
-		"name": "オクラ"
-	},
-	"olive": {
-		"name": "オリーブ"
-	},
-	"olive-oil": {
-		"name": "オリーブ油"
-	},
-	"onion": {
-		"name": "玉ねぎ"
-	},
-	"onion-family": {
-		"name": "タマネギの仲間"
-	},
-	"orange-blossom-water": {
-		"name": "オレンジの花の水"
-	},
-	"oranges": {
-		"name": "オレンジ",
-		"plural_name": "オレンジ"
-	},
-	"oregano": {
-		"name": "オレガノ"
-	},
-	"oysters": {
-		"name": "牡蠣"
-	},
-	"panch-puran": {
-		"name": "パンチフォロン"
-	},
-	"paprika": {
-		"name": "パプリカ"
-	},
-	"parsley": {
-		"name": "パセリ"
-	},
-	"parsnip": {
-		"name": "パースニプ",
-		"plural_name": "パースニップ"
-	},
-	"pear": {
-		"name": "ナシ",
-		"plural_name": "ナシ"
-	},
-	"peas": {
-		"name": "豆"
-	},
-	"pepper": {
-		"name": "コショウ",
-		"plural_name": "コショウ"
-	},
-	"pineapple": {
-		"name": "パイナップル",
-		"plural_name": "パイナップル"
-	},
-	"plantain": {
-		"name": "プランテン",
-		"plural_name": "プランテン"
-	},
-	"poppy-seeds": {
-		"name": "ケシの種"
-	},
-	"potato": {
-		"name": "ジャガイモ",
-		"plural_name": "ジャガイモ"
-	},
-	"poultry": {
-		"name": "鶏肉"
-	},
-	"powdered-sugar": {
-		"name": "粉糖"
-	},
-	"pumpkin": {
-		"name": "カボチャ",
-		"plural_name": "ペポかぼちゃ"
-	},
-	"pumpkin-seeds": {
-		"name": "かぼちゃの種"
-	},
-	"radish": {
-		"name": "大根",
-		"plural_name": "ハツカダイコン"
-	},
-	"raw-sugar": {
-		"name": "生の砂糖"
-	},
-	"refined-sugar": {
-		"name": "精製糖"
-	},
-	"rice": {
-		"name": "米"
-	},
-	"rice-flour": {
-		"name": "米粉"
-	},
-	"rock-sugar": {
-		"name": "氷砂糖"
-	},
-	"rum": {
-		"name": "ラム酒"
-	},
-	"salmon": {
-		"name": "鮭"
-	},
-	"salt": {
-		"name": "塩"
-	},
-	"salt-cod": {
-		"name": "塩タラ"
-	},
-	"scallion": {
-		"name": "シャロット",
-		"plural_name": "シャロット"
-	},
-	"seafood": {
-		"name": "シーフード"
-	},
-	"seeds": {
-		"name": "種"
-	},
-	"sesame-seeds": {
-		"name": "ゴマの種"
-	},
-	"shallot": {
-		"name": "エシャロット",
-		"plural_name": "エシャロット"
-	},
-	"skate": {
-		"name": "ガンギエイ"
-	},
-	"soda": {
-		"name": "ソーダ"
-	},
-	"soda-baking": {
-		"name": "ソーダ、ベーキング"
-	},
-	"soybean": {
-		"name": "大豆"
-	},
-	"spaghetti-squash": {
-		"name": "スパゲッティスカッシュ",
-		"plural_name": "キンシウリ"
-	},
-	"speck": {
-		"name": "スペック"
-	},
-	"spices": {
-		"name": "香辛料"
-	},
-	"spinach": {
-		"name": "ほうれん草"
-	},
-	"spring-onion": {
-		"name": "ネギ",
-		"plural_name": "葉タマネギ"
-	},
-	"squash": {
-		"name": "カボチャ",
-		"plural_name": "カボチャ"
-	},
-	"squash-family": {
-		"name": "カボチャの仲間"
-	},
-	"stockfish": {
-		"name": "ストックフィッシュ"
-	},
-	"sugar": {
-		"name": "砂糖"
-	},
-	"sunchoke": {
-		"name": "キクイモ",
-		"plural_name": "キクイモ"
-	},
-	"sunflower-seeds": {
-		"name": "ヒマワリの種"
-	},
-	"superfine-sugar": {
-		"name": "上白糖"
-	},
-	"sweet-potato": {
-		"name": "サツマイモ",
-		"plural_name": "サツマイモ"
-	},
-	"sweetcorn": {
-		"name": "スイートコーン",
-		"plural_name": "スイートコーン"
-	},
-	"sweeteners": {
-		"name": "甘味料"
-	},
-	"tahini": {
-		"name": "タヒニ"
-	},
-	"taro": {
-		"name": "タロ芋",
-		"plural_name": "タロイモ"
-	},
-	"teff": {
-		"name": "テフ"
-	},
-	"tomato": {
-		"name": "トマト",
-		"plural_name": "トマト"
-	},
-	"trout": {
-		"name": "マス"
-	},
-	"tubers": {
-		"name": "球根",
-		"plural_name": "塊茎"
-	},
-	"tuna": {
-		"name": "マグロ"
-	},
-	"turbanado-sugar": {
-		"name": "中白糖"
-	},
-	"turnip": {
-		"name": "カブ",
-		"plural_name": "カブ"
-	},
-	"unrefined-sugar": {
-		"name": "粗製糖"
-	},
-	"vanilla": {
-		"name": "バニラ"
-	},
-	"vegetables": {
-		"name": "野菜"
-	},
-	"watercress": {
-		"name": "クレソン"
-	},
-	"watermelon": {
-		"name": "スイカ",
-		"plural_name": "スイカ"
-	},
-	"white-mushroom": {
-		"name": "マッシュルーム",
-		"plural_name": "マッシュルーム"
-	},
-	"white-sugar": {
-		"name": "白砂糖"
-	},
-	"xanthan-gum": {
-		"name": "キサンタンガム"
-	},
-	"yam": {
-		"name": "ヤムイモ",
-		"plural_name": "ヤムイモ"
-	},
-	"yeast": {
-		"name": "イースト"
-	},
-	"zucchini": {
-		"name": "ズッキーニ",
-		"plural_name": "ズッキーニ"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "どんぐりかぼちゃ"
+            },
+            "alfalfa-sprouts": {
+                "name": "アルファルファもやし"
+            },
+            "anchovies": {
+                "name": "アンチョビ"
+            },
+            "apples": {
+                "name": "りんご",
+                "plural_name": "りんご"
+            },
+            "artichoke": {
+                "name": "アーティチョーク"
+            },
+            "arugula": {
+                "name": "ルッコラ"
+            },
+            "asparagus": {
+                "name": "アスパラガス"
+            },
+            "avocado": {
+                "name": "アボカド",
+                "plural_name": "アボカド"
+            },
+            "bacon": {
+                "name": "ベーコン"
+            },
+            "baking-powder": {
+                "name": "ベーキングパウダー"
+            },
+            "baking-soda": {
+                "name": "重曹"
+            },
+            "baking-sugar": {
+                "name": "ベーキングシュガー"
+            },
+            "bar-sugar": {
+                "name": "棒砂糖"
+            },
+            "basil": {
+                "name": "バジル"
+            },
+            "beans": {
+                "name": "豆"
+            },
+            "bell-peppers": {
+                "name": "ピーマン",
+                "plural_name": "ピーマン"
+            },
+            "blackberries": {
+                "name": "ブラックベリー"
+            },
+            "bok-choy": {
+                "name": "チンゲンサイ"
+            },
+            "brassicas": {
+                "name": "アブラナ属"
+            },
+            "bread": {
+                "name": "パン"
+            },
+            "breadfruit": {
+                "name": "パンノキ"
+            },
+            "broccoflower": {
+                "name": "ブロッコフラワー"
+            },
+            "broccoli": {
+                "name": "ブロッコリー"
+            },
+            "broccoli-rabe": {
+                "name": "ブロッコリーラーブ"
+            },
+            "broccolini": {
+                "name": "スティックセニョール"
+            },
+            "brown-sugar": {
+                "name": "黒砂糖"
+            },
+            "brussels-sprouts": {
+                "name": "芽キャベツ"
+            },
+            "butter": {
+                "name": "バター"
+            },
+            "butternut-pumpkin": {
+                "name": "バターナッツ・スクワッシュ"
+            },
+            "butternut-squash": {
+                "name": "バターナッツ・スクワッシュ"
+            },
+            "cabbage": {
+                "name": "キャベツ",
+                "plural_name": "キャベツ"
+            },
+            "cactus-edible": {
+                "name": "食用サボテン"
+            },
+            "calabrese": {
+                "name": "カラブレーゼ"
+            },
+            "cane-sugar": {
+                "name": "甘庶糖"
+            },
+            "cannabis": {
+                "name": "大麻"
+            },
+            "capsicum": {
+                "name": "トウガラシ"
+            },
+            "caraway": {
+                "name": "キャラウェイ"
+            },
+            "carrot": {
+                "name": "人参",
+                "plural_name": "人参"
+            },
+            "caster-sugar": {
+                "name": "微粒子グラニュー糖"
+            },
+            "castor-sugar": {
+                "name": "微粒子グラニュー糖"
+            },
+            "catfish": {
+                "name": "ナマズ"
+            },
+            "cauliflower": {
+                "name": "カリフラワー",
+                "plural_name": "カリフラワー"
+            },
+            "cayenne-pepper": {
+                "name": "カイエンペッパー"
+            },
+            "celeriac": {
+                "name": "セルリアック"
+            },
+            "celery": {
+                "name": "セロリ"
+            },
+            "cereal-grains": {
+                "name": "穀物"
+            },
+            "chard": {
+                "name": "フダンソウ"
+            },
+            "cheese": {
+                "name": "チーズ"
+            },
+            "chicory": {
+                "name": "チコリー"
+            },
+            "chilli-peppers": {
+                "name": "チリペッパー",
+                "plural_name": "唐辛子"
+            },
+            "chinese-leaves": {
+                "name": "白菜"
+            },
+            "chives": {
+                "name": "浅葱"
+            },
+            "chocolate": {
+                "name": "チョコレート"
+            },
+            "cilantro": {
+                "name": "コリアンダー"
+            },
+            "cinnamon": {
+                "name": "シナモン"
+            },
+            "clarified-butter": {
+                "name": "澄ましバター"
+            },
+            "coconut": {
+                "name": "ココナッツ",
+                "plural_name": "ココナッツ"
+            },
+            "coconut-milk": {
+                "name": "ココナッツミルク"
+            },
+            "cod": {
+                "name": "タラ"
+            },
+            "coffee": {
+                "name": "コーヒー"
+            },
+            "collard-greens": {
+                "name": "カラードグリーン"
+            },
+            "confectioners-sugar": {
+                "name": "粉糖"
+            },
+            "coriander": {
+                "name": "コリアンダー"
+            },
+            "corn": {
+                "name": "トウモロコシ",
+                "plural_name": "トウモロコシ"
+            },
+            "corn-syrup": {
+                "name": "コーンシロップ"
+            },
+            "cottonseed-oil": {
+                "name": "綿実油"
+            },
+            "courgette": {
+                "name": "ズッキーニ"
+            },
+            "cream-of-tartar": {
+                "name": "ケレモル"
+            },
+            "cucumber": {
+                "name": "きゅうり",
+                "plural_name": "きゅうり"
+            },
+            "cumin": {
+                "name": "クミン"
+            },
+            "daikon": {
+                "name": "大根",
+                "plural_name": "大根"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "乳製品および乳製品代替品"
+            },
+            "dandelion": {
+                "name": "タンポポ"
+            },
+            "demerara-sugar": {
+                "name": "デメララ砂糖"
+            },
+            "dough": {
+                "name": "生地"
+            },
+            "edible-cactus": {
+                "name": "食用サボテン"
+            },
+            "eggplant": {
+                "name": "茄子",
+                "plural_name": "茄子"
+            },
+            "eggs": {
+                "name": "卵",
+                "plural_name": "卵"
+            },
+            "endive": {
+                "name": "エンダイブ",
+                "plural_name": "エンダイブ"
+            },
+            "fats": {
+                "name": "脂質"
+            },
+            "fava-beans": {
+                "name": "そら豆"
+            },
+            "fiddlehead": {
+                "name": "ワラビ"
+            },
+            "fiddlehead-fern": {
+                "name": "ゼンマイ",
+                "plural_name": "フィドルヘッド"
+            },
+            "fish": {
+                "name": "魚"
+            },
+            "five-spice-powder": {
+                "name": "五香粉"
+            },
+            "flour": {
+                "name": "小麦粉"
+            },
+            "frisee": {
+                "name": "エンダイブ"
+            },
+            "fructose": {
+                "name": "果糖"
+            },
+            "fruit": {
+                "name": "果物"
+            },
+            "fruit-sugar": {
+                "name": "果糖"
+            },
+            "ful": {
+                "name": "そら豆"
+            },
+            "garam-masala": {
+                "name": "ガラムマサラ"
+            },
+            "garlic": {
+                "name": "ニンニク",
+                "plural_name": "ニンニク"
+            },
+            "gem-squash": {
+                "name": "ジェムスカッシュ"
+            },
+            "ghee": {
+                "name": "ギー"
+            },
+            "giblets": {
+                "name": "ジブレッツ"
+            },
+            "ginger": {
+                "name": "ショウガ"
+            },
+            "grains": {
+                "name": "穀物"
+            },
+            "granulated-sugar": {
+                "name": "グラニュー糖"
+            },
+            "grape-seed-oil": {
+                "name": "グレープシードオイル"
+            },
+            "green-onion": {
+                "name": "ネギ",
+                "plural_name": "ネギ"
+            },
+            "heart-of-palm": {
+                "name": "ハート・オブ・パーム",
+                "plural_name": "ハート・オブ・パーム"
+            },
+            "hemp": {
+                "name": "ヘンプ"
+            },
+            "herbs": {
+                "name": "ハーブ"
+            },
+            "honey": {
+                "name": "蜂蜜"
+            },
+            "isomalt": {
+                "name": "イソマルト"
+            },
+            "jackfruit": {
+                "name": "パラミツ",
+                "plural_name": "パラミツ"
+            },
+            "jaggery": {
+                "name": "ジャグリー"
+            },
+            "jams": {
+                "name": "ジャム"
+            },
+            "jellies": {
+                "name": "ジェリー"
+            },
+            "jerusalem-artichoke": {
+                "name": "キクイモ"
+            },
+            "jicama": {
+                "name": "ヒカマ"
+            },
+            "kale": {
+                "name": "ケール"
+            },
+            "kohlrabi": {
+                "name": "コールラビ"
+            },
+            "kumara": {
+                "name": "サツマイモ"
+            },
+            "leavening-agents": {
+                "name": "膨張剤"
+            },
+            "leek": {
+                "name": "ねぎ",
+                "plural_name": "セイヨウネギ"
+            },
+            "legumes": {
+                "name": "マメ"
+            },
+            "lemongrass": {
+                "name": "レモングラス"
+            },
+            "lentils": {
+                "name": "レンズ豆"
+            },
+            "lettuce": {
+                "name": "レタス"
+            },
+            "liver": {
+                "name": "レバー",
+                "plural_name": "レバー"
+            },
+            "maize": {
+                "name": "トウモロコシ"
+            },
+            "maple-syrup": {
+                "name": "メープルシロップ"
+            },
+            "meat": {
+                "name": "肉"
+            },
+            "milk": {
+                "name": "牛乳"
+            },
+            "mortadella": {
+                "name": "モルタデッラ"
+            },
+            "mushroom": {
+                "name": "キノコ",
+                "plural_name": "キノコ"
+            },
+            "mussels": {
+                "name": "ムール貝"
+            },
+            "nanaimo-bar-mix": {
+                "name": "ナナイモ・バー・ミックス"
+            },
+            "nori": {
+                "name": "のり"
+            },
+            "nutmeg": {
+                "name": "ナツメグ"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "ナショナルイーストフレーク"
+            },
+            "nuts": {
+                "name": "ナッツ"
+            },
+            "octopuses": {
+                "name": "タコ",
+                "plural_name": "タコ"
+            },
+            "oils": {
+                "name": "油"
+            },
+            "okra": {
+                "name": "オクラ"
+            },
+            "olive": {
+                "name": "オリーブ"
+            },
+            "olive-oil": {
+                "name": "オリーブ油"
+            },
+            "onion": {
+                "name": "玉ねぎ"
+            },
+            "onion-family": {
+                "name": "タマネギの仲間"
+            },
+            "orange-blossom-water": {
+                "name": "オレンジの花の水"
+            },
+            "oranges": {
+                "name": "オレンジ",
+                "plural_name": "オレンジ"
+            },
+            "oregano": {
+                "name": "オレガノ"
+            },
+            "oysters": {
+                "name": "牡蠣"
+            },
+            "panch-puran": {
+                "name": "パンチフォロン"
+            },
+            "paprika": {
+                "name": "パプリカ"
+            },
+            "parsley": {
+                "name": "パセリ"
+            },
+            "parsnip": {
+                "name": "パースニプ",
+                "plural_name": "パースニップ"
+            },
+            "pear": {
+                "name": "ナシ",
+                "plural_name": "ナシ"
+            },
+            "peas": {
+                "name": "豆"
+            },
+            "pepper": {
+                "name": "コショウ",
+                "plural_name": "コショウ"
+            },
+            "pineapple": {
+                "name": "パイナップル",
+                "plural_name": "パイナップル"
+            },
+            "plantain": {
+                "name": "プランテン",
+                "plural_name": "プランテン"
+            },
+            "poppy-seeds": {
+                "name": "ケシの種"
+            },
+            "potato": {
+                "name": "ジャガイモ",
+                "plural_name": "ジャガイモ"
+            },
+            "poultry": {
+                "name": "鶏肉"
+            },
+            "powdered-sugar": {
+                "name": "粉糖"
+            },
+            "pumpkin": {
+                "name": "カボチャ",
+                "plural_name": "ペポかぼちゃ"
+            },
+            "pumpkin-seeds": {
+                "name": "かぼちゃの種"
+            },
+            "radish": {
+                "name": "大根",
+                "plural_name": "ハツカダイコン"
+            },
+            "raw-sugar": {
+                "name": "生の砂糖"
+            },
+            "refined-sugar": {
+                "name": "精製糖"
+            },
+            "rice": {
+                "name": "米"
+            },
+            "rice-flour": {
+                "name": "米粉"
+            },
+            "rock-sugar": {
+                "name": "氷砂糖"
+            },
+            "rum": {
+                "name": "ラム酒"
+            },
+            "salmon": {
+                "name": "鮭"
+            },
+            "salt": {
+                "name": "塩"
+            },
+            "salt-cod": {
+                "name": "塩タラ"
+            },
+            "scallion": {
+                "name": "シャロット",
+                "plural_name": "シャロット"
+            },
+            "seafood": {
+                "name": "シーフード"
+            },
+            "seeds": {
+                "name": "種"
+            },
+            "sesame-seeds": {
+                "name": "ゴマの種"
+            },
+            "shallot": {
+                "name": "エシャロット",
+                "plural_name": "エシャロット"
+            },
+            "skate": {
+                "name": "ガンギエイ"
+            },
+            "soda": {
+                "name": "ソーダ"
+            },
+            "soda-baking": {
+                "name": "ソーダ、ベーキング"
+            },
+            "soybean": {
+                "name": "大豆"
+            },
+            "spaghetti-squash": {
+                "name": "スパゲッティスカッシュ",
+                "plural_name": "キンシウリ"
+            },
+            "speck": {
+                "name": "スペック"
+            },
+            "spices": {
+                "name": "香辛料"
+            },
+            "spinach": {
+                "name": "ほうれん草"
+            },
+            "spring-onion": {
+                "name": "ネギ",
+                "plural_name": "葉タマネギ"
+            },
+            "squash": {
+                "name": "カボチャ",
+                "plural_name": "カボチャ"
+            },
+            "squash-family": {
+                "name": "カボチャの仲間"
+            },
+            "stockfish": {
+                "name": "ストックフィッシュ"
+            },
+            "sugar": {
+                "name": "砂糖"
+            },
+            "sunchoke": {
+                "name": "キクイモ",
+                "plural_name": "キクイモ"
+            },
+            "sunflower-seeds": {
+                "name": "ヒマワリの種"
+            },
+            "superfine-sugar": {
+                "name": "上白糖"
+            },
+            "sweet-potato": {
+                "name": "サツマイモ",
+                "plural_name": "サツマイモ"
+            },
+            "sweetcorn": {
+                "name": "スイートコーン",
+                "plural_name": "スイートコーン"
+            },
+            "sweeteners": {
+                "name": "甘味料"
+            },
+            "tahini": {
+                "name": "タヒニ"
+            },
+            "taro": {
+                "name": "タロ芋",
+                "plural_name": "タロイモ"
+            },
+            "teff": {
+                "name": "テフ"
+            },
+            "tomato": {
+                "name": "トマト",
+                "plural_name": "トマト"
+            },
+            "trout": {
+                "name": "マス"
+            },
+            "tubers": {
+                "name": "球根",
+                "plural_name": "塊茎"
+            },
+            "tuna": {
+                "name": "マグロ"
+            },
+            "turbanado-sugar": {
+                "name": "中白糖"
+            },
+            "turnip": {
+                "name": "カブ",
+                "plural_name": "カブ"
+            },
+            "unrefined-sugar": {
+                "name": "粗製糖"
+            },
+            "vanilla": {
+                "name": "バニラ"
+            },
+            "vegetables": {
+                "name": "野菜"
+            },
+            "watercress": {
+                "name": "クレソン"
+            },
+            "watermelon": {
+                "name": "スイカ",
+                "plural_name": "スイカ"
+            },
+            "white-mushroom": {
+                "name": "マッシュルーム",
+                "plural_name": "マッシュルーム"
+            },
+            "white-sugar": {
+                "name": "白砂糖"
+            },
+            "xanthan-gum": {
+                "name": "キサンタンガム"
+            },
+            "yam": {
+                "name": "ヤムイモ",
+                "plural_name": "ヤムイモ"
+            },
+            "yeast": {
+                "name": "イースト"
+            },
+            "zucchini": {
+                "name": "ズッキーニ",
+                "plural_name": "ズッキーニ"
+            }
+        }
+    },
+    "青果物": {
+        "foods": {}
+    },
+    "穀物": {
+        "foods": {}
+    },
+    "果物": {
+        "foods": {}
+    },
+    "野菜": {
+        "foods": {}
+    },
+    "肉": {
+        "foods": {}
+    },
+    "魚介類": {
+        "foods": {}
+    },
+    "飲料": {
+        "foods": {}
+    },
+    "焼き物": {
+        "foods": {}
+    },
+    "缶詰": {
+        "foods": {}
+    },
+    "調味料": {
+        "foods": {}
+    },
+    "砂糖菓子": {
+        "foods": {}
+    },
+    "乳製品": {
+        "foods": {}
+    },
+    "冷凍食品": {
+        "foods": {}
+    },
+    "健康食品": {
+        "foods": {}
+    },
+    "家庭": {
+        "foods": {}
+    },
+    "食肉製品": {
+        "foods": {}
+    },
+    "おやつ": {
+        "foods": {}
+    },
+    "香辛料": {
+        "foods": {}
+    },
+    "お菓子": {
+        "foods": {}
+    },
+    "お酒": {
+        "foods": {}
+    },
+    "その他": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ko-KR.json
+++ b/mealie/repos/seed/resources/foods/locales/ko-KR.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "멸치"
-	},
-	"apples": {
-		"name": "사과",
-		"plural_name": "사과들"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "아스파라거스"
-	},
-	"avocado": {
-		"name": "아보카도",
-		"plural_name": "아보카도"
-	},
-	"bacon": {
-		"name": "베이컨"
-	},
-	"baking-powder": {
-		"name": "베이킹 파우더"
-	},
-	"baking-soda": {
-		"name": "베이킹 소다"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "피망",
-		"plural_name": "피망"
-	},
-	"blackberries": {
-		"name": "블랙 베리"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "빵"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "브로콜리"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "흑설탕"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "버터"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "메기"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "멸치"
+            },
+            "apples": {
+                "name": "사과",
+                "plural_name": "사과들"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "아스파라거스"
+            },
+            "avocado": {
+                "name": "아보카도",
+                "plural_name": "아보카도"
+            },
+            "bacon": {
+                "name": "베이컨"
+            },
+            "baking-powder": {
+                "name": "베이킹 파우더"
+            },
+            "baking-soda": {
+                "name": "베이킹 소다"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "피망",
+                "plural_name": "피망"
+            },
+            "blackberries": {
+                "name": "블랙 베리"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "빵"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "브로콜리"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "흑설탕"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "버터"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "메기"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "cheese"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rice"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Produce": {
+        "foods": {}
+    },
+    "곡물": {
+        "foods": {}
+    },
+    "과일류": {
+        "foods": {}
+    },
+    "채소": {
+        "foods": {}
+    },
+    "육류": {
+        "foods": {}
+    },
+    "해산물": {
+        "foods": {}
+    },
+    "음료": {
+        "foods": {}
+    },
+    "제빵 음식": {
+        "foods": {}
+    },
+    "Canned Goods": {
+        "foods": {}
+    },
+    "조미료": {
+        "foods": {}
+    },
+    "Confectionary": {
+        "foods": {}
+    },
+    "유제품": {
+        "foods": {}
+    },
+    "Frozen Foods": {
+        "foods": {}
+    },
+    "Health Foods": {
+        "foods": {}
+    },
+    "Household": {
+        "foods": {}
+    },
+    "Meat Products": {
+        "foods": {}
+    },
+    "간식": {
+        "foods": {}
+    },
+    "Sweets": {
+        "foods": {}
+    },
+    "주류": {
+        "foods": {}
+    },
+    "기타": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/lt-LT.json
+++ b/mealie/repos/seed/resources/foods/locales/lt-LT.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "liucernos daigai"
-	},
-	"anchovies": {
-		"name": "ančiuviai"
-	},
-	"apples": {
-		"name": "obuoliai",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artišokas"
-	},
-	"arugula": {
-		"name": "gražgarstė"
-	},
-	"asparagus": {
-		"name": "smidrai"
-	},
-	"avocado": {
-		"name": "avokadas",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "šoninė"
-	},
-	"baking-powder": {
-		"name": "kepimo milteliai"
-	},
-	"baking-soda": {
-		"name": "kepimo milteliai"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "bazilikas"
-	},
-	"beans": {
-		"name": "pupelės"
-	},
-	"bell-peppers": {
-		"name": "paprikos",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "gervuogės"
-	},
-	"bok-choy": {
-		"name": "kininiai bastučiai"
-	},
-	"brassicas": {
-		"name": "kopūstinės daržovės"
-	},
-	"bread": {
-		"name": "duona"
-	},
-	"breadfruit": {
-		"name": "duonvaisis"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "brokolis"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "rudasis cukrus"
-	},
-	"brussels-sprouts": {
-		"name": "briuselio kopūstai"
-	},
-	"butter": {
-		"name": "sviestas"
-	},
-	"butternut-pumpkin": {
-		"name": "muskusinis moliūgas"
-	},
-	"butternut-squash": {
-		"name": "sviestinis moliūgas"
-	},
-	"cabbage": {
-		"name": "kopūstas",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "opuncija"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cukranendrių cukrus"
-	},
-	"cannabis": {
-		"name": "kanapės"
-	},
-	"capsicum": {
-		"name": "paprikos"
-	},
-	"caraway": {
-		"name": "kmynai"
-	},
-	"carrot": {
-		"name": "morka",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "smulkusis cukrus"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "šamas"
-	},
-	"cauliflower": {
-		"name": "žiedinis kopūstas",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "kajeno pipirai"
-	},
-	"celeriac": {
-		"name": "saliero šaknis"
-	},
-	"celery": {
-		"name": "salieras"
-	},
-	"cereal-grains": {
-		"name": "kruopos"
-	},
-	"chard": {
-		"name": "burokėlių lapai"
-	},
-	"cheese": {
-		"name": "sūris"
-	},
-	"chicory": {
-		"name": "cikorija"
-	},
-	"chilli-peppers": {
-		"name": "aitriosios paprikos",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "kininis kopūstas"
-	},
-	"chives": {
-		"name": "svogūnų laiškai"
-	},
-	"chocolate": {
-		"name": "šokoladas"
-	},
-	"cilantro": {
-		"name": "kalendra"
-	},
-	"cinnamon": {
-		"name": "cinamonas"
-	},
-	"clarified-butter": {
-		"name": "lydytas sviestas"
-	},
-	"coconut": {
-		"name": "kokosas",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "kokosų pienas"
-	},
-	"cod": {
-		"name": "menkė"
-	},
-	"coffee": {
-		"name": "kava"
-	},
-	"collard-greens": {
-		"name": "lapiniai kopūstai"
-	},
-	"confectioners-sugar": {
-		"name": "cukraus pudra"
-	},
-	"coriander": {
-		"name": "kalendra"
-	},
-	"corn": {
-		"name": "kukurūzai",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "kukurūzų sirupas"
-	},
-	"cottonseed-oil": {
-		"name": "medvilnės aliejus"
-	},
-	"courgette": {
-		"name": "cukinija"
-	},
-	"cream-of-tartar": {
-		"name": "vyno akmuo"
-	},
-	"cucumber": {
-		"name": "agurkas",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "kuminas"
-	},
-	"daikon": {
-		"name": "ridikas",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "pieno produktai ir pieno pakaitalai"
-	},
-	"dandelion": {
-		"name": "pienė"
-	},
-	"demerara-sugar": {
-		"name": "cukranendrių cukrus \"Demerara\""
-	},
-	"dough": {
-		"name": "tešla"
-	},
-	"edible-cactus": {
-		"name": "opuncija"
-	},
-	"eggplant": {
-		"name": "baklažanas",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "kiaušiniai",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "trūkažolė",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "riebalai"
-	},
-	"fava-beans": {
-		"name": "pupos"
-	},
-	"fiddlehead": {
-		"name": "paparčių ūgliai"
-	},
-	"fiddlehead-fern": {
-		"name": "papartis",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "žuvis"
-	},
-	"five-spice-powder": {
-		"name": "penkių prieskonių mišinys"
-	},
-	"flour": {
-		"name": "miltai"
-	},
-	"frisee": {
-		"name": "lapinės salotos"
-	},
-	"fructose": {
-		"name": "fruktozė"
-	},
-	"fruit": {
-		"name": "vaisius"
-	},
-	"fruit-sugar": {
-		"name": "fruktozė"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "česnakas",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "apvaliosios cukinijos"
-	},
-	"ghee": {
-		"name": "lydytas/ghee sviestas"
-	},
-	"giblets": {
-		"name": "viduriai"
-	},
-	"ginger": {
-		"name": "imbieras"
-	},
-	"grains": {
-		"name": "grūdai"
-	},
-	"granulated-sugar": {
-		"name": "cukrus"
-	},
-	"grape-seed-oil": {
-		"name": "vynuogių kauliukų aliejus"
-	},
-	"green-onion": {
-		"name": "laiškiniai svogūnai",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "kanapės"
-	},
-	"herbs": {
-		"name": "žolelės"
-	},
-	"honey": {
-		"name": "medus"
-	},
-	"isomalt": {
-		"name": "izomaltas"
-	},
-	"jackfruit": {
-		"name": "duonvaisis",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "cukranendrių cukrus \"Jaggery\""
-	},
-	"jams": {
-		"name": "uogienės"
-	},
-	"jellies": {
-		"name": "drebučiai"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambas"
-	},
-	"jicama": {
-		"name": "ropinė gumbapupė"
-	},
-	"kale": {
-		"name": "lapiniai kopūstai"
-	},
-	"kohlrabi": {
-		"name": "kaliaropė"
-	},
-	"kumara": {
-		"name": "batatas"
-	},
-	"leavening-agents": {
-		"name": "kildinimo medžiagos"
-	},
-	"leek": {
-		"name": "poras",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "ankštinės daržovės"
-	},
-	"lemongrass": {
-		"name": "citrinžolė"
-	},
-	"lentils": {
-		"name": "lęšiai"
-	},
-	"lettuce": {
-		"name": "salotos"
-	},
-	"liver": {
-		"name": "kepenys",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "kukurūzai"
-	},
-	"maple-syrup": {
-		"name": "klevų sirupas"
-	},
-	"meat": {
-		"name": "mėsa"
-	},
-	"milk": {
-		"name": "pienas"
-	},
-	"mortadella": {
-		"name": "itališka dešra \"Mortadella\""
-	},
-	"mushroom": {
-		"name": "grybai",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "midijos"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "jūros dumblių lapai"
-	},
-	"nutmeg": {
-		"name": "muskato riešutas"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "maistinių mielių dribsniai"
-	},
-	"nuts": {
-		"name": "riešutai"
-	},
-	"octopuses": {
-		"name": "aštuonkojai",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "aliejai"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "alyvuogė"
-	},
-	"olive-oil": {
-		"name": "alyvuogių aliejus"
-	},
-	"onion": {
-		"name": "svogūnas"
-	},
-	"onion-family": {
-		"name": "svogūnų šeima"
-	},
-	"orange-blossom-water": {
-		"name": "apelsinų žiedų vanduo"
-	},
-	"oranges": {
-		"name": "apelsinai",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "raudonėlis"
-	},
-	"oysters": {
-		"name": "austrės"
-	},
-	"panch-puran": {
-		"name": "prieskonių mišinys \"Panch Puran\""
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "petražolės"
-	},
-	"parsnip": {
-		"name": "pastarnokas",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "kriaušė",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "žirniai"
-	},
-	"pepper": {
-		"name": "pipiras",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananasas",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "mažieji bananai",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "aguonos"
-	},
-	"potato": {
-		"name": "bulvė",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "paukštiena"
-	},
-	"powdered-sugar": {
-		"name": "cukraus pudra"
-	},
-	"pumpkin": {
-		"name": "moliūgas",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "moliūgų sėklos"
-	},
-	"radish": {
-		"name": "ridikėlis",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "nerafinuotas cukrus"
-	},
-	"refined-sugar": {
-		"name": "rafinuotas cukrus"
-	},
-	"rice": {
-		"name": "ryžiai"
-	},
-	"rice-flour": {
-		"name": "ryžių miltai"
-	},
-	"rock-sugar": {
-		"name": "stambiakristalis cukrus"
-	},
-	"rum": {
-		"name": "romas"
-	},
-	"salmon": {
-		"name": "lašiša"
-	},
-	"salt": {
-		"name": "druska"
-	},
-	"salt-cod": {
-		"name": "sūdyta menkė"
-	},
-	"scallion": {
-		"name": "laiškinis svogūnas",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "jūros gėrybės"
-	},
-	"seeds": {
-		"name": "sėklos"
-	},
-	"sesame-seeds": {
-		"name": "sezamo sėklos"
-	},
-	"shallot": {
-		"name": "šalotiniai svogūnai",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "raja"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "kepimo milteliai"
-	},
-	"soybean": {
-		"name": "sojos pupelės"
-	},
-	"spaghetti-squash": {
-		"name": "spagetinis moliūgas",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "itališkas \"Speck\" kumpis"
-	},
-	"spices": {
-		"name": "prieskoniai"
-	},
-	"spinach": {
-		"name": "špinatai"
-	},
-	"spring-onion": {
-		"name": "svogūnų laiškai",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "moliūgas",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "džiovinta žuvis"
-	},
-	"sugar": {
-		"name": "cukrus"
-	},
-	"sunchoke": {
-		"name": "topinambas",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "saulėgrąžų sėklos"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "batatas",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "saldusis kukurūzas",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "saldikliai"
-	},
-	"tahini": {
-		"name": "sezamų pasta"
-	},
-	"taro": {
-		"name": "taras",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "pomidoras",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "upėtakis"
-	},
-	"tubers": {
-		"name": "šakniavaisiai",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tunas"
-	},
-	"turbanado-sugar": {
-		"name": "cukranendrių cukrus \"Turbinado\""
-	},
-	"turnip": {
-		"name": "ropė",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "nerafinuotas cukrus"
-	},
-	"vanilla": {
-		"name": "vanilė"
-	},
-	"vegetables": {
-		"name": "daržovės"
-	},
-	"watercress": {
-		"name": "rėžiukas"
-	},
-	"watermelon": {
-		"name": "arbūzas",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "pievagrybiai",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "baltasis cukrus"
-	},
-	"xanthan-gum": {
-		"name": "ksantano derva"
-	},
-	"yam": {
-		"name": "dioskorėja",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "mielės"
-	},
-	"zucchini": {
-		"name": "cukinijos",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "liucernos daigai"
+            },
+            "anchovies": {
+                "name": "ančiuviai"
+            },
+            "apples": {
+                "name": "obuoliai",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artišokas"
+            },
+            "arugula": {
+                "name": "gražgarstė"
+            },
+            "asparagus": {
+                "name": "smidrai"
+            },
+            "avocado": {
+                "name": "avokadas",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "šoninė"
+            },
+            "baking-powder": {
+                "name": "kepimo milteliai"
+            },
+            "baking-soda": {
+                "name": "kepimo milteliai"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "bazilikas"
+            },
+            "beans": {
+                "name": "pupelės"
+            },
+            "bell-peppers": {
+                "name": "paprikos",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "gervuogės"
+            },
+            "bok-choy": {
+                "name": "kininiai bastučiai"
+            },
+            "brassicas": {
+                "name": "kopūstinės daržovės"
+            },
+            "bread": {
+                "name": "duona"
+            },
+            "breadfruit": {
+                "name": "duonvaisis"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "brokolis"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "rudasis cukrus"
+            },
+            "brussels-sprouts": {
+                "name": "briuselio kopūstai"
+            },
+            "butter": {
+                "name": "sviestas"
+            },
+            "butternut-pumpkin": {
+                "name": "muskusinis moliūgas"
+            },
+            "butternut-squash": {
+                "name": "sviestinis moliūgas"
+            },
+            "cabbage": {
+                "name": "kopūstas",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "opuncija"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cukranendrių cukrus"
+            },
+            "cannabis": {
+                "name": "kanapės"
+            },
+            "capsicum": {
+                "name": "paprikos"
+            },
+            "caraway": {
+                "name": "kmynai"
+            },
+            "carrot": {
+                "name": "morka",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "smulkusis cukrus"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "šamas"
+            },
+            "cauliflower": {
+                "name": "žiedinis kopūstas",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "kajeno pipirai"
+            },
+            "celeriac": {
+                "name": "saliero šaknis"
+            },
+            "celery": {
+                "name": "salieras"
+            },
+            "cereal-grains": {
+                "name": "kruopos"
+            },
+            "chard": {
+                "name": "burokėlių lapai"
+            },
+            "cheese": {
+                "name": "sūris"
+            },
+            "chicory": {
+                "name": "cikorija"
+            },
+            "chilli-peppers": {
+                "name": "aitriosios paprikos",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "kininis kopūstas"
+            },
+            "chives": {
+                "name": "svogūnų laiškai"
+            },
+            "chocolate": {
+                "name": "šokoladas"
+            },
+            "cilantro": {
+                "name": "kalendra"
+            },
+            "cinnamon": {
+                "name": "cinamonas"
+            },
+            "clarified-butter": {
+                "name": "lydytas sviestas"
+            },
+            "coconut": {
+                "name": "kokosas",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "kokosų pienas"
+            },
+            "cod": {
+                "name": "menkė"
+            },
+            "coffee": {
+                "name": "kava"
+            },
+            "collard-greens": {
+                "name": "lapiniai kopūstai"
+            },
+            "confectioners-sugar": {
+                "name": "cukraus pudra"
+            },
+            "coriander": {
+                "name": "kalendra"
+            },
+            "corn": {
+                "name": "kukurūzai",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "kukurūzų sirupas"
+            },
+            "cottonseed-oil": {
+                "name": "medvilnės aliejus"
+            },
+            "courgette": {
+                "name": "cukinija"
+            },
+            "cream-of-tartar": {
+                "name": "vyno akmuo"
+            },
+            "cucumber": {
+                "name": "agurkas",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "kuminas"
+            },
+            "daikon": {
+                "name": "ridikas",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "pieno produktai ir pieno pakaitalai"
+            },
+            "dandelion": {
+                "name": "pienė"
+            },
+            "demerara-sugar": {
+                "name": "cukranendrių cukrus \"Demerara\""
+            },
+            "dough": {
+                "name": "tešla"
+            },
+            "edible-cactus": {
+                "name": "opuncija"
+            },
+            "eggplant": {
+                "name": "baklažanas",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "kiaušiniai",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "trūkažolė",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "riebalai"
+            },
+            "fava-beans": {
+                "name": "pupos"
+            },
+            "fiddlehead": {
+                "name": "paparčių ūgliai"
+            },
+            "fiddlehead-fern": {
+                "name": "papartis",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "žuvis"
+            },
+            "five-spice-powder": {
+                "name": "penkių prieskonių mišinys"
+            },
+            "flour": {
+                "name": "miltai"
+            },
+            "frisee": {
+                "name": "lapinės salotos"
+            },
+            "fructose": {
+                "name": "fruktozė"
+            },
+            "fruit": {
+                "name": "vaisius"
+            },
+            "fruit-sugar": {
+                "name": "fruktozė"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "česnakas",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "apvaliosios cukinijos"
+            },
+            "ghee": {
+                "name": "lydytas/ghee sviestas"
+            },
+            "giblets": {
+                "name": "viduriai"
+            },
+            "ginger": {
+                "name": "imbieras"
+            },
+            "grains": {
+                "name": "grūdai"
+            },
+            "granulated-sugar": {
+                "name": "cukrus"
+            },
+            "grape-seed-oil": {
+                "name": "vynuogių kauliukų aliejus"
+            },
+            "green-onion": {
+                "name": "laiškiniai svogūnai",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "kanapės"
+            },
+            "herbs": {
+                "name": "žolelės"
+            },
+            "honey": {
+                "name": "medus"
+            },
+            "isomalt": {
+                "name": "izomaltas"
+            },
+            "jackfruit": {
+                "name": "duonvaisis",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "cukranendrių cukrus \"Jaggery\""
+            },
+            "jams": {
+                "name": "uogienės"
+            },
+            "jellies": {
+                "name": "drebučiai"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambas"
+            },
+            "jicama": {
+                "name": "ropinė gumbapupė"
+            },
+            "kale": {
+                "name": "lapiniai kopūstai"
+            },
+            "kohlrabi": {
+                "name": "kaliaropė"
+            },
+            "kumara": {
+                "name": "batatas"
+            },
+            "leavening-agents": {
+                "name": "kildinimo medžiagos"
+            },
+            "leek": {
+                "name": "poras",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "ankštinės daržovės"
+            },
+            "lemongrass": {
+                "name": "citrinžolė"
+            },
+            "lentils": {
+                "name": "lęšiai"
+            },
+            "lettuce": {
+                "name": "salotos"
+            },
+            "liver": {
+                "name": "kepenys",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "kukurūzai"
+            },
+            "maple-syrup": {
+                "name": "klevų sirupas"
+            },
+            "meat": {
+                "name": "mėsa"
+            },
+            "milk": {
+                "name": "pienas"
+            },
+            "mortadella": {
+                "name": "itališka dešra \"Mortadella\""
+            },
+            "mushroom": {
+                "name": "grybai",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "midijos"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "jūros dumblių lapai"
+            },
+            "nutmeg": {
+                "name": "muskato riešutas"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "maistinių mielių dribsniai"
+            },
+            "nuts": {
+                "name": "riešutai"
+            },
+            "octopuses": {
+                "name": "aštuonkojai",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "aliejai"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "alyvuogė"
+            },
+            "olive-oil": {
+                "name": "alyvuogių aliejus"
+            },
+            "onion": {
+                "name": "svogūnas"
+            },
+            "onion-family": {
+                "name": "svogūnų šeima"
+            },
+            "orange-blossom-water": {
+                "name": "apelsinų žiedų vanduo"
+            },
+            "oranges": {
+                "name": "apelsinai",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "raudonėlis"
+            },
+            "oysters": {
+                "name": "austrės"
+            },
+            "panch-puran": {
+                "name": "prieskonių mišinys \"Panch Puran\""
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "petražolės"
+            },
+            "parsnip": {
+                "name": "pastarnokas",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "kriaušė",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "žirniai"
+            },
+            "pepper": {
+                "name": "pipiras",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananasas",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "mažieji bananai",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "aguonos"
+            },
+            "potato": {
+                "name": "bulvė",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "paukštiena"
+            },
+            "powdered-sugar": {
+                "name": "cukraus pudra"
+            },
+            "pumpkin": {
+                "name": "moliūgas",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "moliūgų sėklos"
+            },
+            "radish": {
+                "name": "ridikėlis",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "nerafinuotas cukrus"
+            },
+            "refined-sugar": {
+                "name": "rafinuotas cukrus"
+            },
+            "rice": {
+                "name": "ryžiai"
+            },
+            "rice-flour": {
+                "name": "ryžių miltai"
+            },
+            "rock-sugar": {
+                "name": "stambiakristalis cukrus"
+            },
+            "rum": {
+                "name": "romas"
+            },
+            "salmon": {
+                "name": "lašiša"
+            },
+            "salt": {
+                "name": "druska"
+            },
+            "salt-cod": {
+                "name": "sūdyta menkė"
+            },
+            "scallion": {
+                "name": "laiškinis svogūnas",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "jūros gėrybės"
+            },
+            "seeds": {
+                "name": "sėklos"
+            },
+            "sesame-seeds": {
+                "name": "sezamo sėklos"
+            },
+            "shallot": {
+                "name": "šalotiniai svogūnai",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "raja"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "kepimo milteliai"
+            },
+            "soybean": {
+                "name": "sojos pupelės"
+            },
+            "spaghetti-squash": {
+                "name": "spagetinis moliūgas",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "itališkas \"Speck\" kumpis"
+            },
+            "spices": {
+                "name": "prieskoniai"
+            },
+            "spinach": {
+                "name": "špinatai"
+            },
+            "spring-onion": {
+                "name": "svogūnų laiškai",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "moliūgas",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "džiovinta žuvis"
+            },
+            "sugar": {
+                "name": "cukrus"
+            },
+            "sunchoke": {
+                "name": "topinambas",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "saulėgrąžų sėklos"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "batatas",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "saldusis kukurūzas",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "saldikliai"
+            },
+            "tahini": {
+                "name": "sezamų pasta"
+            },
+            "taro": {
+                "name": "taras",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "pomidoras",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "upėtakis"
+            },
+            "tubers": {
+                "name": "šakniavaisiai",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tunas"
+            },
+            "turbanado-sugar": {
+                "name": "cukranendrių cukrus \"Turbinado\""
+            },
+            "turnip": {
+                "name": "ropė",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "nerafinuotas cukrus"
+            },
+            "vanilla": {
+                "name": "vanilė"
+            },
+            "vegetables": {
+                "name": "daržovės"
+            },
+            "watercress": {
+                "name": "rėžiukas"
+            },
+            "watermelon": {
+                "name": "arbūzas",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "pievagrybiai",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "baltasis cukrus"
+            },
+            "xanthan-gum": {
+                "name": "ksantano derva"
+            },
+            "yam": {
+                "name": "dioskorėja",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "mielės"
+            },
+            "zucchini": {
+                "name": "cukinijos",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Produktai": {
+        "foods": {}
+    },
+    "Grūdai": {
+        "foods": {}
+    },
+    "Vaisiai": {
+        "foods": {}
+    },
+    "Daržovės": {
+        "foods": {}
+    },
+    "Mėsa": {
+        "foods": {}
+    },
+    "Jūros gėrybės": {
+        "foods": {}
+    },
+    "Gėrimai": {
+        "foods": {}
+    },
+    "Kepiniai": {
+        "foods": {}
+    },
+    "Konservuoti produktai": {
+        "foods": {}
+    },
+    "Padažai": {
+        "foods": {}
+    },
+    "Konditerijos gaminiai": {
+        "foods": {}
+    },
+    "Pieno produktai": {
+        "foods": {}
+    },
+    "Šaldyti produktai": {
+        "foods": {}
+    },
+    "Sveikas maistas": {
+        "foods": {}
+    },
+    "Buitinės prekės": {
+        "foods": {}
+    },
+    "Mėsos produktai": {
+        "foods": {}
+    },
+    "Užkandžiai": {
+        "foods": {}
+    },
+    "Prieskoniai": {
+        "foods": {}
+    },
+    "Saldumynai": {
+        "foods": {}
+    },
+    "Alkoholiniai gėrimai": {
+        "foods": {}
+    },
+    "Kita": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/lv-LV.json
+++ b/mealie/repos/seed/resources/foods/locales/lv-LV.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "ozolzīles skvošs"
-	},
-	"alfalfa-sprouts": {
-		"name": "lucernas kāposti"
-	},
-	"anchovies": {
-		"name": "anšovs"
-	},
-	"apples": {
-		"name": "ābols",
-		"plural_name": "āboli"
-	},
-	"artichoke": {
-		"name": "artišoks"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "sparģeļi"
-	},
-	"avocado": {
-		"name": "avokādo",
-		"plural_name": "avokādo"
-	},
-	"bacon": {
-		"name": "bekons"
-	},
-	"baking-powder": {
-		"name": "cepamais pulveris"
-	},
-	"baking-soda": {
-		"name": "cepamā soda"
-	},
-	"baking-sugar": {
-		"name": "cepamais pulveris"
-	},
-	"bar-sugar": {
-		"name": "batoniņu cukurs"
-	},
-	"basil": {
-		"name": "baziliks"
-	},
-	"beans": {
-		"name": "pupiņas"
-	},
-	"bell-peppers": {
-		"name": "bulgāru pipari",
-		"plural_name": "paprika"
-	},
-	"blackberries": {
-		"name": "kazenes"
-	},
-	"bok-choy": {
-		"name": "pak čoi"
-	},
-	"brassicas": {
-		"name": "brasiccas"
-	},
-	"bread": {
-		"name": "maize"
-	},
-	"breadfruit": {
-		"name": "augļu maize"
-	},
-	"broccoflower": {
-		"name": "brokopuķe"
-	},
-	"broccoli": {
-		"name": "brokoļi"
-	},
-	"broccoli-rabe": {
-		"name": "brokoļu rabe"
-	},
-	"broccolini": {
-		"name": "brokoļi"
-	},
-	"brown-sugar": {
-		"name": "brūnais cukurs"
-	},
-	"brussels-sprouts": {
-		"name": "briseles kāposti"
-	},
-	"butter": {
-		"name": "sviests"
-	},
-	"butternut-pumpkin": {
-		"name": "sviestriekstu ķirbis"
-	},
-	"butternut-squash": {
-		"name": "butternut skvošs"
-	},
-	"cabbage": {
-		"name": "kāposti",
-		"plural_name": "kāposti"
-	},
-	"cactus-edible": {
-		"name": "kaktuss, ēdams"
-	},
-	"calabrese": {
-		"name": "kalabrēze"
-	},
-	"cane-sugar": {
-		"name": "niedru cukurs"
-	},
-	"cannabis": {
-		"name": "kaņepes"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "ķimenes"
-	},
-	"carrot": {
-		"name": "burkāns",
-		"plural_name": "burkāni"
-	},
-	"caster-sugar": {
-		"name": "pūdercukurs"
-	},
-	"castor-sugar": {
-		"name": "rīcincukurs"
-	},
-	"catfish": {
-		"name": "sams"
-	},
-	"cauliflower": {
-		"name": "ziedkāposti",
-		"plural_name": "ziedkāposti"
-	},
-	"cayenne-pepper": {
-		"name": "kajēnas pipari"
-	},
-	"celeriac": {
-		"name": "selerijas sakne"
-	},
-	"celery": {
-		"name": "selerijas"
-	},
-	"cereal-grains": {
-		"name": "labības graudi"
-	},
-	"chard": {
-		"name": "mangolds"
-	},
-	"cheese": {
-		"name": "siers"
-	},
-	"chicory": {
-		"name": "cigoriņi"
-	},
-	"chilli-peppers": {
-		"name": "čili pipari",
-		"plural_name": "čili pipari"
-	},
-	"chinese-leaves": {
-		"name": "ķīniešu lapas"
-	},
-	"chives": {
-		"name": "maurloki"
-	},
-	"chocolate": {
-		"name": "šokolāde"
-	},
-	"cilantro": {
-		"name": "koriandrs"
-	},
-	"cinnamon": {
-		"name": "kanēlis"
-	},
-	"clarified-butter": {
-		"name": "dzidrināts sviests"
-	},
-	"coconut": {
-		"name": "kokosrieksts",
-		"plural_name": "kokosrieksti"
-	},
-	"coconut-milk": {
-		"name": "kokosriekstu piens"
-	},
-	"cod": {
-		"name": "menca"
-	},
-	"coffee": {
-		"name": "kafija"
-	},
-	"collard-greens": {
-		"name": "zaļie kolrābji"
-	},
-	"confectioners-sugar": {
-		"name": "konditorejas cukurs"
-	},
-	"coriander": {
-		"name": "koriandrs"
-	},
-	"corn": {
-		"name": "kukurūza",
-		"plural_name": "kukurūzas"
-	},
-	"corn-syrup": {
-		"name": "kukurūzas sīrups"
-	},
-	"cottonseed-oil": {
-		"name": "kokvilnas sēklu eļļa"
-	},
-	"courgette": {
-		"name": "kabacis"
-	},
-	"cream-of-tartar": {
-		"name": "vīnskābes krēms"
-	},
-	"cucumber": {
-		"name": "gurķis",
-		"plural_name": "gurķi"
-	},
-	"cumin": {
-		"name": "ķimenes"
-	},
-	"daikon": {
-		"name": "daikons",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "piena produkti un piena aizstājēji"
-	},
-	"dandelion": {
-		"name": "pienene"
-	},
-	"demerara-sugar": {
-		"name": "demerāras cukurs"
-	},
-	"dough": {
-		"name": "mīkla"
-	},
-	"edible-cactus": {
-		"name": "ēdamais kaktuss"
-	},
-	"eggplant": {
-		"name": "baklažāns",
-		"plural_name": "baklažāni"
-	},
-	"eggs": {
-		"name": "ola",
-		"plural_name": "olas"
-	},
-	"endive": {
-		"name": "endīvija",
-		"plural_name": "endīvijas"
-	},
-	"fats": {
-		"name": "tauki"
-	},
-	"fava-beans": {
-		"name": "fava pupiņas"
-	},
-	"fiddlehead": {
-		"name": "vijolgalvis"
-	},
-	"fiddlehead-fern": {
-		"name": "vijoļgalvas paparde",
-		"plural_name": "vijoļgalvas papardes"
-	},
-	"fish": {
-		"name": "zivs"
-	},
-	"five-spice-powder": {
-		"name": "piecu garšvielu pulveris"
-	},
-	"flour": {
-		"name": "milti"
-	},
-	"frisee": {
-		"name": "frīze"
-	},
-	"fructose": {
-		"name": "fruktoze"
-	},
-	"fruit": {
-		"name": "auglis"
-	},
-	"fruit-sugar": {
-		"name": "augļu cukurs"
-	},
-	"ful": {
-		"name": "fulls"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "ķiploki",
-		"plural_name": "ķiploki"
-	},
-	"gem-squash": {
-		"name": "gem skvošs"
-	},
-	"ghee": {
-		"name": "gī"
-	},
-	"giblets": {
-		"name": "ķidas"
-	},
-	"ginger": {
-		"name": "ingvers"
-	},
-	"grains": {
-		"name": "graudi"
-	},
-	"granulated-sugar": {
-		"name": "granulēts cukurs"
-	},
-	"grape-seed-oil": {
-		"name": "vīnogu kauliņu eļļa"
-	},
-	"green-onion": {
-		"name": "zaļais sīpols",
-		"plural_name": "zaļie sīpoli"
-	},
-	"heart-of-palm": {
-		"name": "palmu sirds",
-		"plural_name": "plaukstu sirdis"
-	},
-	"hemp": {
-		"name": "kaņepes"
-	},
-	"herbs": {
-		"name": "garšaugi"
-	},
-	"honey": {
-		"name": "medus"
-	},
-	"isomalt": {
-		"name": "izomalts"
-	},
-	"jackfruit": {
-		"name": "džekfrūts",
-		"plural_name": "džekfrūti"
-	},
-	"jaggery": {
-		"name": "džagerija"
-	},
-	"jams": {
-		"name": "ievārījums"
-	},
-	"jellies": {
-		"name": "želejas"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambūrs"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kacenkāposts"
-	},
-	"kohlrabi": {
-		"name": "kolrābis"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "raugošanas līdzekļi"
-	},
-	"leek": {
-		"name": "puravs",
-		"plural_name": "puravi"
-	},
-	"legumes": {
-		"name": "pākšaugi"
-	},
-	"lemongrass": {
-		"name": "citronzāle"
-	},
-	"lentils": {
-		"name": "lēcas"
-	},
-	"lettuce": {
-		"name": "salāti"
-	},
-	"liver": {
-		"name": "aknas",
-		"plural_name": "aknas"
-	},
-	"maize": {
-		"name": "kukurūza"
-	},
-	"maple-syrup": {
-		"name": "kļavu sīrups"
-	},
-	"meat": {
-		"name": "gaļu"
-	},
-	"milk": {
-		"name": "piens"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "sēne",
-		"plural_name": "sēnes"
-	},
-	"mussels": {
-		"name": "mīdijas"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bāra maisījums"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muskatrieksts"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "uztura rauga pārslas"
-	},
-	"nuts": {
-		"name": "rieksti"
-	},
-	"octopuses": {
-		"name": "astoņkājis",
-		"plural_name": "astoņkāji"
-	},
-	"oils": {
-		"name": "eļļas"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olīve"
-	},
-	"olive-oil": {
-		"name": "olīveļļa"
-	},
-	"onion": {
-		"name": "sīpols"
-	},
-	"onion-family": {
-		"name": "sīpolu ģimene"
-	},
-	"orange-blossom-water": {
-		"name": "apelsīnu ziedu ūdens"
-	},
-	"oranges": {
-		"name": "apelsīns",
-		"plural_name": "apelsīni"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "austeres"
-	},
-	"panch-puran": {
-		"name": "puran panch"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "pētersīļi"
-	},
-	"parsnip": {
-		"name": "pastinaks",
-		"plural_name": "pastinaki"
-	},
-	"pear": {
-		"name": "bumbieris",
-		"plural_name": "bumbieri"
-	},
-	"peas": {
-		"name": "zirņi"
-	},
-	"pepper": {
-		"name": "pipari",
-		"plural_name": "pipari"
-	},
-	"pineapple": {
-		"name": "ananass",
-		"plural_name": "ananasi"
-	},
-	"plantain": {
-		"name": "ceļmallapa",
-		"plural_name": "ceļmallapas"
-	},
-	"poppy-seeds": {
-		"name": "magoņu sēklas"
-	},
-	"potato": {
-		"name": "kartupelis",
-		"plural_name": "kartupeļi"
-	},
-	"poultry": {
-		"name": "mājputni"
-	},
-	"powdered-sugar": {
-		"name": "pūdercukurs"
-	},
-	"pumpkin": {
-		"name": "ķirbis",
-		"plural_name": "ķirbji"
-	},
-	"pumpkin-seeds": {
-		"name": "ķirbju sēklas"
-	},
-	"radish": {
-		"name": "redīsi",
-		"plural_name": "redīsi"
-	},
-	"raw-sugar": {
-		"name": "jēlcukurs"
-	},
-	"refined-sugar": {
-		"name": "rafinēts cukurs"
-	},
-	"rice": {
-		"name": "rīsi"
-	},
-	"rice-flour": {
-		"name": "rīsu milti"
-	},
-	"rock-sugar": {
-		"name": "akmens cukurs"
-	},
-	"rum": {
-		"name": "rums"
-	},
-	"salmon": {
-		"name": "lasis"
-	},
-	"salt": {
-		"name": "sāls"
-	},
-	"salt-cod": {
-		"name": "sāls menca"
-	},
-	"scallion": {
-		"name": "ķemmīšgliemene",
-		"plural_name": "ķemmīšgliemenes"
-	},
-	"seafood": {
-		"name": "jūras veltes"
-	},
-	"seeds": {
-		"name": "sēklas"
-	},
-	"sesame-seeds": {
-		"name": "sezama sēklas"
-	},
-	"shallot": {
-		"name": "šalotes",
-		"plural_name": "šalotes"
-	},
-	"skate": {
-		"name": "skeit"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, cepamais"
-	},
-	"soybean": {
-		"name": "sojas pupas"
-	},
-	"spaghetti-squash": {
-		"name": "spageti skvošs",
-		"plural_name": "spageti skvoši"
-	},
-	"speck": {
-		"name": "speķis"
-	},
-	"spices": {
-		"name": "garšvielas"
-	},
-	"spinach": {
-		"name": "spināti"
-	},
-	"spring-onion": {
-		"name": "pavasara sīpols",
-		"plural_name": "pavasara sīpoli"
-	},
-	"squash": {
-		"name": "skvošs",
-		"plural_name": "skvoši"
-	},
-	"squash-family": {
-		"name": "skvoša ģimene"
-	},
-	"stockfish": {
-		"name": "zvēru zivis"
-	},
-	"sugar": {
-		"name": "cukurs"
-	},
-	"sunchoke": {
-		"name": "bumbuļu topinambūrs",
-		"plural_name": "bumbuļu topinambūri"
-	},
-	"sunflower-seeds": {
-		"name": "saulespuķu sēklas"
-	},
-	"superfine-sugar": {
-		"name": "supersmalks cukurs"
-	},
-	"sweet-potato": {
-		"name": "saldais kartupelis",
-		"plural_name": "saldie kartupeļi"
-	},
-	"sweetcorn": {
-		"name": "cukurkukurūza",
-		"plural_name": "cukurkukurūzas"
-	},
-	"sweeteners": {
-		"name": "saldinātāji"
-	},
-	"tahini": {
-		"name": "tahīni"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taro"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomāts",
-		"plural_name": "tomāti"
-	},
-	"trout": {
-		"name": "forele"
-	},
-	"tubers": {
-		"name": "bumbuļi",
-		"plural_name": "bumbuļi"
-	},
-	"tuna": {
-		"name": "tuncis"
-	},
-	"turbanado-sugar": {
-		"name": "turbanādo cukurs"
-	},
-	"turnip": {
-		"name": "rācenis",
-		"plural_name": "rāceņi"
-	},
-	"unrefined-sugar": {
-		"name": "nerafinēts cukurs"
-	},
-	"vanilla": {
-		"name": "vaniļa"
-	},
-	"vegetables": {
-		"name": "dārzeņi"
-	},
-	"watercress": {
-		"name": "ūdenskrese"
-	},
-	"watermelon": {
-		"name": "arbūzs",
-		"plural_name": "arbūzi"
-	},
-	"white-mushroom": {
-		"name": "baltā sēne",
-		"plural_name": "baltās sēnes"
-	},
-	"white-sugar": {
-		"name": "baltais cukurs"
-	},
-	"xanthan-gum": {
-		"name": "ksantāna sveķi"
-	},
-	"yam": {
-		"name": "jamss",
-		"plural_name": "žamji"
-	},
-	"yeast": {
-		"name": "raugs"
-	},
-	"zucchini": {
-		"name": "cukini",
-		"plural_name": "cukini"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "ozolzīles skvošs"
+            },
+            "alfalfa-sprouts": {
+                "name": "lucernas kāposti"
+            },
+            "anchovies": {
+                "name": "anšovs"
+            },
+            "apples": {
+                "name": "ābols",
+                "plural_name": "āboli"
+            },
+            "artichoke": {
+                "name": "artišoks"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "sparģeļi"
+            },
+            "avocado": {
+                "name": "avokādo",
+                "plural_name": "avokādo"
+            },
+            "bacon": {
+                "name": "bekons"
+            },
+            "baking-powder": {
+                "name": "cepamais pulveris"
+            },
+            "baking-soda": {
+                "name": "cepamā soda"
+            },
+            "baking-sugar": {
+                "name": "cepamais pulveris"
+            },
+            "bar-sugar": {
+                "name": "batoniņu cukurs"
+            },
+            "basil": {
+                "name": "baziliks"
+            },
+            "beans": {
+                "name": "pupiņas"
+            },
+            "bell-peppers": {
+                "name": "bulgāru pipari",
+                "plural_name": "paprika"
+            },
+            "blackberries": {
+                "name": "kazenes"
+            },
+            "bok-choy": {
+                "name": "pak čoi"
+            },
+            "brassicas": {
+                "name": "brasiccas"
+            },
+            "bread": {
+                "name": "maize"
+            },
+            "breadfruit": {
+                "name": "augļu maize"
+            },
+            "broccoflower": {
+                "name": "brokopuķe"
+            },
+            "broccoli": {
+                "name": "brokoļi"
+            },
+            "broccoli-rabe": {
+                "name": "brokoļu rabe"
+            },
+            "broccolini": {
+                "name": "brokoļi"
+            },
+            "brown-sugar": {
+                "name": "brūnais cukurs"
+            },
+            "brussels-sprouts": {
+                "name": "briseles kāposti"
+            },
+            "butter": {
+                "name": "sviests"
+            },
+            "butternut-pumpkin": {
+                "name": "sviestriekstu ķirbis"
+            },
+            "butternut-squash": {
+                "name": "butternut skvošs"
+            },
+            "cabbage": {
+                "name": "kāposti",
+                "plural_name": "kāposti"
+            },
+            "cactus-edible": {
+                "name": "kaktuss, ēdams"
+            },
+            "calabrese": {
+                "name": "kalabrēze"
+            },
+            "cane-sugar": {
+                "name": "niedru cukurs"
+            },
+            "cannabis": {
+                "name": "kaņepes"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "ķimenes"
+            },
+            "carrot": {
+                "name": "burkāns",
+                "plural_name": "burkāni"
+            },
+            "caster-sugar": {
+                "name": "pūdercukurs"
+            },
+            "castor-sugar": {
+                "name": "rīcincukurs"
+            },
+            "catfish": {
+                "name": "sams"
+            },
+            "cauliflower": {
+                "name": "ziedkāposti",
+                "plural_name": "ziedkāposti"
+            },
+            "cayenne-pepper": {
+                "name": "kajēnas pipari"
+            },
+            "celeriac": {
+                "name": "selerijas sakne"
+            },
+            "celery": {
+                "name": "selerijas"
+            },
+            "cereal-grains": {
+                "name": "labības graudi"
+            },
+            "chard": {
+                "name": "mangolds"
+            },
+            "cheese": {
+                "name": "siers"
+            },
+            "chicory": {
+                "name": "cigoriņi"
+            },
+            "chilli-peppers": {
+                "name": "čili pipari",
+                "plural_name": "čili pipari"
+            },
+            "chinese-leaves": {
+                "name": "ķīniešu lapas"
+            },
+            "chives": {
+                "name": "maurloki"
+            },
+            "chocolate": {
+                "name": "šokolāde"
+            },
+            "cilantro": {
+                "name": "koriandrs"
+            },
+            "cinnamon": {
+                "name": "kanēlis"
+            },
+            "clarified-butter": {
+                "name": "dzidrināts sviests"
+            },
+            "coconut": {
+                "name": "kokosrieksts",
+                "plural_name": "kokosrieksti"
+            },
+            "coconut-milk": {
+                "name": "kokosriekstu piens"
+            },
+            "cod": {
+                "name": "menca"
+            },
+            "coffee": {
+                "name": "kafija"
+            },
+            "collard-greens": {
+                "name": "zaļie kolrābji"
+            },
+            "confectioners-sugar": {
+                "name": "konditorejas cukurs"
+            },
+            "coriander": {
+                "name": "koriandrs"
+            },
+            "corn": {
+                "name": "kukurūza",
+                "plural_name": "kukurūzas"
+            },
+            "corn-syrup": {
+                "name": "kukurūzas sīrups"
+            },
+            "cottonseed-oil": {
+                "name": "kokvilnas sēklu eļļa"
+            },
+            "courgette": {
+                "name": "kabacis"
+            },
+            "cream-of-tartar": {
+                "name": "vīnskābes krēms"
+            },
+            "cucumber": {
+                "name": "gurķis",
+                "plural_name": "gurķi"
+            },
+            "cumin": {
+                "name": "ķimenes"
+            },
+            "daikon": {
+                "name": "daikons",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "piena produkti un piena aizstājēji"
+            },
+            "dandelion": {
+                "name": "pienene"
+            },
+            "demerara-sugar": {
+                "name": "demerāras cukurs"
+            },
+            "dough": {
+                "name": "mīkla"
+            },
+            "edible-cactus": {
+                "name": "ēdamais kaktuss"
+            },
+            "eggplant": {
+                "name": "baklažāns",
+                "plural_name": "baklažāni"
+            },
+            "eggs": {
+                "name": "ola",
+                "plural_name": "olas"
+            },
+            "endive": {
+                "name": "endīvija",
+                "plural_name": "endīvijas"
+            },
+            "fats": {
+                "name": "tauki"
+            },
+            "fava-beans": {
+                "name": "fava pupiņas"
+            },
+            "fiddlehead": {
+                "name": "vijolgalvis"
+            },
+            "fiddlehead-fern": {
+                "name": "vijoļgalvas paparde",
+                "plural_name": "vijoļgalvas papardes"
+            },
+            "fish": {
+                "name": "zivs"
+            },
+            "five-spice-powder": {
+                "name": "piecu garšvielu pulveris"
+            },
+            "flour": {
+                "name": "milti"
+            },
+            "frisee": {
+                "name": "frīze"
+            },
+            "fructose": {
+                "name": "fruktoze"
+            },
+            "fruit": {
+                "name": "auglis"
+            },
+            "fruit-sugar": {
+                "name": "augļu cukurs"
+            },
+            "ful": {
+                "name": "fulls"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "ķiploki",
+                "plural_name": "ķiploki"
+            },
+            "gem-squash": {
+                "name": "gem skvošs"
+            },
+            "ghee": {
+                "name": "gī"
+            },
+            "giblets": {
+                "name": "ķidas"
+            },
+            "ginger": {
+                "name": "ingvers"
+            },
+            "grains": {
+                "name": "graudi"
+            },
+            "granulated-sugar": {
+                "name": "granulēts cukurs"
+            },
+            "grape-seed-oil": {
+                "name": "vīnogu kauliņu eļļa"
+            },
+            "green-onion": {
+                "name": "zaļais sīpols",
+                "plural_name": "zaļie sīpoli"
+            },
+            "heart-of-palm": {
+                "name": "palmu sirds",
+                "plural_name": "plaukstu sirdis"
+            },
+            "hemp": {
+                "name": "kaņepes"
+            },
+            "herbs": {
+                "name": "garšaugi"
+            },
+            "honey": {
+                "name": "medus"
+            },
+            "isomalt": {
+                "name": "izomalts"
+            },
+            "jackfruit": {
+                "name": "džekfrūts",
+                "plural_name": "džekfrūti"
+            },
+            "jaggery": {
+                "name": "džagerija"
+            },
+            "jams": {
+                "name": "ievārījums"
+            },
+            "jellies": {
+                "name": "želejas"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambūrs"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kacenkāposts"
+            },
+            "kohlrabi": {
+                "name": "kolrābis"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "raugošanas līdzekļi"
+            },
+            "leek": {
+                "name": "puravs",
+                "plural_name": "puravi"
+            },
+            "legumes": {
+                "name": "pākšaugi"
+            },
+            "lemongrass": {
+                "name": "citronzāle"
+            },
+            "lentils": {
+                "name": "lēcas"
+            },
+            "lettuce": {
+                "name": "salāti"
+            },
+            "liver": {
+                "name": "aknas",
+                "plural_name": "aknas"
+            },
+            "maize": {
+                "name": "kukurūza"
+            },
+            "maple-syrup": {
+                "name": "kļavu sīrups"
+            },
+            "meat": {
+                "name": "gaļu"
+            },
+            "milk": {
+                "name": "piens"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "sēne",
+                "plural_name": "sēnes"
+            },
+            "mussels": {
+                "name": "mīdijas"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bāra maisījums"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muskatrieksts"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "uztura rauga pārslas"
+            },
+            "nuts": {
+                "name": "rieksti"
+            },
+            "octopuses": {
+                "name": "astoņkājis",
+                "plural_name": "astoņkāji"
+            },
+            "oils": {
+                "name": "eļļas"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olīve"
+            },
+            "olive-oil": {
+                "name": "olīveļļa"
+            },
+            "onion": {
+                "name": "sīpols"
+            },
+            "onion-family": {
+                "name": "sīpolu ģimene"
+            },
+            "orange-blossom-water": {
+                "name": "apelsīnu ziedu ūdens"
+            },
+            "oranges": {
+                "name": "apelsīns",
+                "plural_name": "apelsīni"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "austeres"
+            },
+            "panch-puran": {
+                "name": "puran panch"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "pētersīļi"
+            },
+            "parsnip": {
+                "name": "pastinaks",
+                "plural_name": "pastinaki"
+            },
+            "pear": {
+                "name": "bumbieris",
+                "plural_name": "bumbieri"
+            },
+            "peas": {
+                "name": "zirņi"
+            },
+            "pepper": {
+                "name": "pipari",
+                "plural_name": "pipari"
+            },
+            "pineapple": {
+                "name": "ananass",
+                "plural_name": "ananasi"
+            },
+            "plantain": {
+                "name": "ceļmallapa",
+                "plural_name": "ceļmallapas"
+            },
+            "poppy-seeds": {
+                "name": "magoņu sēklas"
+            },
+            "potato": {
+                "name": "kartupelis",
+                "plural_name": "kartupeļi"
+            },
+            "poultry": {
+                "name": "mājputni"
+            },
+            "powdered-sugar": {
+                "name": "pūdercukurs"
+            },
+            "pumpkin": {
+                "name": "ķirbis",
+                "plural_name": "ķirbji"
+            },
+            "pumpkin-seeds": {
+                "name": "ķirbju sēklas"
+            },
+            "radish": {
+                "name": "redīsi",
+                "plural_name": "redīsi"
+            },
+            "raw-sugar": {
+                "name": "jēlcukurs"
+            },
+            "refined-sugar": {
+                "name": "rafinēts cukurs"
+            },
+            "rice": {
+                "name": "rīsi"
+            },
+            "rice-flour": {
+                "name": "rīsu milti"
+            },
+            "rock-sugar": {
+                "name": "akmens cukurs"
+            },
+            "rum": {
+                "name": "rums"
+            },
+            "salmon": {
+                "name": "lasis"
+            },
+            "salt": {
+                "name": "sāls"
+            },
+            "salt-cod": {
+                "name": "sāls menca"
+            },
+            "scallion": {
+                "name": "ķemmīšgliemene",
+                "plural_name": "ķemmīšgliemenes"
+            },
+            "seafood": {
+                "name": "jūras veltes"
+            },
+            "seeds": {
+                "name": "sēklas"
+            },
+            "sesame-seeds": {
+                "name": "sezama sēklas"
+            },
+            "shallot": {
+                "name": "šalotes",
+                "plural_name": "šalotes"
+            },
+            "skate": {
+                "name": "skeit"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, cepamais"
+            },
+            "soybean": {
+                "name": "sojas pupas"
+            },
+            "spaghetti-squash": {
+                "name": "spageti skvošs",
+                "plural_name": "spageti skvoši"
+            },
+            "speck": {
+                "name": "speķis"
+            },
+            "spices": {
+                "name": "garšvielas"
+            },
+            "spinach": {
+                "name": "spināti"
+            },
+            "spring-onion": {
+                "name": "pavasara sīpols",
+                "plural_name": "pavasara sīpoli"
+            },
+            "squash": {
+                "name": "skvošs",
+                "plural_name": "skvoši"
+            },
+            "squash-family": {
+                "name": "skvoša ģimene"
+            },
+            "stockfish": {
+                "name": "zvēru zivis"
+            },
+            "sugar": {
+                "name": "cukurs"
+            },
+            "sunchoke": {
+                "name": "bumbuļu topinambūrs",
+                "plural_name": "bumbuļu topinambūri"
+            },
+            "sunflower-seeds": {
+                "name": "saulespuķu sēklas"
+            },
+            "superfine-sugar": {
+                "name": "supersmalks cukurs"
+            },
+            "sweet-potato": {
+                "name": "saldais kartupelis",
+                "plural_name": "saldie kartupeļi"
+            },
+            "sweetcorn": {
+                "name": "cukurkukurūza",
+                "plural_name": "cukurkukurūzas"
+            },
+            "sweeteners": {
+                "name": "saldinātāji"
+            },
+            "tahini": {
+                "name": "tahīni"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taro"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomāts",
+                "plural_name": "tomāti"
+            },
+            "trout": {
+                "name": "forele"
+            },
+            "tubers": {
+                "name": "bumbuļi",
+                "plural_name": "bumbuļi"
+            },
+            "tuna": {
+                "name": "tuncis"
+            },
+            "turbanado-sugar": {
+                "name": "turbanādo cukurs"
+            },
+            "turnip": {
+                "name": "rācenis",
+                "plural_name": "rāceņi"
+            },
+            "unrefined-sugar": {
+                "name": "nerafinēts cukurs"
+            },
+            "vanilla": {
+                "name": "vaniļa"
+            },
+            "vegetables": {
+                "name": "dārzeņi"
+            },
+            "watercress": {
+                "name": "ūdenskrese"
+            },
+            "watermelon": {
+                "name": "arbūzs",
+                "plural_name": "arbūzi"
+            },
+            "white-mushroom": {
+                "name": "baltā sēne",
+                "plural_name": "baltās sēnes"
+            },
+            "white-sugar": {
+                "name": "baltais cukurs"
+            },
+            "xanthan-gum": {
+                "name": "ksantāna sveķi"
+            },
+            "yam": {
+                "name": "jamss",
+                "plural_name": "žamji"
+            },
+            "yeast": {
+                "name": "raugs"
+            },
+            "zucchini": {
+                "name": "cukini",
+                "plural_name": "cukini"
+            }
+        }
+    },
+    "Gatavot": {
+        "foods": {}
+    },
+    "Labība": {
+        "foods": {}
+    },
+    "Augļi": {
+        "foods": {}
+    },
+    "Dārzeņi": {
+        "foods": {}
+    },
+    "Gaļa": {
+        "foods": {}
+    },
+    "Jūras veltes": {
+        "foods": {}
+    },
+    "Dzērieni": {
+        "foods": {}
+    },
+    "Ceptas preces": {
+        "foods": {}
+    },
+    "Konservētas preces": {
+        "foods": {}
+    },
+    "Garšvielas": {
+        "foods": {}
+    },
+    "Konditorejas izstrādājumi": {
+        "foods": {}
+    },
+    "Piena produkti": {
+        "foods": {}
+    },
+    "Saldēti pārtikas produkti": {
+        "foods": {}
+    },
+    "Veselīga pārtika": {
+        "foods": {}
+    },
+    "Mājsaimniecība": {
+        "foods": {}
+    },
+    "Gaļas produkti": {
+        "foods": {}
+    },
+    "Uzkodas": {
+        "foods": {}
+    },
+    "Saldumi": {
+        "foods": {}
+    },
+    "Alkohols": {
+        "foods": {}
+    },
+    "Cits": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/nl-NL.json
+++ b/mealie/repos/seed/resources/foods/locales/nl-NL.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "eikelpompoen"
-	},
-	"alfalfa-sprouts": {
-		"name": "kiemgroente"
-	},
-	"anchovies": {
-		"name": "ansjovis"
-	},
-	"apples": {
-		"name": "appels",
-		"plural_name": "appels"
-	},
-	"artichoke": {
-		"name": "artisjok"
-	},
-	"arugula": {
-		"name": "rucola"
-	},
-	"asparagus": {
-		"name": "asperge"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "spek"
-	},
-	"baking-powder": {
-		"name": "bakpoeder"
-	},
-	"baking-soda": {
-		"name": "baksoda"
-	},
-	"baking-sugar": {
-		"name": "bak suiker"
-	},
-	"bar-sugar": {
-		"name": "rietsuiker"
-	},
-	"basil": {
-		"name": "basilicum"
-	},
-	"beans": {
-		"name": "bonen"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "paprika"
-	},
-	"blackberries": {
-		"name": "braambessen"
-	},
-	"bok-choy": {
-		"name": "paksoi"
-	},
-	"brassicas": {
-		"name": "kool"
-	},
-	"bread": {
-		"name": "brood"
-	},
-	"breadfruit": {
-		"name": "broodvruchten"
-	},
-	"broccoflower": {
-		"name": "romanesco"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "bruine suiker"
-	},
-	"brussels-sprouts": {
-		"name": "spruiten"
-	},
-	"butter": {
-		"name": "boter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pompoen"
-	},
-	"butternut-squash": {
-		"name": "butternut pompoen"
-	},
-	"cabbage": {
-		"name": "kool",
-		"plural_name": "kolen"
-	},
-	"cactus-edible": {
-		"name": "cactus, eetbaar"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "rietsuiker"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "karwij"
-	},
-	"carrot": {
-		"name": "wortel",
-		"plural_name": "wortels"
-	},
-	"caster-sugar": {
-		"name": "basterdsuiker"
-	},
-	"castor-sugar": {
-		"name": "basterdsuiker"
-	},
-	"catfish": {
-		"name": "meerval"
-	},
-	"cauliflower": {
-		"name": "bloemkool",
-		"plural_name": "bloemkolen"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne peper"
-	},
-	"celeriac": {
-		"name": "knolselder"
-	},
-	"celery": {
-		"name": "selderij"
-	},
-	"cereal-grains": {
-		"name": "ontbijtgranen"
-	},
-	"chard": {
-		"name": "snijbiet"
-	},
-	"cheese": {
-		"name": "kaas"
-	},
-	"chicory": {
-		"name": "witlof"
-	},
-	"chilli-peppers": {
-		"name": "chili peper",
-		"plural_name": "chili pepers"
-	},
-	"chinese-leaves": {
-		"name": "chinese kool"
-	},
-	"chives": {
-		"name": "bieslook"
-	},
-	"chocolate": {
-		"name": "chocolade"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "kaneel"
-	},
-	"clarified-butter": {
-		"name": "geklaarde boter"
-	},
-	"coconut": {
-		"name": "kokosnoot",
-		"plural_name": "kokosnoten"
-	},
-	"coconut-milk": {
-		"name": "kokosmelk"
-	},
-	"cod": {
-		"name": "kabeljauw"
-	},
-	"coffee": {
-		"name": "koffie"
-	},
-	"collard-greens": {
-		"name": "galicische kool"
-	},
-	"confectioners-sugar": {
-		"name": "poedersuiker"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "maïs",
-		"plural_name": "maïs"
-	},
-	"corn-syrup": {
-		"name": "maisstroop"
-	},
-	"cottonseed-oil": {
-		"name": "katoenzaadolie"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "wijnsteen"
-	},
-	"cucumber": {
-		"name": "komkommer",
-		"plural_name": "komkommers"
-	},
-	"cumin": {
-		"name": "komijn"
-	},
-	"daikon": {
-		"name": "witte rammenas",
-		"plural_name": "witte rammenassen"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "zuivelproducten en zuivelvervangers"
-	},
-	"dandelion": {
-		"name": "paardenbloem"
-	},
-	"demerara-sugar": {
-		"name": "demerara suiker"
-	},
-	"dough": {
-		"name": "deeg"
-	},
-	"edible-cactus": {
-		"name": "eetbare cactus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "aubergines"
-	},
-	"eggs": {
-		"name": "eieren",
-		"plural_name": "eieren"
-	},
-	"endive": {
-		"name": "andijvie",
-		"plural_name": "andijvie"
-	},
-	"fats": {
-		"name": "vetten"
-	},
-	"fava-beans": {
-		"name": "tuinbonen"
-	},
-	"fiddlehead": {
-		"name": "varenkrul"
-	},
-	"fiddlehead-fern": {
-		"name": "varenkrul",
-		"plural_name": "varenkrul"
-	},
-	"fish": {
-		"name": "vis"
-	},
-	"five-spice-powder": {
-		"name": "vijfkruidenpoeder"
-	},
-	"flour": {
-		"name": "bloem"
-	},
-	"frisee": {
-		"name": "krulandijvie"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit suiker"
-	},
-	"ful": {
-		"name": "peul"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "knoflook",
-		"plural_name": "knoflook"
-	},
-	"gem-squash": {
-		"name": "citroenpompoen"
-	},
-	"ghee": {
-		"name": "geklaarde boter"
-	},
-	"giblets": {
-		"name": "kip-ingewanden"
-	},
-	"ginger": {
-		"name": "gember"
-	},
-	"grains": {
-		"name": "granen"
-	},
-	"granulated-sugar": {
-		"name": "kristalsuiker"
-	},
-	"grape-seed-oil": {
-		"name": "druivenpitolie"
-	},
-	"green-onion": {
-		"name": "groene ui",
-		"plural_name": "groene uien"
-	},
-	"heart-of-palm": {
-		"name": "hart van palm",
-		"plural_name": "hart van palm"
-	},
-	"hemp": {
-		"name": "hennep"
-	},
-	"herbs": {
-		"name": "kruiden"
-	},
-	"honey": {
-		"name": "honing"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "confituur"
-	},
-	"jellies": {
-		"name": "geleien"
-	},
-	"jerusalem-artichoke": {
-		"name": "aardpeer"
-	},
-	"jicama": {
-		"name": "yamboon"
-	},
-	"kale": {
-		"name": "boerenkool"
-	},
-	"kohlrabi": {
-		"name": "koolrabi"
-	},
-	"kumara": {
-		"name": "zoete aardappel"
-	},
-	"leavening-agents": {
-		"name": "rijsmiddelen"
-	},
-	"leek": {
-		"name": "prei",
-		"plural_name": "preien"
-	},
-	"legumes": {
-		"name": "peulvruchten"
-	},
-	"lemongrass": {
-		"name": "citroengras"
-	},
-	"lentils": {
-		"name": "linzen"
-	},
-	"lettuce": {
-		"name": "sla"
-	},
-	"liver": {
-		"name": "lever",
-		"plural_name": "levers"
-	},
-	"maize": {
-		"name": "maïs"
-	},
-	"maple-syrup": {
-		"name": "ahornsiroop"
-	},
-	"meat": {
-		"name": "vlees"
-	},
-	"milk": {
-		"name": "melk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "paddestoel",
-		"plural_name": "paddenstoelen"
-	},
-	"mussels": {
-		"name": "mosselen"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo barmix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nootmuskaat"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "gistvlokken"
-	},
-	"nuts": {
-		"name": "noten"
-	},
-	"octopuses": {
-		"name": "octopussen",
-		"plural_name": "octopussen"
-	},
-	"oils": {
-		"name": "oliën"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olijf"
-	},
-	"olive-oil": {
-		"name": "olijfolie"
-	},
-	"onion": {
-		"name": "ui"
-	},
-	"onion-family": {
-		"name": "uien familie"
-	},
-	"orange-blossom-water": {
-		"name": "sinaasappelbloesem"
-	},
-	"oranges": {
-		"name": "sinaasappel",
-		"plural_name": "sinaasappels"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oester"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "peterselie"
-	},
-	"parsnip": {
-		"name": "pastinaak",
-		"plural_name": "pastinaken"
-	},
-	"pear": {
-		"name": "peer",
-		"plural_name": "peren"
-	},
-	"peas": {
-		"name": "erwten"
-	},
-	"pepper": {
-		"name": "peper",
-		"plural_name": "pepers"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananassen"
-	},
-	"plantain": {
-		"name": "bakbanaan",
-		"plural_name": "bakbananen"
-	},
-	"poppy-seeds": {
-		"name": "papaver zaden"
-	},
-	"potato": {
-		"name": "aardappel",
-		"plural_name": "aardappelen"
-	},
-	"poultry": {
-		"name": "gevogelte"
-	},
-	"powdered-sugar": {
-		"name": "poedersuiker"
-	},
-	"pumpkin": {
-		"name": "pompoen",
-		"plural_name": "pompoenen"
-	},
-	"pumpkin-seeds": {
-		"name": "pompoenpitten"
-	},
-	"radish": {
-		"name": "radijs",
-		"plural_name": "radijsjes"
-	},
-	"raw-sugar": {
-		"name": "ruwe suiker"
-	},
-	"refined-sugar": {
-		"name": "gerafineerde suiker"
-	},
-	"rice": {
-		"name": "rijst"
-	},
-	"rice-flour": {
-		"name": "rijstbloem"
-	},
-	"rock-sugar": {
-		"name": "kandijsuiker"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "zalm"
-	},
-	"salt": {
-		"name": "zout"
-	},
-	"salt-cod": {
-		"name": "gezoute kabeljauw"
-	},
-	"scallion": {
-		"name": "lente-ui",
-		"plural_name": "lente-uien"
-	},
-	"seafood": {
-		"name": "zeevruchten"
-	},
-	"seeds": {
-		"name": "zaden"
-	},
-	"sesame-seeds": {
-		"name": "sesamzaad"
-	},
-	"shallot": {
-		"name": "sjalotte",
-		"plural_name": "sjalotjes"
-	},
-	"skate": {
-		"name": "rog"
-	},
-	"soda": {
-		"name": "bruiswater"
-	},
-	"soda-baking": {
-		"name": "soda, bakken"
-	},
-	"soybean": {
-		"name": "sojaboon"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti pompoen",
-		"plural_name": "spaghetti pompoenen"
-	},
-	"speck": {
-		"name": "spek"
-	},
-	"spices": {
-		"name": "kruiden"
-	},
-	"spinach": {
-		"name": "spinazie"
-	},
-	"spring-onion": {
-		"name": "lente-ui",
-		"plural_name": "lente-uitjes"
-	},
-	"squash": {
-		"name": "pompoen",
-		"plural_name": "pompoenen"
-	},
-	"squash-family": {
-		"name": "pompoen familie"
-	},
-	"stockfish": {
-		"name": "stokvis"
-	},
-	"sugar": {
-		"name": "suiker"
-	},
-	"sunchoke": {
-		"name": "aardpeer",
-		"plural_name": "aardperen"
-	},
-	"sunflower-seeds": {
-		"name": "zonnebloempitten"
-	},
-	"superfine-sugar": {
-		"name": "superfijne suiker"
-	},
-	"sweet-potato": {
-		"name": "zoete aardappel",
-		"plural_name": "zoete aardappelen"
-	},
-	"sweetcorn": {
-		"name": "zoete maïs",
-		"plural_name": "zoete maïs"
-	},
-	"sweeteners": {
-		"name": "zoetstoffen"
-	},
-	"tahini": {
-		"name": "tahin"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "abessijns liefdegras"
-	},
-	"tomato": {
-		"name": "tomaat",
-		"plural_name": "tomaten"
-	},
-	"trout": {
-		"name": "forel"
-	},
-	"tubers": {
-		"name": "knolgewassen",
-		"plural_name": "knolgewassen"
-	},
-	"tuna": {
-		"name": "tonijn"
-	},
-	"turbanado-sugar": {
-		"name": "natuurlijke bruine suiker"
-	},
-	"turnip": {
-		"name": "knolraap",
-		"plural_name": "knolrapen"
-	},
-	"unrefined-sugar": {
-		"name": "ongerafineerde suiker"
-	},
-	"vanilla": {
-		"name": "vanille"
-	},
-	"vegetables": {
-		"name": "groenten"
-	},
-	"watercress": {
-		"name": "waterkers"
-	},
-	"watermelon": {
-		"name": "watermeloen",
-		"plural_name": "watermeloenen"
-	},
-	"white-mushroom": {
-		"name": "witte paddenstoel",
-		"plural_name": "witte paddenstoelen"
-	},
-	"white-sugar": {
-		"name": "witte suiker"
-	},
-	"xanthan-gum": {
-		"name": "xanthaangom"
-	},
-	"yam": {
-		"name": "yamswortel",
-		"plural_name": "yamswortels"
-	},
-	"yeast": {
-		"name": "gist"
-	},
-	"zucchini": {
-		"name": "courgette",
-		"plural_name": "courgettes"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "eikelpompoen"
+            },
+            "alfalfa-sprouts": {
+                "name": "kiemgroente"
+            },
+            "anchovies": {
+                "name": "ansjovis"
+            },
+            "apples": {
+                "name": "appels",
+                "plural_name": "appels"
+            },
+            "artichoke": {
+                "name": "artisjok"
+            },
+            "arugula": {
+                "name": "rucola"
+            },
+            "asparagus": {
+                "name": "asperge"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "spek"
+            },
+            "baking-powder": {
+                "name": "bakpoeder"
+            },
+            "baking-soda": {
+                "name": "baksoda"
+            },
+            "baking-sugar": {
+                "name": "bak suiker"
+            },
+            "bar-sugar": {
+                "name": "rietsuiker"
+            },
+            "basil": {
+                "name": "basilicum"
+            },
+            "beans": {
+                "name": "bonen"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "paprika"
+            },
+            "blackberries": {
+                "name": "braambessen"
+            },
+            "bok-choy": {
+                "name": "paksoi"
+            },
+            "brassicas": {
+                "name": "kool"
+            },
+            "bread": {
+                "name": "brood"
+            },
+            "breadfruit": {
+                "name": "broodvruchten"
+            },
+            "broccoflower": {
+                "name": "romanesco"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "bruine suiker"
+            },
+            "brussels-sprouts": {
+                "name": "spruiten"
+            },
+            "butter": {
+                "name": "boter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pompoen"
+            },
+            "butternut-squash": {
+                "name": "butternut pompoen"
+            },
+            "cabbage": {
+                "name": "kool",
+                "plural_name": "kolen"
+            },
+            "cactus-edible": {
+                "name": "cactus, eetbaar"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "rietsuiker"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "karwij"
+            },
+            "carrot": {
+                "name": "wortel",
+                "plural_name": "wortels"
+            },
+            "caster-sugar": {
+                "name": "basterdsuiker"
+            },
+            "castor-sugar": {
+                "name": "basterdsuiker"
+            },
+            "catfish": {
+                "name": "meerval"
+            },
+            "cauliflower": {
+                "name": "bloemkool",
+                "plural_name": "bloemkolen"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne peper"
+            },
+            "celeriac": {
+                "name": "knolselder"
+            },
+            "celery": {
+                "name": "selderij"
+            },
+            "cereal-grains": {
+                "name": "ontbijtgranen"
+            },
+            "chard": {
+                "name": "snijbiet"
+            },
+            "cheese": {
+                "name": "kaas"
+            },
+            "chicory": {
+                "name": "witlof"
+            },
+            "chilli-peppers": {
+                "name": "chili peper",
+                "plural_name": "chili pepers"
+            },
+            "chinese-leaves": {
+                "name": "chinese kool"
+            },
+            "chives": {
+                "name": "bieslook"
+            },
+            "chocolate": {
+                "name": "chocolade"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "kaneel"
+            },
+            "clarified-butter": {
+                "name": "geklaarde boter"
+            },
+            "coconut": {
+                "name": "kokosnoot",
+                "plural_name": "kokosnoten"
+            },
+            "coconut-milk": {
+                "name": "kokosmelk"
+            },
+            "cod": {
+                "name": "kabeljauw"
+            },
+            "coffee": {
+                "name": "koffie"
+            },
+            "collard-greens": {
+                "name": "galicische kool"
+            },
+            "confectioners-sugar": {
+                "name": "poedersuiker"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "maïs",
+                "plural_name": "maïs"
+            },
+            "corn-syrup": {
+                "name": "maisstroop"
+            },
+            "cottonseed-oil": {
+                "name": "katoenzaadolie"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "wijnsteen"
+            },
+            "cucumber": {
+                "name": "komkommer",
+                "plural_name": "komkommers"
+            },
+            "cumin": {
+                "name": "komijn"
+            },
+            "daikon": {
+                "name": "witte rammenas",
+                "plural_name": "witte rammenassen"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "zuivelproducten en zuivelvervangers"
+            },
+            "dandelion": {
+                "name": "paardenbloem"
+            },
+            "demerara-sugar": {
+                "name": "demerara suiker"
+            },
+            "dough": {
+                "name": "deeg"
+            },
+            "edible-cactus": {
+                "name": "eetbare cactus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "aubergines"
+            },
+            "eggs": {
+                "name": "eieren",
+                "plural_name": "eieren"
+            },
+            "endive": {
+                "name": "andijvie",
+                "plural_name": "andijvie"
+            },
+            "fats": {
+                "name": "vetten"
+            },
+            "fava-beans": {
+                "name": "tuinbonen"
+            },
+            "fiddlehead": {
+                "name": "varenkrul"
+            },
+            "fiddlehead-fern": {
+                "name": "varenkrul",
+                "plural_name": "varenkrul"
+            },
+            "fish": {
+                "name": "vis"
+            },
+            "five-spice-powder": {
+                "name": "vijfkruidenpoeder"
+            },
+            "flour": {
+                "name": "bloem"
+            },
+            "frisee": {
+                "name": "krulandijvie"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit suiker"
+            },
+            "ful": {
+                "name": "peul"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "knoflook",
+                "plural_name": "knoflook"
+            },
+            "gem-squash": {
+                "name": "citroenpompoen"
+            },
+            "ghee": {
+                "name": "geklaarde boter"
+            },
+            "giblets": {
+                "name": "kip-ingewanden"
+            },
+            "ginger": {
+                "name": "gember"
+            },
+            "grains": {
+                "name": "granen"
+            },
+            "granulated-sugar": {
+                "name": "kristalsuiker"
+            },
+            "grape-seed-oil": {
+                "name": "druivenpitolie"
+            },
+            "green-onion": {
+                "name": "groene ui",
+                "plural_name": "groene uien"
+            },
+            "heart-of-palm": {
+                "name": "hart van palm",
+                "plural_name": "hart van palm"
+            },
+            "hemp": {
+                "name": "hennep"
+            },
+            "herbs": {
+                "name": "kruiden"
+            },
+            "honey": {
+                "name": "honing"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "confituur"
+            },
+            "jellies": {
+                "name": "geleien"
+            },
+            "jerusalem-artichoke": {
+                "name": "aardpeer"
+            },
+            "jicama": {
+                "name": "yamboon"
+            },
+            "kale": {
+                "name": "boerenkool"
+            },
+            "kohlrabi": {
+                "name": "koolrabi"
+            },
+            "kumara": {
+                "name": "zoete aardappel"
+            },
+            "leavening-agents": {
+                "name": "rijsmiddelen"
+            },
+            "leek": {
+                "name": "prei",
+                "plural_name": "preien"
+            },
+            "legumes": {
+                "name": "peulvruchten"
+            },
+            "lemongrass": {
+                "name": "citroengras"
+            },
+            "lentils": {
+                "name": "linzen"
+            },
+            "lettuce": {
+                "name": "sla"
+            },
+            "liver": {
+                "name": "lever",
+                "plural_name": "levers"
+            },
+            "maize": {
+                "name": "maïs"
+            },
+            "maple-syrup": {
+                "name": "ahornsiroop"
+            },
+            "meat": {
+                "name": "vlees"
+            },
+            "milk": {
+                "name": "melk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "paddestoel",
+                "plural_name": "paddenstoelen"
+            },
+            "mussels": {
+                "name": "mosselen"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo barmix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nootmuskaat"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "gistvlokken"
+            },
+            "nuts": {
+                "name": "noten"
+            },
+            "octopuses": {
+                "name": "octopussen",
+                "plural_name": "octopussen"
+            },
+            "oils": {
+                "name": "oliën"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olijf"
+            },
+            "olive-oil": {
+                "name": "olijfolie"
+            },
+            "onion": {
+                "name": "ui"
+            },
+            "onion-family": {
+                "name": "uien familie"
+            },
+            "orange-blossom-water": {
+                "name": "sinaasappelbloesem"
+            },
+            "oranges": {
+                "name": "sinaasappel",
+                "plural_name": "sinaasappels"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oester"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "peterselie"
+            },
+            "parsnip": {
+                "name": "pastinaak",
+                "plural_name": "pastinaken"
+            },
+            "pear": {
+                "name": "peer",
+                "plural_name": "peren"
+            },
+            "peas": {
+                "name": "erwten"
+            },
+            "pepper": {
+                "name": "peper",
+                "plural_name": "pepers"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananassen"
+            },
+            "plantain": {
+                "name": "bakbanaan",
+                "plural_name": "bakbananen"
+            },
+            "poppy-seeds": {
+                "name": "papaver zaden"
+            },
+            "potato": {
+                "name": "aardappel",
+                "plural_name": "aardappelen"
+            },
+            "poultry": {
+                "name": "gevogelte"
+            },
+            "powdered-sugar": {
+                "name": "poedersuiker"
+            },
+            "pumpkin": {
+                "name": "pompoen",
+                "plural_name": "pompoenen"
+            },
+            "pumpkin-seeds": {
+                "name": "pompoenpitten"
+            },
+            "radish": {
+                "name": "radijs",
+                "plural_name": "radijsjes"
+            },
+            "raw-sugar": {
+                "name": "ruwe suiker"
+            },
+            "refined-sugar": {
+                "name": "gerafineerde suiker"
+            },
+            "rice": {
+                "name": "rijst"
+            },
+            "rice-flour": {
+                "name": "rijstbloem"
+            },
+            "rock-sugar": {
+                "name": "kandijsuiker"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "zalm"
+            },
+            "salt": {
+                "name": "zout"
+            },
+            "salt-cod": {
+                "name": "gezoute kabeljauw"
+            },
+            "scallion": {
+                "name": "lente-ui",
+                "plural_name": "lente-uien"
+            },
+            "seafood": {
+                "name": "zeevruchten"
+            },
+            "seeds": {
+                "name": "zaden"
+            },
+            "sesame-seeds": {
+                "name": "sesamzaad"
+            },
+            "shallot": {
+                "name": "sjalotte",
+                "plural_name": "sjalotjes"
+            },
+            "skate": {
+                "name": "rog"
+            },
+            "soda": {
+                "name": "bruiswater"
+            },
+            "soda-baking": {
+                "name": "soda, bakken"
+            },
+            "soybean": {
+                "name": "sojaboon"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti pompoen",
+                "plural_name": "spaghetti pompoenen"
+            },
+            "speck": {
+                "name": "spek"
+            },
+            "spices": {
+                "name": "kruiden"
+            },
+            "spinach": {
+                "name": "spinazie"
+            },
+            "spring-onion": {
+                "name": "lente-ui",
+                "plural_name": "lente-uitjes"
+            },
+            "squash": {
+                "name": "pompoen",
+                "plural_name": "pompoenen"
+            },
+            "squash-family": {
+                "name": "pompoen familie"
+            },
+            "stockfish": {
+                "name": "stokvis"
+            },
+            "sugar": {
+                "name": "suiker"
+            },
+            "sunchoke": {
+                "name": "aardpeer",
+                "plural_name": "aardperen"
+            },
+            "sunflower-seeds": {
+                "name": "zonnebloempitten"
+            },
+            "superfine-sugar": {
+                "name": "superfijne suiker"
+            },
+            "sweet-potato": {
+                "name": "zoete aardappel",
+                "plural_name": "zoete aardappelen"
+            },
+            "sweetcorn": {
+                "name": "zoete maïs",
+                "plural_name": "zoete maïs"
+            },
+            "sweeteners": {
+                "name": "zoetstoffen"
+            },
+            "tahini": {
+                "name": "tahin"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "abessijns liefdegras"
+            },
+            "tomato": {
+                "name": "tomaat",
+                "plural_name": "tomaten"
+            },
+            "trout": {
+                "name": "forel"
+            },
+            "tubers": {
+                "name": "knolgewassen",
+                "plural_name": "knolgewassen"
+            },
+            "tuna": {
+                "name": "tonijn"
+            },
+            "turbanado-sugar": {
+                "name": "natuurlijke bruine suiker"
+            },
+            "turnip": {
+                "name": "knolraap",
+                "plural_name": "knolrapen"
+            },
+            "unrefined-sugar": {
+                "name": "ongerafineerde suiker"
+            },
+            "vanilla": {
+                "name": "vanille"
+            },
+            "vegetables": {
+                "name": "groenten"
+            },
+            "watercress": {
+                "name": "waterkers"
+            },
+            "watermelon": {
+                "name": "watermeloen",
+                "plural_name": "watermeloenen"
+            },
+            "white-mushroom": {
+                "name": "witte paddenstoel",
+                "plural_name": "witte paddenstoelen"
+            },
+            "white-sugar": {
+                "name": "witte suiker"
+            },
+            "xanthan-gum": {
+                "name": "xanthaangom"
+            },
+            "yam": {
+                "name": "yamswortel",
+                "plural_name": "yamswortels"
+            },
+            "yeast": {
+                "name": "gist"
+            },
+            "zucchini": {
+                "name": "courgette",
+                "plural_name": "courgettes"
+            }
+        }
+    },
+    "Groenten en fruit": {
+        "foods": {}
+    },
+    "Granen": {
+        "foods": {}
+    },
+    "Fruit": {
+        "foods": {}
+    },
+    "Groenten": {
+        "foods": {}
+    },
+    "Vlees": {
+        "foods": {}
+    },
+    "Zeevruchten": {
+        "foods": {}
+    },
+    "Dranken": {
+        "foods": {}
+    },
+    "Gebakken producten": {
+        "foods": {}
+    },
+    "Ingeblikt eten": {
+        "foods": {}
+    },
+    "Specerijen": {
+        "foods": {}
+    },
+    "Zoetigheden": {
+        "foods": {}
+    },
+    "Zuivelproducten": {
+        "foods": {}
+    },
+    "Bevroren eten": {
+        "foods": {}
+    },
+    "Gezond eten": {
+        "foods": {}
+    },
+    "Huishouden": {
+        "foods": {}
+    },
+    "Vleesproducten": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Kruiden": {
+        "foods": {}
+    },
+    "Snoepgoed": {
+        "foods": {}
+    },
+    "Alcohol": {
+        "foods": {}
+    },
+    "Anders": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/no-NO.json
+++ b/mealie/repos/seed/resources/foods/locales/no-NO.json
@@ -1,692 +1,759 @@
 {
-    "acorn-squash": {
-        "name": "pepper squash"
-    },
-    "alfalfa-sprouts": {
-        "name": "alfalfaspirer"
-    },
-    "anchovies": {
-        "name": "ansjos"
-    },
-    "apples": {
-        "name": "eple",
-        "plural_name": "epler"
-    },
-    "artichoke": {
-        "name": "artisjokk"
-    },
-    "arugula": {
-        "name": "ruccola"
-    },
-    "asparagus": {
-        "name": "asparges"
-    },
-    "avocado": {
-        "name": "avokado",
-        "plural_name": "avokadoer"
-    },
-    "bacon": {
-        "name": "bacon"
-    },
-    "baking-powder": {
-        "name": "bakepulver"
-    },
-    "baking-soda": {
-        "name": "natron"
-    },
-    "baking-sugar": {
-        "name": "melis"
-    },
-    "bar-sugar": {
-        "name": "bar-sukker"
-    },
-    "basil": {
-        "name": "basilikum"
-    },
-    "beans": {
-        "name": "bønner"
-    },
-    "bell-peppers": {
-        "name": "paprika",
-        "plural_name": "paprikaer"
-    },
-    "blackberries": {
-        "name": "bjørnebær"
-    },
-    "bok-choy": {
-        "name": "pak choi"
-    },
-    "brassicas": {
-        "name": "brassicae"
-    },
-    "bread": {
-        "name": "brød"
-    },
-    "breadfruit": {
-        "name": "brødfrukt"
-    },
-    "broccoflower": {
-        "name": "blomkål"
-    },
-    "broccoli": {
-        "name": "brokkoli"
-    },
-    "broccoli-rabe": {
-        "name": "rapini"
-    },
-    "broccolini": {
-        "name": "brokkolini"
-    },
-    "brown-sugar": {
-        "name": "brunt sukker"
-    },
-    "brussels-sprouts": {
-        "name": "rosenkål"
-    },
-    "butter": {
-        "name": "smør"
-    },
-    "butternut-pumpkin": {
-        "name": "flaskegresskar"
-    },
-    "butternut-squash": {
-        "name": "butternut squash"
-    },
-    "cabbage": {
-        "name": "kål",
-        "plural_name": "kål"
-    },
-    "cactus-edible": {
-        "name": "kaktus, spiselig"
-    },
-    "calabrese": {
-        "name": "calabrese"
-    },
-    "cane-sugar": {
-        "name": "rørsukker"
-    },
-    "cannabis": {
-        "name": "cannabis"
-    },
-    "capsicum": {
-        "name": "chilipepper"
-    },
-    "caraway": {
-        "name": "karve"
-    },
-    "carrot": {
-        "name": "gulrot",
-        "plural_name": "gulrøtter"
-    },
-    "caster-sugar": {
-        "name": "finmalt sukker"
-    },
-    "castor-sugar": {
-        "name": "perlesukker"
-    },
-    "catfish": {
-        "name": "malle"
-    },
-    "cauliflower": {
-        "name": "blomkål",
-        "plural_name": "blomkål"
-    },
-    "cayenne-pepper": {
-        "name": "kayenne pepper"
-    },
-    "celeriac": {
-        "name": "sellerirot"
-    },
-    "celery": {
-        "name": "selleri"
-    },
-    "cereal-grains": {
-        "name": "frokostblandingkorn"
-    },
-    "chard": {
-        "name": "bladbete"
-    },
-    "cheese": {
-        "name": "ost"
-    },
-    "chicory": {
-        "name": "sikori"
-    },
-    "chilli-peppers": {
-        "name": "chilli Pepper",
-        "plural_name": "chilli pepper"
-    },
-    "chinese-leaves": {
-        "name": "kinakål"
-    },
-    "chives": {
-        "name": "gressløk"
-    },
-    "chocolate": {
-        "name": "sjokolade"
-    },
-    "cilantro": {
-        "name": "koriander"
-    },
-    "cinnamon": {
-        "name": "kanel"
-    },
-    "clarified-butter": {
-        "name": "klarnet smør"
-    },
-    "coconut": {
-        "name": "kokosnøtt",
-        "plural_name": "kokosnøtter"
-    },
-    "coconut-milk": {
-        "name": "kokosnøttmelk"
-    },
-    "cod": {
-        "name": "torsk"
-    },
-    "coffee": {
-        "name": "kaffe"
-    },
-    "collard-greens": {
-        "name": "grønnkål"
-    },
-    "confectioners-sugar": {
-        "name": "melis"
-    },
-    "coriander": {
-        "name": "koriander"
-    },
-    "corn": {
-        "name": "mais",
-        "plural_name": "mais"
-    },
-    "corn-syrup": {
-        "name": "maissirup"
-    },
-    "cottonseed-oil": {
-        "name": "bomullsfrøolje"
-    },
-    "courgette": {
-        "name": "squash"
-    },
-    "cream-of-tartar": {
-        "name": "krem av tartar"
-    },
-    "cucumber": {
-        "name": "agurk",
-        "plural_name": "agurker"
-    },
-    "cumin": {
-        "name": "spisskummen"
-    },
-    "daikon": {
-        "name": "daikon-reddik",
-        "plural_name": "daikons"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "meieriprodukter og melkeerstatninger"
-    },
-    "dandelion": {
-        "name": "løvetann"
-    },
-    "demerara-sugar": {
-        "name": "demerarasukker"
-    },
-    "dough": {
-        "name": "deig"
-    },
-    "edible-cactus": {
-        "name": "spisbar kaktus"
-    },
-    "eggplant": {
-        "name": "aubergine",
-        "plural_name": "auberginer"
-    },
-    "eggs": {
-        "name": "egg",
-        "plural_name": "egg"
-    },
-    "endive": {
-        "name": "endive",
-        "plural_name": "endives"
-    },
-    "fats": {
-        "name": "fett"
-    },
-    "fava-beans": {
-        "name": "favabønne"
-    },
-    "fiddlehead": {
-        "name": "bregne"
-    },
-    "fiddlehead-fern": {
-        "name": "strutseving",
-        "plural_name": "fiddlehead ferns"
-    },
-    "fish": {
-        "name": "fisk"
-    },
-    "five-spice-powder": {
-        "name": "fem krydderpulver"
-    },
-    "flour": {
-        "name": "mel"
-    },
-    "frisee": {
-        "name": "friséesalat"
-    },
-    "fructose": {
-        "name": "fruktose"
-    },
-    "fruit": {
-        "name": "frukt"
-    },
-    "fruit-sugar": {
-        "name": "fruktsukker"
-    },
-    "ful": {
-        "name": "full"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "hvitløk",
-        "plural_name": "hvitløker"
-    },
-    "gem-squash": {
-        "name": "gem squash"
-    },
-    "ghee": {
-        "name": "ghi"
-    },
-    "giblets": {
-        "name": "innmat av fugl"
-    },
-    "ginger": {
-        "name": "ingefær"
-    },
-    "grains": {
-        "name": "korn"
-    },
-    "granulated-sugar": {
-        "name": "strøsukker"
-    },
-    "grape-seed-oil": {
-        "name": "druekjerneolje"
-    },
-    "green-onion": {
-        "name": "vårløk",
-        "plural_name": "grønne løker"
-    },
-    "heart-of-palm": {
-        "name": "palmehjerte",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "hamp"
-    },
-    "herbs": {
-        "name": "urter"
-    },
-    "honey": {
-        "name": "honning"
-    },
-    "isomalt": {
-        "name": "isomalt"
-    },
-    "jackfruit": {
-        "name": "jackfrukt",
-        "plural_name": "jackfruits"
-    },
-    "jaggery": {
-        "name": "jaggery"
-    },
-    "jams": {
-        "name": "syltetøy"
-    },
-    "jellies": {
-        "name": "gele"
-    },
-    "jerusalem-artichoke": {
-        "name": "jordskokk"
-    },
-    "jicama": {
-        "name": "jicama"
-    },
-    "kale": {
-        "name": "kål"
-    },
-    "kohlrabi": {
-        "name": "kålrabi"
-    },
-    "kumara": {
-        "name": "søtpotet"
-    },
-    "leavening-agents": {
-        "name": "hevemiddel"
-    },
-    "leek": {
-        "name": "purre",
-        "plural_name": "purrer"
-    },
-    "legumes": {
-        "name": "belgvekster"
-    },
-    "lemongrass": {
-        "name": "sitrongress"
-    },
-    "lentils": {
-        "name": "linser"
-    },
-    "lettuce": {
-        "name": "salat"
-    },
-    "liver": {
-        "name": "lever",
-        "plural_name": "livers"
-    },
-    "maize": {
-        "name": "mais"
-    },
-    "maple-syrup": {
-        "name": "lønnesirup"
-    },
-    "meat": {
-        "name": "kjøtt"
-    },
-    "milk": {
-        "name": "melk"
-    },
-    "mortadella": {
-        "name": "mortadella"
-    },
-    "mushroom": {
-        "name": "sopp",
-        "plural_name": "sopper"
-    },
-    "mussels": {
-        "name": "blåskjell"
-    },
-    "nanaimo-bar-mix": {
-        "name": "nanaimo bardblanding"
-    },
-    "nori": {
-        "name": "nori"
-    },
-    "nutmeg": {
-        "name": "muskat"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "næringsgjær"
-    },
-    "nuts": {
-        "name": "nøtter"
-    },
-    "octopuses": {
-        "name": "blekksprut",
-        "plural_name": "octopuses"
-    },
-    "oils": {
-        "name": "oljer"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "oliven"
-    },
-    "olive-oil": {
-        "name": "oliven olje"
-    },
-    "onion": {
-        "name": "løk"
-    },
-    "onion-family": {
-        "name": "løkfamilien"
-    },
-    "orange-blossom-water": {
-        "name": "oransje blossom vann"
-    },
-    "oranges": {
-        "name": "appelsin",
-        "plural_name": "appelsiner"
-    },
-    "oregano": {
-        "name": "oregano"
-    },
-    "oysters": {
-        "name": "østers"
-    },
-    "panch-puran": {
-        "name": "panch phoron"
-    },
-    "paprika": {
-        "name": "paprikakrydder"
-    },
-    "parsley": {
-        "name": "persille"
-    },
-    "parsnip": {
-        "name": "pastinakk",
-        "plural_name": "parsnips"
-    },
-    "pear": {
-        "name": "pære",
-        "plural_name": "pærer"
-    },
-    "peas": {
-        "name": "erter"
-    },
-    "pepper": {
-        "name": "pepper",
-        "plural_name": "peppers"
-    },
-    "pineapple": {
-        "name": "ananas",
-        "plural_name": "ananaser"
-    },
-    "plantain": {
-        "name": "kokebanan",
-        "plural_name": "kokebananer"
-    },
-    "poppy-seeds": {
-        "name": "valmuefrø"
-    },
-    "potato": {
-        "name": "potet",
-        "plural_name": "poteter"
-    },
-    "poultry": {
-        "name": "fjærfe"
-    },
-    "powdered-sugar": {
-        "name": "melis"
-    },
-    "pumpkin": {
-        "name": "gresskar",
-        "plural_name": "gresskar"
-    },
-    "pumpkin-seeds": {
-        "name": "gresskarfrø"
-    },
-    "radish": {
-        "name": "reddik",
-        "plural_name": "reddiker"
-    },
-    "raw-sugar": {
-        "name": "brunt sukker"
-    },
-    "refined-sugar": {
-        "name": "raffinert sukker"
-    },
-    "rice": {
-        "name": "ris"
-    },
-    "rice-flour": {
-        "name": "rismel"
-    },
-    "rock-sugar": {
-        "name": "brunt sukker"
-    },
-    "rum": {
-        "name": "rom"
-    },
-    "salmon": {
-        "name": "laks"
-    },
-    "salt": {
-        "name": "salt"
-    },
-    "salt-cod": {
-        "name": "salt torsk"
-    },
-    "scallion": {
-        "name": "vårløk",
-        "plural_name": "scallions"
-    },
-    "seafood": {
-        "name": "sjømat"
-    },
-    "seeds": {
-        "name": "frø"
-    },
-    "sesame-seeds": {
-        "name": "sesamfrø"
-    },
-    "shallot": {
-        "name": "sjalottløk",
-        "plural_name": "shallots"
-    },
-    "skate": {
-        "name": "skate"
-    },
-    "soda": {
-        "name": "brus"
-    },
-    "soda-baking": {
-        "name": "natron"
-    },
-    "soybean": {
-        "name": "soyabønne"
-    },
-    "spaghetti-squash": {
-        "name": "spagetti squash",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "spekk"
-    },
-    "spices": {
-        "name": "krydder"
-    },
-    "spinach": {
-        "name": "spinat"
-    },
-    "spring-onion": {
-        "name": "vårløk",
-        "plural_name": "vårløker"
-    },
-    "squash": {
-        "name": "squash",
-        "plural_name": "squash"
-    },
-    "squash-family": {
-        "name": "squash familien"
-    },
-    "stockfish": {
-        "name": "tørrfisk"
-    },
-    "sugar": {
-        "name": "sukker"
-    },
-    "sunchoke": {
-        "name": "jordskokk",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "solsikkefrø"
-    },
-    "superfine-sugar": {
-        "name": "finkornet sukker"
-    },
-    "sweet-potato": {
-        "name": "søtpotet",
-        "plural_name": "søtpoteter"
-    },
-    "sweetcorn": {
-        "name": "sukkermais",
-        "plural_name": "sukkermais"
-    },
-    "sweeteners": {
-        "name": "søtningsmiddel"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "taro",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "teff"
-    },
-    "tomato": {
-        "name": "tomat",
-        "plural_name": "tomater"
-    },
-    "trout": {
-        "name": "ørret"
-    },
-    "tubers": {
-        "name": "knoll",
-        "plural_name": "tubers"
-    },
-    "tuna": {
-        "name": "tunfisk"
-    },
-    "turbanado-sugar": {
-        "name": "turbanado sukker"
-    },
-    "turnip": {
-        "name": "nepe",
-        "plural_name": "neper"
-    },
-    "unrefined-sugar": {
-        "name": "uraffinert sukker"
-    },
-    "vanilla": {
-        "name": "vanilje"
-    },
-    "vegetables": {
-        "name": "grønnsaker"
-    },
-    "watercress": {
-        "name": "brønnkarse"
-    },
-    "watermelon": {
-        "name": "vannmelon",
-        "plural_name": "vannmeloner"
-    },
-    "white-mushroom": {
-        "name": "sjampinjong",
-        "plural_name": "sjampinjonger"
-    },
-    "white-sugar": {
-        "name": "sukker"
-    },
-    "xanthan-gum": {
-        "name": "xanthan gum"
-    },
-    "yam": {
-        "name": "yams",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "gjær"
-    },
-    "zucchini": {
-        "name": "squash",
-        "plural_name": "zucchinis"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "pepper squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfaspirer"
+            },
+            "anchovies": {
+                "name": "ansjos"
+            },
+            "apples": {
+                "name": "eple",
+                "plural_name": "epler"
+            },
+            "artichoke": {
+                "name": "artisjokk"
+            },
+            "arugula": {
+                "name": "ruccola"
+            },
+            "asparagus": {
+                "name": "asparges"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avokadoer"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "bakepulver"
+            },
+            "baking-soda": {
+                "name": "natron"
+            },
+            "baking-sugar": {
+                "name": "melis"
+            },
+            "bar-sugar": {
+                "name": "bar-sukker"
+            },
+            "basil": {
+                "name": "basilikum"
+            },
+            "beans": {
+                "name": "bønner"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "paprikaer"
+            },
+            "blackberries": {
+                "name": "bjørnebær"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "brassicae"
+            },
+            "bread": {
+                "name": "brød"
+            },
+            "breadfruit": {
+                "name": "brødfrukt"
+            },
+            "broccoflower": {
+                "name": "blomkål"
+            },
+            "broccoli": {
+                "name": "brokkoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "brokkolini"
+            },
+            "brown-sugar": {
+                "name": "brunt sukker"
+            },
+            "brussels-sprouts": {
+                "name": "rosenkål"
+            },
+            "butter": {
+                "name": "smør"
+            },
+            "butternut-pumpkin": {
+                "name": "flaskegresskar"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "kål",
+                "plural_name": "kål"
+            },
+            "cactus-edible": {
+                "name": "kaktus, spiselig"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "rørsukker"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "chilipepper"
+            },
+            "caraway": {
+                "name": "karve"
+            },
+            "carrot": {
+                "name": "gulrot",
+                "plural_name": "gulrøtter"
+            },
+            "caster-sugar": {
+                "name": "finmalt sukker"
+            },
+            "castor-sugar": {
+                "name": "perlesukker"
+            },
+            "catfish": {
+                "name": "malle"
+            },
+            "cauliflower": {
+                "name": "blomkål",
+                "plural_name": "blomkål"
+            },
+            "cayenne-pepper": {
+                "name": "kayenne pepper"
+            },
+            "celeriac": {
+                "name": "sellerirot"
+            },
+            "celery": {
+                "name": "selleri"
+            },
+            "cereal-grains": {
+                "name": "frokostblandingkorn"
+            },
+            "chard": {
+                "name": "bladbete"
+            },
+            "cheese": {
+                "name": "ost"
+            },
+            "chicory": {
+                "name": "sikori"
+            },
+            "chilli-peppers": {
+                "name": "chilli Pepper",
+                "plural_name": "chilli pepper"
+            },
+            "chinese-leaves": {
+                "name": "kinakål"
+            },
+            "chives": {
+                "name": "gressløk"
+            },
+            "chocolate": {
+                "name": "sjokolade"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "kanel"
+            },
+            "clarified-butter": {
+                "name": "klarnet smør"
+            },
+            "coconut": {
+                "name": "kokosnøtt",
+                "plural_name": "kokosnøtter"
+            },
+            "coconut-milk": {
+                "name": "kokosnøttmelk"
+            },
+            "cod": {
+                "name": "torsk"
+            },
+            "coffee": {
+                "name": "kaffe"
+            },
+            "collard-greens": {
+                "name": "grønnkål"
+            },
+            "confectioners-sugar": {
+                "name": "melis"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "mais",
+                "plural_name": "mais"
+            },
+            "corn-syrup": {
+                "name": "maissirup"
+            },
+            "cottonseed-oil": {
+                "name": "bomullsfrøolje"
+            },
+            "courgette": {
+                "name": "squash"
+            },
+            "cream-of-tartar": {
+                "name": "krem av tartar"
+            },
+            "cucumber": {
+                "name": "agurk",
+                "plural_name": "agurker"
+            },
+            "cumin": {
+                "name": "spisskummen"
+            },
+            "daikon": {
+                "name": "daikon-reddik",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "meieriprodukter og melkeerstatninger"
+            },
+            "dandelion": {
+                "name": "løvetann"
+            },
+            "demerara-sugar": {
+                "name": "demerarasukker"
+            },
+            "dough": {
+                "name": "deig"
+            },
+            "edible-cactus": {
+                "name": "spisbar kaktus"
+            },
+            "eggplant": {
+                "name": "aubergine",
+                "plural_name": "auberginer"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "egg"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fett"
+            },
+            "fava-beans": {
+                "name": "favabønne"
+            },
+            "fiddlehead": {
+                "name": "bregne"
+            },
+            "fiddlehead-fern": {
+                "name": "strutseving",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fisk"
+            },
+            "five-spice-powder": {
+                "name": "fem krydderpulver"
+            },
+            "flour": {
+                "name": "mel"
+            },
+            "frisee": {
+                "name": "friséesalat"
+            },
+            "fructose": {
+                "name": "fruktose"
+            },
+            "fruit": {
+                "name": "frukt"
+            },
+            "fruit-sugar": {
+                "name": "fruktsukker"
+            },
+            "ful": {
+                "name": "full"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "hvitløk",
+                "plural_name": "hvitløker"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghi"
+            },
+            "giblets": {
+                "name": "innmat av fugl"
+            },
+            "ginger": {
+                "name": "ingefær"
+            },
+            "grains": {
+                "name": "korn"
+            },
+            "granulated-sugar": {
+                "name": "strøsukker"
+            },
+            "grape-seed-oil": {
+                "name": "druekjerneolje"
+            },
+            "green-onion": {
+                "name": "vårløk",
+                "plural_name": "grønne løker"
+            },
+            "heart-of-palm": {
+                "name": "palmehjerte",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hamp"
+            },
+            "herbs": {
+                "name": "urter"
+            },
+            "honey": {
+                "name": "honning"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfrukt",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "syltetøy"
+            },
+            "jellies": {
+                "name": "gele"
+            },
+            "jerusalem-artichoke": {
+                "name": "jordskokk"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kål"
+            },
+            "kohlrabi": {
+                "name": "kålrabi"
+            },
+            "kumara": {
+                "name": "søtpotet"
+            },
+            "leavening-agents": {
+                "name": "hevemiddel"
+            },
+            "leek": {
+                "name": "purre",
+                "plural_name": "purrer"
+            },
+            "legumes": {
+                "name": "belgvekster"
+            },
+            "lemongrass": {
+                "name": "sitrongress"
+            },
+            "lentils": {
+                "name": "linser"
+            },
+            "lettuce": {
+                "name": "salat"
+            },
+            "liver": {
+                "name": "lever",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "mais"
+            },
+            "maple-syrup": {
+                "name": "lønnesirup"
+            },
+            "meat": {
+                "name": "kjøtt"
+            },
+            "milk": {
+                "name": "melk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "sopp",
+                "plural_name": "sopper"
+            },
+            "mussels": {
+                "name": "blåskjell"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bardblanding"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muskat"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "næringsgjær"
+            },
+            "nuts": {
+                "name": "nøtter"
+            },
+            "octopuses": {
+                "name": "blekksprut",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oljer"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliven"
+            },
+            "olive-oil": {
+                "name": "oliven olje"
+            },
+            "onion": {
+                "name": "løk"
+            },
+            "onion-family": {
+                "name": "løkfamilien"
+            },
+            "orange-blossom-water": {
+                "name": "oransje blossom vann"
+            },
+            "oranges": {
+                "name": "appelsin",
+                "plural_name": "appelsiner"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "østers"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprikakrydder"
+            },
+            "parsley": {
+                "name": "persille"
+            },
+            "parsnip": {
+                "name": "pastinakk",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pære",
+                "plural_name": "pærer"
+            },
+            "peas": {
+                "name": "erter"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananaser"
+            },
+            "plantain": {
+                "name": "kokebanan",
+                "plural_name": "kokebananer"
+            },
+            "poppy-seeds": {
+                "name": "valmuefrø"
+            },
+            "potato": {
+                "name": "potet",
+                "plural_name": "poteter"
+            },
+            "poultry": {
+                "name": "fjærfe"
+            },
+            "powdered-sugar": {
+                "name": "melis"
+            },
+            "pumpkin": {
+                "name": "gresskar",
+                "plural_name": "gresskar"
+            },
+            "pumpkin-seeds": {
+                "name": "gresskarfrø"
+            },
+            "radish": {
+                "name": "reddik",
+                "plural_name": "reddiker"
+            },
+            "raw-sugar": {
+                "name": "brunt sukker"
+            },
+            "refined-sugar": {
+                "name": "raffinert sukker"
+            },
+            "rice": {
+                "name": "ris"
+            },
+            "rice-flour": {
+                "name": "rismel"
+            },
+            "rock-sugar": {
+                "name": "brunt sukker"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "laks"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt torsk"
+            },
+            "scallion": {
+                "name": "vårløk",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "sjømat"
+            },
+            "seeds": {
+                "name": "frø"
+            },
+            "sesame-seeds": {
+                "name": "sesamfrø"
+            },
+            "shallot": {
+                "name": "sjalottløk",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "brus"
+            },
+            "soda-baking": {
+                "name": "natron"
+            },
+            "soybean": {
+                "name": "soyabønne"
+            },
+            "spaghetti-squash": {
+                "name": "spagetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "spekk"
+            },
+            "spices": {
+                "name": "krydder"
+            },
+            "spinach": {
+                "name": "spinat"
+            },
+            "spring-onion": {
+                "name": "vårløk",
+                "plural_name": "vårløker"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squash"
+            },
+            "squash-family": {
+                "name": "squash familien"
+            },
+            "stockfish": {
+                "name": "tørrfisk"
+            },
+            "sugar": {
+                "name": "sukker"
+            },
+            "sunchoke": {
+                "name": "jordskokk",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "solsikkefrø"
+            },
+            "superfine-sugar": {
+                "name": "finkornet sukker"
+            },
+            "sweet-potato": {
+                "name": "søtpotet",
+                "plural_name": "søtpoteter"
+            },
+            "sweetcorn": {
+                "name": "sukkermais",
+                "plural_name": "sukkermais"
+            },
+            "sweeteners": {
+                "name": "søtningsmiddel"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomat",
+                "plural_name": "tomater"
+            },
+            "trout": {
+                "name": "ørret"
+            },
+            "tubers": {
+                "name": "knoll",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tunfisk"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sukker"
+            },
+            "turnip": {
+                "name": "nepe",
+                "plural_name": "neper"
+            },
+            "unrefined-sugar": {
+                "name": "uraffinert sukker"
+            },
+            "vanilla": {
+                "name": "vanilje"
+            },
+            "vegetables": {
+                "name": "grønnsaker"
+            },
+            "watercress": {
+                "name": "brønnkarse"
+            },
+            "watermelon": {
+                "name": "vannmelon",
+                "plural_name": "vannmeloner"
+            },
+            "white-mushroom": {
+                "name": "sjampinjong",
+                "plural_name": "sjampinjonger"
+            },
+            "white-sugar": {
+                "name": "sukker"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yams",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "gjær"
+            },
+            "zucchini": {
+                "name": "squash",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Jordbruksprodukt": {
+        "foods": {}
+    },
+    "Korn": {
+        "foods": {}
+    },
+    "Frukt": {
+        "foods": {}
+    },
+    "Grønnsaker": {
+        "foods": {}
+    },
+    "Kjøtt": {
+        "foods": {}
+    },
+    "Sjømat": {
+        "foods": {}
+    },
+    "Drikkevarer": {
+        "foods": {}
+    },
+    "Bakevarer": {
+        "foods": {}
+    },
+    "Hermetikk": {
+        "foods": {}
+    },
+    "Tilbehør": {
+        "foods": {}
+    },
+    "Konfekt": {
+        "foods": {}
+    },
+    "Meieriprodukter": {
+        "foods": {}
+    },
+    "Frossen mat": {
+        "foods": {}
+    },
+    "Helsekost": {
+        "foods": {}
+    },
+    "Husholdning": {
+        "foods": {}
+    },
+    "Kjøttprodukter": {
+        "foods": {}
+    },
+    "Snacks": {
+        "foods": {}
+    },
+    "Krydder": {
+        "foods": {}
+    },
+    "Søtsaker": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Annet": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/no-NO.json
+++ b/mealie/repos/seed/resources/foods/locales/no-NO.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "pepper squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfaspirer"
-	},
-	"anchovies": {
-		"name": "ansjos"
-	},
-	"apples": {
-		"name": "eple",
-		"plural_name": "epler"
-	},
-	"artichoke": {
-		"name": "artisjokk"
-	},
-	"arugula": {
-		"name": "ruccola"
-	},
-	"asparagus": {
-		"name": "asparges"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avokadoer"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "bakepulver"
-	},
-	"baking-soda": {
-		"name": "natron"
-	},
-	"baking-sugar": {
-		"name": "melis"
-	},
-	"bar-sugar": {
-		"name": "bar-sukker"
-	},
-	"basil": {
-		"name": "basilikum"
-	},
-	"beans": {
-		"name": "bønner"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "paprikaer"
-	},
-	"blackberries": {
-		"name": "bjørnebær"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "brassicae"
-	},
-	"bread": {
-		"name": "brød"
-	},
-	"breadfruit": {
-		"name": "brødfrukt"
-	},
-	"broccoflower": {
-		"name": "blomkål"
-	},
-	"broccoli": {
-		"name": "brokkoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "brokkolini"
-	},
-	"brown-sugar": {
-		"name": "brunt sukker"
-	},
-	"brussels-sprouts": {
-		"name": "rosenkål"
-	},
-	"butter": {
-		"name": "smør"
-	},
-	"butternut-pumpkin": {
-		"name": "flaskegresskar"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "kål",
-		"plural_name": "kål"
-	},
-	"cactus-edible": {
-		"name": "kaktus, spiselig"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "rørsukker"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "chilipepper"
-	},
-	"caraway": {
-		"name": "karve"
-	},
-	"carrot": {
-		"name": "gulrot",
-		"plural_name": "gulrøtter"
-	},
-	"caster-sugar": {
-		"name": "finmalt sukker"
-	},
-	"castor-sugar": {
-		"name": "perlesukker"
-	},
-	"catfish": {
-		"name": "malle"
-	},
-	"cauliflower": {
-		"name": "blomkål",
-		"plural_name": "blomkål"
-	},
-	"cayenne-pepper": {
-		"name": "kayenne pepper"
-	},
-	"celeriac": {
-		"name": "sellerirot"
-	},
-	"celery": {
-		"name": "selleri"
-	},
-	"cereal-grains": {
-		"name": "frokostblandingkorn"
-	},
-	"chard": {
-		"name": "bladbete"
-	},
-	"cheese": {
-		"name": "ost"
-	},
-	"chicory": {
-		"name": "sikori"
-	},
-	"chilli-peppers": {
-		"name": "chilli Pepper",
-		"plural_name": "chilli pepper"
-	},
-	"chinese-leaves": {
-		"name": "kinakål"
-	},
-	"chives": {
-		"name": "gressløk"
-	},
-	"chocolate": {
-		"name": "sjokolade"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "kanel"
-	},
-	"clarified-butter": {
-		"name": "klarnet smør"
-	},
-	"coconut": {
-		"name": "kokosnøtt",
-		"plural_name": "kokosnøtter"
-	},
-	"coconut-milk": {
-		"name": "kokosnøttmelk"
-	},
-	"cod": {
-		"name": "torsk"
-	},
-	"coffee": {
-		"name": "kaffe"
-	},
-	"collard-greens": {
-		"name": "grønnkål"
-	},
-	"confectioners-sugar": {
-		"name": "melis"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "mais",
-		"plural_name": "mais"
-	},
-	"corn-syrup": {
-		"name": "maissirup"
-	},
-	"cottonseed-oil": {
-		"name": "bomullsfrøolje"
-	},
-	"courgette": {
-		"name": "squash"
-	},
-	"cream-of-tartar": {
-		"name": "krem av tartar"
-	},
-	"cucumber": {
-		"name": "agurk",
-		"plural_name": "agurker"
-	},
-	"cumin": {
-		"name": "spisskummen"
-	},
-	"daikon": {
-		"name": "daikon-reddik",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "meieriprodukter og melkeerstatninger"
-	},
-	"dandelion": {
-		"name": "løvetann"
-	},
-	"demerara-sugar": {
-		"name": "demerarasukker"
-	},
-	"dough": {
-		"name": "deig"
-	},
-	"edible-cactus": {
-		"name": "spisbar kaktus"
-	},
-	"eggplant": {
-		"name": "aubergine",
-		"plural_name": "auberginer"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "egg"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fett"
-	},
-	"fava-beans": {
-		"name": "favabønne"
-	},
-	"fiddlehead": {
-		"name": "bregne"
-	},
-	"fiddlehead-fern": {
-		"name": "strutseving",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fisk"
-	},
-	"five-spice-powder": {
-		"name": "fem krydderpulver"
-	},
-	"flour": {
-		"name": "mel"
-	},
-	"frisee": {
-		"name": "friséesalat"
-	},
-	"fructose": {
-		"name": "fruktose"
-	},
-	"fruit": {
-		"name": "frukt"
-	},
-	"fruit-sugar": {
-		"name": "fruktsukker"
-	},
-	"ful": {
-		"name": "full"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "hvitløk",
-		"plural_name": "hvitløker"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghi"
-	},
-	"giblets": {
-		"name": "innmat av fugl"
-	},
-	"ginger": {
-		"name": "ingefær"
-	},
-	"grains": {
-		"name": "korn"
-	},
-	"granulated-sugar": {
-		"name": "strøsukker"
-	},
-	"grape-seed-oil": {
-		"name": "druekjerneolje"
-	},
-	"green-onion": {
-		"name": "vårløk",
-		"plural_name": "grønne løker"
-	},
-	"heart-of-palm": {
-		"name": "palmehjerte",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hamp"
-	},
-	"herbs": {
-		"name": "urter"
-	},
-	"honey": {
-		"name": "honning"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfrukt",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "syltetøy"
-	},
-	"jellies": {
-		"name": "gele"
-	},
-	"jerusalem-artichoke": {
-		"name": "jordskokk"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kål"
-	},
-	"kohlrabi": {
-		"name": "kålrabi"
-	},
-	"kumara": {
-		"name": "søtpotet"
-	},
-	"leavening-agents": {
-		"name": "hevemiddel"
-	},
-	"leek": {
-		"name": "purre",
-		"plural_name": "purrer"
-	},
-	"legumes": {
-		"name": "belgvekster"
-	},
-	"lemongrass": {
-		"name": "sitrongress"
-	},
-	"lentils": {
-		"name": "linser"
-	},
-	"lettuce": {
-		"name": "salat"
-	},
-	"liver": {
-		"name": "lever",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "mais"
-	},
-	"maple-syrup": {
-		"name": "lønnesirup"
-	},
-	"meat": {
-		"name": "kjøtt"
-	},
-	"milk": {
-		"name": "melk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "sopp",
-		"plural_name": "sopper"
-	},
-	"mussels": {
-		"name": "blåskjell"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bardblanding"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muskat"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "næringsgjær"
-	},
-	"nuts": {
-		"name": "nøtter"
-	},
-	"octopuses": {
-		"name": "blekksprut",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oljer"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliven"
-	},
-	"olive-oil": {
-		"name": "oliven olje"
-	},
-	"onion": {
-		"name": "løk"
-	},
-	"onion-family": {
-		"name": "løkfamilien"
-	},
-	"orange-blossom-water": {
-		"name": "oransje blossom vann"
-	},
-	"oranges": {
-		"name": "appelsin",
-		"plural_name": "appelsiner"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "østers"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprikakrydder"
-	},
-	"parsley": {
-		"name": "persille"
-	},
-	"parsnip": {
-		"name": "pastinakk",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pære",
-		"plural_name": "pærer"
-	},
-	"peas": {
-		"name": "erter"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananaser"
-	},
-	"plantain": {
-		"name": "kokebanan",
-		"plural_name": "kokebananer"
-	},
-	"poppy-seeds": {
-		"name": "valmuefrø"
-	},
-	"potato": {
-		"name": "potet",
-		"plural_name": "poteter"
-	},
-	"poultry": {
-		"name": "fjærfe"
-	},
-	"powdered-sugar": {
-		"name": "melis"
-	},
-	"pumpkin": {
-		"name": "gresskar",
-		"plural_name": "gresskar"
-	},
-	"pumpkin-seeds": {
-		"name": "gresskarfrø"
-	},
-	"radish": {
-		"name": "reddik",
-		"plural_name": "reddiker"
-	},
-	"raw-sugar": {
-		"name": "brunt sukker"
-	},
-	"refined-sugar": {
-		"name": "raffinert sukker"
-	},
-	"rice": {
-		"name": "ris"
-	},
-	"rice-flour": {
-		"name": "rismel"
-	},
-	"rock-sugar": {
-		"name": "brunt sukker"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "laks"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt torsk"
-	},
-	"scallion": {
-		"name": "vårløk",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "sjømat"
-	},
-	"seeds": {
-		"name": "frø"
-	},
-	"sesame-seeds": {
-		"name": "sesamfrø"
-	},
-	"shallot": {
-		"name": "sjalottløk",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "brus"
-	},
-	"soda-baking": {
-		"name": "natron"
-	},
-	"soybean": {
-		"name": "soyabønne"
-	},
-	"spaghetti-squash": {
-		"name": "spagetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "spekk"
-	},
-	"spices": {
-		"name": "krydder"
-	},
-	"spinach": {
-		"name": "spinat"
-	},
-	"spring-onion": {
-		"name": "vårløk",
-		"plural_name": "vårløker"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squash"
-	},
-	"squash-family": {
-		"name": "squash familien"
-	},
-	"stockfish": {
-		"name": "tørrfisk"
-	},
-	"sugar": {
-		"name": "sukker"
-	},
-	"sunchoke": {
-		"name": "jordskokk",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "solsikkefrø"
-	},
-	"superfine-sugar": {
-		"name": "finkornet sukker"
-	},
-	"sweet-potato": {
-		"name": "søtpotet",
-		"plural_name": "søtpoteter"
-	},
-	"sweetcorn": {
-		"name": "sukkermais",
-		"plural_name": "sukkermais"
-	},
-	"sweeteners": {
-		"name": "søtningsmiddel"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomat",
-		"plural_name": "tomater"
-	},
-	"trout": {
-		"name": "ørret"
-	},
-	"tubers": {
-		"name": "knoll",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tunfisk"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sukker"
-	},
-	"turnip": {
-		"name": "nepe",
-		"plural_name": "neper"
-	},
-	"unrefined-sugar": {
-		"name": "uraffinert sukker"
-	},
-	"vanilla": {
-		"name": "vanilje"
-	},
-	"vegetables": {
-		"name": "grønnsaker"
-	},
-	"watercress": {
-		"name": "brønnkarse"
-	},
-	"watermelon": {
-		"name": "vannmelon",
-		"plural_name": "vannmeloner"
-	},
-	"white-mushroom": {
-		"name": "sjampinjong",
-		"plural_name": "sjampinjonger"
-	},
-	"white-sugar": {
-		"name": "sukker"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yams",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "gjær"
-	},
-	"zucchini": {
-		"name": "squash",
-		"plural_name": "zucchinis"
-	}
+    "acorn-squash": {
+        "name": "pepper squash"
+    },
+    "alfalfa-sprouts": {
+        "name": "alfalfaspirer"
+    },
+    "anchovies": {
+        "name": "ansjos"
+    },
+    "apples": {
+        "name": "eple",
+        "plural_name": "epler"
+    },
+    "artichoke": {
+        "name": "artisjokk"
+    },
+    "arugula": {
+        "name": "ruccola"
+    },
+    "asparagus": {
+        "name": "asparges"
+    },
+    "avocado": {
+        "name": "avokado",
+        "plural_name": "avokadoer"
+    },
+    "bacon": {
+        "name": "bacon"
+    },
+    "baking-powder": {
+        "name": "bakepulver"
+    },
+    "baking-soda": {
+        "name": "natron"
+    },
+    "baking-sugar": {
+        "name": "melis"
+    },
+    "bar-sugar": {
+        "name": "bar-sukker"
+    },
+    "basil": {
+        "name": "basilikum"
+    },
+    "beans": {
+        "name": "bønner"
+    },
+    "bell-peppers": {
+        "name": "paprika",
+        "plural_name": "paprikaer"
+    },
+    "blackberries": {
+        "name": "bjørnebær"
+    },
+    "bok-choy": {
+        "name": "pak choi"
+    },
+    "brassicas": {
+        "name": "brassicae"
+    },
+    "bread": {
+        "name": "brød"
+    },
+    "breadfruit": {
+        "name": "brødfrukt"
+    },
+    "broccoflower": {
+        "name": "blomkål"
+    },
+    "broccoli": {
+        "name": "brokkoli"
+    },
+    "broccoli-rabe": {
+        "name": "rapini"
+    },
+    "broccolini": {
+        "name": "brokkolini"
+    },
+    "brown-sugar": {
+        "name": "brunt sukker"
+    },
+    "brussels-sprouts": {
+        "name": "rosenkål"
+    },
+    "butter": {
+        "name": "smør"
+    },
+    "butternut-pumpkin": {
+        "name": "flaskegresskar"
+    },
+    "butternut-squash": {
+        "name": "butternut squash"
+    },
+    "cabbage": {
+        "name": "kål",
+        "plural_name": "kål"
+    },
+    "cactus-edible": {
+        "name": "kaktus, spiselig"
+    },
+    "calabrese": {
+        "name": "calabrese"
+    },
+    "cane-sugar": {
+        "name": "rørsukker"
+    },
+    "cannabis": {
+        "name": "cannabis"
+    },
+    "capsicum": {
+        "name": "chilipepper"
+    },
+    "caraway": {
+        "name": "karve"
+    },
+    "carrot": {
+        "name": "gulrot",
+        "plural_name": "gulrøtter"
+    },
+    "caster-sugar": {
+        "name": "finmalt sukker"
+    },
+    "castor-sugar": {
+        "name": "perlesukker"
+    },
+    "catfish": {
+        "name": "malle"
+    },
+    "cauliflower": {
+        "name": "blomkål",
+        "plural_name": "blomkål"
+    },
+    "cayenne-pepper": {
+        "name": "kayenne pepper"
+    },
+    "celeriac": {
+        "name": "sellerirot"
+    },
+    "celery": {
+        "name": "selleri"
+    },
+    "cereal-grains": {
+        "name": "frokostblandingkorn"
+    },
+    "chard": {
+        "name": "bladbete"
+    },
+    "cheese": {
+        "name": "ost"
+    },
+    "chicory": {
+        "name": "sikori"
+    },
+    "chilli-peppers": {
+        "name": "chilli Pepper",
+        "plural_name": "chilli pepper"
+    },
+    "chinese-leaves": {
+        "name": "kinakål"
+    },
+    "chives": {
+        "name": "gressløk"
+    },
+    "chocolate": {
+        "name": "sjokolade"
+    },
+    "cilantro": {
+        "name": "koriander"
+    },
+    "cinnamon": {
+        "name": "kanel"
+    },
+    "clarified-butter": {
+        "name": "klarnet smør"
+    },
+    "coconut": {
+        "name": "kokosnøtt",
+        "plural_name": "kokosnøtter"
+    },
+    "coconut-milk": {
+        "name": "kokosnøttmelk"
+    },
+    "cod": {
+        "name": "torsk"
+    },
+    "coffee": {
+        "name": "kaffe"
+    },
+    "collard-greens": {
+        "name": "grønnkål"
+    },
+    "confectioners-sugar": {
+        "name": "melis"
+    },
+    "coriander": {
+        "name": "koriander"
+    },
+    "corn": {
+        "name": "mais",
+        "plural_name": "mais"
+    },
+    "corn-syrup": {
+        "name": "maissirup"
+    },
+    "cottonseed-oil": {
+        "name": "bomullsfrøolje"
+    },
+    "courgette": {
+        "name": "squash"
+    },
+    "cream-of-tartar": {
+        "name": "krem av tartar"
+    },
+    "cucumber": {
+        "name": "agurk",
+        "plural_name": "agurker"
+    },
+    "cumin": {
+        "name": "spisskummen"
+    },
+    "daikon": {
+        "name": "daikon-reddik",
+        "plural_name": "daikons"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "meieriprodukter og melkeerstatninger"
+    },
+    "dandelion": {
+        "name": "løvetann"
+    },
+    "demerara-sugar": {
+        "name": "demerarasukker"
+    },
+    "dough": {
+        "name": "deig"
+    },
+    "edible-cactus": {
+        "name": "spisbar kaktus"
+    },
+    "eggplant": {
+        "name": "aubergine",
+        "plural_name": "auberginer"
+    },
+    "eggs": {
+        "name": "egg",
+        "plural_name": "egg"
+    },
+    "endive": {
+        "name": "endive",
+        "plural_name": "endives"
+    },
+    "fats": {
+        "name": "fett"
+    },
+    "fava-beans": {
+        "name": "favabønne"
+    },
+    "fiddlehead": {
+        "name": "bregne"
+    },
+    "fiddlehead-fern": {
+        "name": "strutseving",
+        "plural_name": "fiddlehead ferns"
+    },
+    "fish": {
+        "name": "fisk"
+    },
+    "five-spice-powder": {
+        "name": "fem krydderpulver"
+    },
+    "flour": {
+        "name": "mel"
+    },
+    "frisee": {
+        "name": "friséesalat"
+    },
+    "fructose": {
+        "name": "fruktose"
+    },
+    "fruit": {
+        "name": "frukt"
+    },
+    "fruit-sugar": {
+        "name": "fruktsukker"
+    },
+    "ful": {
+        "name": "full"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "hvitløk",
+        "plural_name": "hvitløker"
+    },
+    "gem-squash": {
+        "name": "gem squash"
+    },
+    "ghee": {
+        "name": "ghi"
+    },
+    "giblets": {
+        "name": "innmat av fugl"
+    },
+    "ginger": {
+        "name": "ingefær"
+    },
+    "grains": {
+        "name": "korn"
+    },
+    "granulated-sugar": {
+        "name": "strøsukker"
+    },
+    "grape-seed-oil": {
+        "name": "druekjerneolje"
+    },
+    "green-onion": {
+        "name": "vårløk",
+        "plural_name": "grønne løker"
+    },
+    "heart-of-palm": {
+        "name": "palmehjerte",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "hamp"
+    },
+    "herbs": {
+        "name": "urter"
+    },
+    "honey": {
+        "name": "honning"
+    },
+    "isomalt": {
+        "name": "isomalt"
+    },
+    "jackfruit": {
+        "name": "jackfrukt",
+        "plural_name": "jackfruits"
+    },
+    "jaggery": {
+        "name": "jaggery"
+    },
+    "jams": {
+        "name": "syltetøy"
+    },
+    "jellies": {
+        "name": "gele"
+    },
+    "jerusalem-artichoke": {
+        "name": "jordskokk"
+    },
+    "jicama": {
+        "name": "jicama"
+    },
+    "kale": {
+        "name": "kål"
+    },
+    "kohlrabi": {
+        "name": "kålrabi"
+    },
+    "kumara": {
+        "name": "søtpotet"
+    },
+    "leavening-agents": {
+        "name": "hevemiddel"
+    },
+    "leek": {
+        "name": "purre",
+        "plural_name": "purrer"
+    },
+    "legumes": {
+        "name": "belgvekster"
+    },
+    "lemongrass": {
+        "name": "sitrongress"
+    },
+    "lentils": {
+        "name": "linser"
+    },
+    "lettuce": {
+        "name": "salat"
+    },
+    "liver": {
+        "name": "lever",
+        "plural_name": "livers"
+    },
+    "maize": {
+        "name": "mais"
+    },
+    "maple-syrup": {
+        "name": "lønnesirup"
+    },
+    "meat": {
+        "name": "kjøtt"
+    },
+    "milk": {
+        "name": "melk"
+    },
+    "mortadella": {
+        "name": "mortadella"
+    },
+    "mushroom": {
+        "name": "sopp",
+        "plural_name": "sopper"
+    },
+    "mussels": {
+        "name": "blåskjell"
+    },
+    "nanaimo-bar-mix": {
+        "name": "nanaimo bardblanding"
+    },
+    "nori": {
+        "name": "nori"
+    },
+    "nutmeg": {
+        "name": "muskat"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "næringsgjær"
+    },
+    "nuts": {
+        "name": "nøtter"
+    },
+    "octopuses": {
+        "name": "blekksprut",
+        "plural_name": "octopuses"
+    },
+    "oils": {
+        "name": "oljer"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "oliven"
+    },
+    "olive-oil": {
+        "name": "oliven olje"
+    },
+    "onion": {
+        "name": "løk"
+    },
+    "onion-family": {
+        "name": "løkfamilien"
+    },
+    "orange-blossom-water": {
+        "name": "oransje blossom vann"
+    },
+    "oranges": {
+        "name": "appelsin",
+        "plural_name": "appelsiner"
+    },
+    "oregano": {
+        "name": "oregano"
+    },
+    "oysters": {
+        "name": "østers"
+    },
+    "panch-puran": {
+        "name": "panch phoron"
+    },
+    "paprika": {
+        "name": "paprikakrydder"
+    },
+    "parsley": {
+        "name": "persille"
+    },
+    "parsnip": {
+        "name": "pastinakk",
+        "plural_name": "parsnips"
+    },
+    "pear": {
+        "name": "pære",
+        "plural_name": "pærer"
+    },
+    "peas": {
+        "name": "erter"
+    },
+    "pepper": {
+        "name": "pepper",
+        "plural_name": "peppers"
+    },
+    "pineapple": {
+        "name": "ananas",
+        "plural_name": "ananaser"
+    },
+    "plantain": {
+        "name": "kokebanan",
+        "plural_name": "kokebananer"
+    },
+    "poppy-seeds": {
+        "name": "valmuefrø"
+    },
+    "potato": {
+        "name": "potet",
+        "plural_name": "poteter"
+    },
+    "poultry": {
+        "name": "fjærfe"
+    },
+    "powdered-sugar": {
+        "name": "melis"
+    },
+    "pumpkin": {
+        "name": "gresskar",
+        "plural_name": "gresskar"
+    },
+    "pumpkin-seeds": {
+        "name": "gresskarfrø"
+    },
+    "radish": {
+        "name": "reddik",
+        "plural_name": "reddiker"
+    },
+    "raw-sugar": {
+        "name": "brunt sukker"
+    },
+    "refined-sugar": {
+        "name": "raffinert sukker"
+    },
+    "rice": {
+        "name": "ris"
+    },
+    "rice-flour": {
+        "name": "rismel"
+    },
+    "rock-sugar": {
+        "name": "brunt sukker"
+    },
+    "rum": {
+        "name": "rom"
+    },
+    "salmon": {
+        "name": "laks"
+    },
+    "salt": {
+        "name": "salt"
+    },
+    "salt-cod": {
+        "name": "salt torsk"
+    },
+    "scallion": {
+        "name": "vårløk",
+        "plural_name": "scallions"
+    },
+    "seafood": {
+        "name": "sjømat"
+    },
+    "seeds": {
+        "name": "frø"
+    },
+    "sesame-seeds": {
+        "name": "sesamfrø"
+    },
+    "shallot": {
+        "name": "sjalottløk",
+        "plural_name": "shallots"
+    },
+    "skate": {
+        "name": "skate"
+    },
+    "soda": {
+        "name": "brus"
+    },
+    "soda-baking": {
+        "name": "natron"
+    },
+    "soybean": {
+        "name": "soyabønne"
+    },
+    "spaghetti-squash": {
+        "name": "spagetti squash",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "spekk"
+    },
+    "spices": {
+        "name": "krydder"
+    },
+    "spinach": {
+        "name": "spinat"
+    },
+    "spring-onion": {
+        "name": "vårløk",
+        "plural_name": "vårløker"
+    },
+    "squash": {
+        "name": "squash",
+        "plural_name": "squash"
+    },
+    "squash-family": {
+        "name": "squash familien"
+    },
+    "stockfish": {
+        "name": "tørrfisk"
+    },
+    "sugar": {
+        "name": "sukker"
+    },
+    "sunchoke": {
+        "name": "jordskokk",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "solsikkefrø"
+    },
+    "superfine-sugar": {
+        "name": "finkornet sukker"
+    },
+    "sweet-potato": {
+        "name": "søtpotet",
+        "plural_name": "søtpoteter"
+    },
+    "sweetcorn": {
+        "name": "sukkermais",
+        "plural_name": "sukkermais"
+    },
+    "sweeteners": {
+        "name": "søtningsmiddel"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "taro",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "teff"
+    },
+    "tomato": {
+        "name": "tomat",
+        "plural_name": "tomater"
+    },
+    "trout": {
+        "name": "ørret"
+    },
+    "tubers": {
+        "name": "knoll",
+        "plural_name": "tubers"
+    },
+    "tuna": {
+        "name": "tunfisk"
+    },
+    "turbanado-sugar": {
+        "name": "turbanado sukker"
+    },
+    "turnip": {
+        "name": "nepe",
+        "plural_name": "neper"
+    },
+    "unrefined-sugar": {
+        "name": "uraffinert sukker"
+    },
+    "vanilla": {
+        "name": "vanilje"
+    },
+    "vegetables": {
+        "name": "grønnsaker"
+    },
+    "watercress": {
+        "name": "brønnkarse"
+    },
+    "watermelon": {
+        "name": "vannmelon",
+        "plural_name": "vannmeloner"
+    },
+    "white-mushroom": {
+        "name": "sjampinjong",
+        "plural_name": "sjampinjonger"
+    },
+    "white-sugar": {
+        "name": "sukker"
+    },
+    "xanthan-gum": {
+        "name": "xanthan gum"
+    },
+    "yam": {
+        "name": "yams",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "gjær"
+    },
+    "zucchini": {
+        "name": "squash",
+        "plural_name": "zucchinis"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/pl-PL.json
+++ b/mealie/repos/seed/resources/foods/locales/pl-PL.json
@@ -1,692 +1,756 @@
 {
-    "acorn-squash": {
-        "name": "dynia żołędziowa"
-    },
-    "alfalfa-sprouts": {
-        "name": "kiełki lucerny"
-    },
-    "anchovies": {
-        "name": "anchois"
-    },
-    "apples": {
-        "name": "jabłko",
-        "plural_name": "jabłka"
-    },
-    "artichoke": {
-        "name": "karczoch"
-    },
-    "arugula": {
-        "name": "rukola"
-    },
-    "asparagus": {
-        "name": "szparag"
-    },
-    "avocado": {
-        "name": "awokado",
-        "plural_name": "awokado"
-    },
-    "bacon": {
-        "name": "bekon"
-    },
-    "baking-powder": {
-        "name": "proszek do pieczenia"
-    },
-    "baking-soda": {
-        "name": "soda do pieczenia"
-    },
-    "baking-sugar": {
-        "name": "cukier do pieczenia"
-    },
-    "bar-sugar": {
-        "name": "cukier barowy"
-    },
-    "basil": {
-        "name": "bazylia"
-    },
-    "beans": {
-        "name": "fasola"
-    },
-    "bell-peppers": {
-        "name": "papryka",
-        "plural_name": "papryki"
-    },
-    "blackberries": {
-        "name": "jeżyna"
-    },
-    "bok-choy": {
-        "name": "pak choi"
-    },
-    "brassicas": {
-        "name": "kapusty"
-    },
-    "bread": {
-        "name": "chleb"
-    },
-    "breadfruit": {
-        "name": "chlebowiec"
-    },
-    "broccoflower": {
-        "name": "zielony kalafior"
-    },
-    "broccoli": {
-        "name": "brokuł"
-    },
-    "broccoli-rabe": {
-        "name": "rapini"
-    },
-    "broccolini": {
-        "name": "brokuły"
-    },
-    "brown-sugar": {
-        "name": "cukier brązowy"
-    },
-    "brussels-sprouts": {
-        "name": "brukselka"
-    },
-    "butter": {
-        "name": "masło"
-    },
-    "butternut-pumpkin": {
-        "name": "dynia piżmowa"
-    },
-    "butternut-squash": {
-        "name": "miąższ dyni piżmowej"
-    },
-    "cabbage": {
-        "name": "kapusta",
-        "plural_name": "kapusty"
-    },
-    "cactus-edible": {
-        "name": "kaktus, jadalny"
-    },
-    "calabrese": {
-        "name": "nero d'avola"
-    },
-    "cane-sugar": {
-        "name": "cukier trzcinowy"
-    },
-    "cannabis": {
-        "name": "konopia indyjska"
-    },
-    "capsicum": {
-        "name": "papryka roczna"
-    },
-    "caraway": {
-        "name": "kminek"
-    },
-    "carrot": {
-        "name": "marchew",
-        "plural_name": "marchewki"
-    },
-    "caster-sugar": {
-        "name": "cukier drobny"
-    },
-    "castor-sugar": {
-        "name": "cukier puder"
-    },
-    "catfish": {
-        "name": "sum"
-    },
-    "cauliflower": {
-        "name": "kalafior",
-        "plural_name": "kalafiory"
-    },
-    "cayenne-pepper": {
-        "name": "pieprz cayenne"
-    },
-    "celeriac": {
-        "name": "seler"
-    },
-    "celery": {
-        "name": "seler naciowy"
-    },
-    "cereal-grains": {
-        "name": "ziarna zbóż"
-    },
-    "chard": {
-        "name": "botwina"
-    },
-    "cheese": {
-        "name": "ser"
-    },
-    "chicory": {
-        "name": "cykoria"
-    },
-    "chilli-peppers": {
-        "name": "papryczka chilli",
-        "plural_name": "papryczki chilli"
-    },
-    "chinese-leaves": {
-        "name": "kapusta pekińska"
-    },
-    "chives": {
-        "name": "szczypiorek"
-    },
-    "chocolate": {
-        "name": "czekolada"
-    },
-    "cilantro": {
-        "name": "kolendra"
-    },
-    "cinnamon": {
-        "name": "cynamon"
-    },
-    "clarified-butter": {
-        "name": "masło klarowane"
-    },
-    "coconut": {
-        "name": "kokos",
-        "plural_name": "orzechy kokosowe"
-    },
-    "coconut-milk": {
-        "name": "mleko kokosowe"
-    },
-    "cod": {
-        "name": "dorsz"
-    },
-    "coffee": {
-        "name": "kawa"
-    },
-    "collard-greens": {
-        "name": "warzywa kapustne"
-    },
-    "confectioners-sugar": {
-        "name": "cukier cukierników"
-    },
-    "coriander": {
-        "name": "kolendra"
-    },
-    "corn": {
-        "name": "kukurydza",
-        "plural_name": "kukurydze"
-    },
-    "corn-syrup": {
-        "name": "syrop kukurydziany"
-    },
-    "cottonseed-oil": {
-        "name": "olej bawełniany"
-    },
-    "courgette": {
-        "name": "cukinia"
-    },
-    "cream-of-tartar": {
-        "name": "kwaśny winian potasu"
-    },
-    "cucumber": {
-        "name": "ogórek",
-        "plural_name": "ogórki"
-    },
-    "cumin": {
-        "name": "kminek"
-    },
-    "daikon": {
-        "name": "rzodkiew japońska",
-        "plural_name": "rzodkwie japońskie"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "przetwory i substytuty mleczne"
-    },
-    "dandelion": {
-        "name": "mniszek lekarski"
-    },
-    "demerara-sugar": {
-        "name": "cukier demerara"
-    },
-    "dough": {
-        "name": "ciasto"
-    },
-    "edible-cactus": {
-        "name": "kaktus jadalny"
-    },
-    "eggplant": {
-        "name": "bakłażan",
-        "plural_name": "bakłażany"
-    },
-    "eggs": {
-        "name": "jajka",
-        "plural_name": "jajka"
-    },
-    "endive": {
-        "name": "endywia",
-        "plural_name": "endywie"
-    },
-    "fats": {
-        "name": "tłuszcze"
-    },
-    "fava-beans": {
-        "name": "bób"
-    },
-    "fiddlehead": {
-        "name": "pędy paproci"
-    },
-    "fiddlehead-fern": {
-        "name": "pastorał paproci",
-        "plural_name": "fiddlehead ferns"
-    },
-    "fish": {
-        "name": "ryba"
-    },
-    "five-spice-powder": {
-        "name": "przyprawa pięciu smaków"
-    },
-    "flour": {
-        "name": "mąka"
-    },
-    "frisee": {
-        "name": "endywia kędzierzawa"
-    },
-    "fructose": {
-        "name": "fruktoza"
-    },
-    "fruit": {
-        "name": "owoc"
-    },
-    "fruit-sugar": {
-        "name": "cukier z owoców"
-    },
-    "ful": {
-        "name": "słonecznik bulwiasty"
-    },
-    "garam-masala": {
-        "name": "garam masala"
-    },
-    "garlic": {
-        "name": "czosnek",
-        "plural_name": "czosnki"
-    },
-    "gem-squash": {
-        "name": "dynia zielona"
-    },
-    "ghee": {
-        "name": "ghee"
-    },
-    "giblets": {
-        "name": "podroby"
-    },
-    "ginger": {
-        "name": "imbir"
-    },
-    "grains": {
-        "name": "zboże"
-    },
-    "granulated-sugar": {
-        "name": "cukier granulowany"
-    },
-    "grape-seed-oil": {
-        "name": "olej z nasion winogrona"
-    },
-    "green-onion": {
-        "name": "zielona cebula",
-        "plural_name": "zielone cebule"
-    },
-    "heart-of-palm": {
-        "name": "serce palmy",
-        "plural_name": "serca palm"
-    },
-    "hemp": {
-        "name": "konopia"
-    },
-    "herbs": {
-        "name": "zioła"
-    },
-    "honey": {
-        "name": "miód"
-    },
-    "isomalt": {
-        "name": "izomalt"
-    },
-    "jackfruit": {
-        "name": "chlebowiec różnolistny",
-        "plural_name": "jackfruits"
-    },
-    "jaggery": {
-        "name": "cukier trzcinowy"
-    },
-    "jams": {
-        "name": "dżemy"
-    },
-    "jellies": {
-        "name": "galaretki"
-    },
-    "jerusalem-artichoke": {
-        "name": "topinambur"
-    },
-    "jicama": {
-        "name": "kłębian kątowaty"
-    },
-    "kale": {
-        "name": "jarmuż"
-    },
-    "kohlrabi": {
-        "name": "kalarepa"
-    },
-    "kumara": {
-        "name": "kumara"
-    },
-    "leavening-agents": {
-        "name": "środki spulchniające"
-    },
-    "leek": {
-        "name": "por",
-        "plural_name": "pory"
-    },
-    "legumes": {
-        "name": "rośliny strączkowe"
-    },
-    "lemongrass": {
-        "name": "trawa cytrynowa"
-    },
-    "lentils": {
-        "name": "soczewica"
-    },
-    "lettuce": {
-        "name": "sałata"
-    },
-    "liver": {
-        "name": "wątróbka",
-        "plural_name": "wątróbki"
-    },
-    "maize": {
-        "name": "kukurydza"
-    },
-    "maple-syrup": {
-        "name": "syrop klonowy"
-    },
-    "meat": {
-        "name": "mięso"
-    },
-    "milk": {
-        "name": "mleko"
-    },
-    "mortadella": {
-        "name": "mortadela"
-    },
-    "mushroom": {
-        "name": "grzyb",
-        "plural_name": "grzyby"
-    },
-    "mussels": {
-        "name": "małże"
-    },
-    "nanaimo-bar-mix": {
-        "name": "mieszanka batoników nanaimo"
-    },
-    "nori": {
-        "name": "nori"
-    },
-    "nutmeg": {
-        "name": "gałka muszkatołowa"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "płatki drożdżowe"
-    },
-    "nuts": {
-        "name": "orzechy"
-    },
-    "octopuses": {
-        "name": "ośmiornica",
-        "plural_name": "ośmiornice"
-    },
-    "oils": {
-        "name": "oleje"
-    },
-    "okra": {
-        "name": "okra"
-    },
-    "olive": {
-        "name": "oliwa"
-    },
-    "olive-oil": {
-        "name": "oliwa z oliwek"
-    },
-    "onion": {
-        "name": "cebula"
-    },
-    "onion-family": {
-        "name": "rodzina cebul"
-    },
-    "orange-blossom-water": {
-        "name": "woda z kwiatu pomarańczy"
-    },
-    "oranges": {
-        "name": "pomarańcza",
-        "plural_name": "pomarańcze"
-    },
-    "oregano": {
-        "name": "oregano"
-    },
-    "oysters": {
-        "name": "ostrygi"
-    },
-    "panch-puran": {
-        "name": "panch phoron"
-    },
-    "paprika": {
-        "name": "papryka słodka"
-    },
-    "parsley": {
-        "name": "pietruszka"
-    },
-    "parsnip": {
-        "name": "pasternak",
-        "plural_name": "pasternaki"
-    },
-    "pear": {
-        "name": "gruszka",
-        "plural_name": "gruszki"
-    },
-    "peas": {
-        "name": "groszek"
-    },
-    "pepper": {
-        "name": "pieprz",
-        "plural_name": "pieprz"
-    },
-    "pineapple": {
-        "name": "ananas",
-        "plural_name": "ananasy"
-    },
-    "plantain": {
-        "name": "banan",
-        "plural_name": "banany"
-    },
-    "poppy-seeds": {
-        "name": "mak"
-    },
-    "potato": {
-        "name": "ziemniak",
-        "plural_name": "ziemniaki"
-    },
-    "poultry": {
-        "name": "drób"
-    },
-    "powdered-sugar": {
-        "name": "cukier w proszku"
-    },
-    "pumpkin": {
-        "name": "dynia",
-        "plural_name": "dynie"
-    },
-    "pumpkin-seeds": {
-        "name": "nasiona dyni"
-    },
-    "radish": {
-        "name": "rzodkiew",
-        "plural_name": "rzodkiewki"
-    },
-    "raw-sugar": {
-        "name": "cukier surowy"
-    },
-    "refined-sugar": {
-        "name": "cukier rafinowany"
-    },
-    "rice": {
-        "name": "ryż"
-    },
-    "rice-flour": {
-        "name": "mąka ryżowa"
-    },
-    "rock-sugar": {
-        "name": "kryształki cukru"
-    },
-    "rum": {
-        "name": "rum"
-    },
-    "salmon": {
-        "name": "łosoś"
-    },
-    "salt": {
-        "name": "sól"
-    },
-    "salt-cod": {
-        "name": "solony dorsz"
-    },
-    "scallion": {
-        "name": "cebula dymka",
-        "plural_name": "cebule dymnki"
-    },
-    "seafood": {
-        "name": "owoce morza"
-    },
-    "seeds": {
-        "name": "nasiona"
-    },
-    "sesame-seeds": {
-        "name": "ziarenka sezamu"
-    },
-    "shallot": {
-        "name": "szalotka",
-        "plural_name": "szalotki"
-    },
-    "skate": {
-        "name": "raja"
-    },
-    "soda": {
-        "name": "woda sodowa"
-    },
-    "soda-baking": {
-        "name": "soda do pieczenia"
-    },
-    "soybean": {
-        "name": "soja"
-    },
-    "spaghetti-squash": {
-        "name": "dynia makaronowa",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "boczek wędzony"
-    },
-    "spices": {
-        "name": "przyprawy"
-    },
-    "spinach": {
-        "name": "szpinak"
-    },
-    "spring-onion": {
-        "name": "zielona cebulka",
-        "plural_name": "zielone cebulki"
-    },
-    "squash": {
-        "name": "kabaczek",
-        "plural_name": "kabaczki"
-    },
-    "squash-family": {
-        "name": "dyniowate"
-    },
-    "stockfish": {
-        "name": "suszona ryba"
-    },
-    "sugar": {
-        "name": "cukier"
-    },
-    "sunchoke": {
-        "name": "słonecznik bulwiasty",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "nasiona słonecznika"
-    },
-    "superfine-sugar": {
-        "name": "bardzo drobny cukier"
-    },
-    "sweet-potato": {
-        "name": "batat",
-        "plural_name": "bataty"
-    },
-    "sweetcorn": {
-        "name": "kukurydza",
-        "plural_name": "kukurydze"
-    },
-    "sweeteners": {
-        "name": "słodziki"
-    },
-    "tahini": {
-        "name": "tahini"
-    },
-    "taro": {
-        "name": "kolokazja jadalna",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "miłka abisyńska"
-    },
-    "tomato": {
-        "name": "pomidor",
-        "plural_name": "pomidory"
-    },
-    "trout": {
-        "name": "pstrąg"
-    },
-    "tubers": {
-        "name": "bulwy",
-        "plural_name": "bulwy"
-    },
-    "tuna": {
-        "name": "tuńczyk"
-    },
-    "turbanado-sugar": {
-        "name": "cukier turbinado"
-    },
-    "turnip": {
-        "name": "rzepa",
-        "plural_name": "rzepy"
-    },
-    "unrefined-sugar": {
-        "name": "cukier nierafinowany"
-    },
-    "vanilla": {
-        "name": "wanilia"
-    },
-    "vegetables": {
-        "name": "warzywa"
-    },
-    "watercress": {
-        "name": "rukiew wodna"
-    },
-    "watermelon": {
-        "name": "arbuz",
-        "plural_name": "arbuzy"
-    },
-    "white-mushroom": {
-        "name": "pieczarki",
-        "plural_name": "białe pieczarki"
-    },
-    "white-sugar": {
-        "name": "cukier biały"
-    },
-    "xanthan-gum": {
-        "name": "guma ksantanowa"
-    },
-    "yam": {
-        "name": "pochrzyn",
-        "plural_name": "pochrzyny"
-    },
-    "yeast": {
-        "name": "drożdże"
-    },
-    "zucchini": {
-        "name": "cukinia",
-        "plural_name": "cukinie"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "dynia żołędziowa"
+            },
+            "alfalfa-sprouts": {
+                "name": "kiełki lucerny"
+            },
+            "anchovies": {
+                "name": "anchois"
+            },
+            "apples": {
+                "name": "jabłko",
+                "plural_name": "jabłka"
+            },
+            "artichoke": {
+                "name": "karczoch"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "szparag"
+            },
+            "avocado": {
+                "name": "awokado",
+                "plural_name": "awokado"
+            },
+            "bacon": {
+                "name": "bekon"
+            },
+            "baking-powder": {
+                "name": "proszek do pieczenia"
+            },
+            "baking-soda": {
+                "name": "soda do pieczenia"
+            },
+            "baking-sugar": {
+                "name": "cukier do pieczenia"
+            },
+            "bar-sugar": {
+                "name": "cukier barowy"
+            },
+            "basil": {
+                "name": "bazylia"
+            },
+            "beans": {
+                "name": "fasola"
+            },
+            "bell-peppers": {
+                "name": "papryka",
+                "plural_name": "papryki"
+            },
+            "blackberries": {
+                "name": "jeżyna"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "kapusty"
+            },
+            "bread": {
+                "name": "chleb"
+            },
+            "breadfruit": {
+                "name": "chlebowiec"
+            },
+            "broccoflower": {
+                "name": "zielony kalafior"
+            },
+            "broccoli": {
+                "name": "brokuł"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "brokuły"
+            },
+            "brown-sugar": {
+                "name": "cukier brązowy"
+            },
+            "brussels-sprouts": {
+                "name": "brukselka"
+            },
+            "butter": {
+                "name": "masło"
+            },
+            "butternut-pumpkin": {
+                "name": "dynia piżmowa"
+            },
+            "butternut-squash": {
+                "name": "miąższ dyni piżmowej"
+            },
+            "cabbage": {
+                "name": "kapusta",
+                "plural_name": "kapusty"
+            },
+            "cactus-edible": {
+                "name": "kaktus, jadalny"
+            },
+            "calabrese": {
+                "name": "nero d'avola"
+            },
+            "cane-sugar": {
+                "name": "cukier trzcinowy"
+            },
+            "cannabis": {
+                "name": "konopia indyjska"
+            },
+            "capsicum": {
+                "name": "papryka roczna"
+            },
+            "caraway": {
+                "name": "kminek"
+            },
+            "carrot": {
+                "name": "marchew",
+                "plural_name": "marchewki"
+            },
+            "caster-sugar": {
+                "name": "cukier drobny"
+            },
+            "castor-sugar": {
+                "name": "cukier puder"
+            },
+            "catfish": {
+                "name": "sum"
+            },
+            "cauliflower": {
+                "name": "kalafior",
+                "plural_name": "kalafiory"
+            },
+            "cayenne-pepper": {
+                "name": "pieprz cayenne"
+            },
+            "celeriac": {
+                "name": "seler"
+            },
+            "celery": {
+                "name": "seler naciowy"
+            },
+            "cereal-grains": {
+                "name": "ziarna zbóż"
+            },
+            "chard": {
+                "name": "botwina"
+            },
+            "cheese": {
+                "name": "ser"
+            },
+            "chicory": {
+                "name": "cykoria"
+            },
+            "chilli-peppers": {
+                "name": "papryczka chilli",
+                "plural_name": "papryczki chilli"
+            },
+            "chinese-leaves": {
+                "name": "kapusta pekińska"
+            },
+            "chives": {
+                "name": "szczypiorek"
+            },
+            "chocolate": {
+                "name": "czekolada"
+            },
+            "cilantro": {
+                "name": "kolendra"
+            },
+            "cinnamon": {
+                "name": "cynamon"
+            },
+            "clarified-butter": {
+                "name": "masło klarowane"
+            },
+            "coconut": {
+                "name": "kokos",
+                "plural_name": "orzechy kokosowe"
+            },
+            "coconut-milk": {
+                "name": "mleko kokosowe"
+            },
+            "cod": {
+                "name": "dorsz"
+            },
+            "coffee": {
+                "name": "kawa"
+            },
+            "collard-greens": {
+                "name": "warzywa kapustne"
+            },
+            "confectioners-sugar": {
+                "name": "cukier cukierników"
+            },
+            "coriander": {
+                "name": "kolendra"
+            },
+            "corn": {
+                "name": "kukurydza",
+                "plural_name": "kukurydze"
+            },
+            "corn-syrup": {
+                "name": "syrop kukurydziany"
+            },
+            "cottonseed-oil": {
+                "name": "olej bawełniany"
+            },
+            "courgette": {
+                "name": "cukinia"
+            },
+            "cream-of-tartar": {
+                "name": "kwaśny winian potasu"
+            },
+            "cucumber": {
+                "name": "ogórek",
+                "plural_name": "ogórki"
+            },
+            "cumin": {
+                "name": "kminek"
+            },
+            "daikon": {
+                "name": "rzodkiew japońska",
+                "plural_name": "rzodkwie japońskie"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "przetwory i substytuty mleczne"
+            },
+            "dandelion": {
+                "name": "mniszek lekarski"
+            },
+            "demerara-sugar": {
+                "name": "cukier demerara"
+            },
+            "dough": {
+                "name": "ciasto"
+            },
+            "edible-cactus": {
+                "name": "kaktus jadalny"
+            },
+            "eggplant": {
+                "name": "bakłażan",
+                "plural_name": "bakłażany"
+            },
+            "eggs": {
+                "name": "jajka",
+                "plural_name": "jajka"
+            },
+            "endive": {
+                "name": "endywia",
+                "plural_name": "endywie"
+            },
+            "fats": {
+                "name": "tłuszcze"
+            },
+            "fava-beans": {
+                "name": "bób"
+            },
+            "fiddlehead": {
+                "name": "pędy paproci"
+            },
+            "fiddlehead-fern": {
+                "name": "pastorał paproci",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "ryba"
+            },
+            "five-spice-powder": {
+                "name": "przyprawa pięciu smaków"
+            },
+            "flour": {
+                "name": "mąka"
+            },
+            "frisee": {
+                "name": "endywia kędzierzawa"
+            },
+            "fructose": {
+                "name": "fruktoza"
+            },
+            "fruit": {
+                "name": "owoc"
+            },
+            "fruit-sugar": {
+                "name": "cukier z owoców"
+            },
+            "ful": {
+                "name": "słonecznik bulwiasty"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "czosnek",
+                "plural_name": "czosnki"
+            },
+            "gem-squash": {
+                "name": "dynia zielona"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "podroby"
+            },
+            "ginger": {
+                "name": "imbir"
+            },
+            "grains": {
+                "name": "zboże"
+            },
+            "granulated-sugar": {
+                "name": "cukier granulowany"
+            },
+            "grape-seed-oil": {
+                "name": "olej z nasion winogrona"
+            },
+            "green-onion": {
+                "name": "zielona cebula",
+                "plural_name": "zielone cebule"
+            },
+            "heart-of-palm": {
+                "name": "serce palmy",
+                "plural_name": "serca palm"
+            },
+            "hemp": {
+                "name": "konopia"
+            },
+            "herbs": {
+                "name": "zioła"
+            },
+            "honey": {
+                "name": "miód"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "chlebowiec różnolistny",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "cukier trzcinowy"
+            },
+            "jams": {
+                "name": "dżemy"
+            },
+            "jellies": {
+                "name": "galaretki"
+            },
+            "jerusalem-artichoke": {
+                "name": "topinambur"
+            },
+            "jicama": {
+                "name": "kłębian kątowaty"
+            },
+            "kale": {
+                "name": "jarmuż"
+            },
+            "kohlrabi": {
+                "name": "kalarepa"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "środki spulchniające"
+            },
+            "leek": {
+                "name": "por",
+                "plural_name": "pory"
+            },
+            "legumes": {
+                "name": "rośliny strączkowe"
+            },
+            "lemongrass": {
+                "name": "trawa cytrynowa"
+            },
+            "lentils": {
+                "name": "soczewica"
+            },
+            "lettuce": {
+                "name": "sałata"
+            },
+            "liver": {
+                "name": "wątróbka",
+                "plural_name": "wątróbki"
+            },
+            "maize": {
+                "name": "kukurydza"
+            },
+            "maple-syrup": {
+                "name": "syrop klonowy"
+            },
+            "meat": {
+                "name": "mięso"
+            },
+            "milk": {
+                "name": "mleko"
+            },
+            "mortadella": {
+                "name": "mortadela"
+            },
+            "mushroom": {
+                "name": "grzyb",
+                "plural_name": "grzyby"
+            },
+            "mussels": {
+                "name": "małże"
+            },
+            "nanaimo-bar-mix": {
+                "name": "mieszanka batoników nanaimo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "gałka muszkatołowa"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "płatki drożdżowe"
+            },
+            "nuts": {
+                "name": "orzechy"
+            },
+            "octopuses": {
+                "name": "ośmiornica",
+                "plural_name": "ośmiornice"
+            },
+            "oils": {
+                "name": "oleje"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliwa"
+            },
+            "olive-oil": {
+                "name": "oliwa z oliwek"
+            },
+            "onion": {
+                "name": "cebula"
+            },
+            "onion-family": {
+                "name": "rodzina cebul"
+            },
+            "orange-blossom-water": {
+                "name": "woda z kwiatu pomarańczy"
+            },
+            "oranges": {
+                "name": "pomarańcza",
+                "plural_name": "pomarańcze"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "ostrygi"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "papryka słodka"
+            },
+            "parsley": {
+                "name": "pietruszka"
+            },
+            "parsnip": {
+                "name": "pasternak",
+                "plural_name": "pasternaki"
+            },
+            "pear": {
+                "name": "gruszka",
+                "plural_name": "gruszki"
+            },
+            "peas": {
+                "name": "groszek"
+            },
+            "pepper": {
+                "name": "pieprz",
+                "plural_name": "pieprz"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananasy"
+            },
+            "plantain": {
+                "name": "banan",
+                "plural_name": "banany"
+            },
+            "poppy-seeds": {
+                "name": "mak"
+            },
+            "potato": {
+                "name": "ziemniak",
+                "plural_name": "ziemniaki"
+            },
+            "poultry": {
+                "name": "drób"
+            },
+            "powdered-sugar": {
+                "name": "cukier w proszku"
+            },
+            "pumpkin": {
+                "name": "dynia",
+                "plural_name": "dynie"
+            },
+            "pumpkin-seeds": {
+                "name": "nasiona dyni"
+            },
+            "radish": {
+                "name": "rzodkiew",
+                "plural_name": "rzodkiewki"
+            },
+            "raw-sugar": {
+                "name": "cukier surowy"
+            },
+            "refined-sugar": {
+                "name": "cukier rafinowany"
+            },
+            "rice": {
+                "name": "ryż"
+            },
+            "rice-flour": {
+                "name": "mąka ryżowa"
+            },
+            "rock-sugar": {
+                "name": "kryształki cukru"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "łosoś"
+            },
+            "salt": {
+                "name": "sól"
+            },
+            "salt-cod": {
+                "name": "solony dorsz"
+            },
+            "scallion": {
+                "name": "cebula dymka",
+                "plural_name": "cebule dymnki"
+            },
+            "seafood": {
+                "name": "owoce morza"
+            },
+            "seeds": {
+                "name": "nasiona"
+            },
+            "sesame-seeds": {
+                "name": "ziarenka sezamu"
+            },
+            "shallot": {
+                "name": "szalotka",
+                "plural_name": "szalotki"
+            },
+            "skate": {
+                "name": "raja"
+            },
+            "soda": {
+                "name": "woda sodowa"
+            },
+            "soda-baking": {
+                "name": "soda do pieczenia"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "dynia makaronowa",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "boczek wędzony"
+            },
+            "spices": {
+                "name": "przyprawy"
+            },
+            "spinach": {
+                "name": "szpinak"
+            },
+            "spring-onion": {
+                "name": "zielona cebulka",
+                "plural_name": "zielone cebulki"
+            },
+            "squash": {
+                "name": "kabaczek",
+                "plural_name": "kabaczki"
+            },
+            "squash-family": {
+                "name": "dyniowate"
+            },
+            "stockfish": {
+                "name": "suszona ryba"
+            },
+            "sugar": {
+                "name": "cukier"
+            },
+            "sunchoke": {
+                "name": "słonecznik bulwiasty",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "nasiona słonecznika"
+            },
+            "superfine-sugar": {
+                "name": "bardzo drobny cukier"
+            },
+            "sweet-potato": {
+                "name": "batat",
+                "plural_name": "bataty"
+            },
+            "sweetcorn": {
+                "name": "kukurydza",
+                "plural_name": "kukurydze"
+            },
+            "sweeteners": {
+                "name": "słodziki"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "kolokazja jadalna",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "miłka abisyńska"
+            },
+            "tomato": {
+                "name": "pomidor",
+                "plural_name": "pomidory"
+            },
+            "trout": {
+                "name": "pstrąg"
+            },
+            "tubers": {
+                "name": "bulwy",
+                "plural_name": "bulwy"
+            },
+            "tuna": {
+                "name": "tuńczyk"
+            },
+            "turbanado-sugar": {
+                "name": "cukier turbinado"
+            },
+            "turnip": {
+                "name": "rzepa",
+                "plural_name": "rzepy"
+            },
+            "unrefined-sugar": {
+                "name": "cukier nierafinowany"
+            },
+            "vanilla": {
+                "name": "wanilia"
+            },
+            "vegetables": {
+                "name": "warzywa"
+            },
+            "watercress": {
+                "name": "rukiew wodna"
+            },
+            "watermelon": {
+                "name": "arbuz",
+                "plural_name": "arbuzy"
+            },
+            "white-mushroom": {
+                "name": "pieczarki",
+                "plural_name": "białe pieczarki"
+            },
+            "white-sugar": {
+                "name": "cukier biały"
+            },
+            "xanthan-gum": {
+                "name": "guma ksantanowa"
+            },
+            "yam": {
+                "name": "pochrzyn",
+                "plural_name": "pochrzyny"
+            },
+            "yeast": {
+                "name": "drożdże"
+            },
+            "zucchini": {
+                "name": "cukinia",
+                "plural_name": "cukinie"
+            }
+        }
+    },
+    "Wyroby": {
+        "foods": {}
+    },
+    "Ziarna": {
+        "foods": {}
+    },
+    "Owoce": {
+        "foods": {}
+    },
+    "Warzywa": {
+        "foods": {}
+    },
+    "Mięso": {
+        "foods": {}
+    },
+    "Owoce morza": {
+        "foods": {}
+    },
+    "Napoje": {
+        "foods": {}
+    },
+    "Wyroby piekarnicze": {
+        "foods": {}
+    },
+    "Wyroby puszkowe": {
+        "foods": {}
+    },
+    "Przyprawy": {
+        "foods": {}
+    },
+    "Wyroby cukiernicze": {
+        "foods": {}
+    },
+    "Nabiał": {
+        "foods": {}
+    },
+    "Mrożona żywność": {
+        "foods": {}
+    },
+    "Żywność zdrowotna": {
+        "foods": {}
+    },
+    "Wyroby gospodarstwa domowego": {
+        "foods": {}
+    },
+    "Produkty mięsne": {
+        "foods": {}
+    },
+    "Przekąski": {
+        "foods": {}
+    },
+    "Słodycze": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Inne": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/pl-PL.json
+++ b/mealie/repos/seed/resources/foods/locales/pl-PL.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "dynia żołędziowa"
-	},
-	"alfalfa-sprouts": {
-		"name": "kiełki lucerny"
-	},
-	"anchovies": {
-		"name": "anchois"
-	},
-	"apples": {
-		"name": "jabłko",
-		"plural_name": "jabłka"
-	},
-	"artichoke": {
-		"name": "karczoch"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "szparag"
-	},
-	"avocado": {
-		"name": "awokado",
-		"plural_name": "awokado"
-	},
-	"bacon": {
-		"name": "bekon"
-	},
-	"baking-powder": {
-		"name": "proszek do pieczenia"
-	},
-	"baking-soda": {
-		"name": "soda do pieczenia"
-	},
-	"baking-sugar": {
-		"name": "cukier do pieczenia"
-	},
-	"bar-sugar": {
-		"name": "cukier barowy"
-	},
-	"basil": {
-		"name": "bazylia"
-	},
-	"beans": {
-		"name": "fasola"
-	},
-	"bell-peppers": {
-		"name": "papryka",
-		"plural_name": "papryki"
-	},
-	"blackberries": {
-		"name": "jeżyna"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "kapusty"
-	},
-	"bread": {
-		"name": "chleb"
-	},
-	"breadfruit": {
-		"name": "chlebowiec"
-	},
-	"broccoflower": {
-		"name": "zielony kalafior"
-	},
-	"broccoli": {
-		"name": "brokuł"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "brokuły"
-	},
-	"brown-sugar": {
-		"name": "cukier brązowy"
-	},
-	"brussels-sprouts": {
-		"name": "brukselka"
-	},
-	"butter": {
-		"name": "masło"
-	},
-	"butternut-pumpkin": {
-		"name": "dynia piżmowa"
-	},
-	"butternut-squash": {
-		"name": "miąższ dyni piżmowej"
-	},
-	"cabbage": {
-		"name": "kapusta",
-		"plural_name": "kapusty"
-	},
-	"cactus-edible": {
-		"name": "kaktus, jadalny"
-	},
-	"calabrese": {
-		"name": "nero d'avola"
-	},
-	"cane-sugar": {
-		"name": "cukier trzcinowy"
-	},
-	"cannabis": {
-		"name": "konopia indyjska"
-	},
-	"capsicum": {
-		"name": "papryka roczna"
-	},
-	"caraway": {
-		"name": "kminek"
-	},
-	"carrot": {
-		"name": "marchew",
-		"plural_name": "marchewki"
-	},
-	"caster-sugar": {
-		"name": "cukier drobny"
-	},
-	"castor-sugar": {
-		"name": "cukier puder"
-	},
-	"catfish": {
-		"name": "sum"
-	},
-	"cauliflower": {
-		"name": "kalafior",
-		"plural_name": "kalafiory"
-	},
-	"cayenne-pepper": {
-		"name": "pieprz cayenne"
-	},
-	"celeriac": {
-		"name": "seler"
-	},
-	"celery": {
-		"name": "seler naciowy"
-	},
-	"cereal-grains": {
-		"name": "ziarna zbóż"
-	},
-	"chard": {
-		"name": "botwina"
-	},
-	"cheese": {
-		"name": "ser"
-	},
-	"chicory": {
-		"name": "cykoria"
-	},
-	"chilli-peppers": {
-		"name": "papryczka chilli",
-		"plural_name": "papryczki chilli"
-	},
-	"chinese-leaves": {
-		"name": "kapusta pekińska"
-	},
-	"chives": {
-		"name": "szczypiorek"
-	},
-	"chocolate": {
-		"name": "czekolada"
-	},
-	"cilantro": {
-		"name": "kolendra"
-	},
-	"cinnamon": {
-		"name": "cynamon"
-	},
-	"clarified-butter": {
-		"name": "masło klarowane"
-	},
-	"coconut": {
-		"name": "kokos",
-		"plural_name": "orzechy kokosowe"
-	},
-	"coconut-milk": {
-		"name": "mleko kokosowe"
-	},
-	"cod": {
-		"name": "dorsz"
-	},
-	"coffee": {
-		"name": "kawa"
-	},
-	"collard-greens": {
-		"name": "warzywa kapustne"
-	},
-	"confectioners-sugar": {
-		"name": "cukier cukierników"
-	},
-	"coriander": {
-		"name": "kolendra"
-	},
-	"corn": {
-		"name": "kukurydza",
-		"plural_name": "kukurydze"
-	},
-	"corn-syrup": {
-		"name": "syrop kukurydziany"
-	},
-	"cottonseed-oil": {
-		"name": "olej bawełniany"
-	},
-	"courgette": {
-		"name": "cukinia"
-	},
-	"cream-of-tartar": {
-		"name": "kwaśny winian potasu"
-	},
-	"cucumber": {
-		"name": "ogórek",
-		"plural_name": "ogórki"
-	},
-	"cumin": {
-		"name": "kminek"
-	},
-	"daikon": {
-		"name": "rzodkiew japońska",
-		"plural_name": "rzodkwie japońskie"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "przetwory i substytuty mleczne"
-	},
-	"dandelion": {
-		"name": "mniszek lekarski"
-	},
-	"demerara-sugar": {
-		"name": "cukier demerara"
-	},
-	"dough": {
-		"name": "ciasto"
-	},
-	"edible-cactus": {
-		"name": "kaktus jadalny"
-	},
-	"eggplant": {
-		"name": "bakłażan",
-		"plural_name": "bakłażany"
-	},
-	"eggs": {
-		"name": "jajka",
-		"plural_name": "jajka"
-	},
-	"endive": {
-		"name": "endywia",
-		"plural_name": "endywie"
-	},
-	"fats": {
-		"name": "tłuszcze"
-	},
-	"fava-beans": {
-		"name": "bób"
-	},
-	"fiddlehead": {
-		"name": "pędy paproci"
-	},
-	"fiddlehead-fern": {
-		"name": "pastorał paproci",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "ryba"
-	},
-	"five-spice-powder": {
-		"name": "przyprawa pięciu smaków"
-	},
-	"flour": {
-		"name": "mąka"
-	},
-	"frisee": {
-		"name": "endywia kędzierzawa"
-	},
-	"fructose": {
-		"name": "fruktoza"
-	},
-	"fruit": {
-		"name": "owoc"
-	},
-	"fruit-sugar": {
-		"name": "cukier z owoców"
-	},
-	"ful": {
-		"name": "słonecznik bulwiasty"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "czosnek",
-		"plural_name": "czosnki"
-	},
-	"gem-squash": {
-		"name": "dynia zielona"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "podroby"
-	},
-	"ginger": {
-		"name": "imbir"
-	},
-	"grains": {
-		"name": "zboże"
-	},
-	"granulated-sugar": {
-		"name": "cukier granulowany"
-	},
-	"grape-seed-oil": {
-		"name": "olej z nasion winogrona"
-	},
-	"green-onion": {
-		"name": "zielona cebula",
-		"plural_name": "zielone cebule"
-	},
-	"heart-of-palm": {
-		"name": "serce palmy",
-		"plural_name": "serca palm"
-	},
-	"hemp": {
-		"name": "konopia"
-	},
-	"herbs": {
-		"name": "zioła"
-	},
-	"honey": {
-		"name": "miód"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "chlebowiec różnolistny",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "cukier trzcinowy"
-	},
-	"jams": {
-		"name": "dżemy"
-	},
-	"jellies": {
-		"name": "galaretki"
-	},
-	"jerusalem-artichoke": {
-		"name": "topinambur"
-	},
-	"jicama": {
-		"name": "kłębian kątowaty"
-	},
-	"kale": {
-		"name": "jarmuż"
-	},
-	"kohlrabi": {
-		"name": "kalarepa"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "środki spulchniające"
-	},
-	"leek": {
-		"name": "por",
-		"plural_name": "pory"
-	},
-	"legumes": {
-		"name": "rośliny strączkowe"
-	},
-	"lemongrass": {
-		"name": "trawa cytrynowa"
-	},
-	"lentils": {
-		"name": "soczewica"
-	},
-	"lettuce": {
-		"name": "sałata"
-	},
-	"liver": {
-		"name": "wątróbka",
-		"plural_name": "wątróbki"
-	},
-	"maize": {
-		"name": "kukurydza"
-	},
-	"maple-syrup": {
-		"name": "syrop klonowy"
-	},
-	"meat": {
-		"name": "mięso"
-	},
-	"milk": {
-		"name": "mleko"
-	},
-	"mortadella": {
-		"name": "mortadela"
-	},
-	"mushroom": {
-		"name": "grzyb",
-		"plural_name": "grzyby"
-	},
-	"mussels": {
-		"name": "małże"
-	},
-	"nanaimo-bar-mix": {
-		"name": "mieszanka batoników nanaimo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "gałka muszkatołowa"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "płatki drożdżowe"
-	},
-	"nuts": {
-		"name": "orzechy"
-	},
-	"octopuses": {
-		"name": "ośmiornica",
-		"plural_name": "ośmiornice"
-	},
-	"oils": {
-		"name": "oleje"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliwa"
-	},
-	"olive-oil": {
-		"name": "oliwa z oliwek"
-	},
-	"onion": {
-		"name": "cebula"
-	},
-	"onion-family": {
-		"name": "rodzina cebul"
-	},
-	"orange-blossom-water": {
-		"name": "woda z kwiatu pomarańczy"
-	},
-	"oranges": {
-		"name": "pomarańcza",
-		"plural_name": "pomarańcze"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "ostrygi"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "papryka słodka"
-	},
-	"parsley": {
-		"name": "pietruszka"
-	},
-	"parsnip": {
-		"name": "pasternak",
-		"plural_name": "pasternaki"
-	},
-	"pear": {
-		"name": "gruszka",
-		"plural_name": "gruszki"
-	},
-	"peas": {
-		"name": "groszek"
-	},
-	"pepper": {
-		"name": "pieprz",
-		"plural_name": "pieprz"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananasy"
-	},
-	"plantain": {
-		"name": "banan",
-		"plural_name": "banany"
-	},
-	"poppy-seeds": {
-		"name": "mak"
-	},
-	"potato": {
-		"name": "ziemniak",
-		"plural_name": "ziemniaki"
-	},
-	"poultry": {
-		"name": "drób"
-	},
-	"powdered-sugar": {
-		"name": "cukier w proszku"
-	},
-	"pumpkin": {
-		"name": "dynia",
-		"plural_name": "dynie"
-	},
-	"pumpkin-seeds": {
-		"name": "nasiona dyni"
-	},
-	"radish": {
-		"name": "rzodkiew",
-		"plural_name": "rzodkiewki"
-	},
-	"raw-sugar": {
-		"name": "cukier surowy"
-	},
-	"refined-sugar": {
-		"name": "cukier rafinowany"
-	},
-	"rice": {
-		"name": "ryż"
-	},
-	"rice-flour": {
-		"name": "mąka ryżowa"
-	},
-	"rock-sugar": {
-		"name": "kryształki cukru"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "łosoś"
-	},
-	"salt": {
-		"name": "sól"
-	},
-	"salt-cod": {
-		"name": "solony dorsz"
-	},
-	"scallion": {
-		"name": "cebula dymka",
-		"plural_name": "cebule dymnki"
-	},
-	"seafood": {
-		"name": "owoce morza"
-	},
-	"seeds": {
-		"name": "nasiona"
-	},
-	"sesame-seeds": {
-		"name": "ziarenka sezamu"
-	},
-	"shallot": {
-		"name": "szalotka",
-		"plural_name": "szalotki"
-	},
-	"skate": {
-		"name": "raja"
-	},
-	"soda": {
-		"name": "woda sodowa"
-	},
-	"soda-baking": {
-		"name": "soda do pieczenia"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "dynia makaronowa",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "boczek wędzony"
-	},
-	"spices": {
-		"name": "przyprawy"
-	},
-	"spinach": {
-		"name": "szpinak"
-	},
-	"spring-onion": {
-		"name": "zielona cebulka",
-		"plural_name": "zielone cebulki"
-	},
-	"squash": {
-		"name": "kabaczek",
-		"plural_name": "kabaczki"
-	},
-	"squash-family": {
-		"name": "dyniowate"
-	},
-	"stockfish": {
-		"name": "suszona ryba"
-	},
-	"sugar": {
-		"name": "cukier"
-	},
-	"sunchoke": {
-		"name": "słonecznik bulwiasty",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "nasiona słonecznika"
-	},
-	"superfine-sugar": {
-		"name": "bardzo drobny cukier"
-	},
-	"sweet-potato": {
-		"name": "batat",
-		"plural_name": "bataty"
-	},
-	"sweetcorn": {
-		"name": "kukurydza",
-		"plural_name": "kukurydze"
-	},
-	"sweeteners": {
-		"name": "słodziki"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "kolokazja jadalna",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "miłka abisyńska"
-	},
-	"tomato": {
-		"name": "pomidor",
-		"plural_name": "pomidory"
-	},
-	"trout": {
-		"name": "pstrąg"
-	},
-	"tubers": {
-		"name": "bulwy",
-		"plural_name": "bulwy"
-	},
-	"tuna": {
-		"name": "tuńczyk"
-	},
-	"turbanado-sugar": {
-		"name": "cukier turbinado"
-	},
-	"turnip": {
-		"name": "rzepa",
-		"plural_name": "rzepy"
-	},
-	"unrefined-sugar": {
-		"name": "cukier nierafinowany"
-	},
-	"vanilla": {
-		"name": "wanilia"
-	},
-	"vegetables": {
-		"name": "warzywa"
-	},
-	"watercress": {
-		"name": "rukiew wodna"
-	},
-	"watermelon": {
-		"name": "arbuz",
-		"plural_name": "arbuzy"
-	},
-	"white-mushroom": {
-		"name": "pieczarki",
-		"plural_name": "białe pieczarki"
-	},
-	"white-sugar": {
-		"name": "cukier biały"
-	},
-	"xanthan-gum": {
-		"name": "guma ksantanowa"
-	},
-	"yam": {
-		"name": "pochrzyn",
-		"plural_name": "pochrzyny"
-	},
-	"yeast": {
-		"name": "drożdże"
-	},
-	"zucchini": {
-		"name": "cukinia",
-		"plural_name": "cukinie"
-	}
+    "acorn-squash": {
+        "name": "dynia żołędziowa"
+    },
+    "alfalfa-sprouts": {
+        "name": "kiełki lucerny"
+    },
+    "anchovies": {
+        "name": "anchois"
+    },
+    "apples": {
+        "name": "jabłko",
+        "plural_name": "jabłka"
+    },
+    "artichoke": {
+        "name": "karczoch"
+    },
+    "arugula": {
+        "name": "rukola"
+    },
+    "asparagus": {
+        "name": "szparag"
+    },
+    "avocado": {
+        "name": "awokado",
+        "plural_name": "awokado"
+    },
+    "bacon": {
+        "name": "bekon"
+    },
+    "baking-powder": {
+        "name": "proszek do pieczenia"
+    },
+    "baking-soda": {
+        "name": "soda do pieczenia"
+    },
+    "baking-sugar": {
+        "name": "cukier do pieczenia"
+    },
+    "bar-sugar": {
+        "name": "cukier barowy"
+    },
+    "basil": {
+        "name": "bazylia"
+    },
+    "beans": {
+        "name": "fasola"
+    },
+    "bell-peppers": {
+        "name": "papryka",
+        "plural_name": "papryki"
+    },
+    "blackberries": {
+        "name": "jeżyna"
+    },
+    "bok-choy": {
+        "name": "pak choi"
+    },
+    "brassicas": {
+        "name": "kapusty"
+    },
+    "bread": {
+        "name": "chleb"
+    },
+    "breadfruit": {
+        "name": "chlebowiec"
+    },
+    "broccoflower": {
+        "name": "zielony kalafior"
+    },
+    "broccoli": {
+        "name": "brokuł"
+    },
+    "broccoli-rabe": {
+        "name": "rapini"
+    },
+    "broccolini": {
+        "name": "brokuły"
+    },
+    "brown-sugar": {
+        "name": "cukier brązowy"
+    },
+    "brussels-sprouts": {
+        "name": "brukselka"
+    },
+    "butter": {
+        "name": "masło"
+    },
+    "butternut-pumpkin": {
+        "name": "dynia piżmowa"
+    },
+    "butternut-squash": {
+        "name": "miąższ dyni piżmowej"
+    },
+    "cabbage": {
+        "name": "kapusta",
+        "plural_name": "kapusty"
+    },
+    "cactus-edible": {
+        "name": "kaktus, jadalny"
+    },
+    "calabrese": {
+        "name": "nero d'avola"
+    },
+    "cane-sugar": {
+        "name": "cukier trzcinowy"
+    },
+    "cannabis": {
+        "name": "konopia indyjska"
+    },
+    "capsicum": {
+        "name": "papryka roczna"
+    },
+    "caraway": {
+        "name": "kminek"
+    },
+    "carrot": {
+        "name": "marchew",
+        "plural_name": "marchewki"
+    },
+    "caster-sugar": {
+        "name": "cukier drobny"
+    },
+    "castor-sugar": {
+        "name": "cukier puder"
+    },
+    "catfish": {
+        "name": "sum"
+    },
+    "cauliflower": {
+        "name": "kalafior",
+        "plural_name": "kalafiory"
+    },
+    "cayenne-pepper": {
+        "name": "pieprz cayenne"
+    },
+    "celeriac": {
+        "name": "seler"
+    },
+    "celery": {
+        "name": "seler naciowy"
+    },
+    "cereal-grains": {
+        "name": "ziarna zbóż"
+    },
+    "chard": {
+        "name": "botwina"
+    },
+    "cheese": {
+        "name": "ser"
+    },
+    "chicory": {
+        "name": "cykoria"
+    },
+    "chilli-peppers": {
+        "name": "papryczka chilli",
+        "plural_name": "papryczki chilli"
+    },
+    "chinese-leaves": {
+        "name": "kapusta pekińska"
+    },
+    "chives": {
+        "name": "szczypiorek"
+    },
+    "chocolate": {
+        "name": "czekolada"
+    },
+    "cilantro": {
+        "name": "kolendra"
+    },
+    "cinnamon": {
+        "name": "cynamon"
+    },
+    "clarified-butter": {
+        "name": "masło klarowane"
+    },
+    "coconut": {
+        "name": "kokos",
+        "plural_name": "orzechy kokosowe"
+    },
+    "coconut-milk": {
+        "name": "mleko kokosowe"
+    },
+    "cod": {
+        "name": "dorsz"
+    },
+    "coffee": {
+        "name": "kawa"
+    },
+    "collard-greens": {
+        "name": "warzywa kapustne"
+    },
+    "confectioners-sugar": {
+        "name": "cukier cukierników"
+    },
+    "coriander": {
+        "name": "kolendra"
+    },
+    "corn": {
+        "name": "kukurydza",
+        "plural_name": "kukurydze"
+    },
+    "corn-syrup": {
+        "name": "syrop kukurydziany"
+    },
+    "cottonseed-oil": {
+        "name": "olej bawełniany"
+    },
+    "courgette": {
+        "name": "cukinia"
+    },
+    "cream-of-tartar": {
+        "name": "kwaśny winian potasu"
+    },
+    "cucumber": {
+        "name": "ogórek",
+        "plural_name": "ogórki"
+    },
+    "cumin": {
+        "name": "kminek"
+    },
+    "daikon": {
+        "name": "rzodkiew japońska",
+        "plural_name": "rzodkwie japońskie"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "przetwory i substytuty mleczne"
+    },
+    "dandelion": {
+        "name": "mniszek lekarski"
+    },
+    "demerara-sugar": {
+        "name": "cukier demerara"
+    },
+    "dough": {
+        "name": "ciasto"
+    },
+    "edible-cactus": {
+        "name": "kaktus jadalny"
+    },
+    "eggplant": {
+        "name": "bakłażan",
+        "plural_name": "bakłażany"
+    },
+    "eggs": {
+        "name": "jajka",
+        "plural_name": "jajka"
+    },
+    "endive": {
+        "name": "endywia",
+        "plural_name": "endywie"
+    },
+    "fats": {
+        "name": "tłuszcze"
+    },
+    "fava-beans": {
+        "name": "bób"
+    },
+    "fiddlehead": {
+        "name": "pędy paproci"
+    },
+    "fiddlehead-fern": {
+        "name": "pastorał paproci",
+        "plural_name": "fiddlehead ferns"
+    },
+    "fish": {
+        "name": "ryba"
+    },
+    "five-spice-powder": {
+        "name": "przyprawa pięciu smaków"
+    },
+    "flour": {
+        "name": "mąka"
+    },
+    "frisee": {
+        "name": "endywia kędzierzawa"
+    },
+    "fructose": {
+        "name": "fruktoza"
+    },
+    "fruit": {
+        "name": "owoc"
+    },
+    "fruit-sugar": {
+        "name": "cukier z owoców"
+    },
+    "ful": {
+        "name": "słonecznik bulwiasty"
+    },
+    "garam-masala": {
+        "name": "garam masala"
+    },
+    "garlic": {
+        "name": "czosnek",
+        "plural_name": "czosnki"
+    },
+    "gem-squash": {
+        "name": "dynia zielona"
+    },
+    "ghee": {
+        "name": "ghee"
+    },
+    "giblets": {
+        "name": "podroby"
+    },
+    "ginger": {
+        "name": "imbir"
+    },
+    "grains": {
+        "name": "zboże"
+    },
+    "granulated-sugar": {
+        "name": "cukier granulowany"
+    },
+    "grape-seed-oil": {
+        "name": "olej z nasion winogrona"
+    },
+    "green-onion": {
+        "name": "zielona cebula",
+        "plural_name": "zielone cebule"
+    },
+    "heart-of-palm": {
+        "name": "serce palmy",
+        "plural_name": "serca palm"
+    },
+    "hemp": {
+        "name": "konopia"
+    },
+    "herbs": {
+        "name": "zioła"
+    },
+    "honey": {
+        "name": "miód"
+    },
+    "isomalt": {
+        "name": "izomalt"
+    },
+    "jackfruit": {
+        "name": "chlebowiec różnolistny",
+        "plural_name": "jackfruits"
+    },
+    "jaggery": {
+        "name": "cukier trzcinowy"
+    },
+    "jams": {
+        "name": "dżemy"
+    },
+    "jellies": {
+        "name": "galaretki"
+    },
+    "jerusalem-artichoke": {
+        "name": "topinambur"
+    },
+    "jicama": {
+        "name": "kłębian kątowaty"
+    },
+    "kale": {
+        "name": "jarmuż"
+    },
+    "kohlrabi": {
+        "name": "kalarepa"
+    },
+    "kumara": {
+        "name": "kumara"
+    },
+    "leavening-agents": {
+        "name": "środki spulchniające"
+    },
+    "leek": {
+        "name": "por",
+        "plural_name": "pory"
+    },
+    "legumes": {
+        "name": "rośliny strączkowe"
+    },
+    "lemongrass": {
+        "name": "trawa cytrynowa"
+    },
+    "lentils": {
+        "name": "soczewica"
+    },
+    "lettuce": {
+        "name": "sałata"
+    },
+    "liver": {
+        "name": "wątróbka",
+        "plural_name": "wątróbki"
+    },
+    "maize": {
+        "name": "kukurydza"
+    },
+    "maple-syrup": {
+        "name": "syrop klonowy"
+    },
+    "meat": {
+        "name": "mięso"
+    },
+    "milk": {
+        "name": "mleko"
+    },
+    "mortadella": {
+        "name": "mortadela"
+    },
+    "mushroom": {
+        "name": "grzyb",
+        "plural_name": "grzyby"
+    },
+    "mussels": {
+        "name": "małże"
+    },
+    "nanaimo-bar-mix": {
+        "name": "mieszanka batoników nanaimo"
+    },
+    "nori": {
+        "name": "nori"
+    },
+    "nutmeg": {
+        "name": "gałka muszkatołowa"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "płatki drożdżowe"
+    },
+    "nuts": {
+        "name": "orzechy"
+    },
+    "octopuses": {
+        "name": "ośmiornica",
+        "plural_name": "ośmiornice"
+    },
+    "oils": {
+        "name": "oleje"
+    },
+    "okra": {
+        "name": "okra"
+    },
+    "olive": {
+        "name": "oliwa"
+    },
+    "olive-oil": {
+        "name": "oliwa z oliwek"
+    },
+    "onion": {
+        "name": "cebula"
+    },
+    "onion-family": {
+        "name": "rodzina cebul"
+    },
+    "orange-blossom-water": {
+        "name": "woda z kwiatu pomarańczy"
+    },
+    "oranges": {
+        "name": "pomarańcza",
+        "plural_name": "pomarańcze"
+    },
+    "oregano": {
+        "name": "oregano"
+    },
+    "oysters": {
+        "name": "ostrygi"
+    },
+    "panch-puran": {
+        "name": "panch phoron"
+    },
+    "paprika": {
+        "name": "papryka słodka"
+    },
+    "parsley": {
+        "name": "pietruszka"
+    },
+    "parsnip": {
+        "name": "pasternak",
+        "plural_name": "pasternaki"
+    },
+    "pear": {
+        "name": "gruszka",
+        "plural_name": "gruszki"
+    },
+    "peas": {
+        "name": "groszek"
+    },
+    "pepper": {
+        "name": "pieprz",
+        "plural_name": "pieprz"
+    },
+    "pineapple": {
+        "name": "ananas",
+        "plural_name": "ananasy"
+    },
+    "plantain": {
+        "name": "banan",
+        "plural_name": "banany"
+    },
+    "poppy-seeds": {
+        "name": "mak"
+    },
+    "potato": {
+        "name": "ziemniak",
+        "plural_name": "ziemniaki"
+    },
+    "poultry": {
+        "name": "drób"
+    },
+    "powdered-sugar": {
+        "name": "cukier w proszku"
+    },
+    "pumpkin": {
+        "name": "dynia",
+        "plural_name": "dynie"
+    },
+    "pumpkin-seeds": {
+        "name": "nasiona dyni"
+    },
+    "radish": {
+        "name": "rzodkiew",
+        "plural_name": "rzodkiewki"
+    },
+    "raw-sugar": {
+        "name": "cukier surowy"
+    },
+    "refined-sugar": {
+        "name": "cukier rafinowany"
+    },
+    "rice": {
+        "name": "ryż"
+    },
+    "rice-flour": {
+        "name": "mąka ryżowa"
+    },
+    "rock-sugar": {
+        "name": "kryształki cukru"
+    },
+    "rum": {
+        "name": "rum"
+    },
+    "salmon": {
+        "name": "łosoś"
+    },
+    "salt": {
+        "name": "sól"
+    },
+    "salt-cod": {
+        "name": "solony dorsz"
+    },
+    "scallion": {
+        "name": "cebula dymka",
+        "plural_name": "cebule dymnki"
+    },
+    "seafood": {
+        "name": "owoce morza"
+    },
+    "seeds": {
+        "name": "nasiona"
+    },
+    "sesame-seeds": {
+        "name": "ziarenka sezamu"
+    },
+    "shallot": {
+        "name": "szalotka",
+        "plural_name": "szalotki"
+    },
+    "skate": {
+        "name": "raja"
+    },
+    "soda": {
+        "name": "woda sodowa"
+    },
+    "soda-baking": {
+        "name": "soda do pieczenia"
+    },
+    "soybean": {
+        "name": "soja"
+    },
+    "spaghetti-squash": {
+        "name": "dynia makaronowa",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "boczek wędzony"
+    },
+    "spices": {
+        "name": "przyprawy"
+    },
+    "spinach": {
+        "name": "szpinak"
+    },
+    "spring-onion": {
+        "name": "zielona cebulka",
+        "plural_name": "zielone cebulki"
+    },
+    "squash": {
+        "name": "kabaczek",
+        "plural_name": "kabaczki"
+    },
+    "squash-family": {
+        "name": "dyniowate"
+    },
+    "stockfish": {
+        "name": "suszona ryba"
+    },
+    "sugar": {
+        "name": "cukier"
+    },
+    "sunchoke": {
+        "name": "słonecznik bulwiasty",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "nasiona słonecznika"
+    },
+    "superfine-sugar": {
+        "name": "bardzo drobny cukier"
+    },
+    "sweet-potato": {
+        "name": "batat",
+        "plural_name": "bataty"
+    },
+    "sweetcorn": {
+        "name": "kukurydza",
+        "plural_name": "kukurydze"
+    },
+    "sweeteners": {
+        "name": "słodziki"
+    },
+    "tahini": {
+        "name": "tahini"
+    },
+    "taro": {
+        "name": "kolokazja jadalna",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "miłka abisyńska"
+    },
+    "tomato": {
+        "name": "pomidor",
+        "plural_name": "pomidory"
+    },
+    "trout": {
+        "name": "pstrąg"
+    },
+    "tubers": {
+        "name": "bulwy",
+        "plural_name": "bulwy"
+    },
+    "tuna": {
+        "name": "tuńczyk"
+    },
+    "turbanado-sugar": {
+        "name": "cukier turbinado"
+    },
+    "turnip": {
+        "name": "rzepa",
+        "plural_name": "rzepy"
+    },
+    "unrefined-sugar": {
+        "name": "cukier nierafinowany"
+    },
+    "vanilla": {
+        "name": "wanilia"
+    },
+    "vegetables": {
+        "name": "warzywa"
+    },
+    "watercress": {
+        "name": "rukiew wodna"
+    },
+    "watermelon": {
+        "name": "arbuz",
+        "plural_name": "arbuzy"
+    },
+    "white-mushroom": {
+        "name": "pieczarki",
+        "plural_name": "białe pieczarki"
+    },
+    "white-sugar": {
+        "name": "cukier biały"
+    },
+    "xanthan-gum": {
+        "name": "guma ksantanowa"
+    },
+    "yam": {
+        "name": "pochrzyn",
+        "plural_name": "pochrzyny"
+    },
+    "yeast": {
+        "name": "drożdże"
+    },
+    "zucchini": {
+        "name": "cukinia",
+        "plural_name": "cukinie"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/pt-BR.json
+++ b/mealie/repos/seed/resources/foods/locales/pt-BR.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "abóbora-bolota"
-	},
-	"alfalfa-sprouts": {
-		"name": "broto de alfafa"
-	},
-	"anchovies": {
-		"name": "anchovas"
-	},
-	"apples": {
-		"name": "maçãs",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "alcachofra"
-	},
-	"arugula": {
-		"name": "rúcula"
-	},
-	"asparagus": {
-		"name": "aspargo"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "fermento em pó"
-	},
-	"baking-soda": {
-		"name": "bicarbonato de sódio"
-	},
-	"baking-sugar": {
-		"name": "açúcar de confeiteiro"
-	},
-	"bar-sugar": {
-		"name": "açúcar refinado"
-	},
-	"basil": {
-		"name": "manjericão"
-	},
-	"beans": {
-		"name": "feijões"
-	},
-	"bell-peppers": {
-		"name": "pimentões",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "amoras silvestres"
-	},
-	"bok-choy": {
-		"name": "acelga"
-	},
-	"brassicas": {
-		"name": "brássicas"
-	},
-	"bread": {
-		"name": "pão"
-	},
-	"breadfruit": {
-		"name": "fruta-pão"
-	},
-	"broccoflower": {
-		"name": "brócolis"
-	},
-	"broccoli": {
-		"name": "brócolis"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "baby brócolis"
-	},
-	"brown-sugar": {
-		"name": "açúcar mascavo"
-	},
-	"brussels-sprouts": {
-		"name": "couve-de-bruxelas"
-	},
-	"butter": {
-		"name": "manteiga"
-	},
-	"butternut-pumpkin": {
-		"name": "abóbora noz"
-	},
-	"butternut-squash": {
-		"name": "abóbora-cheirosa"
-	},
-	"cabbage": {
-		"name": "repolho",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cacto, comestível"
-	},
-	"calabrese": {
-		"name": "calabresa"
-	},
-	"cane-sugar": {
-		"name": "açúcar de cana"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "páprica"
-	},
-	"caraway": {
-		"name": "cominho"
-	},
-	"carrot": {
-		"name": "cenoura",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "açúcar refinado"
-	},
-	"castor-sugar": {
-		"name": "açúcar de confeiteiro"
-	},
-	"catfish": {
-		"name": "bagre"
-	},
-	"cauliflower": {
-		"name": "couve-flor",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "pimenta caiena"
-	},
-	"celeriac": {
-		"name": "aipo-rábano"
-	},
-	"celery": {
-		"name": "aipo"
-	},
-	"cereal-grains": {
-		"name": "grãos de cereais"
-	},
-	"chard": {
-		"name": "acelga"
-	},
-	"cheese": {
-		"name": "queijo"
-	},
-	"chicory": {
-		"name": "chicória"
-	},
-	"chilli-peppers": {
-		"name": "pimenta picante",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "couve-china"
-	},
-	"chives": {
-		"name": "cebolinha"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "coentro"
-	},
-	"cinnamon": {
-		"name": "canela"
-	},
-	"clarified-butter": {
-		"name": "manteiga clarificada"
-	},
-	"coconut": {
-		"name": "coco",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "leite de coco"
-	},
-	"cod": {
-		"name": "bacalhau"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "couve-galega"
-	},
-	"confectioners-sugar": {
-		"name": "açúcar de confeiteiro"
-	},
-	"coriander": {
-		"name": "coentro"
-	},
-	"corn": {
-		"name": "milho",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "xarope de milho"
-	},
-	"cottonseed-oil": {
-		"name": "óleo de semente algodão"
-	},
-	"courgette": {
-		"name": "abobrinha"
-	},
-	"cream-of-tartar": {
-		"name": "creme de tartar"
-	},
-	"cucumber": {
-		"name": "pepino",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cominho"
-	},
-	"daikon": {
-		"name": "rabanete",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produtos lácteos e substitutos de leite"
-	},
-	"dandelion": {
-		"name": "dente-de-leão"
-	},
-	"demerara-sugar": {
-		"name": "açúcar demerara"
-	},
-	"dough": {
-		"name": "massa"
-	},
-	"edible-cactus": {
-		"name": "Cacto comestível"
-	},
-	"eggplant": {
-		"name": "berinjela",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "ovos",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endívia",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "gorduras"
-	},
-	"fava-beans": {
-		"name": "feijão-fava"
-	},
-	"fiddlehead": {
-		"name": "Broto de Samambaia"
-	},
-	"fiddlehead-fern": {
-		"name": "broto de samambaia",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "peixe"
-	},
-	"five-spice-powder": {
-		"name": "pó de cinco especiarias"
-	},
-	"flour": {
-		"name": "farinha"
-	},
-	"frisee": {
-		"name": "chicória ondulada"
-	},
-	"fructose": {
-		"name": "frutose"
-	},
-	"fruit": {
-		"name": "fruta"
-	},
-	"fruit-sugar": {
-		"name": "açúcar de fruta"
-	},
-	"ful": {
-		"name": "flor de jasmim"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "alho",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "abóbora coroa"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "miúdos"
-	},
-	"ginger": {
-		"name": "gengibre"
-	},
-	"grains": {
-		"name": "cereais"
-	},
-	"granulated-sugar": {
-		"name": "açúcar cristal"
-	},
-	"grape-seed-oil": {
-		"name": "óleo de semente de uva"
-	},
-	"green-onion": {
-		"name": "Cebola Verde",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "palmito",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "cânhamo"
-	},
-	"herbs": {
-		"name": "ervas"
-	},
-	"honey": {
-		"name": "mel"
-	},
-	"isomalt": {
-		"name": "açúcar isomalte"
-	},
-	"jackfruit": {
-		"name": "jaca",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "açúcar mascavo"
-	},
-	"jams": {
-		"name": "geléias"
-	},
-	"jellies": {
-		"name": "gelatinas"
-	},
-	"jerusalem-artichoke": {
-		"name": "alcachofra de Jerusalém"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "couve"
-	},
-	"kohlrabi": {
-		"name": "couve-rábano"
-	},
-	"kumara": {
-		"name": "batata doce kumara"
-	},
-	"leavening-agents": {
-		"name": "fermento químico"
-	},
-	"leek": {
-		"name": "alho-porró",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "leguminosas"
-	},
-	"lemongrass": {
-		"name": "capim-limão"
-	},
-	"lentils": {
-		"name": "lentilhas"
-	},
-	"lettuce": {
-		"name": "alface"
-	},
-	"liver": {
-		"name": "fígado",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "milho"
-	},
-	"maple-syrup": {
-		"name": "xarope de bordo"
-	},
-	"meat": {
-		"name": "carne"
-	},
-	"milk": {
-		"name": "leite"
-	},
-	"mortadella": {
-		"name": "mortadela"
-	},
-	"mushroom": {
-		"name": "cogumelo",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mexilhões"
-	},
-	"nanaimo-bar-mix": {
-		"name": "açúcar mascavo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "noz-moscada"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "levedura nutricional em flocos"
-	},
-	"nuts": {
-		"name": "nozes"
-	},
-	"octopuses": {
-		"name": "polvos",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "óleos"
-	},
-	"okra": {
-		"name": "quiabo"
-	},
-	"olive": {
-		"name": "azeitona"
-	},
-	"olive-oil": {
-		"name": "azeite de oliva"
-	},
-	"onion": {
-		"name": "cebola"
-	},
-	"onion-family": {
-		"name": "família das amarilidáceas"
-	},
-	"orange-blossom-water": {
-		"name": "água de flor laranja"
-	},
-	"oranges": {
-		"name": "laranjas",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "orégano"
-	},
-	"oysters": {
-		"name": "ostras"
-	},
-	"panch-puran": {
-		"name": "mistura pronta de 5 especiarias indianas"
-	},
-	"paprika": {
-		"name": "páprica"
-	},
-	"parsley": {
-		"name": "salsinha"
-	},
-	"parsnip": {
-		"name": "pastinaca ou cherovia",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pêra",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "ervilha"
-	},
-	"pepper": {
-		"name": "pimenta",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "abacaxi",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "banana-da-terra",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "sementes de papoula"
-	},
-	"potato": {
-		"name": "batata",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "carne de frango"
-	},
-	"powdered-sugar": {
-		"name": "açucar de confeiteiro"
-	},
-	"pumpkin": {
-		"name": "abóbora",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "sementes de abóbora"
-	},
-	"radish": {
-		"name": "rabanete",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "açúcar mascavo"
-	},
-	"refined-sugar": {
-		"name": "açúcar refinado"
-	},
-	"rice": {
-		"name": "arroz"
-	},
-	"rice-flour": {
-		"name": "farinha de arroz"
-	},
-	"rock-sugar": {
-		"name": "açúcar em cubo"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmão"
-	},
-	"salt": {
-		"name": "sal"
-	},
-	"salt-cod": {
-		"name": "bacalhau salgado"
-	},
-	"scallion": {
-		"name": "cebolinha",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "frutos do mar"
-	},
-	"seeds": {
-		"name": "sementes"
-	},
-	"sesame-seeds": {
-		"name": "sementes de gergelim"
-	},
-	"shallot": {
-		"name": "chalota",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "raia"
-	},
-	"soda": {
-		"name": "refrigerante"
-	},
-	"soda-baking": {
-		"name": "bicarbonato de sódio"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "espaguete de abobrinha",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "presunto"
-	},
-	"spices": {
-		"name": "temperos"
-	},
-	"spinach": {
-		"name": "espinafre"
-	},
-	"spring-onion": {
-		"name": "cebolinha",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "abóbora",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "família das abóboras"
-	},
-	"stockfish": {
-		"name": "bacalhau seco"
-	},
-	"sugar": {
-		"name": "açúcar"
-	},
-	"sunchoke": {
-		"name": "Alcachofra de Jerusalém",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sementes de girassol"
-	},
-	"superfine-sugar": {
-		"name": "açúcar refinado"
-	},
-	"sweet-potato": {
-		"name": "batata doce",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "milho-doce",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "adoçantes"
-	},
-	"tahini": {
-		"name": "tahine"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "tefe"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "truta"
-	},
-	"tubers": {
-		"name": "tubérculos",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "atum"
-	},
-	"turbanado-sugar": {
-		"name": "açúcar mascavo não-processado"
-	},
-	"turnip": {
-		"name": "nabo",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "açúcar não refinado"
-	},
-	"vanilla": {
-		"name": "baunilha"
-	},
-	"vegetables": {
-		"name": "vegetais"
-	},
-	"watercress": {
-		"name": "agrião"
-	},
-	"watermelon": {
-		"name": "melancia",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "cogumelo branco",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "açúcar cristal"
-	},
-	"xanthan-gum": {
-		"name": "goma xantana"
-	},
-	"yam": {
-		"name": "mandioca",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "fermento"
-	},
-	"zucchini": {
-		"name": "abobrinha",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "abóbora-bolota"
+            },
+            "alfalfa-sprouts": {
+                "name": "broto de alfafa"
+            },
+            "anchovies": {
+                "name": "anchovas"
+            },
+            "apples": {
+                "name": "maçãs",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "alcachofra"
+            },
+            "arugula": {
+                "name": "rúcula"
+            },
+            "asparagus": {
+                "name": "aspargo"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "fermento em pó"
+            },
+            "baking-soda": {
+                "name": "bicarbonato de sódio"
+            },
+            "baking-sugar": {
+                "name": "açúcar de confeiteiro"
+            },
+            "bar-sugar": {
+                "name": "açúcar refinado"
+            },
+            "basil": {
+                "name": "manjericão"
+            },
+            "beans": {
+                "name": "feijões"
+            },
+            "bell-peppers": {
+                "name": "pimentões",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "amoras silvestres"
+            },
+            "bok-choy": {
+                "name": "acelga"
+            },
+            "brassicas": {
+                "name": "brássicas"
+            },
+            "bread": {
+                "name": "pão"
+            },
+            "breadfruit": {
+                "name": "fruta-pão"
+            },
+            "broccoflower": {
+                "name": "brócolis"
+            },
+            "broccoli": {
+                "name": "brócolis"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "baby brócolis"
+            },
+            "brown-sugar": {
+                "name": "açúcar mascavo"
+            },
+            "brussels-sprouts": {
+                "name": "couve-de-bruxelas"
+            },
+            "butter": {
+                "name": "manteiga"
+            },
+            "butternut-pumpkin": {
+                "name": "abóbora noz"
+            },
+            "butternut-squash": {
+                "name": "abóbora-cheirosa"
+            },
+            "cabbage": {
+                "name": "repolho",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cacto, comestível"
+            },
+            "calabrese": {
+                "name": "calabresa"
+            },
+            "cane-sugar": {
+                "name": "açúcar de cana"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "páprica"
+            },
+            "caraway": {
+                "name": "cominho"
+            },
+            "carrot": {
+                "name": "cenoura",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "açúcar refinado"
+            },
+            "castor-sugar": {
+                "name": "açúcar de confeiteiro"
+            },
+            "catfish": {
+                "name": "bagre"
+            },
+            "cauliflower": {
+                "name": "couve-flor",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "pimenta caiena"
+            },
+            "celeriac": {
+                "name": "aipo-rábano"
+            },
+            "celery": {
+                "name": "aipo"
+            },
+            "cereal-grains": {
+                "name": "grãos de cereais"
+            },
+            "chard": {
+                "name": "acelga"
+            },
+            "cheese": {
+                "name": "queijo"
+            },
+            "chicory": {
+                "name": "chicória"
+            },
+            "chilli-peppers": {
+                "name": "pimenta picante",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "couve-china"
+            },
+            "chives": {
+                "name": "cebolinha"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "coentro"
+            },
+            "cinnamon": {
+                "name": "canela"
+            },
+            "clarified-butter": {
+                "name": "manteiga clarificada"
+            },
+            "coconut": {
+                "name": "coco",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "leite de coco"
+            },
+            "cod": {
+                "name": "bacalhau"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "couve-galega"
+            },
+            "confectioners-sugar": {
+                "name": "açúcar de confeiteiro"
+            },
+            "coriander": {
+                "name": "coentro"
+            },
+            "corn": {
+                "name": "milho",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "xarope de milho"
+            },
+            "cottonseed-oil": {
+                "name": "óleo de semente algodão"
+            },
+            "courgette": {
+                "name": "abobrinha"
+            },
+            "cream-of-tartar": {
+                "name": "creme de tartar"
+            },
+            "cucumber": {
+                "name": "pepino",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cominho"
+            },
+            "daikon": {
+                "name": "rabanete",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produtos lácteos e substitutos de leite"
+            },
+            "dandelion": {
+                "name": "dente-de-leão"
+            },
+            "demerara-sugar": {
+                "name": "açúcar demerara"
+            },
+            "dough": {
+                "name": "massa"
+            },
+            "edible-cactus": {
+                "name": "Cacto comestível"
+            },
+            "eggplant": {
+                "name": "berinjela",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "ovos",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endívia",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "gorduras"
+            },
+            "fava-beans": {
+                "name": "feijão-fava"
+            },
+            "fiddlehead": {
+                "name": "Broto de Samambaia"
+            },
+            "fiddlehead-fern": {
+                "name": "broto de samambaia",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "peixe"
+            },
+            "five-spice-powder": {
+                "name": "pó de cinco especiarias"
+            },
+            "flour": {
+                "name": "farinha"
+            },
+            "frisee": {
+                "name": "chicória ondulada"
+            },
+            "fructose": {
+                "name": "frutose"
+            },
+            "fruit": {
+                "name": "fruta"
+            },
+            "fruit-sugar": {
+                "name": "açúcar de fruta"
+            },
+            "ful": {
+                "name": "flor de jasmim"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "alho",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "abóbora coroa"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "miúdos"
+            },
+            "ginger": {
+                "name": "gengibre"
+            },
+            "grains": {
+                "name": "cereais"
+            },
+            "granulated-sugar": {
+                "name": "açúcar cristal"
+            },
+            "grape-seed-oil": {
+                "name": "óleo de semente de uva"
+            },
+            "green-onion": {
+                "name": "Cebola Verde",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "palmito",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "cânhamo"
+            },
+            "herbs": {
+                "name": "ervas"
+            },
+            "honey": {
+                "name": "mel"
+            },
+            "isomalt": {
+                "name": "açúcar isomalte"
+            },
+            "jackfruit": {
+                "name": "jaca",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "açúcar mascavo"
+            },
+            "jams": {
+                "name": "geléias"
+            },
+            "jellies": {
+                "name": "gelatinas"
+            },
+            "jerusalem-artichoke": {
+                "name": "alcachofra de Jerusalém"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "couve"
+            },
+            "kohlrabi": {
+                "name": "couve-rábano"
+            },
+            "kumara": {
+                "name": "batata doce kumara"
+            },
+            "leavening-agents": {
+                "name": "fermento químico"
+            },
+            "leek": {
+                "name": "alho-porró",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "leguminosas"
+            },
+            "lemongrass": {
+                "name": "capim-limão"
+            },
+            "lentils": {
+                "name": "lentilhas"
+            },
+            "lettuce": {
+                "name": "alface"
+            },
+            "liver": {
+                "name": "fígado",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "milho"
+            },
+            "maple-syrup": {
+                "name": "xarope de bordo"
+            },
+            "meat": {
+                "name": "carne"
+            },
+            "milk": {
+                "name": "leite"
+            },
+            "mortadella": {
+                "name": "mortadela"
+            },
+            "mushroom": {
+                "name": "cogumelo",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mexilhões"
+            },
+            "nanaimo-bar-mix": {
+                "name": "açúcar mascavo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "noz-moscada"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "levedura nutricional em flocos"
+            },
+            "nuts": {
+                "name": "nozes"
+            },
+            "octopuses": {
+                "name": "polvos",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "óleos"
+            },
+            "okra": {
+                "name": "quiabo"
+            },
+            "olive": {
+                "name": "azeitona"
+            },
+            "olive-oil": {
+                "name": "azeite de oliva"
+            },
+            "onion": {
+                "name": "cebola"
+            },
+            "onion-family": {
+                "name": "família das amarilidáceas"
+            },
+            "orange-blossom-water": {
+                "name": "água de flor laranja"
+            },
+            "oranges": {
+                "name": "laranjas",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "orégano"
+            },
+            "oysters": {
+                "name": "ostras"
+            },
+            "panch-puran": {
+                "name": "mistura pronta de 5 especiarias indianas"
+            },
+            "paprika": {
+                "name": "páprica"
+            },
+            "parsley": {
+                "name": "salsinha"
+            },
+            "parsnip": {
+                "name": "pastinaca ou cherovia",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pêra",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "ervilha"
+            },
+            "pepper": {
+                "name": "pimenta",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "abacaxi",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "banana-da-terra",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "sementes de papoula"
+            },
+            "potato": {
+                "name": "batata",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "carne de frango"
+            },
+            "powdered-sugar": {
+                "name": "açucar de confeiteiro"
+            },
+            "pumpkin": {
+                "name": "abóbora",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "sementes de abóbora"
+            },
+            "radish": {
+                "name": "rabanete",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "açúcar mascavo"
+            },
+            "refined-sugar": {
+                "name": "açúcar refinado"
+            },
+            "rice": {
+                "name": "arroz"
+            },
+            "rice-flour": {
+                "name": "farinha de arroz"
+            },
+            "rock-sugar": {
+                "name": "açúcar em cubo"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmão"
+            },
+            "salt": {
+                "name": "sal"
+            },
+            "salt-cod": {
+                "name": "bacalhau salgado"
+            },
+            "scallion": {
+                "name": "cebolinha",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "frutos do mar"
+            },
+            "seeds": {
+                "name": "sementes"
+            },
+            "sesame-seeds": {
+                "name": "sementes de gergelim"
+            },
+            "shallot": {
+                "name": "chalota",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "raia"
+            },
+            "soda": {
+                "name": "refrigerante"
+            },
+            "soda-baking": {
+                "name": "bicarbonato de sódio"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "espaguete de abobrinha",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "presunto"
+            },
+            "spices": {
+                "name": "temperos"
+            },
+            "spinach": {
+                "name": "espinafre"
+            },
+            "spring-onion": {
+                "name": "cebolinha",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "abóbora",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "família das abóboras"
+            },
+            "stockfish": {
+                "name": "bacalhau seco"
+            },
+            "sugar": {
+                "name": "açúcar"
+            },
+            "sunchoke": {
+                "name": "Alcachofra de Jerusalém",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sementes de girassol"
+            },
+            "superfine-sugar": {
+                "name": "açúcar refinado"
+            },
+            "sweet-potato": {
+                "name": "batata doce",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "milho-doce",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "adoçantes"
+            },
+            "tahini": {
+                "name": "tahine"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "tefe"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "truta"
+            },
+            "tubers": {
+                "name": "tubérculos",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "atum"
+            },
+            "turbanado-sugar": {
+                "name": "açúcar mascavo não-processado"
+            },
+            "turnip": {
+                "name": "nabo",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "açúcar não refinado"
+            },
+            "vanilla": {
+                "name": "baunilha"
+            },
+            "vegetables": {
+                "name": "vegetais"
+            },
+            "watercress": {
+                "name": "agrião"
+            },
+            "watermelon": {
+                "name": "melancia",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "cogumelo branco",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "açúcar cristal"
+            },
+            "xanthan-gum": {
+                "name": "goma xantana"
+            },
+            "yam": {
+                "name": "mandioca",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "fermento"
+            },
+            "zucchini": {
+                "name": "abobrinha",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Verdura": {
+        "foods": {}
+    },
+    "Grãos": {
+        "foods": {}
+    },
+    "Frutas": {
+        "foods": {}
+    },
+    "Legumes": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Frutos do mar": {
+        "foods": {}
+    },
+    "Bebidas": {
+        "foods": {}
+    },
+    "Produtos cozidos": {
+        "foods": {}
+    },
+    "Enlatados": {
+        "foods": {}
+    },
+    "Condimentos": {
+        "foods": {}
+    },
+    "Confeitaria": {
+        "foods": {}
+    },
+    "Lacticínios": {
+        "foods": {}
+    },
+    "Alimentos Congelados": {
+        "foods": {}
+    },
+    "Alimentos saudáveis": {
+        "foods": {}
+    },
+    "Casa": {
+        "foods": {}
+    },
+    "Produtos de carne": {
+        "foods": {}
+    },
+    "Lanches": {
+        "foods": {}
+    },
+    "Temperos": {
+        "foods": {}
+    },
+    "Doces": {
+        "foods": {}
+    },
+    "Álcool": {
+        "foods": {}
+    },
+    "Outros": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/pt-PT.json
+++ b/mealie/repos/seed/resources/foods/locales/pt-PT.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "abóbora-bolota"
-	},
-	"alfalfa-sprouts": {
-		"name": "rebentos de alfafa"
-	},
-	"anchovies": {
-		"name": "anchovas"
-	},
-	"apples": {
-		"name": "maçãs",
-		"plural_name": "maçãs"
-	},
-	"artichoke": {
-		"name": "alcachofra"
-	},
-	"arugula": {
-		"name": "rúcula"
-	},
-	"asparagus": {
-		"name": "espargos"
-	},
-	"avocado": {
-		"name": "abacate",
-		"plural_name": "abacate"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "fermento em pó"
-	},
-	"baking-soda": {
-		"name": "bicarbonato de sódio"
-	},
-	"baking-sugar": {
-		"name": "açúcar granulado"
-	},
-	"bar-sugar": {
-		"name": "açúcar em pó"
-	},
-	"basil": {
-		"name": "manjericão"
-	},
-	"beans": {
-		"name": "feijões"
-	},
-	"bell-peppers": {
-		"name": "pimentões",
-		"plural_name": "pimentões"
-	},
-	"blackberries": {
-		"name": "amoras"
-	},
-	"bok-choy": {
-		"name": "couve chinesa"
-	},
-	"brassicas": {
-		"name": "crucíferas"
-	},
-	"bread": {
-		"name": "pão"
-	},
-	"breadfruit": {
-		"name": "fruta-pão"
-	},
-	"broccoflower": {
-		"name": "couve-romanesca"
-	},
-	"broccoli": {
-		"name": "brócolos"
-	},
-	"broccoli-rabe": {
-		"name": "grelo de brócolo"
-	},
-	"broccolini": {
-		"name": "bimi"
-	},
-	"brown-sugar": {
-		"name": "açúcar mascavado"
-	},
-	"brussels-sprouts": {
-		"name": "couve-de-bruxelas"
-	},
-	"butter": {
-		"name": "manteiga"
-	},
-	"butternut-pumpkin": {
-		"name": "abóbora manteiga"
-	},
-	"butternut-squash": {
-		"name": "puré de abóbora manteiga"
-	},
-	"cabbage": {
-		"name": "repolho",
-		"plural_name": "repolhos"
-	},
-	"cactus-edible": {
-		"name": "cato, comestível"
-	},
-	"calabrese": {
-		"name": "brócolo calabrese"
-	},
-	"cane-sugar": {
-		"name": "açúcar de cana"
-	},
-	"cannabis": {
-		"name": "canábis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "alcarávia"
-	},
-	"carrot": {
-		"name": "cenoura",
-		"plural_name": "cenouras"
-	},
-	"caster-sugar": {
-		"name": "açucar refinado"
-	},
-	"castor-sugar": {
-		"name": "açúcar de confeiteiro"
-	},
-	"catfish": {
-		"name": "peixe-gato"
-	},
-	"cauliflower": {
-		"name": "couve-flor",
-		"plural_name": "couves-flor"
-	},
-	"cayenne-pepper": {
-		"name": "pimenta caiena"
-	},
-	"celeriac": {
-		"name": "aipo-rábano"
-	},
-	"celery": {
-		"name": "aipo"
-	},
-	"cereal-grains": {
-		"name": "grãos de cereal"
-	},
-	"chard": {
-		"name": "acelga"
-	},
-	"cheese": {
-		"name": "queijo"
-	},
-	"chicory": {
-		"name": "chicória"
-	},
-	"chilli-peppers": {
-		"name": "pimenta chili",
-		"plural_name": "pimentas de chili"
-	},
-	"chinese-leaves": {
-		"name": "folhas chinesas"
-	},
-	"chives": {
-		"name": "cebolinho"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "coentros"
-	},
-	"cinnamon": {
-		"name": "canela"
-	},
-	"clarified-butter": {
-		"name": "manteiga clarificada"
-	},
-	"coconut": {
-		"name": "coco",
-		"plural_name": "cocos"
-	},
-	"coconut-milk": {
-		"name": "leite de coco"
-	},
-	"cod": {
-		"name": "bacalhau"
-	},
-	"coffee": {
-		"name": "café"
-	},
-	"collard-greens": {
-		"name": "couve-galega"
-	},
-	"confectioners-sugar": {
-		"name": "açúcar em pó"
-	},
-	"coriander": {
-		"name": "coentro"
-	},
-	"corn": {
-		"name": "milho",
-		"plural_name": "milhos"
-	},
-	"corn-syrup": {
-		"name": "xarope de milho"
-	},
-	"cottonseed-oil": {
-		"name": "óleo de algodão"
-	},
-	"courgette": {
-		"name": "curgete"
-	},
-	"cream-of-tartar": {
-		"name": "cremor tártaro"
-	},
-	"cucumber": {
-		"name": "pepino",
-		"plural_name": "pepinos"
-	},
-	"cumin": {
-		"name": "cominho"
-	},
-	"daikon": {
-		"name": "rabanete branco",
-		"plural_name": "rabanetes brancos"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produtos lácteos e substitutos de leite"
-	},
-	"dandelion": {
-		"name": "dente-de-leão"
-	},
-	"demerara-sugar": {
-		"name": "açúcar demerara"
-	},
-	"dough": {
-		"name": "massa"
-	},
-	"edible-cactus": {
-		"name": "cato comestível"
-	},
-	"eggplant": {
-		"name": "beringela",
-		"plural_name": "beringelas"
-	},
-	"eggs": {
-		"name": "ovo",
-		"plural_name": "ovos"
-	},
-	"endive": {
-		"name": "endívia",
-		"plural_name": "endívias"
-	},
-	"fats": {
-		"name": "gorduras"
-	},
-	"fava-beans": {
-		"name": "favas"
-	},
-	"fiddlehead": {
-		"name": "rebentos de feto comestíveis"
-	},
-	"fiddlehead-fern": {
-		"name": "rebentos de fetos",
-		"plural_name": "fetos de cabeça de peixe"
-	},
-	"fish": {
-		"name": "peixe"
-	},
-	"five-spice-powder": {
-		"name": "cinco especiarias chinesas em pó"
-	},
-	"flour": {
-		"name": "farinha"
-	},
-	"frisee": {
-		"name": "chicória"
-	},
-	"fructose": {
-		"name": "frutose"
-	},
-	"fruit": {
-		"name": "fruta"
-	},
-	"fruit-sugar": {
-		"name": "frutose"
-	},
-	"ful": {
-		"name": "ful medames"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "alho",
-		"plural_name": "alhos"
-	},
-	"gem-squash": {
-		"name": "abóbora gem"
-	},
-	"ghee": {
-		"name": "manteiga ghee"
-	},
-	"giblets": {
-		"name": "miúdos de aves"
-	},
-	"ginger": {
-		"name": "gengibre"
-	},
-	"grains": {
-		"name": "grãos"
-	},
-	"granulated-sugar": {
-		"name": "açúcar granulado"
-	},
-	"grape-seed-oil": {
-		"name": "óleo de semente de uva"
-	},
-	"green-onion": {
-		"name": "cebola verde",
-		"plural_name": "cebolas verdes"
-	},
-	"heart-of-palm": {
-		"name": "miolo de palma",
-		"plural_name": "corações de palma"
-	},
-	"hemp": {
-		"name": "cânhamo"
-	},
-	"herbs": {
-		"name": "ervas"
-	},
-	"honey": {
-		"name": "mel"
-	},
-	"isomalt": {
-		"name": "isomalte"
-	},
-	"jackfruit": {
-		"name": "jaca",
-		"plural_name": "jacas"
-	},
-	"jaggery": {
-		"name": "açúcar mascavo"
-	},
-	"jams": {
-		"name": "geleias"
-	},
-	"jellies": {
-		"name": "gelatinas"
-	},
-	"jerusalem-artichoke": {
-		"name": "alcachofra-de-jerusalém"
-	},
-	"jicama": {
-		"name": "nabo-mexicano"
-	},
-	"kale": {
-		"name": "couve"
-	},
-	"kohlrabi": {
-		"name": "couve-rábano"
-	},
-	"kumara": {
-		"name": "batata-doce"
-	},
-	"leavening-agents": {
-		"name": "fermentos"
-	},
-	"leek": {
-		"name": "alho-françês",
-		"plural_name": "alho-françês"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "erva-príncipe"
-	},
-	"lentils": {
-		"name": "lentilhas"
-	},
-	"lettuce": {
-		"name": "alface"
-	},
-	"liver": {
-		"name": "fígado",
-		"plural_name": "figados"
-	},
-	"maize": {
-		"name": "milho"
-	},
-	"maple-syrup": {
-		"name": "xarope de acer"
-	},
-	"meat": {
-		"name": "carne"
-	},
-	"milk": {
-		"name": "leite"
-	},
-	"mortadella": {
-		"name": "mortadela"
-	},
-	"mushroom": {
-		"name": "cogumelo",
-		"plural_name": "cogumelos"
-	},
-	"mussels": {
-		"name": "mexilhão"
-	},
-	"nanaimo-bar-mix": {
-		"name": "mistura de barras nanaimo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "noz-moscada"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "flocos de levedura nutricional"
-	},
-	"nuts": {
-		"name": "frutos secos"
-	},
-	"octopuses": {
-		"name": "polvos",
-		"plural_name": "polvos"
-	},
-	"oils": {
-		"name": "óleos"
-	},
-	"okra": {
-		"name": "quiabo"
-	},
-	"olive": {
-		"name": "azeitona"
-	},
-	"olive-oil": {
-		"name": "azeite"
-	},
-	"onion": {
-		"name": "cebola"
-	},
-	"onion-family": {
-		"name": "família das cebolas"
-	},
-	"orange-blossom-water": {
-		"name": "água de flor de laranjeira"
-	},
-	"oranges": {
-		"name": "laranjas",
-		"plural_name": "laranjas"
-	},
-	"oregano": {
-		"name": "orégão"
-	},
-	"oysters": {
-		"name": "ostras"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "colorau"
-	},
-	"parsley": {
-		"name": "salsa"
-	},
-	"parsnip": {
-		"name": "cherovia",
-		"plural_name": "cherovias"
-	},
-	"pear": {
-		"name": "pera",
-		"plural_name": "peras"
-	},
-	"peas": {
-		"name": "ervilhas"
-	},
-	"pepper": {
-		"name": "pimenta",
-		"plural_name": "pimentos"
-	},
-	"pineapple": {
-		"name": "ananás",
-		"plural_name": "ananases"
-	},
-	"plantain": {
-		"name": "plátano",
-		"plural_name": "plátanos"
-	},
-	"poppy-seeds": {
-		"name": "sementes de papoila"
-	},
-	"potato": {
-		"name": "batata",
-		"plural_name": "batatas"
-	},
-	"poultry": {
-		"name": "carne de aves"
-	},
-	"powdered-sugar": {
-		"name": "açúcar em pó"
-	},
-	"pumpkin": {
-		"name": "abóbora",
-		"plural_name": "abóboras"
-	},
-	"pumpkin-seeds": {
-		"name": "sementes de abóbora"
-	},
-	"radish": {
-		"name": "rabanete",
-		"plural_name": "rabanetes"
-	},
-	"raw-sugar": {
-		"name": "açúcar mascavado"
-	},
-	"refined-sugar": {
-		"name": "açúcar refinado"
-	},
-	"rice": {
-		"name": "arroz"
-	},
-	"rice-flour": {
-		"name": "farinha de arroz"
-	},
-	"rock-sugar": {
-		"name": "açúcar mascavo"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmão"
-	},
-	"salt": {
-		"name": "sal"
-	},
-	"salt-cod": {
-		"name": "bacalhau salgado"
-	},
-	"scallion": {
-		"name": "cebolinho",
-		"plural_name": "cebolinhas"
-	},
-	"seafood": {
-		"name": "marisco"
-	},
-	"seeds": {
-		"name": "sementes"
-	},
-	"sesame-seeds": {
-		"name": "sementes de sésamo"
-	},
-	"shallot": {
-		"name": "chalota",
-		"plural_name": "chalotas"
-	},
-	"skate": {
-		"name": "raia"
-	},
-	"soda": {
-		"name": "gasosa"
-	},
-	"soda-baking": {
-		"name": "bicaburnato de sódio"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "abóbora esparguete",
-		"plural_name": "abóboras esparguete"
-	},
-	"speck": {
-		"name": "presunto tirolês"
-	},
-	"spices": {
-		"name": "especiarias"
-	},
-	"spinach": {
-		"name": "espinafre"
-	},
-	"spring-onion": {
-		"name": "cebolinho",
-		"plural_name": "cebolinhos"
-	},
-	"squash": {
-		"name": "abóbora",
-		"plural_name": "abóboras"
-	},
-	"squash-family": {
-		"name": "família das abóboras"
-	},
-	"stockfish": {
-		"name": "bacalhau seco"
-	},
-	"sugar": {
-		"name": "açúcar"
-	},
-	"sunchoke": {
-		"name": "alcachofra-girassol",
-		"plural_name": "alcachofras-girassol"
-	},
-	"sunflower-seeds": {
-		"name": "sementes de girassol"
-	},
-	"superfine-sugar": {
-		"name": "açúcar superfino"
-	},
-	"sweet-potato": {
-		"name": "batata-doce",
-		"plural_name": "batatas doces"
-	},
-	"sweetcorn": {
-		"name": "milho doce",
-		"plural_name": "milhos doces"
-	},
-	"sweeteners": {
-		"name": "adoçantes"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "tefe"
-	},
-	"tomato": {
-		"name": "tomate",
-		"plural_name": "tomates"
-	},
-	"trout": {
-		"name": "truta"
-	},
-	"tubers": {
-		"name": "tuberculos",
-		"plural_name": "tubérculos"
-	},
-	"tuna": {
-		"name": "atum"
-	},
-	"turbanado-sugar": {
-		"name": "açucar turbinado"
-	},
-	"turnip": {
-		"name": "nabo",
-		"plural_name": "nabos"
-	},
-	"unrefined-sugar": {
-		"name": "açúcar não refinado"
-	},
-	"vanilla": {
-		"name": "baunilha"
-	},
-	"vegetables": {
-		"name": "vegetais"
-	},
-	"watercress": {
-		"name": "agrião"
-	},
-	"watermelon": {
-		"name": "melancia",
-		"plural_name": "melancias"
-	},
-	"white-mushroom": {
-		"name": "cogumelo branco",
-		"plural_name": "cogumelos brancos"
-	},
-	"white-sugar": {
-		"name": "açúcar branco"
-	},
-	"xanthan-gum": {
-		"name": "goma xantana"
-	},
-	"yam": {
-		"name": "inhame",
-		"plural_name": "inhames"
-	},
-	"yeast": {
-		"name": "levedura"
-	},
-	"zucchini": {
-		"name": "courgette",
-		"plural_name": "curgetes"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "abóbora-bolota"
+            },
+            "alfalfa-sprouts": {
+                "name": "rebentos de alfafa"
+            },
+            "anchovies": {
+                "name": "anchovas"
+            },
+            "apples": {
+                "name": "maçãs",
+                "plural_name": "maçãs"
+            },
+            "artichoke": {
+                "name": "alcachofra"
+            },
+            "arugula": {
+                "name": "rúcula"
+            },
+            "asparagus": {
+                "name": "espargos"
+            },
+            "avocado": {
+                "name": "abacate",
+                "plural_name": "abacate"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "fermento em pó"
+            },
+            "baking-soda": {
+                "name": "bicarbonato de sódio"
+            },
+            "baking-sugar": {
+                "name": "açúcar granulado"
+            },
+            "bar-sugar": {
+                "name": "açúcar em pó"
+            },
+            "basil": {
+                "name": "manjericão"
+            },
+            "beans": {
+                "name": "feijões"
+            },
+            "bell-peppers": {
+                "name": "pimentões",
+                "plural_name": "pimentões"
+            },
+            "blackberries": {
+                "name": "amoras"
+            },
+            "bok-choy": {
+                "name": "couve chinesa"
+            },
+            "brassicas": {
+                "name": "crucíferas"
+            },
+            "bread": {
+                "name": "pão"
+            },
+            "breadfruit": {
+                "name": "fruta-pão"
+            },
+            "broccoflower": {
+                "name": "couve-romanesca"
+            },
+            "broccoli": {
+                "name": "brócolos"
+            },
+            "broccoli-rabe": {
+                "name": "grelo de brócolo"
+            },
+            "broccolini": {
+                "name": "bimi"
+            },
+            "brown-sugar": {
+                "name": "açúcar mascavado"
+            },
+            "brussels-sprouts": {
+                "name": "couve-de-bruxelas"
+            },
+            "butter": {
+                "name": "manteiga"
+            },
+            "butternut-pumpkin": {
+                "name": "abóbora manteiga"
+            },
+            "butternut-squash": {
+                "name": "puré de abóbora manteiga"
+            },
+            "cabbage": {
+                "name": "repolho",
+                "plural_name": "repolhos"
+            },
+            "cactus-edible": {
+                "name": "cato, comestível"
+            },
+            "calabrese": {
+                "name": "brócolo calabrese"
+            },
+            "cane-sugar": {
+                "name": "açúcar de cana"
+            },
+            "cannabis": {
+                "name": "canábis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "alcarávia"
+            },
+            "carrot": {
+                "name": "cenoura",
+                "plural_name": "cenouras"
+            },
+            "caster-sugar": {
+                "name": "açucar refinado"
+            },
+            "castor-sugar": {
+                "name": "açúcar de confeiteiro"
+            },
+            "catfish": {
+                "name": "peixe-gato"
+            },
+            "cauliflower": {
+                "name": "couve-flor",
+                "plural_name": "couves-flor"
+            },
+            "cayenne-pepper": {
+                "name": "pimenta caiena"
+            },
+            "celeriac": {
+                "name": "aipo-rábano"
+            },
+            "celery": {
+                "name": "aipo"
+            },
+            "cereal-grains": {
+                "name": "grãos de cereal"
+            },
+            "chard": {
+                "name": "acelga"
+            },
+            "cheese": {
+                "name": "queijo"
+            },
+            "chicory": {
+                "name": "chicória"
+            },
+            "chilli-peppers": {
+                "name": "pimenta chili",
+                "plural_name": "pimentas de chili"
+            },
+            "chinese-leaves": {
+                "name": "folhas chinesas"
+            },
+            "chives": {
+                "name": "cebolinho"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "coentros"
+            },
+            "cinnamon": {
+                "name": "canela"
+            },
+            "clarified-butter": {
+                "name": "manteiga clarificada"
+            },
+            "coconut": {
+                "name": "coco",
+                "plural_name": "cocos"
+            },
+            "coconut-milk": {
+                "name": "leite de coco"
+            },
+            "cod": {
+                "name": "bacalhau"
+            },
+            "coffee": {
+                "name": "café"
+            },
+            "collard-greens": {
+                "name": "couve-galega"
+            },
+            "confectioners-sugar": {
+                "name": "açúcar em pó"
+            },
+            "coriander": {
+                "name": "coentro"
+            },
+            "corn": {
+                "name": "milho",
+                "plural_name": "milhos"
+            },
+            "corn-syrup": {
+                "name": "xarope de milho"
+            },
+            "cottonseed-oil": {
+                "name": "óleo de algodão"
+            },
+            "courgette": {
+                "name": "curgete"
+            },
+            "cream-of-tartar": {
+                "name": "cremor tártaro"
+            },
+            "cucumber": {
+                "name": "pepino",
+                "plural_name": "pepinos"
+            },
+            "cumin": {
+                "name": "cominho"
+            },
+            "daikon": {
+                "name": "rabanete branco",
+                "plural_name": "rabanetes brancos"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produtos lácteos e substitutos de leite"
+            },
+            "dandelion": {
+                "name": "dente-de-leão"
+            },
+            "demerara-sugar": {
+                "name": "açúcar demerara"
+            },
+            "dough": {
+                "name": "massa"
+            },
+            "edible-cactus": {
+                "name": "cato comestível"
+            },
+            "eggplant": {
+                "name": "beringela",
+                "plural_name": "beringelas"
+            },
+            "eggs": {
+                "name": "ovo",
+                "plural_name": "ovos"
+            },
+            "endive": {
+                "name": "endívia",
+                "plural_name": "endívias"
+            },
+            "fats": {
+                "name": "gorduras"
+            },
+            "fava-beans": {
+                "name": "favas"
+            },
+            "fiddlehead": {
+                "name": "rebentos de feto comestíveis"
+            },
+            "fiddlehead-fern": {
+                "name": "rebentos de fetos",
+                "plural_name": "fetos de cabeça de peixe"
+            },
+            "fish": {
+                "name": "peixe"
+            },
+            "five-spice-powder": {
+                "name": "cinco especiarias chinesas em pó"
+            },
+            "flour": {
+                "name": "farinha"
+            },
+            "frisee": {
+                "name": "chicória"
+            },
+            "fructose": {
+                "name": "frutose"
+            },
+            "fruit": {
+                "name": "fruta"
+            },
+            "fruit-sugar": {
+                "name": "frutose"
+            },
+            "ful": {
+                "name": "ful medames"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "alho",
+                "plural_name": "alhos"
+            },
+            "gem-squash": {
+                "name": "abóbora gem"
+            },
+            "ghee": {
+                "name": "manteiga ghee"
+            },
+            "giblets": {
+                "name": "miúdos de aves"
+            },
+            "ginger": {
+                "name": "gengibre"
+            },
+            "grains": {
+                "name": "grãos"
+            },
+            "granulated-sugar": {
+                "name": "açúcar granulado"
+            },
+            "grape-seed-oil": {
+                "name": "óleo de semente de uva"
+            },
+            "green-onion": {
+                "name": "cebola verde",
+                "plural_name": "cebolas verdes"
+            },
+            "heart-of-palm": {
+                "name": "miolo de palma",
+                "plural_name": "corações de palma"
+            },
+            "hemp": {
+                "name": "cânhamo"
+            },
+            "herbs": {
+                "name": "ervas"
+            },
+            "honey": {
+                "name": "mel"
+            },
+            "isomalt": {
+                "name": "isomalte"
+            },
+            "jackfruit": {
+                "name": "jaca",
+                "plural_name": "jacas"
+            },
+            "jaggery": {
+                "name": "açúcar mascavo"
+            },
+            "jams": {
+                "name": "geleias"
+            },
+            "jellies": {
+                "name": "gelatinas"
+            },
+            "jerusalem-artichoke": {
+                "name": "alcachofra-de-jerusalém"
+            },
+            "jicama": {
+                "name": "nabo-mexicano"
+            },
+            "kale": {
+                "name": "couve"
+            },
+            "kohlrabi": {
+                "name": "couve-rábano"
+            },
+            "kumara": {
+                "name": "batata-doce"
+            },
+            "leavening-agents": {
+                "name": "fermentos"
+            },
+            "leek": {
+                "name": "alho-françês",
+                "plural_name": "alho-françês"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "erva-príncipe"
+            },
+            "lentils": {
+                "name": "lentilhas"
+            },
+            "lettuce": {
+                "name": "alface"
+            },
+            "liver": {
+                "name": "fígado",
+                "plural_name": "figados"
+            },
+            "maize": {
+                "name": "milho"
+            },
+            "maple-syrup": {
+                "name": "xarope de acer"
+            },
+            "meat": {
+                "name": "carne"
+            },
+            "milk": {
+                "name": "leite"
+            },
+            "mortadella": {
+                "name": "mortadela"
+            },
+            "mushroom": {
+                "name": "cogumelo",
+                "plural_name": "cogumelos"
+            },
+            "mussels": {
+                "name": "mexilhão"
+            },
+            "nanaimo-bar-mix": {
+                "name": "mistura de barras nanaimo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "noz-moscada"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "flocos de levedura nutricional"
+            },
+            "nuts": {
+                "name": "frutos secos"
+            },
+            "octopuses": {
+                "name": "polvos",
+                "plural_name": "polvos"
+            },
+            "oils": {
+                "name": "óleos"
+            },
+            "okra": {
+                "name": "quiabo"
+            },
+            "olive": {
+                "name": "azeitona"
+            },
+            "olive-oil": {
+                "name": "azeite"
+            },
+            "onion": {
+                "name": "cebola"
+            },
+            "onion-family": {
+                "name": "família das cebolas"
+            },
+            "orange-blossom-water": {
+                "name": "água de flor de laranjeira"
+            },
+            "oranges": {
+                "name": "laranjas",
+                "plural_name": "laranjas"
+            },
+            "oregano": {
+                "name": "orégão"
+            },
+            "oysters": {
+                "name": "ostras"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "colorau"
+            },
+            "parsley": {
+                "name": "salsa"
+            },
+            "parsnip": {
+                "name": "cherovia",
+                "plural_name": "cherovias"
+            },
+            "pear": {
+                "name": "pera",
+                "plural_name": "peras"
+            },
+            "peas": {
+                "name": "ervilhas"
+            },
+            "pepper": {
+                "name": "pimenta",
+                "plural_name": "pimentos"
+            },
+            "pineapple": {
+                "name": "ananás",
+                "plural_name": "ananases"
+            },
+            "plantain": {
+                "name": "plátano",
+                "plural_name": "plátanos"
+            },
+            "poppy-seeds": {
+                "name": "sementes de papoila"
+            },
+            "potato": {
+                "name": "batata",
+                "plural_name": "batatas"
+            },
+            "poultry": {
+                "name": "carne de aves"
+            },
+            "powdered-sugar": {
+                "name": "açúcar em pó"
+            },
+            "pumpkin": {
+                "name": "abóbora",
+                "plural_name": "abóboras"
+            },
+            "pumpkin-seeds": {
+                "name": "sementes de abóbora"
+            },
+            "radish": {
+                "name": "rabanete",
+                "plural_name": "rabanetes"
+            },
+            "raw-sugar": {
+                "name": "açúcar mascavado"
+            },
+            "refined-sugar": {
+                "name": "açúcar refinado"
+            },
+            "rice": {
+                "name": "arroz"
+            },
+            "rice-flour": {
+                "name": "farinha de arroz"
+            },
+            "rock-sugar": {
+                "name": "açúcar mascavo"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmão"
+            },
+            "salt": {
+                "name": "sal"
+            },
+            "salt-cod": {
+                "name": "bacalhau salgado"
+            },
+            "scallion": {
+                "name": "cebolinho",
+                "plural_name": "cebolinhas"
+            },
+            "seafood": {
+                "name": "marisco"
+            },
+            "seeds": {
+                "name": "sementes"
+            },
+            "sesame-seeds": {
+                "name": "sementes de sésamo"
+            },
+            "shallot": {
+                "name": "chalota",
+                "plural_name": "chalotas"
+            },
+            "skate": {
+                "name": "raia"
+            },
+            "soda": {
+                "name": "gasosa"
+            },
+            "soda-baking": {
+                "name": "bicaburnato de sódio"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "abóbora esparguete",
+                "plural_name": "abóboras esparguete"
+            },
+            "speck": {
+                "name": "presunto tirolês"
+            },
+            "spices": {
+                "name": "especiarias"
+            },
+            "spinach": {
+                "name": "espinafre"
+            },
+            "spring-onion": {
+                "name": "cebolinho",
+                "plural_name": "cebolinhos"
+            },
+            "squash": {
+                "name": "abóbora",
+                "plural_name": "abóboras"
+            },
+            "squash-family": {
+                "name": "família das abóboras"
+            },
+            "stockfish": {
+                "name": "bacalhau seco"
+            },
+            "sugar": {
+                "name": "açúcar"
+            },
+            "sunchoke": {
+                "name": "alcachofra-girassol",
+                "plural_name": "alcachofras-girassol"
+            },
+            "sunflower-seeds": {
+                "name": "sementes de girassol"
+            },
+            "superfine-sugar": {
+                "name": "açúcar superfino"
+            },
+            "sweet-potato": {
+                "name": "batata-doce",
+                "plural_name": "batatas doces"
+            },
+            "sweetcorn": {
+                "name": "milho doce",
+                "plural_name": "milhos doces"
+            },
+            "sweeteners": {
+                "name": "adoçantes"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "tefe"
+            },
+            "tomato": {
+                "name": "tomate",
+                "plural_name": "tomates"
+            },
+            "trout": {
+                "name": "truta"
+            },
+            "tubers": {
+                "name": "tuberculos",
+                "plural_name": "tubérculos"
+            },
+            "tuna": {
+                "name": "atum"
+            },
+            "turbanado-sugar": {
+                "name": "açucar turbinado"
+            },
+            "turnip": {
+                "name": "nabo",
+                "plural_name": "nabos"
+            },
+            "unrefined-sugar": {
+                "name": "açúcar não refinado"
+            },
+            "vanilla": {
+                "name": "baunilha"
+            },
+            "vegetables": {
+                "name": "vegetais"
+            },
+            "watercress": {
+                "name": "agrião"
+            },
+            "watermelon": {
+                "name": "melancia",
+                "plural_name": "melancias"
+            },
+            "white-mushroom": {
+                "name": "cogumelo branco",
+                "plural_name": "cogumelos brancos"
+            },
+            "white-sugar": {
+                "name": "açúcar branco"
+            },
+            "xanthan-gum": {
+                "name": "goma xantana"
+            },
+            "yam": {
+                "name": "inhame",
+                "plural_name": "inhames"
+            },
+            "yeast": {
+                "name": "levedura"
+            },
+            "zucchini": {
+                "name": "courgette",
+                "plural_name": "curgetes"
+            }
+        }
+    },
+    "Produto": {
+        "foods": {}
+    },
+    "Grãos": {
+        "foods": {}
+    },
+    "Frutas": {
+        "foods": {}
+    },
+    "Vegetais": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Marisco": {
+        "foods": {}
+    },
+    "Bebidas": {
+        "foods": {}
+    },
+    "Produtos de pastelaria": {
+        "foods": {}
+    },
+    "Enlatados": {
+        "foods": {}
+    },
+    "Condimentos": {
+        "foods": {}
+    },
+    "Confeitaria": {
+        "foods": {}
+    },
+    "Lacticínios": {
+        "foods": {}
+    },
+    "Congelados": {
+        "foods": {}
+    },
+    "Alimentos para Saúde": {
+        "foods": {}
+    },
+    "Casa": {
+        "foods": {}
+    },
+    "Produtos à base de carne": {
+        "foods": {}
+    },
+    "Petiscos": {
+        "foods": {}
+    },
+    "Especiarias": {
+        "foods": {}
+    },
+    "Doces": {
+        "foods": {}
+    },
+    "Álcool": {
+        "foods": {}
+    },
+    "Outros": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ro-RO.json
+++ b/mealie/repos/seed/resources/foods/locales/ro-RO.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "dovleac ghindă"
-	},
-	"alfalfa-sprouts": {
-		"name": "vlăstari de lucernă"
-	},
-	"anchovies": {
-		"name": "anșoa"
-	},
-	"apples": {
-		"name": "mere",
-		"plural_name": "mere"
-	},
-	"artichoke": {
-		"name": "anghinare"
-	},
-	"arugula": {
-		"name": "rucola"
-	},
-	"asparagus": {
-		"name": "sparanghel"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "praf de copt"
-	},
-	"baking-soda": {
-		"name": "bicarbonat de sodiu"
-	},
-	"baking-sugar": {
-		"name": "zahăr pudră"
-	},
-	"bar-sugar": {
-		"name": "zahăr fin"
-	},
-	"basil": {
-		"name": "busuioc"
-	},
-	"beans": {
-		"name": "fasole"
-	},
-	"bell-peppers": {
-		"name": "ardei gras",
-		"plural_name": "ardei gras"
-	},
-	"blackberries": {
-		"name": "mure"
-	},
-	"bok-choy": {
-		"name": "varză chinezească"
-	},
-	"brassicas": {
-		"name": "brasicacee"
-	},
-	"bread": {
-		"name": "pâine"
-	},
-	"breadfruit": {
-		"name": "fructul de pâine"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "brocoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli asiatic"
-	},
-	"broccolini": {
-		"name": "broccoli tânăr"
-	},
-	"brown-sugar": {
-		"name": "zahăr brun"
-	},
-	"brussels-sprouts": {
-		"name": "varză de Bruxelles"
-	},
-	"butter": {
-		"name": "unt"
-	},
-	"butternut-pumpkin": {
-		"name": "dovleac plăcintar"
-	},
-	"butternut-squash": {
-		"name": "dovleac butternut"
-	},
-	"cabbage": {
-		"name": "varză",
-		"plural_name": "verze"
-	},
-	"cactus-edible": {
-		"name": "cactus, comestibil"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "zahăr din trestie"
-	},
-	"cannabis": {
-		"name": "canabis"
-	},
-	"capsicum": {
-		"name": "ardei gras"
-	},
-	"caraway": {
-		"name": "chimen"
-	},
-	"carrot": {
-		"name": "morcov",
-		"plural_name": "morcovi"
-	},
-	"caster-sugar": {
-		"name": "zahăr tos fin"
-	},
-	"castor-sugar": {
-		"name": "zahăr tos fin"
-	},
-	"catfish": {
-		"name": "somn"
-	},
-	"cauliflower": {
-		"name": "conopidă",
-		"plural_name": "conopidă"
-	},
-	"cayenne-pepper": {
-		"name": "piper cayenne"
-	},
-	"celeriac": {
-		"name": "țelină"
-	},
-	"celery": {
-		"name": "țelină"
-	},
-	"cereal-grains": {
-		"name": "boabe de cereale"
-	},
-	"chard": {
-		"name": "sfeclă elvețiană"
-	},
-	"cheese": {
-		"name": "brânză"
-	},
-	"chicory": {
-		"name": "cicoare"
-	},
-	"chilli-peppers": {
-		"name": "ardei iuţi",
-		"plural_name": "ardei iuți"
-	},
-	"chinese-leaves": {
-		"name": "frunze chinezești"
-	},
-	"chives": {
-		"name": "arpagic"
-	},
-	"chocolate": {
-		"name": "ciocolată"
-	},
-	"cilantro": {
-		"name": "coriandru"
-	},
-	"cinnamon": {
-		"name": "scorţişoară"
-	},
-	"clarified-butter": {
-		"name": "unt clarificat sau ghee"
-	},
-	"coconut": {
-		"name": "nucă de cocos",
-		"plural_name": "nuci de cocos"
-	},
-	"coconut-milk": {
-		"name": "lapte de cocos"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "cafea"
-	},
-	"collard-greens": {
-		"name": "varză creață"
-	},
-	"confectioners-sugar": {
-		"name": "zahăr pudră"
-	},
-	"coriander": {
-		"name": "coriandru"
-	},
-	"corn": {
-		"name": "porumb",
-		"plural_name": "porumbi"
-	},
-	"corn-syrup": {
-		"name": "sirop de porumb"
-	},
-	"cottonseed-oil": {
-		"name": "ulei de bumbac"
-	},
-	"courgette": {
-		"name": "dovlecel"
-	},
-	"cream-of-tartar": {
-		"name": "cremă de tartar"
-	},
-	"cucumber": {
-		"name": "castravete",
-		"plural_name": "castraveți"
-	},
-	"cumin": {
-		"name": "chimion"
-	},
-	"daikon": {
-		"name": "ridiche asiatică",
-		"plural_name": "ridichi asiatice"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "produse lactate şi înlocuitori ai acestora"
-	},
-	"dandelion": {
-		"name": "păpădie"
-	},
-	"demerara-sugar": {
-		"name": "zahăr demerara"
-	},
-	"dough": {
-		"name": "aluat"
-	},
-	"edible-cactus": {
-		"name": "cactus comestibil"
-	},
-	"eggplant": {
-		"name": "vânătă",
-		"plural_name": "vinete"
-	},
-	"eggs": {
-		"name": "ouă",
-		"plural_name": "ouă"
-	},
-	"endive": {
-		"name": "andivă",
-		"plural_name": "andive"
-	},
-	"fats": {
-		"name": "grăsimi"
-	},
-	"fava-beans": {
-		"name": "bob"
-	},
-	"fiddlehead": {
-		"name": "frunze tinere de ferigă"
-	},
-	"fiddlehead-fern": {
-		"name": "frunză tânără de ferigă",
-		"plural_name": "frunze tinere de ferigă"
-	},
-	"fish": {
-		"name": "peşte"
-	},
-	"five-spice-powder": {
-		"name": "amestec de cinci condimente"
-	},
-	"flour": {
-		"name": "făină"
-	},
-	"frisee": {
-		"name": "salată frisée"
-	},
-	"fructose": {
-		"name": "fructoză"
-	},
-	"fruit": {
-		"name": "fruct"
-	},
-	"fruit-sugar": {
-		"name": "zahăr din fructe"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "usturoi",
-		"plural_name": "usturoi"
-	},
-	"gem-squash": {
-		"name": "dovleac gem"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "măruntaie"
-	},
-	"ginger": {
-		"name": "ghimbir"
-	},
-	"grains": {
-		"name": "cereale"
-	},
-	"granulated-sugar": {
-		"name": "zahăr granulat"
-	},
-	"grape-seed-oil": {
-		"name": "ulei de semințe de struguri"
-	},
-	"green-onion": {
-		"name": "ceapă verde",
-		"plural_name": "cepe verzi"
-	},
-	"heart-of-palm": {
-		"name": "miez de palmier",
-		"plural_name": "miezuri de palmier"
-	},
-	"hemp": {
-		"name": "cânepă"
-	},
-	"herbs": {
-		"name": "ierburi"
-	},
-	"honey": {
-		"name": "miere"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruit-uri"
-	},
-	"jaggery": {
-		"name": "zahăr brun nerafinat"
-	},
-	"jams": {
-		"name": "gemuri"
-	},
-	"jellies": {
-		"name": "jeleuri"
-	},
-	"jerusalem-artichoke": {
-		"name": "anghinare de ierusalim"
-	},
-	"jicama": {
-		"name": "nap mexican"
-	},
-	"kale": {
-		"name": "varză furajeră"
-	},
-	"kohlrabi": {
-		"name": "gulie"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "agenți de dospire"
-	},
-	"leek": {
-		"name": "praz",
-		"plural_name": "praz"
-	},
-	"legumes": {
-		"name": "leguminoase"
-	},
-	"lemongrass": {
-		"name": "iarbă de lămâie"
-	},
-	"lentils": {
-		"name": "linte"
-	},
-	"lettuce": {
-		"name": "salată"
-	},
-	"liver": {
-		"name": "ficat",
-		"plural_name": "ficaţi"
-	},
-	"maize": {
-		"name": "porumb"
-	},
-	"maple-syrup": {
-		"name": "sirop de arțar"
-	},
-	"meat": {
-		"name": "carne"
-	},
-	"milk": {
-		"name": "lapte"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "ciupercă",
-		"plural_name": "ciuperci"
-	},
-	"mussels": {
-		"name": "midii"
-	},
-	"nanaimo-bar-mix": {
-		"name": "amestec pentru prăjitura nanaimo"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nucşoară"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "fulgi de drojdie nutritivă"
-	},
-	"nuts": {
-		"name": "nuci"
-	},
-	"octopuses": {
-		"name": "caracatiţe",
-		"plural_name": "caracatiţe"
-	},
-	"oils": {
-		"name": "uleiuri"
-	},
-	"okra": {
-		"name": "bame"
-	},
-	"olive": {
-		"name": "măslină"
-	},
-	"olive-oil": {
-		"name": "ulei de măsline"
-	},
-	"onion": {
-		"name": "ceapă"
-	},
-	"onion-family": {
-		"name": "familie de ceapă"
-	},
-	"orange-blossom-water": {
-		"name": "apă de flori de portocal"
-	},
-	"oranges": {
-		"name": "portocale",
-		"plural_name": "portocale"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "stridii"
-	},
-	"panch-puran": {
-		"name": "amestec de condimente indiene"
-	},
-	"paprika": {
-		"name": "boia"
-	},
-	"parsley": {
-		"name": "pătrunjel"
-	},
-	"parsnip": {
-		"name": "păstârnac",
-		"plural_name": "păstârnac"
-	},
-	"pear": {
-		"name": "pară",
-		"plural_name": "pere"
-	},
-	"peas": {
-		"name": "mazăre"
-	},
-	"pepper": {
-		"name": "piper",
-		"plural_name": "ardei"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "banană",
-		"plural_name": "banane"
-	},
-	"poppy-seeds": {
-		"name": "semințe de mac"
-	},
-	"potato": {
-		"name": "cartof",
-		"plural_name": "cartofi"
-	},
-	"poultry": {
-		"name": "carne de pasăre"
-	},
-	"powdered-sugar": {
-		"name": "zahăr praf"
-	},
-	"pumpkin": {
-		"name": "dovleac",
-		"plural_name": "dovleci"
-	},
-	"pumpkin-seeds": {
-		"name": "semințe de dovleac"
-	},
-	"radish": {
-		"name": "ridiche",
-		"plural_name": "ridichi"
-	},
-	"raw-sugar": {
-		"name": "zahăr brut"
-	},
-	"refined-sugar": {
-		"name": "zahăr rafinat"
-	},
-	"rice": {
-		"name": "orez"
-	},
-	"rice-flour": {
-		"name": "făină de orez"
-	},
-	"rock-sugar": {
-		"name": "zahăr cristalizat"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "somon"
-	},
-	"salt": {
-		"name": "sare"
-	},
-	"salt-cod": {
-		"name": "cod sărat"
-	},
-	"scallion": {
-		"name": "ceapă verde",
-		"plural_name": "cepe verzi"
-	},
-	"seafood": {
-		"name": "fruct de mare"
-	},
-	"seeds": {
-		"name": "semințe"
-	},
-	"sesame-seeds": {
-		"name": "semințe de susan"
-	},
-	"shallot": {
-		"name": "eșalotă",
-		"plural_name": "eșalote"
-	},
-	"skate": {
-		"name": "pește patin"
-	},
-	"soda": {
-		"name": "băutură carbogazoasă"
-	},
-	"soda-baking": {
-		"name": "bicarbonat de sodiu"
-	},
-	"soybean": {
-		"name": "boabe de soia"
-	},
-	"spaghetti-squash": {
-		"name": "dovleac spaghetti",
-		"plural_name": "dovlecei spaghetti"
-	},
-	"speck": {
-		"name": "speck jambon crud-uscat"
-	},
-	"spices": {
-		"name": "condimente"
-	},
-	"spinach": {
-		"name": "spanac"
-	},
-	"spring-onion": {
-		"name": "ceapă verde",
-		"plural_name": "cepe verzi"
-	},
-	"squash": {
-		"name": "dovleac",
-		"plural_name": "dovleci"
-	},
-	"squash-family": {
-		"name": "familia dovleacului"
-	},
-	"stockfish": {
-		"name": "pește uscat"
-	},
-	"sugar": {
-		"name": "zahăr"
-	},
-	"sunchoke": {
-		"name": "topinambur",
-		"plural_name": "topinamburi"
-	},
-	"sunflower-seeds": {
-		"name": "semințe de floarea-soarelui"
-	},
-	"superfine-sugar": {
-		"name": "zahăr extrafin"
-	},
-	"sweet-potato": {
-		"name": "cartof dulce",
-		"plural_name": "cartofi dulci"
-	},
-	"sweetcorn": {
-		"name": "porumb dulce",
-		"plural_name": "porumb dulce"
-	},
-	"sweeteners": {
-		"name": "îndulcitori"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "tarouri"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "roșie",
-		"plural_name": "roșii"
-	},
-	"trout": {
-		"name": "păstrăv"
-	},
-	"tubers": {
-		"name": "tubercul",
-		"plural_name": "tuberculi"
-	},
-	"tuna": {
-		"name": "ton"
-	},
-	"turbanado-sugar": {
-		"name": "zahăr brut"
-	},
-	"turnip": {
-		"name": "nap",
-		"plural_name": "napi"
-	},
-	"unrefined-sugar": {
-		"name": "zahăr nerafinat"
-	},
-	"vanilla": {
-		"name": "vanilie"
-	},
-	"vegetables": {
-		"name": "legume"
-	},
-	"watercress": {
-		"name": "năsturel"
-	},
-	"watermelon": {
-		"name": "pepene",
-		"plural_name": "pepeni verzi"
-	},
-	"white-mushroom": {
-		"name": "ciupercă albă",
-		"plural_name": "ciuperci albe"
-	},
-	"white-sugar": {
-		"name": "zahăr alb"
-	},
-	"xanthan-gum": {
-		"name": "gumă xanthan"
-	},
-	"yam": {
-		"name": "cartof dulce",
-		"plural_name": "cartofi dulci"
-	},
-	"yeast": {
-		"name": "drojdie"
-	},
-	"zucchini": {
-		"name": "dovlecel",
-		"plural_name": "dovlecei"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "dovleac ghindă"
+            },
+            "alfalfa-sprouts": {
+                "name": "vlăstari de lucernă"
+            },
+            "anchovies": {
+                "name": "anșoa"
+            },
+            "apples": {
+                "name": "mere",
+                "plural_name": "mere"
+            },
+            "artichoke": {
+                "name": "anghinare"
+            },
+            "arugula": {
+                "name": "rucola"
+            },
+            "asparagus": {
+                "name": "sparanghel"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "praf de copt"
+            },
+            "baking-soda": {
+                "name": "bicarbonat de sodiu"
+            },
+            "baking-sugar": {
+                "name": "zahăr pudră"
+            },
+            "bar-sugar": {
+                "name": "zahăr fin"
+            },
+            "basil": {
+                "name": "busuioc"
+            },
+            "beans": {
+                "name": "fasole"
+            },
+            "bell-peppers": {
+                "name": "ardei gras",
+                "plural_name": "ardei gras"
+            },
+            "blackberries": {
+                "name": "mure"
+            },
+            "bok-choy": {
+                "name": "varză chinezească"
+            },
+            "brassicas": {
+                "name": "brasicacee"
+            },
+            "bread": {
+                "name": "pâine"
+            },
+            "breadfruit": {
+                "name": "fructul de pâine"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "brocoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli asiatic"
+            },
+            "broccolini": {
+                "name": "broccoli tânăr"
+            },
+            "brown-sugar": {
+                "name": "zahăr brun"
+            },
+            "brussels-sprouts": {
+                "name": "varză de Bruxelles"
+            },
+            "butter": {
+                "name": "unt"
+            },
+            "butternut-pumpkin": {
+                "name": "dovleac plăcintar"
+            },
+            "butternut-squash": {
+                "name": "dovleac butternut"
+            },
+            "cabbage": {
+                "name": "varză",
+                "plural_name": "verze"
+            },
+            "cactus-edible": {
+                "name": "cactus, comestibil"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "zahăr din trestie"
+            },
+            "cannabis": {
+                "name": "canabis"
+            },
+            "capsicum": {
+                "name": "ardei gras"
+            },
+            "caraway": {
+                "name": "chimen"
+            },
+            "carrot": {
+                "name": "morcov",
+                "plural_name": "morcovi"
+            },
+            "caster-sugar": {
+                "name": "zahăr tos fin"
+            },
+            "castor-sugar": {
+                "name": "zahăr tos fin"
+            },
+            "catfish": {
+                "name": "somn"
+            },
+            "cauliflower": {
+                "name": "conopidă",
+                "plural_name": "conopidă"
+            },
+            "cayenne-pepper": {
+                "name": "piper cayenne"
+            },
+            "celeriac": {
+                "name": "țelină"
+            },
+            "celery": {
+                "name": "țelină"
+            },
+            "cereal-grains": {
+                "name": "boabe de cereale"
+            },
+            "chard": {
+                "name": "sfeclă elvețiană"
+            },
+            "cheese": {
+                "name": "brânză"
+            },
+            "chicory": {
+                "name": "cicoare"
+            },
+            "chilli-peppers": {
+                "name": "ardei iuţi",
+                "plural_name": "ardei iuți"
+            },
+            "chinese-leaves": {
+                "name": "frunze chinezești"
+            },
+            "chives": {
+                "name": "arpagic"
+            },
+            "chocolate": {
+                "name": "ciocolată"
+            },
+            "cilantro": {
+                "name": "coriandru"
+            },
+            "cinnamon": {
+                "name": "scorţişoară"
+            },
+            "clarified-butter": {
+                "name": "unt clarificat sau ghee"
+            },
+            "coconut": {
+                "name": "nucă de cocos",
+                "plural_name": "nuci de cocos"
+            },
+            "coconut-milk": {
+                "name": "lapte de cocos"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "cafea"
+            },
+            "collard-greens": {
+                "name": "varză creață"
+            },
+            "confectioners-sugar": {
+                "name": "zahăr pudră"
+            },
+            "coriander": {
+                "name": "coriandru"
+            },
+            "corn": {
+                "name": "porumb",
+                "plural_name": "porumbi"
+            },
+            "corn-syrup": {
+                "name": "sirop de porumb"
+            },
+            "cottonseed-oil": {
+                "name": "ulei de bumbac"
+            },
+            "courgette": {
+                "name": "dovlecel"
+            },
+            "cream-of-tartar": {
+                "name": "cremă de tartar"
+            },
+            "cucumber": {
+                "name": "castravete",
+                "plural_name": "castraveți"
+            },
+            "cumin": {
+                "name": "chimion"
+            },
+            "daikon": {
+                "name": "ridiche asiatică",
+                "plural_name": "ridichi asiatice"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "produse lactate şi înlocuitori ai acestora"
+            },
+            "dandelion": {
+                "name": "păpădie"
+            },
+            "demerara-sugar": {
+                "name": "zahăr demerara"
+            },
+            "dough": {
+                "name": "aluat"
+            },
+            "edible-cactus": {
+                "name": "cactus comestibil"
+            },
+            "eggplant": {
+                "name": "vânătă",
+                "plural_name": "vinete"
+            },
+            "eggs": {
+                "name": "ouă",
+                "plural_name": "ouă"
+            },
+            "endive": {
+                "name": "andivă",
+                "plural_name": "andive"
+            },
+            "fats": {
+                "name": "grăsimi"
+            },
+            "fava-beans": {
+                "name": "bob"
+            },
+            "fiddlehead": {
+                "name": "frunze tinere de ferigă"
+            },
+            "fiddlehead-fern": {
+                "name": "frunză tânără de ferigă",
+                "plural_name": "frunze tinere de ferigă"
+            },
+            "fish": {
+                "name": "peşte"
+            },
+            "five-spice-powder": {
+                "name": "amestec de cinci condimente"
+            },
+            "flour": {
+                "name": "făină"
+            },
+            "frisee": {
+                "name": "salată frisée"
+            },
+            "fructose": {
+                "name": "fructoză"
+            },
+            "fruit": {
+                "name": "fruct"
+            },
+            "fruit-sugar": {
+                "name": "zahăr din fructe"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "usturoi",
+                "plural_name": "usturoi"
+            },
+            "gem-squash": {
+                "name": "dovleac gem"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "măruntaie"
+            },
+            "ginger": {
+                "name": "ghimbir"
+            },
+            "grains": {
+                "name": "cereale"
+            },
+            "granulated-sugar": {
+                "name": "zahăr granulat"
+            },
+            "grape-seed-oil": {
+                "name": "ulei de semințe de struguri"
+            },
+            "green-onion": {
+                "name": "ceapă verde",
+                "plural_name": "cepe verzi"
+            },
+            "heart-of-palm": {
+                "name": "miez de palmier",
+                "plural_name": "miezuri de palmier"
+            },
+            "hemp": {
+                "name": "cânepă"
+            },
+            "herbs": {
+                "name": "ierburi"
+            },
+            "honey": {
+                "name": "miere"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruit-uri"
+            },
+            "jaggery": {
+                "name": "zahăr brun nerafinat"
+            },
+            "jams": {
+                "name": "gemuri"
+            },
+            "jellies": {
+                "name": "jeleuri"
+            },
+            "jerusalem-artichoke": {
+                "name": "anghinare de ierusalim"
+            },
+            "jicama": {
+                "name": "nap mexican"
+            },
+            "kale": {
+                "name": "varză furajeră"
+            },
+            "kohlrabi": {
+                "name": "gulie"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "agenți de dospire"
+            },
+            "leek": {
+                "name": "praz",
+                "plural_name": "praz"
+            },
+            "legumes": {
+                "name": "leguminoase"
+            },
+            "lemongrass": {
+                "name": "iarbă de lămâie"
+            },
+            "lentils": {
+                "name": "linte"
+            },
+            "lettuce": {
+                "name": "salată"
+            },
+            "liver": {
+                "name": "ficat",
+                "plural_name": "ficaţi"
+            },
+            "maize": {
+                "name": "porumb"
+            },
+            "maple-syrup": {
+                "name": "sirop de arțar"
+            },
+            "meat": {
+                "name": "carne"
+            },
+            "milk": {
+                "name": "lapte"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "ciupercă",
+                "plural_name": "ciuperci"
+            },
+            "mussels": {
+                "name": "midii"
+            },
+            "nanaimo-bar-mix": {
+                "name": "amestec pentru prăjitura nanaimo"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nucşoară"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "fulgi de drojdie nutritivă"
+            },
+            "nuts": {
+                "name": "nuci"
+            },
+            "octopuses": {
+                "name": "caracatiţe",
+                "plural_name": "caracatiţe"
+            },
+            "oils": {
+                "name": "uleiuri"
+            },
+            "okra": {
+                "name": "bame"
+            },
+            "olive": {
+                "name": "măslină"
+            },
+            "olive-oil": {
+                "name": "ulei de măsline"
+            },
+            "onion": {
+                "name": "ceapă"
+            },
+            "onion-family": {
+                "name": "familie de ceapă"
+            },
+            "orange-blossom-water": {
+                "name": "apă de flori de portocal"
+            },
+            "oranges": {
+                "name": "portocale",
+                "plural_name": "portocale"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "stridii"
+            },
+            "panch-puran": {
+                "name": "amestec de condimente indiene"
+            },
+            "paprika": {
+                "name": "boia"
+            },
+            "parsley": {
+                "name": "pătrunjel"
+            },
+            "parsnip": {
+                "name": "păstârnac",
+                "plural_name": "păstârnac"
+            },
+            "pear": {
+                "name": "pară",
+                "plural_name": "pere"
+            },
+            "peas": {
+                "name": "mazăre"
+            },
+            "pepper": {
+                "name": "piper",
+                "plural_name": "ardei"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "banană",
+                "plural_name": "banane"
+            },
+            "poppy-seeds": {
+                "name": "semințe de mac"
+            },
+            "potato": {
+                "name": "cartof",
+                "plural_name": "cartofi"
+            },
+            "poultry": {
+                "name": "carne de pasăre"
+            },
+            "powdered-sugar": {
+                "name": "zahăr praf"
+            },
+            "pumpkin": {
+                "name": "dovleac",
+                "plural_name": "dovleci"
+            },
+            "pumpkin-seeds": {
+                "name": "semințe de dovleac"
+            },
+            "radish": {
+                "name": "ridiche",
+                "plural_name": "ridichi"
+            },
+            "raw-sugar": {
+                "name": "zahăr brut"
+            },
+            "refined-sugar": {
+                "name": "zahăr rafinat"
+            },
+            "rice": {
+                "name": "orez"
+            },
+            "rice-flour": {
+                "name": "făină de orez"
+            },
+            "rock-sugar": {
+                "name": "zahăr cristalizat"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "somon"
+            },
+            "salt": {
+                "name": "sare"
+            },
+            "salt-cod": {
+                "name": "cod sărat"
+            },
+            "scallion": {
+                "name": "ceapă verde",
+                "plural_name": "cepe verzi"
+            },
+            "seafood": {
+                "name": "fruct de mare"
+            },
+            "seeds": {
+                "name": "semințe"
+            },
+            "sesame-seeds": {
+                "name": "semințe de susan"
+            },
+            "shallot": {
+                "name": "eșalotă",
+                "plural_name": "eșalote"
+            },
+            "skate": {
+                "name": "pește patin"
+            },
+            "soda": {
+                "name": "băutură carbogazoasă"
+            },
+            "soda-baking": {
+                "name": "bicarbonat de sodiu"
+            },
+            "soybean": {
+                "name": "boabe de soia"
+            },
+            "spaghetti-squash": {
+                "name": "dovleac spaghetti",
+                "plural_name": "dovlecei spaghetti"
+            },
+            "speck": {
+                "name": "speck jambon crud-uscat"
+            },
+            "spices": {
+                "name": "condimente"
+            },
+            "spinach": {
+                "name": "spanac"
+            },
+            "spring-onion": {
+                "name": "ceapă verde",
+                "plural_name": "cepe verzi"
+            },
+            "squash": {
+                "name": "dovleac",
+                "plural_name": "dovleci"
+            },
+            "squash-family": {
+                "name": "familia dovleacului"
+            },
+            "stockfish": {
+                "name": "pește uscat"
+            },
+            "sugar": {
+                "name": "zahăr"
+            },
+            "sunchoke": {
+                "name": "topinambur",
+                "plural_name": "topinamburi"
+            },
+            "sunflower-seeds": {
+                "name": "semințe de floarea-soarelui"
+            },
+            "superfine-sugar": {
+                "name": "zahăr extrafin"
+            },
+            "sweet-potato": {
+                "name": "cartof dulce",
+                "plural_name": "cartofi dulci"
+            },
+            "sweetcorn": {
+                "name": "porumb dulce",
+                "plural_name": "porumb dulce"
+            },
+            "sweeteners": {
+                "name": "îndulcitori"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "tarouri"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "roșie",
+                "plural_name": "roșii"
+            },
+            "trout": {
+                "name": "păstrăv"
+            },
+            "tubers": {
+                "name": "tubercul",
+                "plural_name": "tuberculi"
+            },
+            "tuna": {
+                "name": "ton"
+            },
+            "turbanado-sugar": {
+                "name": "zahăr brut"
+            },
+            "turnip": {
+                "name": "nap",
+                "plural_name": "napi"
+            },
+            "unrefined-sugar": {
+                "name": "zahăr nerafinat"
+            },
+            "vanilla": {
+                "name": "vanilie"
+            },
+            "vegetables": {
+                "name": "legume"
+            },
+            "watercress": {
+                "name": "năsturel"
+            },
+            "watermelon": {
+                "name": "pepene",
+                "plural_name": "pepeni verzi"
+            },
+            "white-mushroom": {
+                "name": "ciupercă albă",
+                "plural_name": "ciuperci albe"
+            },
+            "white-sugar": {
+                "name": "zahăr alb"
+            },
+            "xanthan-gum": {
+                "name": "gumă xanthan"
+            },
+            "yam": {
+                "name": "cartof dulce",
+                "plural_name": "cartofi dulci"
+            },
+            "yeast": {
+                "name": "drojdie"
+            },
+            "zucchini": {
+                "name": "dovlecel",
+                "plural_name": "dovlecei"
+            }
+        }
+    },
+    "Produs": {
+        "foods": {}
+    },
+    "Cereale": {
+        "foods": {}
+    },
+    "Fructe": {
+        "foods": {}
+    },
+    "Legume": {
+        "foods": {}
+    },
+    "Carne": {
+        "foods": {}
+    },
+    "Fructe de Mare": {
+        "foods": {}
+    },
+    "Băuturi": {
+        "foods": {}
+    },
+    "Produse coapte": {
+        "foods": {}
+    },
+    "Produse conservate": {
+        "foods": {}
+    },
+    "Condimente": {
+        "foods": {}
+    },
+    "Cofetărie": {
+        "foods": {}
+    },
+    "Produse lactate": {
+        "foods": {}
+    },
+    "Alimente înghețate": {
+        "foods": {}
+    },
+    "Mâncare Sănătoasă": {
+        "foods": {}
+    },
+    "Gospodărie": {
+        "foods": {}
+    },
+    "Produse din carne": {
+        "foods": {}
+    },
+    "Gustări": {
+        "foods": {}
+    },
+    "Dulciuri": {
+        "foods": {}
+    },
+    "Alcool": {
+        "foods": {}
+    },
+    "Altele": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/ru-RU.json
+++ b/mealie/repos/seed/resources/foods/locales/ru-RU.json
@@ -1,692 +1,759 @@
 {
-    "acorn-squash": {
-        "name": "желудевый сквош"
-    },
-    "alfalfa-sprouts": {
-        "name": "ростки люцерны"
-    },
-    "anchovies": {
-        "name": "анчоусы"
-    },
-    "apples": {
-        "name": "яблоки",
-        "plural_name": "яблоки"
-    },
-    "artichoke": {
-        "name": "артишок"
-    },
-    "arugula": {
-        "name": "руккола"
-    },
-    "asparagus": {
-        "name": "спаржа"
-    },
-    "avocado": {
-        "name": "авокадо",
-        "plural_name": "авокадо"
-    },
-    "bacon": {
-        "name": "бекон"
-    },
-    "baking-powder": {
-        "name": "разрыхлитель"
-    },
-    "baking-soda": {
-        "name": "пищевая сода"
-    },
-    "baking-sugar": {
-        "name": "сахар-песок"
-    },
-    "bar-sugar": {
-        "name": "брусковый сахар"
-    },
-    "basil": {
-        "name": "базилик"
-    },
-    "beans": {
-        "name": "фасоль"
-    },
-    "bell-peppers": {
-        "name": "болгарский перец",
-        "plural_name": "болгарский перец"
-    },
-    "blackberries": {
-        "name": "ежевика"
-    },
-    "bok-choy": {
-        "name": "пекинская капуста"
-    },
-    "brassicas": {
-        "name": "капуста"
-    },
-    "bread": {
-        "name": "хлеб"
-    },
-    "breadfruit": {
-        "name": "плод хлебного дерева"
-    },
-    "broccoflower": {
-        "name": "романеско"
-    },
-    "broccoli": {
-        "name": "брокколи"
-    },
-    "broccoli-rabe": {
-        "name": "рапини"
-    },
-    "broccolini": {
-        "name": "брокколини"
-    },
-    "brown-sugar": {
-        "name": "коричневый сахар"
-    },
-    "brussels-sprouts": {
-        "name": "брюссельская капуста"
-    },
-    "butter": {
-        "name": "сливочное масло"
-    },
-    "butternut-pumpkin": {
-        "name": "тыква баттернат"
-    },
-    "butternut-squash": {
-        "name": "мускатная тыква"
-    },
-    "cabbage": {
-        "name": "капуста",
-        "plural_name": "капуста"
-    },
-    "cactus-edible": {
-        "name": "кактус, съедобный"
-    },
-    "calabrese": {
-        "name": "брокколи калабрезе"
-    },
-    "cane-sugar": {
-        "name": "тростниковый сахар"
-    },
-    "cannabis": {
-        "name": "конопля"
-    },
-    "capsicum": {
-        "name": "стручковый перец"
-    },
-    "caraway": {
-        "name": "тмин"
-    },
-    "carrot": {
-        "name": "морковь",
-        "plural_name": "морковь"
-    },
-    "caster-sugar": {
-        "name": "мелкозернистый сахар"
-    },
-    "castor-sugar": {
-        "name": "сахарная пудра"
-    },
-    "catfish": {
-        "name": "сом"
-    },
-    "cauliflower": {
-        "name": "цветная капуста",
-        "plural_name": "цветная капуста"
-    },
-    "cayenne-pepper": {
-        "name": "кайенский перец"
-    },
-    "celeriac": {
-        "name": "корень сельдерея"
-    },
-    "celery": {
-        "name": "сельдерей"
-    },
-    "cereal-grains": {
-        "name": "злаковое зерно"
-    },
-    "chard": {
-        "name": "мангольд"
-    },
-    "cheese": {
-        "name": "сыр"
-    },
-    "chicory": {
-        "name": "цикорий"
-    },
-    "chilli-peppers": {
-        "name": "перец чили",
-        "plural_name": "перец чили"
-    },
-    "chinese-leaves": {
-        "name": "китайская капуста"
-    },
-    "chives": {
-        "name": "шнитт-лук"
-    },
-    "chocolate": {
-        "name": "шоколад"
-    },
-    "cilantro": {
-        "name": "кинза"
-    },
-    "cinnamon": {
-        "name": "корица"
-    },
-    "clarified-butter": {
-        "name": "топленое масло"
-    },
-    "coconut": {
-        "name": "кокос",
-        "plural_name": "кокосы"
-    },
-    "coconut-milk": {
-        "name": "кокосовое молоко"
-    },
-    "cod": {
-        "name": "треска"
-    },
-    "coffee": {
-        "name": "кофе"
-    },
-    "collard-greens": {
-        "name": "листовая капуста"
-    },
-    "confectioners-sugar": {
-        "name": "кондитерский сахар"
-    },
-    "coriander": {
-        "name": "кориандр"
-    },
-    "corn": {
-        "name": "кукуруза",
-        "plural_name": "кукуруза"
-    },
-    "corn-syrup": {
-        "name": "кукурузный сироп"
-    },
-    "cottonseed-oil": {
-        "name": "хлопковое масло"
-    },
-    "courgette": {
-        "name": "цукини"
-    },
-    "cream-of-tartar": {
-        "name": "винный камень"
-    },
-    "cucumber": {
-        "name": "огурцы",
-        "plural_name": "огурцы"
-    },
-    "cumin": {
-        "name": "зира"
-    },
-    "daikon": {
-        "name": "дайкон",
-        "plural_name": "дайкон"
-    },
-    "dairy-products-and-dairy-substitutes": {
-        "name": "молочные продукты и заменители молочных продуктов"
-    },
-    "dandelion": {
-        "name": "одуванчик"
-    },
-    "demerara-sugar": {
-        "name": "сахар демерара"
-    },
-    "dough": {
-        "name": "тесто"
-    },
-    "edible-cactus": {
-        "name": "съедобный кактус"
-    },
-    "eggplant": {
-        "name": "баклажан",
-        "plural_name": "баклажаны"
-    },
-    "eggs": {
-        "name": "яйца",
-        "plural_name": "яйца"
-    },
-    "endive": {
-        "name": "эндивий",
-        "plural_name": "endives"
-    },
-    "fats": {
-        "name": "жиры"
-    },
-    "fava-beans": {
-        "name": "бобы обыкновенные"
-    },
-    "fiddlehead": {
-        "name": "побеги папоротника"
-    },
-    "fiddlehead-fern": {
-        "name": "побеги папоротника",
-        "plural_name": "побеги папоротника"
-    },
-    "fish": {
-        "name": "рыба"
-    },
-    "five-spice-powder": {
-        "name": "приправа 5 специй"
-    },
-    "flour": {
-        "name": "мука"
-    },
-    "frisee": {
-        "name": "фризе"
-    },
-    "fructose": {
-        "name": "фруктоза"
-    },
-    "fruit": {
-        "name": "фрукты"
-    },
-    "fruit-sugar": {
-        "name": "фруктоза"
-    },
-    "ful": {
-        "name": "фул"
-    },
-    "garam-masala": {
-        "name": "гарам масала"
-    },
-    "garlic": {
-        "name": "чеснок",
-        "plural_name": "чеснок"
-    },
-    "gem-squash": {
-        "name": "тыква Драгоценный камень"
-    },
-    "ghee": {
-        "name": "гхи"
-    },
-    "giblets": {
-        "name": "птичьи потроха"
-    },
-    "ginger": {
-        "name": "имбирь"
-    },
-    "grains": {
-        "name": "крупы"
-    },
-    "granulated-sugar": {
-        "name": "гранулированный сахар"
-    },
-    "grape-seed-oil": {
-        "name": "масло из семян винограда"
-    },
-    "green-onion": {
-        "name": "зеленый лук",
-        "plural_name": "зелёный лук"
-    },
-    "heart-of-palm": {
-        "name": "сердцевина пальмы",
-        "plural_name": "heart of palms"
-    },
-    "hemp": {
-        "name": "конопля"
-    },
-    "herbs": {
-        "name": "травы"
-    },
-    "honey": {
-        "name": "мёд"
-    },
-    "isomalt": {
-        "name": "изомальт"
-    },
-    "jackfruit": {
-        "name": "джекфрут",
-        "plural_name": "джекфрут"
-    },
-    "jaggery": {
-        "name": "джаггери"
-    },
-    "jams": {
-        "name": "джем"
-    },
-    "jellies": {
-        "name": "желе"
-    },
-    "jerusalem-artichoke": {
-        "name": "топинамбур"
-    },
-    "jicama": {
-        "name": "хикама"
-    },
-    "kale": {
-        "name": "кудрявая капуста"
-    },
-    "kohlrabi": {
-        "name": "кольраби"
-    },
-    "kumara": {
-        "name": "батат"
-    },
-    "leavening-agents": {
-        "name": "разрыхлитель"
-    },
-    "leek": {
-        "name": "лук-порей",
-        "plural_name": "лук-порей"
-    },
-    "legumes": {
-        "name": "бобовые"
-    },
-    "lemongrass": {
-        "name": "лемонграсс"
-    },
-    "lentils": {
-        "name": "чечевица"
-    },
-    "lettuce": {
-        "name": "салат"
-    },
-    "liver": {
-        "name": "печень",
-        "plural_name": "livers"
-    },
-    "maize": {
-        "name": "кукуруза"
-    },
-    "maple-syrup": {
-        "name": "кленовый сироп"
-    },
-    "meat": {
-        "name": "мясо"
-    },
-    "milk": {
-        "name": "молоко"
-    },
-    "mortadella": {
-        "name": "мортаделла"
-    },
-    "mushroom": {
-        "name": "грибы",
-        "plural_name": "грибы"
-    },
-    "mussels": {
-        "name": "мидии"
-    },
-    "nanaimo-bar-mix": {
-        "name": "смесь для батончика нанаймо"
-    },
-    "nori": {
-        "name": "нори"
-    },
-    "nutmeg": {
-        "name": "мускат"
-    },
-    "nutritional-yeast-flakes": {
-        "name": "пищевые дрожжи"
-    },
-    "nuts": {
-        "name": "орехи"
-    },
-    "octopuses": {
-        "name": "осьминоги",
-        "plural_name": "осьминоги"
-    },
-    "oils": {
-        "name": "масла"
-    },
-    "okra": {
-        "name": "абельмош"
-    },
-    "olive": {
-        "name": "оливки"
-    },
-    "olive-oil": {
-        "name": "оливковое масло"
-    },
-    "onion": {
-        "name": "лук"
-    },
-    "onion-family": {
-        "name": "лук"
-    },
-    "orange-blossom-water": {
-        "name": "флердоранжевая вода"
-    },
-    "oranges": {
-        "name": "апельсины",
-        "plural_name": "апельсины"
-    },
-    "oregano": {
-        "name": "душица"
-    },
-    "oysters": {
-        "name": "устрицы"
-    },
-    "panch-puran": {
-        "name": "панч пуран"
-    },
-    "paprika": {
-        "name": "паприка"
-    },
-    "parsley": {
-        "name": "петрушка"
-    },
-    "parsnip": {
-        "name": "пастернак",
-        "plural_name": "пастернак"
-    },
-    "pear": {
-        "name": "груша",
-        "plural_name": "груши"
-    },
-    "peas": {
-        "name": "горох"
-    },
-    "pepper": {
-        "name": "перец",
-        "plural_name": "перцы"
-    },
-    "pineapple": {
-        "name": "ананас",
-        "plural_name": "ананасы"
-    },
-    "plantain": {
-        "name": "плантан",
-        "plural_name": "plantains"
-    },
-    "poppy-seeds": {
-        "name": "семена мака"
-    },
-    "potato": {
-        "name": "картофель",
-        "plural_name": "картофель"
-    },
-    "poultry": {
-        "name": "мясо птицы"
-    },
-    "powdered-sugar": {
-        "name": "сахарная пудра"
-    },
-    "pumpkin": {
-        "name": "тыква",
-        "plural_name": "тыквы"
-    },
-    "pumpkin-seeds": {
-        "name": "семена тыквы"
-    },
-    "radish": {
-        "name": "редис",
-        "plural_name": "редис"
-    },
-    "raw-sugar": {
-        "name": "нерафинированный сахар"
-    },
-    "refined-sugar": {
-        "name": "рафинад"
-    },
-    "rice": {
-        "name": "рис"
-    },
-    "rice-flour": {
-        "name": "рисовая мука"
-    },
-    "rock-sugar": {
-        "name": "сахар-кандис"
-    },
-    "rum": {
-        "name": "ром"
-    },
-    "salmon": {
-        "name": "лосось"
-    },
-    "salt": {
-        "name": "соль"
-    },
-    "salt-cod": {
-        "name": "вяленая треска"
-    },
-    "scallion": {
-        "name": "зеленый лук",
-        "plural_name": "scallions"
-    },
-    "seafood": {
-        "name": "морепродукты"
-    },
-    "seeds": {
-        "name": "семена"
-    },
-    "sesame-seeds": {
-        "name": "семена кунжута"
-    },
-    "shallot": {
-        "name": "шалот",
-        "plural_name": "shallots"
-    },
-    "skate": {
-        "name": "скат"
-    },
-    "soda": {
-        "name": "сода"
-    },
-    "soda-baking": {
-        "name": "пищевая сода"
-    },
-    "soybean": {
-        "name": "соевые бобы"
-    },
-    "spaghetti-squash": {
-        "name": "тыква-спагетти",
-        "plural_name": "spaghetti squashes"
-    },
-    "speck": {
-        "name": "шпик"
-    },
-    "spices": {
-        "name": "специи"
-    },
-    "spinach": {
-        "name": "шпинат"
-    },
-    "spring-onion": {
-        "name": "зелёный лук",
-        "plural_name": "зелёный лук"
-    },
-    "squash": {
-        "name": "тыква",
-        "plural_name": "кабачки"
-    },
-    "squash-family": {
-        "name": "тыквы"
-    },
-    "stockfish": {
-        "name": "стокфиск"
-    },
-    "sugar": {
-        "name": "сахар"
-    },
-    "sunchoke": {
-        "name": "топинамбур",
-        "plural_name": "sunchokes"
-    },
-    "sunflower-seeds": {
-        "name": "семена подсолнечника"
-    },
-    "superfine-sugar": {
-        "name": "ультрамелкий сахар"
-    },
-    "sweet-potato": {
-        "name": "сладкий картофель",
-        "plural_name": "sweet potatoes"
-    },
-    "sweetcorn": {
-        "name": "кукуруза сахарная",
-        "plural_name": "sweetcorns"
-    },
-    "sweeteners": {
-        "name": "подсластители"
-    },
-    "tahini": {
-        "name": "тахини"
-    },
-    "taro": {
-        "name": "таро",
-        "plural_name": "taroes"
-    },
-    "teff": {
-        "name": "теф"
-    },
-    "tomato": {
-        "name": "помидор",
-        "plural_name": "помидоры"
-    },
-    "trout": {
-        "name": "форель"
-    },
-    "tubers": {
-        "name": "клубни",
-        "plural_name": "клубни"
-    },
-    "tuna": {
-        "name": "тунец"
-    },
-    "turbanado-sugar": {
-        "name": "сахар турбинадо"
-    },
-    "turnip": {
-        "name": "репа",
-        "plural_name": "репа"
-    },
-    "unrefined-sugar": {
-        "name": "нерафинированный сахар"
-    },
-    "vanilla": {
-        "name": "ваниль"
-    },
-    "vegetables": {
-        "name": "овощи"
-    },
-    "watercress": {
-        "name": "жеруха"
-    },
-    "watermelon": {
-        "name": "арбуз",
-        "plural_name": "арбузы"
-    },
-    "white-mushroom": {
-        "name": "белый гриб",
-        "plural_name": "белые грибы"
-    },
-    "white-sugar": {
-        "name": "рафинад"
-    },
-    "xanthan-gum": {
-        "name": "ксантановая камедь"
-    },
-    "yam": {
-        "name": "ямс",
-        "plural_name": "yams"
-    },
-    "yeast": {
-        "name": "дрожжи"
-    },
-    "zucchini": {
-        "name": "цуккини",
-        "plural_name": "цуккини"
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "желудевый сквош"
+            },
+            "alfalfa-sprouts": {
+                "name": "ростки люцерны"
+            },
+            "anchovies": {
+                "name": "анчоусы"
+            },
+            "apples": {
+                "name": "яблоки",
+                "plural_name": "яблоки"
+            },
+            "artichoke": {
+                "name": "артишок"
+            },
+            "arugula": {
+                "name": "руккола"
+            },
+            "asparagus": {
+                "name": "спаржа"
+            },
+            "avocado": {
+                "name": "авокадо",
+                "plural_name": "авокадо"
+            },
+            "bacon": {
+                "name": "бекон"
+            },
+            "baking-powder": {
+                "name": "разрыхлитель"
+            },
+            "baking-soda": {
+                "name": "пищевая сода"
+            },
+            "baking-sugar": {
+                "name": "сахар-песок"
+            },
+            "bar-sugar": {
+                "name": "брусковый сахар"
+            },
+            "basil": {
+                "name": "базилик"
+            },
+            "beans": {
+                "name": "фасоль"
+            },
+            "bell-peppers": {
+                "name": "болгарский перец",
+                "plural_name": "болгарский перец"
+            },
+            "blackberries": {
+                "name": "ежевика"
+            },
+            "bok-choy": {
+                "name": "пекинская капуста"
+            },
+            "brassicas": {
+                "name": "капуста"
+            },
+            "bread": {
+                "name": "хлеб"
+            },
+            "breadfruit": {
+                "name": "плод хлебного дерева"
+            },
+            "broccoflower": {
+                "name": "романеско"
+            },
+            "broccoli": {
+                "name": "брокколи"
+            },
+            "broccoli-rabe": {
+                "name": "рапини"
+            },
+            "broccolini": {
+                "name": "брокколини"
+            },
+            "brown-sugar": {
+                "name": "коричневый сахар"
+            },
+            "brussels-sprouts": {
+                "name": "брюссельская капуста"
+            },
+            "butter": {
+                "name": "сливочное масло"
+            },
+            "butternut-pumpkin": {
+                "name": "тыква баттернат"
+            },
+            "butternut-squash": {
+                "name": "мускатная тыква"
+            },
+            "cabbage": {
+                "name": "капуста",
+                "plural_name": "капуста"
+            },
+            "cactus-edible": {
+                "name": "кактус, съедобный"
+            },
+            "calabrese": {
+                "name": "брокколи калабрезе"
+            },
+            "cane-sugar": {
+                "name": "тростниковый сахар"
+            },
+            "cannabis": {
+                "name": "конопля"
+            },
+            "capsicum": {
+                "name": "стручковый перец"
+            },
+            "caraway": {
+                "name": "тмин"
+            },
+            "carrot": {
+                "name": "морковь",
+                "plural_name": "морковь"
+            },
+            "caster-sugar": {
+                "name": "мелкозернистый сахар"
+            },
+            "castor-sugar": {
+                "name": "сахарная пудра"
+            },
+            "catfish": {
+                "name": "сом"
+            },
+            "cauliflower": {
+                "name": "цветная капуста",
+                "plural_name": "цветная капуста"
+            },
+            "cayenne-pepper": {
+                "name": "кайенский перец"
+            },
+            "celeriac": {
+                "name": "корень сельдерея"
+            },
+            "celery": {
+                "name": "сельдерей"
+            },
+            "cereal-grains": {
+                "name": "злаковое зерно"
+            },
+            "chard": {
+                "name": "мангольд"
+            },
+            "cheese": {
+                "name": "сыр"
+            },
+            "chicory": {
+                "name": "цикорий"
+            },
+            "chilli-peppers": {
+                "name": "перец чили",
+                "plural_name": "перец чили"
+            },
+            "chinese-leaves": {
+                "name": "китайская капуста"
+            },
+            "chives": {
+                "name": "шнитт-лук"
+            },
+            "chocolate": {
+                "name": "шоколад"
+            },
+            "cilantro": {
+                "name": "кинза"
+            },
+            "cinnamon": {
+                "name": "корица"
+            },
+            "clarified-butter": {
+                "name": "топленое масло"
+            },
+            "coconut": {
+                "name": "кокос",
+                "plural_name": "кокосы"
+            },
+            "coconut-milk": {
+                "name": "кокосовое молоко"
+            },
+            "cod": {
+                "name": "треска"
+            },
+            "coffee": {
+                "name": "кофе"
+            },
+            "collard-greens": {
+                "name": "листовая капуста"
+            },
+            "confectioners-sugar": {
+                "name": "кондитерский сахар"
+            },
+            "coriander": {
+                "name": "кориандр"
+            },
+            "corn": {
+                "name": "кукуруза",
+                "plural_name": "кукуруза"
+            },
+            "corn-syrup": {
+                "name": "кукурузный сироп"
+            },
+            "cottonseed-oil": {
+                "name": "хлопковое масло"
+            },
+            "courgette": {
+                "name": "цукини"
+            },
+            "cream-of-tartar": {
+                "name": "винный камень"
+            },
+            "cucumber": {
+                "name": "огурцы",
+                "plural_name": "огурцы"
+            },
+            "cumin": {
+                "name": "зира"
+            },
+            "daikon": {
+                "name": "дайкон",
+                "plural_name": "дайкон"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "молочные продукты и заменители молочных продуктов"
+            },
+            "dandelion": {
+                "name": "одуванчик"
+            },
+            "demerara-sugar": {
+                "name": "сахар демерара"
+            },
+            "dough": {
+                "name": "тесто"
+            },
+            "edible-cactus": {
+                "name": "съедобный кактус"
+            },
+            "eggplant": {
+                "name": "баклажан",
+                "plural_name": "баклажаны"
+            },
+            "eggs": {
+                "name": "яйца",
+                "plural_name": "яйца"
+            },
+            "endive": {
+                "name": "эндивий",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "жиры"
+            },
+            "fava-beans": {
+                "name": "бобы обыкновенные"
+            },
+            "fiddlehead": {
+                "name": "побеги папоротника"
+            },
+            "fiddlehead-fern": {
+                "name": "побеги папоротника",
+                "plural_name": "побеги папоротника"
+            },
+            "fish": {
+                "name": "рыба"
+            },
+            "five-spice-powder": {
+                "name": "приправа 5 специй"
+            },
+            "flour": {
+                "name": "мука"
+            },
+            "frisee": {
+                "name": "фризе"
+            },
+            "fructose": {
+                "name": "фруктоза"
+            },
+            "fruit": {
+                "name": "фрукты"
+            },
+            "fruit-sugar": {
+                "name": "фруктоза"
+            },
+            "ful": {
+                "name": "фул"
+            },
+            "garam-masala": {
+                "name": "гарам масала"
+            },
+            "garlic": {
+                "name": "чеснок",
+                "plural_name": "чеснок"
+            },
+            "gem-squash": {
+                "name": "тыква Драгоценный камень"
+            },
+            "ghee": {
+                "name": "гхи"
+            },
+            "giblets": {
+                "name": "птичьи потроха"
+            },
+            "ginger": {
+                "name": "имбирь"
+            },
+            "grains": {
+                "name": "крупы"
+            },
+            "granulated-sugar": {
+                "name": "гранулированный сахар"
+            },
+            "grape-seed-oil": {
+                "name": "масло из семян винограда"
+            },
+            "green-onion": {
+                "name": "зеленый лук",
+                "plural_name": "зелёный лук"
+            },
+            "heart-of-palm": {
+                "name": "сердцевина пальмы",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "конопля"
+            },
+            "herbs": {
+                "name": "травы"
+            },
+            "honey": {
+                "name": "мёд"
+            },
+            "isomalt": {
+                "name": "изомальт"
+            },
+            "jackfruit": {
+                "name": "джекфрут",
+                "plural_name": "джекфрут"
+            },
+            "jaggery": {
+                "name": "джаггери"
+            },
+            "jams": {
+                "name": "джем"
+            },
+            "jellies": {
+                "name": "желе"
+            },
+            "jerusalem-artichoke": {
+                "name": "топинамбур"
+            },
+            "jicama": {
+                "name": "хикама"
+            },
+            "kale": {
+                "name": "кудрявая капуста"
+            },
+            "kohlrabi": {
+                "name": "кольраби"
+            },
+            "kumara": {
+                "name": "батат"
+            },
+            "leavening-agents": {
+                "name": "разрыхлитель"
+            },
+            "leek": {
+                "name": "лук-порей",
+                "plural_name": "лук-порей"
+            },
+            "legumes": {
+                "name": "бобовые"
+            },
+            "lemongrass": {
+                "name": "лемонграсс"
+            },
+            "lentils": {
+                "name": "чечевица"
+            },
+            "lettuce": {
+                "name": "салат"
+            },
+            "liver": {
+                "name": "печень",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "кукуруза"
+            },
+            "maple-syrup": {
+                "name": "кленовый сироп"
+            },
+            "meat": {
+                "name": "мясо"
+            },
+            "milk": {
+                "name": "молоко"
+            },
+            "mortadella": {
+                "name": "мортаделла"
+            },
+            "mushroom": {
+                "name": "грибы",
+                "plural_name": "грибы"
+            },
+            "mussels": {
+                "name": "мидии"
+            },
+            "nanaimo-bar-mix": {
+                "name": "смесь для батончика нанаймо"
+            },
+            "nori": {
+                "name": "нори"
+            },
+            "nutmeg": {
+                "name": "мускат"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "пищевые дрожжи"
+            },
+            "nuts": {
+                "name": "орехи"
+            },
+            "octopuses": {
+                "name": "осьминоги",
+                "plural_name": "осьминоги"
+            },
+            "oils": {
+                "name": "масла"
+            },
+            "okra": {
+                "name": "абельмош"
+            },
+            "olive": {
+                "name": "оливки"
+            },
+            "olive-oil": {
+                "name": "оливковое масло"
+            },
+            "onion": {
+                "name": "лук"
+            },
+            "onion-family": {
+                "name": "лук"
+            },
+            "orange-blossom-water": {
+                "name": "флердоранжевая вода"
+            },
+            "oranges": {
+                "name": "апельсины",
+                "plural_name": "апельсины"
+            },
+            "oregano": {
+                "name": "душица"
+            },
+            "oysters": {
+                "name": "устрицы"
+            },
+            "panch-puran": {
+                "name": "панч пуран"
+            },
+            "paprika": {
+                "name": "паприка"
+            },
+            "parsley": {
+                "name": "петрушка"
+            },
+            "parsnip": {
+                "name": "пастернак",
+                "plural_name": "пастернак"
+            },
+            "pear": {
+                "name": "груша",
+                "plural_name": "груши"
+            },
+            "peas": {
+                "name": "горох"
+            },
+            "pepper": {
+                "name": "перец",
+                "plural_name": "перцы"
+            },
+            "pineapple": {
+                "name": "ананас",
+                "plural_name": "ананасы"
+            },
+            "plantain": {
+                "name": "плантан",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "семена мака"
+            },
+            "potato": {
+                "name": "картофель",
+                "plural_name": "картофель"
+            },
+            "poultry": {
+                "name": "мясо птицы"
+            },
+            "powdered-sugar": {
+                "name": "сахарная пудра"
+            },
+            "pumpkin": {
+                "name": "тыква",
+                "plural_name": "тыквы"
+            },
+            "pumpkin-seeds": {
+                "name": "семена тыквы"
+            },
+            "radish": {
+                "name": "редис",
+                "plural_name": "редис"
+            },
+            "raw-sugar": {
+                "name": "нерафинированный сахар"
+            },
+            "refined-sugar": {
+                "name": "рафинад"
+            },
+            "rice": {
+                "name": "рис"
+            },
+            "rice-flour": {
+                "name": "рисовая мука"
+            },
+            "rock-sugar": {
+                "name": "сахар-кандис"
+            },
+            "rum": {
+                "name": "ром"
+            },
+            "salmon": {
+                "name": "лосось"
+            },
+            "salt": {
+                "name": "соль"
+            },
+            "salt-cod": {
+                "name": "вяленая треска"
+            },
+            "scallion": {
+                "name": "зеленый лук",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "морепродукты"
+            },
+            "seeds": {
+                "name": "семена"
+            },
+            "sesame-seeds": {
+                "name": "семена кунжута"
+            },
+            "shallot": {
+                "name": "шалот",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "скат"
+            },
+            "soda": {
+                "name": "сода"
+            },
+            "soda-baking": {
+                "name": "пищевая сода"
+            },
+            "soybean": {
+                "name": "соевые бобы"
+            },
+            "spaghetti-squash": {
+                "name": "тыква-спагетти",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "шпик"
+            },
+            "spices": {
+                "name": "специи"
+            },
+            "spinach": {
+                "name": "шпинат"
+            },
+            "spring-onion": {
+                "name": "зелёный лук",
+                "plural_name": "зелёный лук"
+            },
+            "squash": {
+                "name": "тыква",
+                "plural_name": "кабачки"
+            },
+            "squash-family": {
+                "name": "тыквы"
+            },
+            "stockfish": {
+                "name": "стокфиск"
+            },
+            "sugar": {
+                "name": "сахар"
+            },
+            "sunchoke": {
+                "name": "топинамбур",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "семена подсолнечника"
+            },
+            "superfine-sugar": {
+                "name": "ультрамелкий сахар"
+            },
+            "sweet-potato": {
+                "name": "сладкий картофель",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "кукуруза сахарная",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "подсластители"
+            },
+            "tahini": {
+                "name": "тахини"
+            },
+            "taro": {
+                "name": "таро",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "теф"
+            },
+            "tomato": {
+                "name": "помидор",
+                "plural_name": "помидоры"
+            },
+            "trout": {
+                "name": "форель"
+            },
+            "tubers": {
+                "name": "клубни",
+                "plural_name": "клубни"
+            },
+            "tuna": {
+                "name": "тунец"
+            },
+            "turbanado-sugar": {
+                "name": "сахар турбинадо"
+            },
+            "turnip": {
+                "name": "репа",
+                "plural_name": "репа"
+            },
+            "unrefined-sugar": {
+                "name": "нерафинированный сахар"
+            },
+            "vanilla": {
+                "name": "ваниль"
+            },
+            "vegetables": {
+                "name": "овощи"
+            },
+            "watercress": {
+                "name": "жеруха"
+            },
+            "watermelon": {
+                "name": "арбуз",
+                "plural_name": "арбузы"
+            },
+            "white-mushroom": {
+                "name": "белый гриб",
+                "plural_name": "белые грибы"
+            },
+            "white-sugar": {
+                "name": "рафинад"
+            },
+            "xanthan-gum": {
+                "name": "ксантановая камедь"
+            },
+            "yam": {
+                "name": "ямс",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "дрожжи"
+            },
+            "zucchini": {
+                "name": "цуккини",
+                "plural_name": "цуккини"
+            }
+        }
+    },
+    "Свежие Овощи&фрукты": {
+        "foods": {}
+    },
+    "Крупы": {
+        "foods": {}
+    },
+    "Фрукты": {
+        "foods": {}
+    },
+    "Овощи": {
+        "foods": {}
+    },
+    "Мясо": {
+        "foods": {}
+    },
+    "Морепродукты": {
+        "foods": {}
+    },
+    "Напитки": {
+        "foods": {}
+    },
+    "Выпечка": {
+        "foods": {}
+    },
+    "Консервы": {
+        "foods": {}
+    },
+    "Приправы": {
+        "foods": {}
+    },
+    "Кондитерские изделия": {
+        "foods": {}
+    },
+    "Молочные продукты": {
+        "foods": {}
+    },
+    "Замороженные продукты": {
+        "foods": {}
+    },
+    "Здоровая еда": {
+        "foods": {}
+    },
+    "Домашняя": {
+        "foods": {}
+    },
+    "Мясные продукты": {
+        "foods": {}
+    },
+    "Закуски": {
+        "foods": {}
+    },
+    "Специи": {
+        "foods": {}
+    },
+    "Сладости": {
+        "foods": {}
+    },
+    "Алкоголь": {
+        "foods": {}
+    },
+    "Другое": {
+        "foods": {}
     }
 }

--- a/mealie/repos/seed/resources/foods/locales/ru-RU.json
+++ b/mealie/repos/seed/resources/foods/locales/ru-RU.json
@@ -1,692 +1,692 @@
 {
-	"acorn-squash": {
-		"name": "желудевый сквош"
-	},
-	"alfalfa-sprouts": {
-		"name": "ростки люцерны"
-	},
-	"anchovies": {
-		"name": "анчоусы"
-	},
-	"apples": {
-		"name": "яблоки",
-		"plural_name": "яблоки"
-	},
-	"artichoke": {
-		"name": "артишок"
-	},
-	"arugula": {
-		"name": "руккола"
-	},
-	"asparagus": {
-		"name": "спаржа"
-	},
-	"avocado": {
-		"name": "авокадо",
-		"plural_name": "авокадо"
-	},
-	"bacon": {
-		"name": "бекон"
-	},
-	"baking-powder": {
-		"name": "разрыхлитель"
-	},
-	"baking-soda": {
-		"name": "пищевая сода"
-	},
-	"baking-sugar": {
-		"name": "сахар-песок"
-	},
-	"bar-sugar": {
-		"name": "брусковый сахар"
-	},
-	"basil": {
-		"name": "базилик"
-	},
-	"beans": {
-		"name": "фасоль"
-	},
-	"bell-peppers": {
-		"name": "болгарский перец",
-		"plural_name": "болгарский перец"
-	},
-	"blackberries": {
-		"name": "ежевика"
-	},
-	"bok-choy": {
-		"name": "пекинская капуста"
-	},
-	"brassicas": {
-		"name": "капуста"
-	},
-	"bread": {
-		"name": "хлеб"
-	},
-	"breadfruit": {
-		"name": "плод хлебного дерева"
-	},
-	"broccoflower": {
-		"name": "романеско"
-	},
-	"broccoli": {
-		"name": "брокколи"
-	},
-	"broccoli-rabe": {
-		"name": "рапини"
-	},
-	"broccolini": {
-		"name": "брокколини"
-	},
-	"brown-sugar": {
-		"name": "коричневый сахар"
-	},
-	"brussels-sprouts": {
-		"name": "брюссельская капуста"
-	},
-	"butter": {
-		"name": "сливочное масло"
-	},
-	"butternut-pumpkin": {
-		"name": "тыква баттернат"
-	},
-	"butternut-squash": {
-		"name": "мускатная тыква"
-	},
-	"cabbage": {
-		"name": "капуста",
-		"plural_name": "капуста"
-	},
-	"cactus-edible": {
-		"name": "кактус, съедобный"
-	},
-	"calabrese": {
-		"name": "брокколи калабрезе"
-	},
-	"cane-sugar": {
-		"name": "тростниковый сахар"
-	},
-	"cannabis": {
-		"name": "конопля"
-	},
-	"capsicum": {
-		"name": "стручковый перец"
-	},
-	"caraway": {
-		"name": "тмин"
-	},
-	"carrot": {
-		"name": "морковь",
-		"plural_name": "морковь"
-	},
-	"caster-sugar": {
-		"name": "мелкозернистый сахар"
-	},
-	"castor-sugar": {
-		"name": "сахарная пудра"
-	},
-	"catfish": {
-		"name": "сом"
-	},
-	"cauliflower": {
-		"name": "цветная капуста",
-		"plural_name": "цветная капуста"
-	},
-	"cayenne-pepper": {
-		"name": "кайенский перец"
-	},
-	"celeriac": {
-		"name": "корень сельдерея"
-	},
-	"celery": {
-		"name": "сельдерей"
-	},
-	"cereal-grains": {
-		"name": "злаковое зерно"
-	},
-	"chard": {
-		"name": "мангольд"
-	},
-	"cheese": {
-		"name": "сыр"
-	},
-	"chicory": {
-		"name": "цикорий"
-	},
-	"chilli-peppers": {
-		"name": "перец чили",
-		"plural_name": "перец чили"
-	},
-	"chinese-leaves": {
-		"name": "китайская капуста"
-	},
-	"chives": {
-		"name": "шнитт-лук"
-	},
-	"chocolate": {
-		"name": "шоколад"
-	},
-	"cilantro": {
-		"name": "кинза"
-	},
-	"cinnamon": {
-		"name": "корица"
-	},
-	"clarified-butter": {
-		"name": "топленое масло"
-	},
-	"coconut": {
-		"name": "кокос",
-		"plural_name": "кокосы"
-	},
-	"coconut-milk": {
-		"name": "кокосовое молоко"
-	},
-	"cod": {
-		"name": "треска"
-	},
-	"coffee": {
-		"name": "кофе"
-	},
-	"collard-greens": {
-		"name": "листовая капуста"
-	},
-	"confectioners-sugar": {
-		"name": "кондитерский сахар"
-	},
-	"coriander": {
-		"name": "кориандр"
-	},
-	"corn": {
-		"name": "кукуруза",
-		"plural_name": "кукуруза"
-	},
-	"corn-syrup": {
-		"name": "кукурузный сироп"
-	},
-	"cottonseed-oil": {
-		"name": "хлопковое масло"
-	},
-	"courgette": {
-		"name": "цукини"
-	},
-	"cream-of-tartar": {
-		"name": "винный камень"
-	},
-	"cucumber": {
-		"name": "огурцы",
-		"plural_name": "огурцы"
-	},
-	"cumin": {
-		"name": "зира"
-	},
-	"daikon": {
-		"name": "дайкон",
-		"plural_name": "дайкон"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "молочные продукты и заменители молочных продуктов"
-	},
-	"dandelion": {
-		"name": "одуванчик"
-	},
-	"demerara-sugar": {
-		"name": "сахар демерара"
-	},
-	"dough": {
-		"name": "тесто"
-	},
-	"edible-cactus": {
-		"name": "съедобный кактус"
-	},
-	"eggplant": {
-		"name": "баклажан",
-		"plural_name": "баклажаны"
-	},
-	"eggs": {
-		"name": "яйца",
-		"plural_name": "яйца"
-	},
-	"endive": {
-		"name": "эндивий",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "жиры"
-	},
-	"fava-beans": {
-		"name": "бобы обыкновенные"
-	},
-	"fiddlehead": {
-		"name": "побеги папоротника"
-	},
-	"fiddlehead-fern": {
-		"name": "побеги папоротника",
-		"plural_name": "побеги папоротника"
-	},
-	"fish": {
-		"name": "рыба"
-	},
-	"five-spice-powder": {
-		"name": "приправа 5 специй"
-	},
-	"flour": {
-		"name": "мука"
-	},
-	"frisee": {
-		"name": "фризе"
-	},
-	"fructose": {
-		"name": "фруктоза"
-	},
-	"fruit": {
-		"name": "фрукты"
-	},
-	"fruit-sugar": {
-		"name": "фруктоза"
-	},
-	"ful": {
-		"name": "фул"
-	},
-	"garam-masala": {
-		"name": "гарам масала"
-	},
-	"garlic": {
-		"name": "чеснок",
-		"plural_name": "чеснок"
-	},
-	"gem-squash": {
-		"name": "тыква Драгоценный камень"
-	},
-	"ghee": {
-		"name": "гхи"
-	},
-	"giblets": {
-		"name": "птичьи потроха"
-	},
-	"ginger": {
-		"name": "имбирь"
-	},
-	"grains": {
-		"name": "крупы"
-	},
-	"granulated-sugar": {
-		"name": "гранулированный сахар"
-	},
-	"grape-seed-oil": {
-		"name": "масло из семян винограда"
-	},
-	"green-onion": {
-		"name": "зеленый лук",
-		"plural_name": "зелёный лук"
-	},
-	"heart-of-palm": {
-		"name": "сердцевина пальмы",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "конопля"
-	},
-	"herbs": {
-		"name": "травы"
-	},
-	"honey": {
-		"name": "мёд"
-	},
-	"isomalt": {
-		"name": "изомальт"
-	},
-	"jackfruit": {
-		"name": "джекфрут",
-		"plural_name": "джекфрут"
-	},
-	"jaggery": {
-		"name": "джаггери"
-	},
-	"jams": {
-		"name": "джем"
-	},
-	"jellies": {
-		"name": "желе"
-	},
-	"jerusalem-artichoke": {
-		"name": "топинамбур"
-	},
-	"jicama": {
-		"name": "хикама"
-	},
-	"kale": {
-		"name": "кудрявая капуста"
-	},
-	"kohlrabi": {
-		"name": "кольраби"
-	},
-	"kumara": {
-		"name": "батат"
-	},
-	"leavening-agents": {
-		"name": "разрыхлитель"
-	},
-	"leek": {
-		"name": "лук-порей",
-		"plural_name": "лук-порей"
-	},
-	"legumes": {
-		"name": "бобовые"
-	},
-	"lemongrass": {
-		"name": "лемонграсс"
-	},
-	"lentils": {
-		"name": "чечевица"
-	},
-	"lettuce": {
-		"name": "салат"
-	},
-	"liver": {
-		"name": "печень",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "кукуруза"
-	},
-	"maple-syrup": {
-		"name": "кленовый сироп"
-	},
-	"meat": {
-		"name": "мясо"
-	},
-	"milk": {
-		"name": "молоко"
-	},
-	"mortadella": {
-		"name": "мортаделла"
-	},
-	"mushroom": {
-		"name": "грибы",
-		"plural_name": "грибы"
-	},
-	"mussels": {
-		"name": "мидии"
-	},
-	"nanaimo-bar-mix": {
-		"name": "смесь для батончика нанаймо"
-	},
-	"nori": {
-		"name": "нори"
-	},
-	"nutmeg": {
-		"name": "мускат"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "пищевые дрожжи"
-	},
-	"nuts": {
-		"name": "орехи"
-	},
-	"octopuses": {
-		"name": "осьминоги",
-		"plural_name": "осьминоги"
-	},
-	"oils": {
-		"name": "масла"
-	},
-	"okra": {
-		"name": "абельмош"
-	},
-	"olive": {
-		"name": "оливки"
-	},
-	"olive-oil": {
-		"name": "оливковое масло"
-	},
-	"onion": {
-		"name": "лук"
-	},
-	"onion-family": {
-		"name": "лук"
-	},
-	"orange-blossom-water": {
-		"name": "флердоранжевая вода"
-	},
-	"oranges": {
-		"name": "апельсины",
-		"plural_name": "апельсины"
-	},
-	"oregano": {
-		"name": "душица"
-	},
-	"oysters": {
-		"name": "устрицы"
-	},
-	"panch-puran": {
-		"name": "панч пуран"
-	},
-	"paprika": {
-		"name": "паприка"
-	},
-	"parsley": {
-		"name": "петрушка"
-	},
-	"parsnip": {
-		"name": "пастернак",
-		"plural_name": "пастернак"
-	},
-	"pear": {
-		"name": "груша",
-		"plural_name": "груши"
-	},
-	"peas": {
-		"name": "горох"
-	},
-	"pepper": {
-		"name": "перец",
-		"plural_name": "перцы"
-	},
-	"pineapple": {
-		"name": "ананас",
-		"plural_name": "ананасы"
-	},
-	"plantain": {
-		"name": "плантан",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "семена мака"
-	},
-	"potato": {
-		"name": "картофель",
-		"plural_name": "картофель"
-	},
-	"poultry": {
-		"name": "мясо птицы"
-	},
-	"powdered-sugar": {
-		"name": "сахарная пудра"
-	},
-	"pumpkin": {
-		"name": "тыква",
-		"plural_name": "тыквы"
-	},
-	"pumpkin-seeds": {
-		"name": "семена тыквы"
-	},
-	"radish": {
-		"name": "редис",
-		"plural_name": "редис"
-	},
-	"raw-sugar": {
-		"name": "нерафинированный сахар"
-	},
-	"refined-sugar": {
-		"name": "рафинад"
-	},
-	"rice": {
-		"name": "рис"
-	},
-	"rice-flour": {
-		"name": "рисовая мука"
-	},
-	"rock-sugar": {
-		"name": "сахар-кандис"
-	},
-	"rum": {
-		"name": "ром"
-	},
-	"salmon": {
-		"name": "лосось"
-	},
-	"salt": {
-		"name": "соль"
-	},
-	"salt-cod": {
-		"name": "вяленая треска"
-	},
-	"scallion": {
-		"name": "зеленый лук",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "морепродукты"
-	},
-	"seeds": {
-		"name": "семена"
-	},
-	"sesame-seeds": {
-		"name": "семена кунжута"
-	},
-	"shallot": {
-		"name": "шалот",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "скат"
-	},
-	"soda": {
-		"name": "сода"
-	},
-	"soda-baking": {
-		"name": "пищевая сода"
-	},
-	"soybean": {
-		"name": "соевые бобы"
-	},
-	"spaghetti-squash": {
-		"name": "тыква-спагетти",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "шпик"
-	},
-	"spices": {
-		"name": "специи"
-	},
-	"spinach": {
-		"name": "шпинат"
-	},
-	"spring-onion": {
-		"name": "зелёный лук",
-		"plural_name": "зелёный лук"
-	},
-	"squash": {
-		"name": "тыква",
-		"plural_name": "кабачки"
-	},
-	"squash-family": {
-		"name": "тыквы"
-	},
-	"stockfish": {
-		"name": "стокфиск"
-	},
-	"sugar": {
-		"name": "сахар"
-	},
-	"sunchoke": {
-		"name": "топинамбур",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "семена подсолнечника"
-	},
-	"superfine-sugar": {
-		"name": "ультрамелкий сахар"
-	},
-	"sweet-potato": {
-		"name": "сладкий картофель",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "кукуруза сахарная",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "подсластители"
-	},
-	"tahini": {
-		"name": "тахини"
-	},
-	"taro": {
-		"name": "таро",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "теф"
-	},
-	"tomato": {
-		"name": "помидор",
-		"plural_name": "помидоры"
-	},
-	"trout": {
-		"name": "форель"
-	},
-	"tubers": {
-		"name": "клубни",
-		"plural_name": "клубни"
-	},
-	"tuna": {
-		"name": "тунец"
-	},
-	"turbanado-sugar": {
-		"name": "сахар турбинадо"
-	},
-	"turnip": {
-		"name": "репа",
-		"plural_name": "репа"
-	},
-	"unrefined-sugar": {
-		"name": "нерафинированный сахар"
-	},
-	"vanilla": {
-		"name": "ваниль"
-	},
-	"vegetables": {
-		"name": "овощи"
-	},
-	"watercress": {
-		"name": "жеруха"
-	},
-	"watermelon": {
-		"name": "арбуз",
-		"plural_name": "арбузы"
-	},
-	"white-mushroom": {
-		"name": "белый гриб",
-		"plural_name": "белые грибы"
-	},
-	"white-sugar": {
-		"name": "рафинад"
-	},
-	"xanthan-gum": {
-		"name": "ксантановая камедь"
-	},
-	"yam": {
-		"name": "ямс",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "дрожжи"
-	},
-	"zucchini": {
-		"name": "цуккини",
-		"plural_name": "цуккини"
-	}
+    "acorn-squash": {
+        "name": "желудевый сквош"
+    },
+    "alfalfa-sprouts": {
+        "name": "ростки люцерны"
+    },
+    "anchovies": {
+        "name": "анчоусы"
+    },
+    "apples": {
+        "name": "яблоки",
+        "plural_name": "яблоки"
+    },
+    "artichoke": {
+        "name": "артишок"
+    },
+    "arugula": {
+        "name": "руккола"
+    },
+    "asparagus": {
+        "name": "спаржа"
+    },
+    "avocado": {
+        "name": "авокадо",
+        "plural_name": "авокадо"
+    },
+    "bacon": {
+        "name": "бекон"
+    },
+    "baking-powder": {
+        "name": "разрыхлитель"
+    },
+    "baking-soda": {
+        "name": "пищевая сода"
+    },
+    "baking-sugar": {
+        "name": "сахар-песок"
+    },
+    "bar-sugar": {
+        "name": "брусковый сахар"
+    },
+    "basil": {
+        "name": "базилик"
+    },
+    "beans": {
+        "name": "фасоль"
+    },
+    "bell-peppers": {
+        "name": "болгарский перец",
+        "plural_name": "болгарский перец"
+    },
+    "blackberries": {
+        "name": "ежевика"
+    },
+    "bok-choy": {
+        "name": "пекинская капуста"
+    },
+    "brassicas": {
+        "name": "капуста"
+    },
+    "bread": {
+        "name": "хлеб"
+    },
+    "breadfruit": {
+        "name": "плод хлебного дерева"
+    },
+    "broccoflower": {
+        "name": "романеско"
+    },
+    "broccoli": {
+        "name": "брокколи"
+    },
+    "broccoli-rabe": {
+        "name": "рапини"
+    },
+    "broccolini": {
+        "name": "брокколини"
+    },
+    "brown-sugar": {
+        "name": "коричневый сахар"
+    },
+    "brussels-sprouts": {
+        "name": "брюссельская капуста"
+    },
+    "butter": {
+        "name": "сливочное масло"
+    },
+    "butternut-pumpkin": {
+        "name": "тыква баттернат"
+    },
+    "butternut-squash": {
+        "name": "мускатная тыква"
+    },
+    "cabbage": {
+        "name": "капуста",
+        "plural_name": "капуста"
+    },
+    "cactus-edible": {
+        "name": "кактус, съедобный"
+    },
+    "calabrese": {
+        "name": "брокколи калабрезе"
+    },
+    "cane-sugar": {
+        "name": "тростниковый сахар"
+    },
+    "cannabis": {
+        "name": "конопля"
+    },
+    "capsicum": {
+        "name": "стручковый перец"
+    },
+    "caraway": {
+        "name": "тмин"
+    },
+    "carrot": {
+        "name": "морковь",
+        "plural_name": "морковь"
+    },
+    "caster-sugar": {
+        "name": "мелкозернистый сахар"
+    },
+    "castor-sugar": {
+        "name": "сахарная пудра"
+    },
+    "catfish": {
+        "name": "сом"
+    },
+    "cauliflower": {
+        "name": "цветная капуста",
+        "plural_name": "цветная капуста"
+    },
+    "cayenne-pepper": {
+        "name": "кайенский перец"
+    },
+    "celeriac": {
+        "name": "корень сельдерея"
+    },
+    "celery": {
+        "name": "сельдерей"
+    },
+    "cereal-grains": {
+        "name": "злаковое зерно"
+    },
+    "chard": {
+        "name": "мангольд"
+    },
+    "cheese": {
+        "name": "сыр"
+    },
+    "chicory": {
+        "name": "цикорий"
+    },
+    "chilli-peppers": {
+        "name": "перец чили",
+        "plural_name": "перец чили"
+    },
+    "chinese-leaves": {
+        "name": "китайская капуста"
+    },
+    "chives": {
+        "name": "шнитт-лук"
+    },
+    "chocolate": {
+        "name": "шоколад"
+    },
+    "cilantro": {
+        "name": "кинза"
+    },
+    "cinnamon": {
+        "name": "корица"
+    },
+    "clarified-butter": {
+        "name": "топленое масло"
+    },
+    "coconut": {
+        "name": "кокос",
+        "plural_name": "кокосы"
+    },
+    "coconut-milk": {
+        "name": "кокосовое молоко"
+    },
+    "cod": {
+        "name": "треска"
+    },
+    "coffee": {
+        "name": "кофе"
+    },
+    "collard-greens": {
+        "name": "листовая капуста"
+    },
+    "confectioners-sugar": {
+        "name": "кондитерский сахар"
+    },
+    "coriander": {
+        "name": "кориандр"
+    },
+    "corn": {
+        "name": "кукуруза",
+        "plural_name": "кукуруза"
+    },
+    "corn-syrup": {
+        "name": "кукурузный сироп"
+    },
+    "cottonseed-oil": {
+        "name": "хлопковое масло"
+    },
+    "courgette": {
+        "name": "цукини"
+    },
+    "cream-of-tartar": {
+        "name": "винный камень"
+    },
+    "cucumber": {
+        "name": "огурцы",
+        "plural_name": "огурцы"
+    },
+    "cumin": {
+        "name": "зира"
+    },
+    "daikon": {
+        "name": "дайкон",
+        "plural_name": "дайкон"
+    },
+    "dairy-products-and-dairy-substitutes": {
+        "name": "молочные продукты и заменители молочных продуктов"
+    },
+    "dandelion": {
+        "name": "одуванчик"
+    },
+    "demerara-sugar": {
+        "name": "сахар демерара"
+    },
+    "dough": {
+        "name": "тесто"
+    },
+    "edible-cactus": {
+        "name": "съедобный кактус"
+    },
+    "eggplant": {
+        "name": "баклажан",
+        "plural_name": "баклажаны"
+    },
+    "eggs": {
+        "name": "яйца",
+        "plural_name": "яйца"
+    },
+    "endive": {
+        "name": "эндивий",
+        "plural_name": "endives"
+    },
+    "fats": {
+        "name": "жиры"
+    },
+    "fava-beans": {
+        "name": "бобы обыкновенные"
+    },
+    "fiddlehead": {
+        "name": "побеги папоротника"
+    },
+    "fiddlehead-fern": {
+        "name": "побеги папоротника",
+        "plural_name": "побеги папоротника"
+    },
+    "fish": {
+        "name": "рыба"
+    },
+    "five-spice-powder": {
+        "name": "приправа 5 специй"
+    },
+    "flour": {
+        "name": "мука"
+    },
+    "frisee": {
+        "name": "фризе"
+    },
+    "fructose": {
+        "name": "фруктоза"
+    },
+    "fruit": {
+        "name": "фрукты"
+    },
+    "fruit-sugar": {
+        "name": "фруктоза"
+    },
+    "ful": {
+        "name": "фул"
+    },
+    "garam-masala": {
+        "name": "гарам масала"
+    },
+    "garlic": {
+        "name": "чеснок",
+        "plural_name": "чеснок"
+    },
+    "gem-squash": {
+        "name": "тыква Драгоценный камень"
+    },
+    "ghee": {
+        "name": "гхи"
+    },
+    "giblets": {
+        "name": "птичьи потроха"
+    },
+    "ginger": {
+        "name": "имбирь"
+    },
+    "grains": {
+        "name": "крупы"
+    },
+    "granulated-sugar": {
+        "name": "гранулированный сахар"
+    },
+    "grape-seed-oil": {
+        "name": "масло из семян винограда"
+    },
+    "green-onion": {
+        "name": "зеленый лук",
+        "plural_name": "зелёный лук"
+    },
+    "heart-of-palm": {
+        "name": "сердцевина пальмы",
+        "plural_name": "heart of palms"
+    },
+    "hemp": {
+        "name": "конопля"
+    },
+    "herbs": {
+        "name": "травы"
+    },
+    "honey": {
+        "name": "мёд"
+    },
+    "isomalt": {
+        "name": "изомальт"
+    },
+    "jackfruit": {
+        "name": "джекфрут",
+        "plural_name": "джекфрут"
+    },
+    "jaggery": {
+        "name": "джаггери"
+    },
+    "jams": {
+        "name": "джем"
+    },
+    "jellies": {
+        "name": "желе"
+    },
+    "jerusalem-artichoke": {
+        "name": "топинамбур"
+    },
+    "jicama": {
+        "name": "хикама"
+    },
+    "kale": {
+        "name": "кудрявая капуста"
+    },
+    "kohlrabi": {
+        "name": "кольраби"
+    },
+    "kumara": {
+        "name": "батат"
+    },
+    "leavening-agents": {
+        "name": "разрыхлитель"
+    },
+    "leek": {
+        "name": "лук-порей",
+        "plural_name": "лук-порей"
+    },
+    "legumes": {
+        "name": "бобовые"
+    },
+    "lemongrass": {
+        "name": "лемонграсс"
+    },
+    "lentils": {
+        "name": "чечевица"
+    },
+    "lettuce": {
+        "name": "салат"
+    },
+    "liver": {
+        "name": "печень",
+        "plural_name": "livers"
+    },
+    "maize": {
+        "name": "кукуруза"
+    },
+    "maple-syrup": {
+        "name": "кленовый сироп"
+    },
+    "meat": {
+        "name": "мясо"
+    },
+    "milk": {
+        "name": "молоко"
+    },
+    "mortadella": {
+        "name": "мортаделла"
+    },
+    "mushroom": {
+        "name": "грибы",
+        "plural_name": "грибы"
+    },
+    "mussels": {
+        "name": "мидии"
+    },
+    "nanaimo-bar-mix": {
+        "name": "смесь для батончика нанаймо"
+    },
+    "nori": {
+        "name": "нори"
+    },
+    "nutmeg": {
+        "name": "мускат"
+    },
+    "nutritional-yeast-flakes": {
+        "name": "пищевые дрожжи"
+    },
+    "nuts": {
+        "name": "орехи"
+    },
+    "octopuses": {
+        "name": "осьминоги",
+        "plural_name": "осьминоги"
+    },
+    "oils": {
+        "name": "масла"
+    },
+    "okra": {
+        "name": "абельмош"
+    },
+    "olive": {
+        "name": "оливки"
+    },
+    "olive-oil": {
+        "name": "оливковое масло"
+    },
+    "onion": {
+        "name": "лук"
+    },
+    "onion-family": {
+        "name": "лук"
+    },
+    "orange-blossom-water": {
+        "name": "флердоранжевая вода"
+    },
+    "oranges": {
+        "name": "апельсины",
+        "plural_name": "апельсины"
+    },
+    "oregano": {
+        "name": "душица"
+    },
+    "oysters": {
+        "name": "устрицы"
+    },
+    "panch-puran": {
+        "name": "панч пуран"
+    },
+    "paprika": {
+        "name": "паприка"
+    },
+    "parsley": {
+        "name": "петрушка"
+    },
+    "parsnip": {
+        "name": "пастернак",
+        "plural_name": "пастернак"
+    },
+    "pear": {
+        "name": "груша",
+        "plural_name": "груши"
+    },
+    "peas": {
+        "name": "горох"
+    },
+    "pepper": {
+        "name": "перец",
+        "plural_name": "перцы"
+    },
+    "pineapple": {
+        "name": "ананас",
+        "plural_name": "ананасы"
+    },
+    "plantain": {
+        "name": "плантан",
+        "plural_name": "plantains"
+    },
+    "poppy-seeds": {
+        "name": "семена мака"
+    },
+    "potato": {
+        "name": "картофель",
+        "plural_name": "картофель"
+    },
+    "poultry": {
+        "name": "мясо птицы"
+    },
+    "powdered-sugar": {
+        "name": "сахарная пудра"
+    },
+    "pumpkin": {
+        "name": "тыква",
+        "plural_name": "тыквы"
+    },
+    "pumpkin-seeds": {
+        "name": "семена тыквы"
+    },
+    "radish": {
+        "name": "редис",
+        "plural_name": "редис"
+    },
+    "raw-sugar": {
+        "name": "нерафинированный сахар"
+    },
+    "refined-sugar": {
+        "name": "рафинад"
+    },
+    "rice": {
+        "name": "рис"
+    },
+    "rice-flour": {
+        "name": "рисовая мука"
+    },
+    "rock-sugar": {
+        "name": "сахар-кандис"
+    },
+    "rum": {
+        "name": "ром"
+    },
+    "salmon": {
+        "name": "лосось"
+    },
+    "salt": {
+        "name": "соль"
+    },
+    "salt-cod": {
+        "name": "вяленая треска"
+    },
+    "scallion": {
+        "name": "зеленый лук",
+        "plural_name": "scallions"
+    },
+    "seafood": {
+        "name": "морепродукты"
+    },
+    "seeds": {
+        "name": "семена"
+    },
+    "sesame-seeds": {
+        "name": "семена кунжута"
+    },
+    "shallot": {
+        "name": "шалот",
+        "plural_name": "shallots"
+    },
+    "skate": {
+        "name": "скат"
+    },
+    "soda": {
+        "name": "сода"
+    },
+    "soda-baking": {
+        "name": "пищевая сода"
+    },
+    "soybean": {
+        "name": "соевые бобы"
+    },
+    "spaghetti-squash": {
+        "name": "тыква-спагетти",
+        "plural_name": "spaghetti squashes"
+    },
+    "speck": {
+        "name": "шпик"
+    },
+    "spices": {
+        "name": "специи"
+    },
+    "spinach": {
+        "name": "шпинат"
+    },
+    "spring-onion": {
+        "name": "зелёный лук",
+        "plural_name": "зелёный лук"
+    },
+    "squash": {
+        "name": "тыква",
+        "plural_name": "кабачки"
+    },
+    "squash-family": {
+        "name": "тыквы"
+    },
+    "stockfish": {
+        "name": "стокфиск"
+    },
+    "sugar": {
+        "name": "сахар"
+    },
+    "sunchoke": {
+        "name": "топинамбур",
+        "plural_name": "sunchokes"
+    },
+    "sunflower-seeds": {
+        "name": "семена подсолнечника"
+    },
+    "superfine-sugar": {
+        "name": "ультрамелкий сахар"
+    },
+    "sweet-potato": {
+        "name": "сладкий картофель",
+        "plural_name": "sweet potatoes"
+    },
+    "sweetcorn": {
+        "name": "кукуруза сахарная",
+        "plural_name": "sweetcorns"
+    },
+    "sweeteners": {
+        "name": "подсластители"
+    },
+    "tahini": {
+        "name": "тахини"
+    },
+    "taro": {
+        "name": "таро",
+        "plural_name": "taroes"
+    },
+    "teff": {
+        "name": "теф"
+    },
+    "tomato": {
+        "name": "помидор",
+        "plural_name": "помидоры"
+    },
+    "trout": {
+        "name": "форель"
+    },
+    "tubers": {
+        "name": "клубни",
+        "plural_name": "клубни"
+    },
+    "tuna": {
+        "name": "тунец"
+    },
+    "turbanado-sugar": {
+        "name": "сахар турбинадо"
+    },
+    "turnip": {
+        "name": "репа",
+        "plural_name": "репа"
+    },
+    "unrefined-sugar": {
+        "name": "нерафинированный сахар"
+    },
+    "vanilla": {
+        "name": "ваниль"
+    },
+    "vegetables": {
+        "name": "овощи"
+    },
+    "watercress": {
+        "name": "жеруха"
+    },
+    "watermelon": {
+        "name": "арбуз",
+        "plural_name": "арбузы"
+    },
+    "white-mushroom": {
+        "name": "белый гриб",
+        "plural_name": "белые грибы"
+    },
+    "white-sugar": {
+        "name": "рафинад"
+    },
+    "xanthan-gum": {
+        "name": "ксантановая камедь"
+    },
+    "yam": {
+        "name": "ямс",
+        "plural_name": "yams"
+    },
+    "yeast": {
+        "name": "дрожжи"
+    },
+    "zucchini": {
+        "name": "цуккини",
+        "plural_name": "цуккини"
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/sk-SK.json
+++ b/mealie/repos/seed/resources/foods/locales/sk-SK.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "žaluďová tekvica"
-	},
-	"alfalfa-sprouts": {
-		"name": "klíčky lucerny"
-	},
-	"anchovies": {
-		"name": "sardely"
-	},
-	"apples": {
-		"name": "jablká",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artičoka"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "špargľa"
-	},
-	"avocado": {
-		"name": "avokádo",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "slanina"
-	},
-	"baking-powder": {
-		"name": "prášok do pečiva"
-	},
-	"baking-soda": {
-		"name": "sóda bikarbóna"
-	},
-	"baking-sugar": {
-		"name": "cukor na pečenie"
-	},
-	"bar-sugar": {
-		"name": "kryštálový cukor"
-	},
-	"basil": {
-		"name": "bazalka"
-	},
-	"beans": {
-		"name": "fazuľa"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "Černice"
-	},
-	"bok-choy": {
-		"name": "bok choy kapusta"
-	},
-	"brassicas": {
-		"name": "hlúboviny"
-	},
-	"bread": {
-		"name": "chlieb"
-	},
-	"breadfruit": {
-		"name": "chlebovník"
-	},
-	"broccoflower": {
-		"name": "brokolica romanecso"
-	},
-	"broccoli": {
-		"name": "brokolica"
-	},
-	"broccoli-rabe": {
-		"name": "brokolica rabe"
-	},
-	"broccolini": {
-		"name": "brokolica"
-	},
-	"brown-sugar": {
-		"name": "hnedý cukor"
-	},
-	"brussels-sprouts": {
-		"name": "ružičkový kel"
-	},
-	"butter": {
-		"name": "maslo"
-	},
-	"butternut-pumpkin": {
-		"name": "tekvica z maslových orechov"
-	},
-	"butternut-squash": {
-		"name": "tekvica maslová"
-	},
-	"cabbage": {
-		"name": "kapusta",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "kaktus, jedlý"
-	},
-	"calabrese": {
-		"name": "brokolica calabrese"
-	},
-	"cane-sugar": {
-		"name": "trstinový cukor"
-	},
-	"cannabis": {
-		"name": "marihuana"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "rasca"
-	},
-	"carrot": {
-		"name": "mrkva",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "ricínový cukor"
-	},
-	"castor-sugar": {
-		"name": "ricínový cukor"
-	},
-	"catfish": {
-		"name": "sumec"
-	},
-	"cauliflower": {
-		"name": "karfiol",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "kajenské korenie"
-	},
-	"celeriac": {
-		"name": "Zeler"
-	},
-	"celery": {
-		"name": "zeler"
-	},
-	"cereal-grains": {
-		"name": "obilné zrná"
-	},
-	"chard": {
-		"name": "mandl"
-	},
-	"cheese": {
-		"name": "syr"
-	},
-	"chicory": {
-		"name": "čakanka"
-	},
-	"chilli-peppers": {
-		"name": "čili papričky",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "čínske listy"
-	},
-	"chives": {
-		"name": "pažítka"
-	},
-	"chocolate": {
-		"name": "čokoláda"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "škorica"
-	},
-	"clarified-butter": {
-		"name": "vyčistené maslo"
-	},
-	"coconut": {
-		"name": "kokos",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "kokosové mlieko"
-	},
-	"cod": {
-		"name": "treska"
-	},
-	"coffee": {
-		"name": "káva"
-	},
-	"collard-greens": {
-		"name": "listový kel"
-	},
-	"confectioners-sugar": {
-		"name": "cukrársky cukor"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "kukurica",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "kukuričný sirup"
-	},
-	"cottonseed-oil": {
-		"name": "bavlníkový olej"
-	},
-	"courgette": {
-		"name": "cuketa"
-	},
-	"cream-of-tartar": {
-		"name": "krém z vínneho kameňa"
-	},
-	"cucumber": {
-		"name": "uhorka",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "Rasca"
-	},
-	"daikon": {
-		"name": "reďkovka biela dlhá",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mliečne výrobky a mliečne náhrady"
-	},
-	"dandelion": {
-		"name": "púpava"
-	},
-	"demerara-sugar": {
-		"name": "cukor demerara"
-	},
-	"dough": {
-		"name": "cesto"
-	},
-	"edible-cactus": {
-		"name": "jedlý kaktus"
-	},
-	"eggplant": {
-		"name": "baklažán",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "vajcia",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "čakanka",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "tuky"
-	},
-	"fava-beans": {
-		"name": "fava fazuľa"
-	},
-	"fiddlehead": {
-		"name": "papraď fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "papraď fiddlehead",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "ryba"
-	},
-	"five-spice-powder": {
-		"name": "prášok z piatich korenín"
-	},
-	"flour": {
-		"name": "múka"
-	},
-	"frisee": {
-		"name": "čakanka frisee"
-	},
-	"fructose": {
-		"name": "fruktóza"
-	},
-	"fruit": {
-		"name": "ovocie"
-	},
-	"fruit-sugar": {
-		"name": "ovocný cukor"
-	},
-	"ful": {
-		"name": "úplný"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "cesnak",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "drahokamová tekvica"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "droby"
-	},
-	"ginger": {
-		"name": "zázvor"
-	},
-	"grains": {
-		"name": "zrná"
-	},
-	"granulated-sugar": {
-		"name": "kryštálový cukor"
-	},
-	"grape-seed-oil": {
-		"name": "olej z hroznových jadierok"
-	},
-	"green-onion": {
-		"name": "zelená cibuľa",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "srdce dlane",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "konope"
-	},
-	"herbs": {
-		"name": "bylinky"
-	},
-	"honey": {
-		"name": "med"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "chlebovník rôznolistý",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "surový trstinový cukor"
-	},
-	"jams": {
-		"name": "džemy"
-	},
-	"jellies": {
-		"name": "želé"
-	},
-	"jerusalem-artichoke": {
-		"name": "jeruzalemský artičok"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kel"
-	},
-	"kohlrabi": {
-		"name": "kaleráb"
-	},
-	"kumara": {
-		"name": "Kumara"
-	},
-	"leavening-agents": {
-		"name": "kypriace činidlá"
-	},
-	"leek": {
-		"name": "pór",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "strukoviny"
-	},
-	"lemongrass": {
-		"name": "citrónová tráva"
-	},
-	"lentils": {
-		"name": "šošovica"
-	},
-	"lettuce": {
-		"name": "šalát"
-	},
-	"liver": {
-		"name": "pečeň",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "kukurica"
-	},
-	"maple-syrup": {
-		"name": "javorový sirup"
-	},
-	"meat": {
-		"name": "mäso"
-	},
-	"milk": {
-		"name": "mlieko"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "huba",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mušle"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "morské riasy nori"
-	},
-	"nutmeg": {
-		"name": "muškátový oriešok"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "výživové kvasinkové vločky"
-	},
-	"nuts": {
-		"name": "orechy"
-	},
-	"octopuses": {
-		"name": "chobotnice",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oleje"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliva"
-	},
-	"olive-oil": {
-		"name": "olivový olej"
-	},
-	"onion": {
-		"name": "cibuľa"
-	},
-	"onion-family": {
-		"name": "cibuľová rodina"
-	},
-	"orange-blossom-water": {
-		"name": "voda z pomarančového kvetu"
-	},
-	"oranges": {
-		"name": "pomaranče",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "ustrice"
-	},
-	"panch-puran": {
-		"name": "panch phoron zmes semien"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "petržlen"
-	},
-	"parsnip": {
-		"name": "paštrnák",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "hruška",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "hrach"
-	},
-	"pepper": {
-		"name": "čierne korenie",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananás",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "skorocel",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "makové semená"
-	},
-	"potato": {
-		"name": "zemiak",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "hydina"
-	},
-	"powdered-sugar": {
-		"name": "práškový cukor"
-	},
-	"pumpkin": {
-		"name": "tekvica",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "tekvicové semienka"
-	},
-	"radish": {
-		"name": "reďkovka",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "surový cukor"
-	},
-	"refined-sugar": {
-		"name": "rafinovaný cukor"
-	},
-	"rice": {
-		"name": "ryža"
-	},
-	"rice-flour": {
-		"name": "ryžová múka"
-	},
-	"rock-sugar": {
-		"name": "kamenný cukor"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "losos"
-	},
-	"salt": {
-		"name": "soľ"
-	},
-	"salt-cod": {
-		"name": "slaná treska"
-	},
-	"scallion": {
-		"name": "Pór",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "morské plody"
-	},
-	"seeds": {
-		"name": "semená"
-	},
-	"sesame-seeds": {
-		"name": "sezamové semienka"
-	},
-	"shallot": {
-		"name": "šalota",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "ryba skate"
-	},
-	"soda": {
-		"name": "sóda"
-	},
-	"soda-baking": {
-		"name": "sóda, pečenie"
-	},
-	"soybean": {
-		"name": "sója"
-	},
-	"spaghetti-squash": {
-		"name": "špagetová tekvica",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "smietka"
-	},
-	"spices": {
-		"name": "korenie"
-	},
-	"spinach": {
-		"name": "špenát"
-	},
-	"spring-onion": {
-		"name": "jarná cibuľka",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "tekvica",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "rodina tekvic"
-	},
-	"stockfish": {
-		"name": "sušená ryba"
-	},
-	"sugar": {
-		"name": "cukor"
-	},
-	"sunchoke": {
-		"name": "slnečnica hľuznatá",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "slnečnicové semená"
-	},
-	"superfine-sugar": {
-		"name": "superjemný cukor"
-	},
-	"sweet-potato": {
-		"name": "batát",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "kukurica cukrová",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sladidlá"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "kolokázia jedlá (Taro)",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff - milička abesínska"
-	},
-	"tomato": {
-		"name": "paradajka",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "pstruh"
-	},
-	"tubers": {
-		"name": "hľuzy",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuniak"
-	},
-	"turbanado-sugar": {
-		"name": "cukor turbanado"
-	},
-	"turnip": {
-		"name": "okrúhlica",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "nerafinovaný cukor"
-	},
-	"vanilla": {
-		"name": "vanilka"
-	},
-	"vegetables": {
-		"name": "zelenina"
-	},
-	"watercress": {
-		"name": "žerucha"
-	},
-	"watermelon": {
-		"name": "melón",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "biela huba",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "biely cukor"
-	},
-	"xanthan-gum": {
-		"name": "xantánová guma"
-	},
-	"yam": {
-		"name": "dioskórea huňatá",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "kvasnice"
-	},
-	"zucchini": {
-		"name": "cuketa",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "žaluďová tekvica"
+            },
+            "alfalfa-sprouts": {
+                "name": "klíčky lucerny"
+            },
+            "anchovies": {
+                "name": "sardely"
+            },
+            "apples": {
+                "name": "jablká",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artičoka"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "špargľa"
+            },
+            "avocado": {
+                "name": "avokádo",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "slanina"
+            },
+            "baking-powder": {
+                "name": "prášok do pečiva"
+            },
+            "baking-soda": {
+                "name": "sóda bikarbóna"
+            },
+            "baking-sugar": {
+                "name": "cukor na pečenie"
+            },
+            "bar-sugar": {
+                "name": "kryštálový cukor"
+            },
+            "basil": {
+                "name": "bazalka"
+            },
+            "beans": {
+                "name": "fazuľa"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "Černice"
+            },
+            "bok-choy": {
+                "name": "bok choy kapusta"
+            },
+            "brassicas": {
+                "name": "hlúboviny"
+            },
+            "bread": {
+                "name": "chlieb"
+            },
+            "breadfruit": {
+                "name": "chlebovník"
+            },
+            "broccoflower": {
+                "name": "brokolica romanecso"
+            },
+            "broccoli": {
+                "name": "brokolica"
+            },
+            "broccoli-rabe": {
+                "name": "brokolica rabe"
+            },
+            "broccolini": {
+                "name": "brokolica"
+            },
+            "brown-sugar": {
+                "name": "hnedý cukor"
+            },
+            "brussels-sprouts": {
+                "name": "ružičkový kel"
+            },
+            "butter": {
+                "name": "maslo"
+            },
+            "butternut-pumpkin": {
+                "name": "tekvica z maslových orechov"
+            },
+            "butternut-squash": {
+                "name": "tekvica maslová"
+            },
+            "cabbage": {
+                "name": "kapusta",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "kaktus, jedlý"
+            },
+            "calabrese": {
+                "name": "brokolica calabrese"
+            },
+            "cane-sugar": {
+                "name": "trstinový cukor"
+            },
+            "cannabis": {
+                "name": "marihuana"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "rasca"
+            },
+            "carrot": {
+                "name": "mrkva",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "ricínový cukor"
+            },
+            "castor-sugar": {
+                "name": "ricínový cukor"
+            },
+            "catfish": {
+                "name": "sumec"
+            },
+            "cauliflower": {
+                "name": "karfiol",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "kajenské korenie"
+            },
+            "celeriac": {
+                "name": "Zeler"
+            },
+            "celery": {
+                "name": "zeler"
+            },
+            "cereal-grains": {
+                "name": "obilné zrná"
+            },
+            "chard": {
+                "name": "mandl"
+            },
+            "cheese": {
+                "name": "syr"
+            },
+            "chicory": {
+                "name": "čakanka"
+            },
+            "chilli-peppers": {
+                "name": "čili papričky",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "čínske listy"
+            },
+            "chives": {
+                "name": "pažítka"
+            },
+            "chocolate": {
+                "name": "čokoláda"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "škorica"
+            },
+            "clarified-butter": {
+                "name": "vyčistené maslo"
+            },
+            "coconut": {
+                "name": "kokos",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "kokosové mlieko"
+            },
+            "cod": {
+                "name": "treska"
+            },
+            "coffee": {
+                "name": "káva"
+            },
+            "collard-greens": {
+                "name": "listový kel"
+            },
+            "confectioners-sugar": {
+                "name": "cukrársky cukor"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "kukurica",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "kukuričný sirup"
+            },
+            "cottonseed-oil": {
+                "name": "bavlníkový olej"
+            },
+            "courgette": {
+                "name": "cuketa"
+            },
+            "cream-of-tartar": {
+                "name": "krém z vínneho kameňa"
+            },
+            "cucumber": {
+                "name": "uhorka",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "Rasca"
+            },
+            "daikon": {
+                "name": "reďkovka biela dlhá",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mliečne výrobky a mliečne náhrady"
+            },
+            "dandelion": {
+                "name": "púpava"
+            },
+            "demerara-sugar": {
+                "name": "cukor demerara"
+            },
+            "dough": {
+                "name": "cesto"
+            },
+            "edible-cactus": {
+                "name": "jedlý kaktus"
+            },
+            "eggplant": {
+                "name": "baklažán",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "vajcia",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "čakanka",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "tuky"
+            },
+            "fava-beans": {
+                "name": "fava fazuľa"
+            },
+            "fiddlehead": {
+                "name": "papraď fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "papraď fiddlehead",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "ryba"
+            },
+            "five-spice-powder": {
+                "name": "prášok z piatich korenín"
+            },
+            "flour": {
+                "name": "múka"
+            },
+            "frisee": {
+                "name": "čakanka frisee"
+            },
+            "fructose": {
+                "name": "fruktóza"
+            },
+            "fruit": {
+                "name": "ovocie"
+            },
+            "fruit-sugar": {
+                "name": "ovocný cukor"
+            },
+            "ful": {
+                "name": "úplný"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "cesnak",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "drahokamová tekvica"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "droby"
+            },
+            "ginger": {
+                "name": "zázvor"
+            },
+            "grains": {
+                "name": "zrná"
+            },
+            "granulated-sugar": {
+                "name": "kryštálový cukor"
+            },
+            "grape-seed-oil": {
+                "name": "olej z hroznových jadierok"
+            },
+            "green-onion": {
+                "name": "zelená cibuľa",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "srdce dlane",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "konope"
+            },
+            "herbs": {
+                "name": "bylinky"
+            },
+            "honey": {
+                "name": "med"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "chlebovník rôznolistý",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "surový trstinový cukor"
+            },
+            "jams": {
+                "name": "džemy"
+            },
+            "jellies": {
+                "name": "želé"
+            },
+            "jerusalem-artichoke": {
+                "name": "jeruzalemský artičok"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kel"
+            },
+            "kohlrabi": {
+                "name": "kaleráb"
+            },
+            "kumara": {
+                "name": "Kumara"
+            },
+            "leavening-agents": {
+                "name": "kypriace činidlá"
+            },
+            "leek": {
+                "name": "pór",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "strukoviny"
+            },
+            "lemongrass": {
+                "name": "citrónová tráva"
+            },
+            "lentils": {
+                "name": "šošovica"
+            },
+            "lettuce": {
+                "name": "šalát"
+            },
+            "liver": {
+                "name": "pečeň",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "kukurica"
+            },
+            "maple-syrup": {
+                "name": "javorový sirup"
+            },
+            "meat": {
+                "name": "mäso"
+            },
+            "milk": {
+                "name": "mlieko"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "huba",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mušle"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "morské riasy nori"
+            },
+            "nutmeg": {
+                "name": "muškátový oriešok"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "výživové kvasinkové vločky"
+            },
+            "nuts": {
+                "name": "orechy"
+            },
+            "octopuses": {
+                "name": "chobotnice",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oleje"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliva"
+            },
+            "olive-oil": {
+                "name": "olivový olej"
+            },
+            "onion": {
+                "name": "cibuľa"
+            },
+            "onion-family": {
+                "name": "cibuľová rodina"
+            },
+            "orange-blossom-water": {
+                "name": "voda z pomarančového kvetu"
+            },
+            "oranges": {
+                "name": "pomaranče",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "ustrice"
+            },
+            "panch-puran": {
+                "name": "panch phoron zmes semien"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "petržlen"
+            },
+            "parsnip": {
+                "name": "paštrnák",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "hruška",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "hrach"
+            },
+            "pepper": {
+                "name": "čierne korenie",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananás",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "skorocel",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "makové semená"
+            },
+            "potato": {
+                "name": "zemiak",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "hydina"
+            },
+            "powdered-sugar": {
+                "name": "práškový cukor"
+            },
+            "pumpkin": {
+                "name": "tekvica",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "tekvicové semienka"
+            },
+            "radish": {
+                "name": "reďkovka",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "surový cukor"
+            },
+            "refined-sugar": {
+                "name": "rafinovaný cukor"
+            },
+            "rice": {
+                "name": "ryža"
+            },
+            "rice-flour": {
+                "name": "ryžová múka"
+            },
+            "rock-sugar": {
+                "name": "kamenný cukor"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "losos"
+            },
+            "salt": {
+                "name": "soľ"
+            },
+            "salt-cod": {
+                "name": "slaná treska"
+            },
+            "scallion": {
+                "name": "Pór",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "morské plody"
+            },
+            "seeds": {
+                "name": "semená"
+            },
+            "sesame-seeds": {
+                "name": "sezamové semienka"
+            },
+            "shallot": {
+                "name": "šalota",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "ryba skate"
+            },
+            "soda": {
+                "name": "sóda"
+            },
+            "soda-baking": {
+                "name": "sóda, pečenie"
+            },
+            "soybean": {
+                "name": "sója"
+            },
+            "spaghetti-squash": {
+                "name": "špagetová tekvica",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "smietka"
+            },
+            "spices": {
+                "name": "korenie"
+            },
+            "spinach": {
+                "name": "špenát"
+            },
+            "spring-onion": {
+                "name": "jarná cibuľka",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "tekvica",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "rodina tekvic"
+            },
+            "stockfish": {
+                "name": "sušená ryba"
+            },
+            "sugar": {
+                "name": "cukor"
+            },
+            "sunchoke": {
+                "name": "slnečnica hľuznatá",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "slnečnicové semená"
+            },
+            "superfine-sugar": {
+                "name": "superjemný cukor"
+            },
+            "sweet-potato": {
+                "name": "batát",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "kukurica cukrová",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sladidlá"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "kolokázia jedlá (Taro)",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff - milička abesínska"
+            },
+            "tomato": {
+                "name": "paradajka",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "pstruh"
+            },
+            "tubers": {
+                "name": "hľuzy",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuniak"
+            },
+            "turbanado-sugar": {
+                "name": "cukor turbanado"
+            },
+            "turnip": {
+                "name": "okrúhlica",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "nerafinovaný cukor"
+            },
+            "vanilla": {
+                "name": "vanilka"
+            },
+            "vegetables": {
+                "name": "zelenina"
+            },
+            "watercress": {
+                "name": "žerucha"
+            },
+            "watermelon": {
+                "name": "melón",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "biela huba",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "biely cukor"
+            },
+            "xanthan-gum": {
+                "name": "xantánová guma"
+            },
+            "yam": {
+                "name": "dioskórea huňatá",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "kvasnice"
+            },
+            "zucchini": {
+                "name": "cuketa",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Produkovať": {
+        "foods": {}
+    },
+    "Zrná": {
+        "foods": {}
+    },
+    "Ovocie": {
+        "foods": {}
+    },
+    "Zelenina": {
+        "foods": {}
+    },
+    "Mäso": {
+        "foods": {}
+    },
+    "Morské plody": {
+        "foods": {}
+    },
+    "Nápoje": {
+        "foods": {}
+    },
+    "Pečivo": {
+        "foods": {}
+    },
+    "Konzervy": {
+        "foods": {}
+    },
+    "Koreniny": {
+        "foods": {}
+    },
+    "Cukrovinky": {
+        "foods": {}
+    },
+    "Mliečne výrobky": {
+        "foods": {}
+    },
+    "Mrazené jedlá": {
+        "foods": {}
+    },
+    "Zdravé jedlá": {
+        "foods": {}
+    },
+    "Domácnosť": {
+        "foods": {}
+    },
+    "Mäsové výrobky": {
+        "foods": {}
+    },
+    "Občerstvenie": {
+        "foods": {}
+    },
+    "Korenie": {
+        "foods": {}
+    },
+    "Sladkosti": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Ostatné": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/sl-SI.json
+++ b/mealie/repos/seed/resources/foods/locales/sl-SI.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "želodova buča"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa kalčki"
-	},
-	"anchovies": {
-		"name": "inčuni"
-	},
-	"apples": {
-		"name": "jabolka",
-		"plural_name": "jabolka"
-	},
-	"artichoke": {
-		"name": "artičoke"
-	},
-	"arugula": {
-		"name": "rukola"
-	},
-	"asparagus": {
-		"name": "šparglji"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avokado"
-	},
-	"bacon": {
-		"name": "slanina"
-	},
-	"baking-powder": {
-		"name": "pecilni prašek"
-	},
-	"baking-soda": {
-		"name": "soda bikarbona"
-	},
-	"baking-sugar": {
-		"name": "sladkor za peko"
-	},
-	"bar-sugar": {
-		"name": "palični sladkor"
-	},
-	"basil": {
-		"name": "bazilika"
-	},
-	"beans": {
-		"name": "fižol"
-	},
-	"bell-peppers": {
-		"name": "podolgovate paprike",
-		"plural_name": "podolgovate paprike"
-	},
-	"blackberries": {
-		"name": "robide"
-	},
-	"bok-choy": {
-		"name": "kitajsko zelje"
-	},
-	"brassicas": {
-		"name": "repa"
-	},
-	"bread": {
-		"name": "kruh"
-	},
-	"breadfruit": {
-		"name": "sadni kruh"
-	},
-	"broccoflower": {
-		"name": "cvetovi brokolija"
-	},
-	"broccoli": {
-		"name": "brokoli"
-	},
-	"broccoli-rabe": {
-		"name": "brokoli rabe"
-	},
-	"broccolini": {
-		"name": "brokolini"
-	},
-	"brown-sugar": {
-		"name": "rjavi sladkor"
-	},
-	"brussels-sprouts": {
-		"name": "brstični ohrovt"
-	},
-	"butter": {
-		"name": "maslo"
-	},
-	"butternut-pumpkin": {
-		"name": "sladka buča"
-	},
-	"butternut-squash": {
-		"name": "buče"
-	},
-	"cabbage": {
-		"name": "zelje",
-		"plural_name": "zelje"
-	},
-	"cactus-edible": {
-		"name": "jedilni kaktus"
-	},
-	"calabrese": {
-		"name": "kalabrez"
-	},
-	"cane-sugar": {
-		"name": "trsni sladkor"
-	},
-	"cannabis": {
-		"name": "konoplja"
-	},
-	"capsicum": {
-		"name": "paprika"
-	},
-	"caraway": {
-		"name": "kumina"
-	},
-	"carrot": {
-		"name": "korenje",
-		"plural_name": "korenje"
-	},
-	"caster-sugar": {
-		"name": "trsni sladkor"
-	},
-	"castor-sugar": {
-		"name": "sladkor v prahu"
-	},
-	"catfish": {
-		"name": "som"
-	},
-	"cauliflower": {
-		"name": "cvetača",
-		"plural_name": "cvetača"
-	},
-	"cayenne-pepper": {
-		"name": "kajenski poper"
-	},
-	"celeriac": {
-		"name": "zelena"
-	},
-	"celery": {
-		"name": "zelena"
-	},
-	"cereal-grains": {
-		"name": "žitna zrna"
-	},
-	"chard": {
-		"name": "blitva"
-	},
-	"cheese": {
-		"name": "sir"
-	},
-	"chicory": {
-		"name": "radič"
-	},
-	"chilli-peppers": {
-		"name": "čili paprika",
-		"plural_name": "čili paprika"
-	},
-	"chinese-leaves": {
-		"name": "kitajski listi"
-	},
-	"chives": {
-		"name": "drobnjak"
-	},
-	"chocolate": {
-		"name": "čokolada"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "cimet"
-	},
-	"clarified-butter": {
-		"name": "prečiščeno maslo"
-	},
-	"coconut": {
-		"name": "kokos",
-		"plural_name": "kokos"
-	},
-	"coconut-milk": {
-		"name": "kokosovo mleko"
-	},
-	"cod": {
-		"name": "trska"
-	},
-	"coffee": {
-		"name": "kava"
-	},
-	"collard-greens": {
-		"name": "ovratnik"
-	},
-	"confectioners-sugar": {
-		"name": "slaščičarski sladkor"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "koruza",
-		"plural_name": "koruza"
-	},
-	"corn-syrup": {
-		"name": "koruzni sirup"
-	},
-	"cottonseed-oil": {
-		"name": "bombažno olje"
-	},
-	"courgette": {
-		"name": "bučke"
-	},
-	"cream-of-tartar": {
-		"name": "tatarska omaka"
-	},
-	"cucumber": {
-		"name": "kumare",
-		"plural_name": "kumare"
-	},
-	"cumin": {
-		"name": "kumina"
-	},
-	"daikon": {
-		"name": "daikon redkev",
-		"plural_name": "daikon redkev"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mlečni izdelki in mlečni nadomestki"
-	},
-	"dandelion": {
-		"name": "regrat"
-	},
-	"demerara-sugar": {
-		"name": "demerara sladkor"
-	},
-	"dough": {
-		"name": "testo"
-	},
-	"edible-cactus": {
-		"name": "jedilni kaktus"
-	},
-	"eggplant": {
-		"name": "jajčevec",
-		"plural_name": "jajčevec"
-	},
-	"eggs": {
-		"name": "jajca",
-		"plural_name": "jajca"
-	},
-	"endive": {
-		"name": "endivija",
-		"plural_name": "endivija"
-	},
-	"fats": {
-		"name": "maščobe"
-	},
-	"fava-beans": {
-		"name": "fava fižol"
-	},
-	"fiddlehead": {
-		"name": "praprotni poganjki"
-	},
-	"fiddlehead-fern": {
-		"name": "gosličasta praprot",
-		"plural_name": "gosličasta praprot"
-	},
-	"fish": {
-		"name": "ribe"
-	},
-	"five-spice-powder": {
-		"name": "pet začimb v prahu"
-	},
-	"flour": {
-		"name": "moka"
-	},
-	"frisee": {
-		"name": "frise solata"
-	},
-	"fructose": {
-		"name": "fruktoza"
-	},
-	"fruit": {
-		"name": "sadje"
-	},
-	"fruit-sugar": {
-		"name": "sadni sladkor"
-	},
-	"ful": {
-		"name": "fižol"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "česen",
-		"plural_name": "česen"
-	},
-	"gem-squash": {
-		"name": "poletna buča"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "drobovje"
-	},
-	"ginger": {
-		"name": "ingver"
-	},
-	"grains": {
-		"name": "zrna"
-	},
-	"granulated-sugar": {
-		"name": "sladkor v zrnih"
-	},
-	"grape-seed-oil": {
-		"name": "olje grozdnih pečk"
-	},
-	"green-onion": {
-		"name": "zelena čebula",
-		"plural_name": "zelena čebula"
-	},
-	"heart-of-palm": {
-		"name": "srce palme",
-		"plural_name": "srce palme"
-	},
-	"hemp": {
-		"name": "konoplja"
-	},
-	"herbs": {
-		"name": "zelišča"
-	},
-	"honey": {
-		"name": "med"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "nangka",
-		"plural_name": "nangka"
-	},
-	"jaggery": {
-		"name": "trsni sladkor"
-	},
-	"jams": {
-		"name": "džemi"
-	},
-	"jellies": {
-		"name": "želeji"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerozalemska artičoka"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "ohrovt"
-	},
-	"kohlrabi": {
-		"name": "kolerabe"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "kvas"
-	},
-	"leek": {
-		"name": "por",
-		"plural_name": "por"
-	},
-	"legumes": {
-		"name": "stročnice"
-	},
-	"lemongrass": {
-		"name": "limonina trava"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "solata"
-	},
-	"liver": {
-		"name": "jetra",
-		"plural_name": "jetra"
-	},
-	"maize": {
-		"name": "koruza"
-	},
-	"maple-syrup": {
-		"name": "javorjev sirup"
-	},
-	"meat": {
-		"name": "meso"
-	},
-	"milk": {
-		"name": "mleko"
-	},
-	"mortadella": {
-		"name": "mortadela"
-	},
-	"mushroom": {
-		"name": "gobe",
-		"plural_name": "gobe"
-	},
-	"mussels": {
-		"name": "školjke"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo ploščice"
-	},
-	"nori": {
-		"name": "nori alge"
-	},
-	"nutmeg": {
-		"name": "muškatni orešček"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "prehranski kvasni kosmiči"
-	},
-	"nuts": {
-		"name": "oreščki"
-	},
-	"octopuses": {
-		"name": "hobotnice",
-		"plural_name": "hobotnice"
-	},
-	"oils": {
-		"name": "olja"
-	},
-	"okra": {
-		"name": "jedilni oslez"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olivno olje"
-	},
-	"onion": {
-		"name": "čebula"
-	},
-	"onion-family": {
-		"name": "družina čebul"
-	},
-	"orange-blossom-water": {
-		"name": "voda pomarančnih cvetov"
-	},
-	"oranges": {
-		"name": "pomaranče",
-		"plural_name": "pomaranče"
-	},
-	"oregano": {
-		"name": "origano"
-	},
-	"oysters": {
-		"name": "ostrige"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "peteršilj"
-	},
-	"parsnip": {
-		"name": "pastinak",
-		"plural_name": "pastinak"
-	},
-	"pear": {
-		"name": "hruška",
-		"plural_name": "hruške"
-	},
-	"peas": {
-		"name": "grah"
-	},
-	"pepper": {
-		"name": "poper",
-		"plural_name": "popri"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "trpotec",
-		"plural_name": "trpotec"
-	},
-	"poppy-seeds": {
-		"name": "makova semena"
-	},
-	"potato": {
-		"name": "krompir",
-		"plural_name": "krompir"
-	},
-	"poultry": {
-		"name": "perutnina"
-	},
-	"powdered-sugar": {
-		"name": "sladkor v prahu"
-	},
-	"pumpkin": {
-		"name": "buča",
-		"plural_name": "buča"
-	},
-	"pumpkin-seeds": {
-		"name": "bučna semena"
-	},
-	"radish": {
-		"name": "redkev",
-		"plural_name": "redkev"
-	},
-	"raw-sugar": {
-		"name": "surovi sladkor"
-	},
-	"refined-sugar": {
-		"name": "rafiniran sladkor"
-	},
-	"rice": {
-		"name": "riž"
-	},
-	"rice-flour": {
-		"name": "riževa moka"
-	},
-	"rock-sugar": {
-		"name": "rjavi sladkor"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "losos"
-	},
-	"salt": {
-		"name": "sol"
-	},
-	"salt-cod": {
-		"name": "slana trska"
-	},
-	"scallion": {
-		"name": "česen",
-		"plural_name": "mlada čebula"
-	},
-	"seafood": {
-		"name": "morska hrana"
-	},
-	"seeds": {
-		"name": "semena"
-	},
-	"sesame-seeds": {
-		"name": "sezamova semena"
-	},
-	"shallot": {
-		"name": "šalotka",
-		"plural_name": "šalotka"
-	},
-	"skate": {
-		"name": "skat"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, pecilna"
-	},
-	"soybean": {
-		"name": "soja"
-	},
-	"spaghetti-squash": {
-		"name": "špageti buča",
-		"plural_name": "buča špagetarica"
-	},
-	"speck": {
-		"name": "špeh"
-	},
-	"spices": {
-		"name": "začimbe"
-	},
-	"spinach": {
-		"name": "špinača"
-	},
-	"spring-onion": {
-		"name": "mlada čebulica",
-		"plural_name": "mlada čebulica"
-	},
-	"squash": {
-		"name": "buča",
-		"plural_name": "buča"
-	},
-	"squash-family": {
-		"name": "družina buč"
-	},
-	"stockfish": {
-		"name": "stock riba"
-	},
-	"sugar": {
-		"name": "sladkor"
-	},
-	"sunchoke": {
-		"name": "topinambur",
-		"plural_name": "topinambur"
-	},
-	"sunflower-seeds": {
-		"name": "sončnična semena"
-	},
-	"superfine-sugar": {
-		"name": "sladkor v prahu"
-	},
-	"sweet-potato": {
-		"name": "sladki krompir",
-		"plural_name": "sladki krompir"
-	},
-	"sweetcorn": {
-		"name": "sladka koruza",
-		"plural_name": "sladka koruza"
-	},
-	"sweeteners": {
-		"name": "sladilo"
-	},
-	"tahini": {
-		"name": "tahin"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroji"
-	},
-	"teff": {
-		"name": "tef"
-	},
-	"tomato": {
-		"name": "paradižnik",
-		"plural_name": "paradižnik"
-	},
-	"trout": {
-		"name": "postrv"
-	},
-	"tubers": {
-		"name": "gomolji",
-		"plural_name": "gomolji"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbinado sladkor"
-	},
-	"turnip": {
-		"name": "repa",
-		"plural_name": "repa"
-	},
-	"unrefined-sugar": {
-		"name": "nerafiniran sladkor"
-	},
-	"vanilla": {
-		"name": "vanilija"
-	},
-	"vegetables": {
-		"name": "zelenjava"
-	},
-	"watercress": {
-		"name": "vodna kreša"
-	},
-	"watermelon": {
-		"name": "lubenica",
-		"plural_name": "lubenica"
-	},
-	"white-mushroom": {
-		"name": "bele gobe",
-		"plural_name": "bele gobe"
-	},
-	"white-sugar": {
-		"name": "beli sladkor"
-	},
-	"xanthan-gum": {
-		"name": "ksantan gumi"
-	},
-	"yam": {
-		"name": "marmelada",
-		"plural_name": "marmelada"
-	},
-	"yeast": {
-		"name": "kvas"
-	},
-	"zucchini": {
-		"name": "bučke",
-		"plural_name": "bučke"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "želodova buča"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa kalčki"
+            },
+            "anchovies": {
+                "name": "inčuni"
+            },
+            "apples": {
+                "name": "jabolka",
+                "plural_name": "jabolka"
+            },
+            "artichoke": {
+                "name": "artičoke"
+            },
+            "arugula": {
+                "name": "rukola"
+            },
+            "asparagus": {
+                "name": "šparglji"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avokado"
+            },
+            "bacon": {
+                "name": "slanina"
+            },
+            "baking-powder": {
+                "name": "pecilni prašek"
+            },
+            "baking-soda": {
+                "name": "soda bikarbona"
+            },
+            "baking-sugar": {
+                "name": "sladkor za peko"
+            },
+            "bar-sugar": {
+                "name": "palični sladkor"
+            },
+            "basil": {
+                "name": "bazilika"
+            },
+            "beans": {
+                "name": "fižol"
+            },
+            "bell-peppers": {
+                "name": "podolgovate paprike",
+                "plural_name": "podolgovate paprike"
+            },
+            "blackberries": {
+                "name": "robide"
+            },
+            "bok-choy": {
+                "name": "kitajsko zelje"
+            },
+            "brassicas": {
+                "name": "repa"
+            },
+            "bread": {
+                "name": "kruh"
+            },
+            "breadfruit": {
+                "name": "sadni kruh"
+            },
+            "broccoflower": {
+                "name": "cvetovi brokolija"
+            },
+            "broccoli": {
+                "name": "brokoli"
+            },
+            "broccoli-rabe": {
+                "name": "brokoli rabe"
+            },
+            "broccolini": {
+                "name": "brokolini"
+            },
+            "brown-sugar": {
+                "name": "rjavi sladkor"
+            },
+            "brussels-sprouts": {
+                "name": "brstični ohrovt"
+            },
+            "butter": {
+                "name": "maslo"
+            },
+            "butternut-pumpkin": {
+                "name": "sladka buča"
+            },
+            "butternut-squash": {
+                "name": "buče"
+            },
+            "cabbage": {
+                "name": "zelje",
+                "plural_name": "zelje"
+            },
+            "cactus-edible": {
+                "name": "jedilni kaktus"
+            },
+            "calabrese": {
+                "name": "kalabrez"
+            },
+            "cane-sugar": {
+                "name": "trsni sladkor"
+            },
+            "cannabis": {
+                "name": "konoplja"
+            },
+            "capsicum": {
+                "name": "paprika"
+            },
+            "caraway": {
+                "name": "kumina"
+            },
+            "carrot": {
+                "name": "korenje",
+                "plural_name": "korenje"
+            },
+            "caster-sugar": {
+                "name": "trsni sladkor"
+            },
+            "castor-sugar": {
+                "name": "sladkor v prahu"
+            },
+            "catfish": {
+                "name": "som"
+            },
+            "cauliflower": {
+                "name": "cvetača",
+                "plural_name": "cvetača"
+            },
+            "cayenne-pepper": {
+                "name": "kajenski poper"
+            },
+            "celeriac": {
+                "name": "zelena"
+            },
+            "celery": {
+                "name": "zelena"
+            },
+            "cereal-grains": {
+                "name": "žitna zrna"
+            },
+            "chard": {
+                "name": "blitva"
+            },
+            "cheese": {
+                "name": "sir"
+            },
+            "chicory": {
+                "name": "radič"
+            },
+            "chilli-peppers": {
+                "name": "čili paprika",
+                "plural_name": "čili paprika"
+            },
+            "chinese-leaves": {
+                "name": "kitajski listi"
+            },
+            "chives": {
+                "name": "drobnjak"
+            },
+            "chocolate": {
+                "name": "čokolada"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "cimet"
+            },
+            "clarified-butter": {
+                "name": "prečiščeno maslo"
+            },
+            "coconut": {
+                "name": "kokos",
+                "plural_name": "kokos"
+            },
+            "coconut-milk": {
+                "name": "kokosovo mleko"
+            },
+            "cod": {
+                "name": "trska"
+            },
+            "coffee": {
+                "name": "kava"
+            },
+            "collard-greens": {
+                "name": "ovratnik"
+            },
+            "confectioners-sugar": {
+                "name": "slaščičarski sladkor"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "koruza",
+                "plural_name": "koruza"
+            },
+            "corn-syrup": {
+                "name": "koruzni sirup"
+            },
+            "cottonseed-oil": {
+                "name": "bombažno olje"
+            },
+            "courgette": {
+                "name": "bučke"
+            },
+            "cream-of-tartar": {
+                "name": "tatarska omaka"
+            },
+            "cucumber": {
+                "name": "kumare",
+                "plural_name": "kumare"
+            },
+            "cumin": {
+                "name": "kumina"
+            },
+            "daikon": {
+                "name": "daikon redkev",
+                "plural_name": "daikon redkev"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mlečni izdelki in mlečni nadomestki"
+            },
+            "dandelion": {
+                "name": "regrat"
+            },
+            "demerara-sugar": {
+                "name": "demerara sladkor"
+            },
+            "dough": {
+                "name": "testo"
+            },
+            "edible-cactus": {
+                "name": "jedilni kaktus"
+            },
+            "eggplant": {
+                "name": "jajčevec",
+                "plural_name": "jajčevec"
+            },
+            "eggs": {
+                "name": "jajca",
+                "plural_name": "jajca"
+            },
+            "endive": {
+                "name": "endivija",
+                "plural_name": "endivija"
+            },
+            "fats": {
+                "name": "maščobe"
+            },
+            "fava-beans": {
+                "name": "fava fižol"
+            },
+            "fiddlehead": {
+                "name": "praprotni poganjki"
+            },
+            "fiddlehead-fern": {
+                "name": "gosličasta praprot",
+                "plural_name": "gosličasta praprot"
+            },
+            "fish": {
+                "name": "ribe"
+            },
+            "five-spice-powder": {
+                "name": "pet začimb v prahu"
+            },
+            "flour": {
+                "name": "moka"
+            },
+            "frisee": {
+                "name": "frise solata"
+            },
+            "fructose": {
+                "name": "fruktoza"
+            },
+            "fruit": {
+                "name": "sadje"
+            },
+            "fruit-sugar": {
+                "name": "sadni sladkor"
+            },
+            "ful": {
+                "name": "fižol"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "česen",
+                "plural_name": "česen"
+            },
+            "gem-squash": {
+                "name": "poletna buča"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "drobovje"
+            },
+            "ginger": {
+                "name": "ingver"
+            },
+            "grains": {
+                "name": "zrna"
+            },
+            "granulated-sugar": {
+                "name": "sladkor v zrnih"
+            },
+            "grape-seed-oil": {
+                "name": "olje grozdnih pečk"
+            },
+            "green-onion": {
+                "name": "zelena čebula",
+                "plural_name": "zelena čebula"
+            },
+            "heart-of-palm": {
+                "name": "srce palme",
+                "plural_name": "srce palme"
+            },
+            "hemp": {
+                "name": "konoplja"
+            },
+            "herbs": {
+                "name": "zelišča"
+            },
+            "honey": {
+                "name": "med"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "nangka",
+                "plural_name": "nangka"
+            },
+            "jaggery": {
+                "name": "trsni sladkor"
+            },
+            "jams": {
+                "name": "džemi"
+            },
+            "jellies": {
+                "name": "želeji"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerozalemska artičoka"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "ohrovt"
+            },
+            "kohlrabi": {
+                "name": "kolerabe"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "kvas"
+            },
+            "leek": {
+                "name": "por",
+                "plural_name": "por"
+            },
+            "legumes": {
+                "name": "stročnice"
+            },
+            "lemongrass": {
+                "name": "limonina trava"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "solata"
+            },
+            "liver": {
+                "name": "jetra",
+                "plural_name": "jetra"
+            },
+            "maize": {
+                "name": "koruza"
+            },
+            "maple-syrup": {
+                "name": "javorjev sirup"
+            },
+            "meat": {
+                "name": "meso"
+            },
+            "milk": {
+                "name": "mleko"
+            },
+            "mortadella": {
+                "name": "mortadela"
+            },
+            "mushroom": {
+                "name": "gobe",
+                "plural_name": "gobe"
+            },
+            "mussels": {
+                "name": "školjke"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo ploščice"
+            },
+            "nori": {
+                "name": "nori alge"
+            },
+            "nutmeg": {
+                "name": "muškatni orešček"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "prehranski kvasni kosmiči"
+            },
+            "nuts": {
+                "name": "oreščki"
+            },
+            "octopuses": {
+                "name": "hobotnice",
+                "plural_name": "hobotnice"
+            },
+            "oils": {
+                "name": "olja"
+            },
+            "okra": {
+                "name": "jedilni oslez"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olivno olje"
+            },
+            "onion": {
+                "name": "čebula"
+            },
+            "onion-family": {
+                "name": "družina čebul"
+            },
+            "orange-blossom-water": {
+                "name": "voda pomarančnih cvetov"
+            },
+            "oranges": {
+                "name": "pomaranče",
+                "plural_name": "pomaranče"
+            },
+            "oregano": {
+                "name": "origano"
+            },
+            "oysters": {
+                "name": "ostrige"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "peteršilj"
+            },
+            "parsnip": {
+                "name": "pastinak",
+                "plural_name": "pastinak"
+            },
+            "pear": {
+                "name": "hruška",
+                "plural_name": "hruške"
+            },
+            "peas": {
+                "name": "grah"
+            },
+            "pepper": {
+                "name": "poper",
+                "plural_name": "popri"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "trpotec",
+                "plural_name": "trpotec"
+            },
+            "poppy-seeds": {
+                "name": "makova semena"
+            },
+            "potato": {
+                "name": "krompir",
+                "plural_name": "krompir"
+            },
+            "poultry": {
+                "name": "perutnina"
+            },
+            "powdered-sugar": {
+                "name": "sladkor v prahu"
+            },
+            "pumpkin": {
+                "name": "buča",
+                "plural_name": "buča"
+            },
+            "pumpkin-seeds": {
+                "name": "bučna semena"
+            },
+            "radish": {
+                "name": "redkev",
+                "plural_name": "redkev"
+            },
+            "raw-sugar": {
+                "name": "surovi sladkor"
+            },
+            "refined-sugar": {
+                "name": "rafiniran sladkor"
+            },
+            "rice": {
+                "name": "riž"
+            },
+            "rice-flour": {
+                "name": "riževa moka"
+            },
+            "rock-sugar": {
+                "name": "rjavi sladkor"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "losos"
+            },
+            "salt": {
+                "name": "sol"
+            },
+            "salt-cod": {
+                "name": "slana trska"
+            },
+            "scallion": {
+                "name": "česen",
+                "plural_name": "mlada čebula"
+            },
+            "seafood": {
+                "name": "morska hrana"
+            },
+            "seeds": {
+                "name": "semena"
+            },
+            "sesame-seeds": {
+                "name": "sezamova semena"
+            },
+            "shallot": {
+                "name": "šalotka",
+                "plural_name": "šalotka"
+            },
+            "skate": {
+                "name": "skat"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, pecilna"
+            },
+            "soybean": {
+                "name": "soja"
+            },
+            "spaghetti-squash": {
+                "name": "špageti buča",
+                "plural_name": "buča špagetarica"
+            },
+            "speck": {
+                "name": "špeh"
+            },
+            "spices": {
+                "name": "začimbe"
+            },
+            "spinach": {
+                "name": "špinača"
+            },
+            "spring-onion": {
+                "name": "mlada čebulica",
+                "plural_name": "mlada čebulica"
+            },
+            "squash": {
+                "name": "buča",
+                "plural_name": "buča"
+            },
+            "squash-family": {
+                "name": "družina buč"
+            },
+            "stockfish": {
+                "name": "stock riba"
+            },
+            "sugar": {
+                "name": "sladkor"
+            },
+            "sunchoke": {
+                "name": "topinambur",
+                "plural_name": "topinambur"
+            },
+            "sunflower-seeds": {
+                "name": "sončnična semena"
+            },
+            "superfine-sugar": {
+                "name": "sladkor v prahu"
+            },
+            "sweet-potato": {
+                "name": "sladki krompir",
+                "plural_name": "sladki krompir"
+            },
+            "sweetcorn": {
+                "name": "sladka koruza",
+                "plural_name": "sladka koruza"
+            },
+            "sweeteners": {
+                "name": "sladilo"
+            },
+            "tahini": {
+                "name": "tahin"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroji"
+            },
+            "teff": {
+                "name": "tef"
+            },
+            "tomato": {
+                "name": "paradižnik",
+                "plural_name": "paradižnik"
+            },
+            "trout": {
+                "name": "postrv"
+            },
+            "tubers": {
+                "name": "gomolji",
+                "plural_name": "gomolji"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbinado sladkor"
+            },
+            "turnip": {
+                "name": "repa",
+                "plural_name": "repa"
+            },
+            "unrefined-sugar": {
+                "name": "nerafiniran sladkor"
+            },
+            "vanilla": {
+                "name": "vanilija"
+            },
+            "vegetables": {
+                "name": "zelenjava"
+            },
+            "watercress": {
+                "name": "vodna kreša"
+            },
+            "watermelon": {
+                "name": "lubenica",
+                "plural_name": "lubenica"
+            },
+            "white-mushroom": {
+                "name": "bele gobe",
+                "plural_name": "bele gobe"
+            },
+            "white-sugar": {
+                "name": "beli sladkor"
+            },
+            "xanthan-gum": {
+                "name": "ksantan gumi"
+            },
+            "yam": {
+                "name": "marmelada",
+                "plural_name": "marmelada"
+            },
+            "yeast": {
+                "name": "kvas"
+            },
+            "zucchini": {
+                "name": "bučke",
+                "plural_name": "bučke"
+            }
+        }
+    },
+    "Pridelek": {
+        "foods": {}
+    },
+    "Zrna": {
+        "foods": {}
+    },
+    "Sadje": {
+        "foods": {}
+    },
+    "Zelenjava": {
+        "foods": {}
+    },
+    "Meso": {
+        "foods": {}
+    },
+    "Morska hrana": {
+        "foods": {}
+    },
+    "Pijače": {
+        "foods": {}
+    },
+    "Pečene dobrote": {
+        "foods": {}
+    },
+    "Konzervirana hrana": {
+        "foods": {}
+    },
+    "Začimbe": {
+        "foods": {}
+    },
+    "Slaščičarna": {
+        "foods": {}
+    },
+    "Mlečni produkti": {
+        "foods": {}
+    },
+    "Zmrznjena hrana": {
+        "foods": {}
+    },
+    "Zdrava hrana": {
+        "foods": {}
+    },
+    "Gospodinjstvo": {
+        "foods": {}
+    },
+    "Mesni produkti": {
+        "foods": {}
+    },
+    "Priboljški": {
+        "foods": {}
+    },
+    "Sladkarije": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Drugo": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/sr-SP.json
+++ b/mealie/repos/seed/resources/foods/locales/sr-SP.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "baking soda"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell peppers",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "blackberries"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "bread"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brown sugar"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "butter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "cheese"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rice"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Домаћи производи": {
+        "foods": {}
+    },
+    "Житарице": {
+        "foods": {}
+    },
+    "Воће": {
+        "foods": {}
+    },
+    "Поврће": {
+        "foods": {}
+    },
+    "Месо": {
+        "foods": {}
+    },
+    "Морски плодови": {
+        "foods": {}
+    },
+    "Пића": {
+        "foods": {}
+    },
+    "Пецива": {
+        "foods": {}
+    },
+    "Конзервирана храна": {
+        "foods": {}
+    },
+    "Зачини": {
+        "foods": {}
+    },
+    "Кондиторски производи": {
+        "foods": {}
+    },
+    "Млечни производи": {
+        "foods": {}
+    },
+    "Смрзнута храна": {
+        "foods": {}
+    },
+    "Здрава храна": {
+        "foods": {}
+    },
+    "Домаћинство": {
+        "foods": {}
+    },
+    "Месни производи": {
+        "foods": {}
+    },
+    "Грицкалице": {
+        "foods": {}
+    },
+    "Слаткиши": {
+        "foods": {}
+    },
+    "Алкохол": {
+        "foods": {}
+    },
+    "Остало": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/sv-SE.json
+++ b/mealie/repos/seed/resources/foods/locales/sv-SE.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "peppar squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfagroddar"
-	},
-	"anchovies": {
-		"name": "ansjovis"
-	},
-	"apples": {
-		"name": "äpplen",
-		"plural_name": "äpplen"
-	},
-	"artichoke": {
-		"name": "kronärtskocka"
-	},
-	"arugula": {
-		"name": "ruccola"
-	},
-	"asparagus": {
-		"name": "sparris"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avokado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "bakpulver"
-	},
-	"baking-soda": {
-		"name": "bikarbonat"
-	},
-	"baking-sugar": {
-		"name": "florsocker"
-	},
-	"bar-sugar": {
-		"name": "socker från sockerrör"
-	},
-	"basil": {
-		"name": "basilika"
-	},
-	"beans": {
-		"name": "bönor"
-	},
-	"bell-peppers": {
-		"name": "paprika",
-		"plural_name": "paprika"
-	},
-	"blackberries": {
-		"name": "björnbär"
-	},
-	"bok-choy": {
-		"name": "pak choi"
-	},
-	"brassicas": {
-		"name": "kål"
-	},
-	"bread": {
-		"name": "bröd"
-	},
-	"breadfruit": {
-		"name": "brödfrukt"
-	},
-	"broccoflower": {
-		"name": "broccolo"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccolirybs"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brunt socker"
-	},
-	"brussels-sprouts": {
-		"name": "brysselkål"
-	},
-	"butter": {
-		"name": "smör"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpa"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "vitkål",
-		"plural_name": "kål"
-	},
-	"cactus-edible": {
-		"name": "kaktus, ätbar"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "socker från sockerrör"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "spanskpeppar"
-	},
-	"caraway": {
-		"name": "kummin"
-	},
-	"carrot": {
-		"name": "morot",
-		"plural_name": "morötter"
-	},
-	"caster-sugar": {
-		"name": "strösocker"
-	},
-	"castor-sugar": {
-		"name": "strösocker"
-	},
-	"catfish": {
-		"name": "havskatt"
-	},
-	"cauliflower": {
-		"name": "blomkål",
-		"plural_name": "blomkål"
-	},
-	"cayenne-pepper": {
-		"name": "cayennepeppar"
-	},
-	"celeriac": {
-		"name": "rotselleri"
-	},
-	"celery": {
-		"name": "selleri"
-	},
-	"cereal-grains": {
-		"name": "sädesslag"
-	},
-	"chard": {
-		"name": "mangold"
-	},
-	"cheese": {
-		"name": "ost"
-	},
-	"chicory": {
-		"name": "cikoria"
-	},
-	"chilli-peppers": {
-		"name": "chilipeppar",
-		"plural_name": "chilipeppar"
-	},
-	"chinese-leaves": {
-		"name": "salladskål"
-	},
-	"chives": {
-		"name": "gräslök"
-	},
-	"chocolate": {
-		"name": "choklad"
-	},
-	"cilantro": {
-		"name": "koriander"
-	},
-	"cinnamon": {
-		"name": "kanel"
-	},
-	"clarified-butter": {
-		"name": "skirat smör"
-	},
-	"coconut": {
-		"name": "kokos",
-		"plural_name": "kokosnötter"
-	},
-	"coconut-milk": {
-		"name": "kokosmjölk"
-	},
-	"cod": {
-		"name": "torsk"
-	},
-	"coffee": {
-		"name": "kaffe"
-	},
-	"collard-greens": {
-		"name": "collard"
-	},
-	"confectioners-sugar": {
-		"name": "florsocker"
-	},
-	"coriander": {
-		"name": "koriander"
-	},
-	"corn": {
-		"name": "majs",
-		"plural_name": "majs"
-	},
-	"corn-syrup": {
-		"name": "majssirap"
-	},
-	"cottonseed-oil": {
-		"name": "bomullsfröolja"
-	},
-	"courgette": {
-		"name": "zucchini"
-	},
-	"cream-of-tartar": {
-		"name": "vinsten"
-	},
-	"cucumber": {
-		"name": "gurka",
-		"plural_name": "gurkor"
-	},
-	"cumin": {
-		"name": "spiskummin"
-	},
-	"daikon": {
-		"name": "rättika",
-		"plural_name": "rättikor"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "mejeriprodukter och mejerisubstitut"
-	},
-	"dandelion": {
-		"name": "maskros"
-	},
-	"demerara-sugar": {
-		"name": "råsocker"
-	},
-	"dough": {
-		"name": "deg"
-	},
-	"edible-cactus": {
-		"name": "ätbar kaktus"
-	},
-	"eggplant": {
-		"name": "äggplanta",
-		"plural_name": "äggplantor"
-	},
-	"eggs": {
-		"name": "ägg",
-		"plural_name": "ägg"
-	},
-	"endive": {
-		"name": "endiv",
-		"plural_name": "endiver"
-	},
-	"fats": {
-		"name": "fetter"
-	},
-	"fava-beans": {
-		"name": "bondböna"
-	},
-	"fiddlehead": {
-		"name": "strutbräken"
-	},
-	"fiddlehead-fern": {
-		"name": "strutbräken",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fisk"
-	},
-	"five-spice-powder": {
-		"name": "femkrydda"
-	},
-	"flour": {
-		"name": "mjöl"
-	},
-	"frisee": {
-		"name": "frisésallat"
-	},
-	"fructose": {
-		"name": "fruktos"
-	},
-	"fruit": {
-		"name": "frukt"
-	},
-	"fruit-sugar": {
-		"name": "fruktsocker"
-	},
-	"ful": {
-		"name": "full"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "vitlök",
-		"plural_name": "vitlökar"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "inkråm"
-	},
-	"ginger": {
-		"name": "ingefära"
-	},
-	"grains": {
-		"name": "korn"
-	},
-	"granulated-sugar": {
-		"name": "strösocker"
-	},
-	"grape-seed-oil": {
-		"name": "druvkärneolja"
-	},
-	"green-onion": {
-		"name": "salladslök",
-		"plural_name": "salladslökar"
-	},
-	"heart-of-palm": {
-		"name": "palmhjärta",
-		"plural_name": "palmhjärta"
-	},
-	"hemp": {
-		"name": "hampa"
-	},
-	"herbs": {
-		"name": "örter"
-	},
-	"honey": {
-		"name": "honung"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfrukt",
-		"plural_name": "jackfrukter"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "sylt"
-	},
-	"jellies": {
-		"name": "geléer"
-	},
-	"jerusalem-artichoke": {
-		"name": "jordärtskocka"
-	},
-	"jicama": {
-		"name": "jamsbönrot"
-	},
-	"kale": {
-		"name": "grönkål"
-	},
-	"kohlrabi": {
-		"name": "kålrabbi"
-	},
-	"kumara": {
-		"name": "sötpotatis"
-	},
-	"leavening-agents": {
-		"name": "jäsmedel"
-	},
-	"leek": {
-		"name": "purjolök",
-		"plural_name": "purjolökar"
-	},
-	"legumes": {
-		"name": "baljväxter"
-	},
-	"lemongrass": {
-		"name": "citrongräs"
-	},
-	"lentils": {
-		"name": "linser"
-	},
-	"lettuce": {
-		"name": "sallad"
-	},
-	"liver": {
-		"name": "lever",
-		"plural_name": "levrar"
-	},
-	"maize": {
-		"name": "majs"
-	},
-	"maple-syrup": {
-		"name": "lönnsirap"
-	},
-	"meat": {
-		"name": "kött"
-	},
-	"milk": {
-		"name": "mjölk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "svamp",
-		"plural_name": "svampar"
-	},
-	"mussels": {
-		"name": "musslor"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muskotnöt"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "näringsrika jästflingor"
-	},
-	"nuts": {
-		"name": "nötter"
-	},
-	"octopuses": {
-		"name": "bläckfiskar",
-		"plural_name": "bläckfiskar"
-	},
-	"oils": {
-		"name": "oljor"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "oliv"
-	},
-	"olive-oil": {
-		"name": "olivolja"
-	},
-	"onion": {
-		"name": "lök"
-	},
-	"onion-family": {
-		"name": "lökfamilj"
-	},
-	"orange-blossom-water": {
-		"name": "apelsinblomsvatten"
-	},
-	"oranges": {
-		"name": "apelsiner",
-		"plural_name": "apelsiner"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "ostron"
-	},
-	"panch-puran": {
-		"name": "panch phoron"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "persilja"
-	},
-	"parsnip": {
-		"name": "palsternacka",
-		"plural_name": "palsternackor"
-	},
-	"pear": {
-		"name": "päron",
-		"plural_name": "päron"
-	},
-	"peas": {
-		"name": "ärtor"
-	},
-	"pepper": {
-		"name": "peppar",
-		"plural_name": "paprikor"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "ananas"
-	},
-	"plantain": {
-		"name": "kokbanan",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "vallmofrön"
-	},
-	"potato": {
-		"name": "potatis",
-		"plural_name": "potatis"
-	},
-	"poultry": {
-		"name": "kyckling"
-	},
-	"powdered-sugar": {
-		"name": "florsocker"
-	},
-	"pumpkin": {
-		"name": "pumpa",
-		"plural_name": "pumpor"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpafrön"
-	},
-	"radish": {
-		"name": "rädisa",
-		"plural_name": "rädisor"
-	},
-	"raw-sugar": {
-		"name": "brunt socker"
-	},
-	"refined-sugar": {
-		"name": "raffinerat socker"
-	},
-	"rice": {
-		"name": "ris"
-	},
-	"rice-flour": {
-		"name": "rismjöl"
-	},
-	"rock-sugar": {
-		"name": "sten socker"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "lax"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt torsk"
-	},
-	"scallion": {
-		"name": "salladslök",
-		"plural_name": "salladslökar"
-	},
-	"seafood": {
-		"name": "fisk och skaldjur"
-	},
-	"seeds": {
-		"name": "frön"
-	},
-	"sesame-seeds": {
-		"name": "sesamfrön"
-	},
-	"shallot": {
-		"name": "schalottenlök",
-		"plural_name": "schalottenlökar"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "natriumkarbonat"
-	},
-	"soda-baking": {
-		"name": "bikarbonat"
-	},
-	"soybean": {
-		"name": "sojaböna"
-	},
-	"spaghetti-squash": {
-		"name": "spagettipumpa",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "fläsk"
-	},
-	"spices": {
-		"name": "kryddor"
-	},
-	"spinach": {
-		"name": "spenat"
-	},
-	"spring-onion": {
-		"name": "vårlök",
-		"plural_name": "vårlökar"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squash"
-	},
-	"squash-family": {
-		"name": "squash-familj"
-	},
-	"stockfish": {
-		"name": "torkad fisk"
-	},
-	"sugar": {
-		"name": "socker"
-	},
-	"sunchoke": {
-		"name": "jordärtskocka",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "solrosfrön"
-	},
-	"superfine-sugar": {
-		"name": "strösocker"
-	},
-	"sweet-potato": {
-		"name": "sötpotatis",
-		"plural_name": "sötpotatisar"
-	},
-	"sweetcorn": {
-		"name": "sockermajs",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sötningsmedel"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomat",
-		"plural_name": "tomater"
-	},
-	"trout": {
-		"name": "öring"
-	},
-	"tubers": {
-		"name": "knölar",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tonfisk"
-	},
-	"turbanado-sugar": {
-		"name": "brunt råsocker"
-	},
-	"turnip": {
-		"name": "majrova",
-		"plural_name": "majrovor"
-	},
-	"unrefined-sugar": {
-		"name": "råsocker"
-	},
-	"vanilla": {
-		"name": "vanilj"
-	},
-	"vegetables": {
-		"name": "grönsaker"
-	},
-	"watercress": {
-		"name": "vattenkrasse"
-	},
-	"watermelon": {
-		"name": "vattenmelon",
-		"plural_name": "vattenmeloner"
-	},
-	"white-mushroom": {
-		"name": "schampinjon",
-		"plural_name": "champinjoner"
-	},
-	"white-sugar": {
-		"name": "strösocker"
-	},
-	"xanthan-gum": {
-		"name": "xantangummi"
-	},
-	"yam": {
-		"name": "jams",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "jäst"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinins"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "peppar squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfagroddar"
+            },
+            "anchovies": {
+                "name": "ansjovis"
+            },
+            "apples": {
+                "name": "äpplen",
+                "plural_name": "äpplen"
+            },
+            "artichoke": {
+                "name": "kronärtskocka"
+            },
+            "arugula": {
+                "name": "ruccola"
+            },
+            "asparagus": {
+                "name": "sparris"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avokado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "bakpulver"
+            },
+            "baking-soda": {
+                "name": "bikarbonat"
+            },
+            "baking-sugar": {
+                "name": "florsocker"
+            },
+            "bar-sugar": {
+                "name": "socker från sockerrör"
+            },
+            "basil": {
+                "name": "basilika"
+            },
+            "beans": {
+                "name": "bönor"
+            },
+            "bell-peppers": {
+                "name": "paprika",
+                "plural_name": "paprika"
+            },
+            "blackberries": {
+                "name": "björnbär"
+            },
+            "bok-choy": {
+                "name": "pak choi"
+            },
+            "brassicas": {
+                "name": "kål"
+            },
+            "bread": {
+                "name": "bröd"
+            },
+            "breadfruit": {
+                "name": "brödfrukt"
+            },
+            "broccoflower": {
+                "name": "broccolo"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccolirybs"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brunt socker"
+            },
+            "brussels-sprouts": {
+                "name": "brysselkål"
+            },
+            "butter": {
+                "name": "smör"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpa"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "vitkål",
+                "plural_name": "kål"
+            },
+            "cactus-edible": {
+                "name": "kaktus, ätbar"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "socker från sockerrör"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "spanskpeppar"
+            },
+            "caraway": {
+                "name": "kummin"
+            },
+            "carrot": {
+                "name": "morot",
+                "plural_name": "morötter"
+            },
+            "caster-sugar": {
+                "name": "strösocker"
+            },
+            "castor-sugar": {
+                "name": "strösocker"
+            },
+            "catfish": {
+                "name": "havskatt"
+            },
+            "cauliflower": {
+                "name": "blomkål",
+                "plural_name": "blomkål"
+            },
+            "cayenne-pepper": {
+                "name": "cayennepeppar"
+            },
+            "celeriac": {
+                "name": "rotselleri"
+            },
+            "celery": {
+                "name": "selleri"
+            },
+            "cereal-grains": {
+                "name": "sädesslag"
+            },
+            "chard": {
+                "name": "mangold"
+            },
+            "cheese": {
+                "name": "ost"
+            },
+            "chicory": {
+                "name": "cikoria"
+            },
+            "chilli-peppers": {
+                "name": "chilipeppar",
+                "plural_name": "chilipeppar"
+            },
+            "chinese-leaves": {
+                "name": "salladskål"
+            },
+            "chives": {
+                "name": "gräslök"
+            },
+            "chocolate": {
+                "name": "choklad"
+            },
+            "cilantro": {
+                "name": "koriander"
+            },
+            "cinnamon": {
+                "name": "kanel"
+            },
+            "clarified-butter": {
+                "name": "skirat smör"
+            },
+            "coconut": {
+                "name": "kokos",
+                "plural_name": "kokosnötter"
+            },
+            "coconut-milk": {
+                "name": "kokosmjölk"
+            },
+            "cod": {
+                "name": "torsk"
+            },
+            "coffee": {
+                "name": "kaffe"
+            },
+            "collard-greens": {
+                "name": "collard"
+            },
+            "confectioners-sugar": {
+                "name": "florsocker"
+            },
+            "coriander": {
+                "name": "koriander"
+            },
+            "corn": {
+                "name": "majs",
+                "plural_name": "majs"
+            },
+            "corn-syrup": {
+                "name": "majssirap"
+            },
+            "cottonseed-oil": {
+                "name": "bomullsfröolja"
+            },
+            "courgette": {
+                "name": "zucchini"
+            },
+            "cream-of-tartar": {
+                "name": "vinsten"
+            },
+            "cucumber": {
+                "name": "gurka",
+                "plural_name": "gurkor"
+            },
+            "cumin": {
+                "name": "spiskummin"
+            },
+            "daikon": {
+                "name": "rättika",
+                "plural_name": "rättikor"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "mejeriprodukter och mejerisubstitut"
+            },
+            "dandelion": {
+                "name": "maskros"
+            },
+            "demerara-sugar": {
+                "name": "råsocker"
+            },
+            "dough": {
+                "name": "deg"
+            },
+            "edible-cactus": {
+                "name": "ätbar kaktus"
+            },
+            "eggplant": {
+                "name": "äggplanta",
+                "plural_name": "äggplantor"
+            },
+            "eggs": {
+                "name": "ägg",
+                "plural_name": "ägg"
+            },
+            "endive": {
+                "name": "endiv",
+                "plural_name": "endiver"
+            },
+            "fats": {
+                "name": "fetter"
+            },
+            "fava-beans": {
+                "name": "bondböna"
+            },
+            "fiddlehead": {
+                "name": "strutbräken"
+            },
+            "fiddlehead-fern": {
+                "name": "strutbräken",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fisk"
+            },
+            "five-spice-powder": {
+                "name": "femkrydda"
+            },
+            "flour": {
+                "name": "mjöl"
+            },
+            "frisee": {
+                "name": "frisésallat"
+            },
+            "fructose": {
+                "name": "fruktos"
+            },
+            "fruit": {
+                "name": "frukt"
+            },
+            "fruit-sugar": {
+                "name": "fruktsocker"
+            },
+            "ful": {
+                "name": "full"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "vitlök",
+                "plural_name": "vitlökar"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "inkråm"
+            },
+            "ginger": {
+                "name": "ingefära"
+            },
+            "grains": {
+                "name": "korn"
+            },
+            "granulated-sugar": {
+                "name": "strösocker"
+            },
+            "grape-seed-oil": {
+                "name": "druvkärneolja"
+            },
+            "green-onion": {
+                "name": "salladslök",
+                "plural_name": "salladslökar"
+            },
+            "heart-of-palm": {
+                "name": "palmhjärta",
+                "plural_name": "palmhjärta"
+            },
+            "hemp": {
+                "name": "hampa"
+            },
+            "herbs": {
+                "name": "örter"
+            },
+            "honey": {
+                "name": "honung"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfrukt",
+                "plural_name": "jackfrukter"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "sylt"
+            },
+            "jellies": {
+                "name": "geléer"
+            },
+            "jerusalem-artichoke": {
+                "name": "jordärtskocka"
+            },
+            "jicama": {
+                "name": "jamsbönrot"
+            },
+            "kale": {
+                "name": "grönkål"
+            },
+            "kohlrabi": {
+                "name": "kålrabbi"
+            },
+            "kumara": {
+                "name": "sötpotatis"
+            },
+            "leavening-agents": {
+                "name": "jäsmedel"
+            },
+            "leek": {
+                "name": "purjolök",
+                "plural_name": "purjolökar"
+            },
+            "legumes": {
+                "name": "baljväxter"
+            },
+            "lemongrass": {
+                "name": "citrongräs"
+            },
+            "lentils": {
+                "name": "linser"
+            },
+            "lettuce": {
+                "name": "sallad"
+            },
+            "liver": {
+                "name": "lever",
+                "plural_name": "levrar"
+            },
+            "maize": {
+                "name": "majs"
+            },
+            "maple-syrup": {
+                "name": "lönnsirap"
+            },
+            "meat": {
+                "name": "kött"
+            },
+            "milk": {
+                "name": "mjölk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "svamp",
+                "plural_name": "svampar"
+            },
+            "mussels": {
+                "name": "musslor"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muskotnöt"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "näringsrika jästflingor"
+            },
+            "nuts": {
+                "name": "nötter"
+            },
+            "octopuses": {
+                "name": "bläckfiskar",
+                "plural_name": "bläckfiskar"
+            },
+            "oils": {
+                "name": "oljor"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "oliv"
+            },
+            "olive-oil": {
+                "name": "olivolja"
+            },
+            "onion": {
+                "name": "lök"
+            },
+            "onion-family": {
+                "name": "lökfamilj"
+            },
+            "orange-blossom-water": {
+                "name": "apelsinblomsvatten"
+            },
+            "oranges": {
+                "name": "apelsiner",
+                "plural_name": "apelsiner"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "ostron"
+            },
+            "panch-puran": {
+                "name": "panch phoron"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "persilja"
+            },
+            "parsnip": {
+                "name": "palsternacka",
+                "plural_name": "palsternackor"
+            },
+            "pear": {
+                "name": "päron",
+                "plural_name": "päron"
+            },
+            "peas": {
+                "name": "ärtor"
+            },
+            "pepper": {
+                "name": "peppar",
+                "plural_name": "paprikor"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "ananas"
+            },
+            "plantain": {
+                "name": "kokbanan",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "vallmofrön"
+            },
+            "potato": {
+                "name": "potatis",
+                "plural_name": "potatis"
+            },
+            "poultry": {
+                "name": "kyckling"
+            },
+            "powdered-sugar": {
+                "name": "florsocker"
+            },
+            "pumpkin": {
+                "name": "pumpa",
+                "plural_name": "pumpor"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpafrön"
+            },
+            "radish": {
+                "name": "rädisa",
+                "plural_name": "rädisor"
+            },
+            "raw-sugar": {
+                "name": "brunt socker"
+            },
+            "refined-sugar": {
+                "name": "raffinerat socker"
+            },
+            "rice": {
+                "name": "ris"
+            },
+            "rice-flour": {
+                "name": "rismjöl"
+            },
+            "rock-sugar": {
+                "name": "sten socker"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "lax"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt torsk"
+            },
+            "scallion": {
+                "name": "salladslök",
+                "plural_name": "salladslökar"
+            },
+            "seafood": {
+                "name": "fisk och skaldjur"
+            },
+            "seeds": {
+                "name": "frön"
+            },
+            "sesame-seeds": {
+                "name": "sesamfrön"
+            },
+            "shallot": {
+                "name": "schalottenlök",
+                "plural_name": "schalottenlökar"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "natriumkarbonat"
+            },
+            "soda-baking": {
+                "name": "bikarbonat"
+            },
+            "soybean": {
+                "name": "sojaböna"
+            },
+            "spaghetti-squash": {
+                "name": "spagettipumpa",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "fläsk"
+            },
+            "spices": {
+                "name": "kryddor"
+            },
+            "spinach": {
+                "name": "spenat"
+            },
+            "spring-onion": {
+                "name": "vårlök",
+                "plural_name": "vårlökar"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squash"
+            },
+            "squash-family": {
+                "name": "squash-familj"
+            },
+            "stockfish": {
+                "name": "torkad fisk"
+            },
+            "sugar": {
+                "name": "socker"
+            },
+            "sunchoke": {
+                "name": "jordärtskocka",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "solrosfrön"
+            },
+            "superfine-sugar": {
+                "name": "strösocker"
+            },
+            "sweet-potato": {
+                "name": "sötpotatis",
+                "plural_name": "sötpotatisar"
+            },
+            "sweetcorn": {
+                "name": "sockermajs",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sötningsmedel"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomat",
+                "plural_name": "tomater"
+            },
+            "trout": {
+                "name": "öring"
+            },
+            "tubers": {
+                "name": "knölar",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tonfisk"
+            },
+            "turbanado-sugar": {
+                "name": "brunt råsocker"
+            },
+            "turnip": {
+                "name": "majrova",
+                "plural_name": "majrovor"
+            },
+            "unrefined-sugar": {
+                "name": "råsocker"
+            },
+            "vanilla": {
+                "name": "vanilj"
+            },
+            "vegetables": {
+                "name": "grönsaker"
+            },
+            "watercress": {
+                "name": "vattenkrasse"
+            },
+            "watermelon": {
+                "name": "vattenmelon",
+                "plural_name": "vattenmeloner"
+            },
+            "white-mushroom": {
+                "name": "schampinjon",
+                "plural_name": "champinjoner"
+            },
+            "white-sugar": {
+                "name": "strösocker"
+            },
+            "xanthan-gum": {
+                "name": "xantangummi"
+            },
+            "yam": {
+                "name": "jams",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "jäst"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinins"
+            }
+        }
+    },
+    "Jordbruksprodukter": {
+        "foods": {}
+    },
+    "Spannmål": {
+        "foods": {}
+    },
+    "Frukter": {
+        "foods": {}
+    },
+    "Grönsaker": {
+        "foods": {}
+    },
+    "Kött": {
+        "foods": {}
+    },
+    "Fisk- och skaldjur": {
+        "foods": {}
+    },
+    "Drycker": {
+        "foods": {}
+    },
+    "Bakade varor": {
+        "foods": {}
+    },
+    "Konserverade varor": {
+        "foods": {}
+    },
+    "Smaktillsatser": {
+        "foods": {}
+    },
+    "Konfektyr": {
+        "foods": {}
+    },
+    "Mejeriprodukter": {
+        "foods": {}
+    },
+    "Frysta livsmedel": {
+        "foods": {}
+    },
+    "Hälsolivsmedel": {
+        "foods": {}
+    },
+    "Hushåll": {
+        "foods": {}
+    },
+    "Köttprodukter": {
+        "foods": {}
+    },
+    "Tilltugg": {
+        "foods": {}
+    },
+    "Kryddor": {
+        "foods": {}
+    },
+    "Sötsaker": {
+        "foods": {}
+    },
+    "Alkohol": {
+        "foods": {}
+    },
+    "Övrigt": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/tr-TR.json
+++ b/mealie/repos/seed/resources/foods/locales/tr-TR.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "meşe palamudu kabağı"
-	},
-	"alfalfa-sprouts": {
-		"name": "yonca filizi"
-	},
-	"anchovies": {
-		"name": "hamsi"
-	},
-	"apples": {
-		"name": "elma",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "enginar"
-	},
-	"arugula": {
-		"name": "roka"
-	},
-	"asparagus": {
-		"name": "kuşkonmaz"
-	},
-	"avocado": {
-		"name": "avokado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "domuz pastırması"
-	},
-	"baking-powder": {
-		"name": "kabartma tozu"
-	},
-	"baking-soda": {
-		"name": "karbonat"
-	},
-	"baking-sugar": {
-		"name": "fırınlama şekeri"
-	},
-	"bar-sugar": {
-		"name": "kesme şeker"
-	},
-	"basil": {
-		"name": "fesleğen"
-	},
-	"beans": {
-		"name": "fasulye"
-	},
-	"bell-peppers": {
-		"name": "kırmızı biber",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "böğürtlen"
-	},
-	"bok-choy": {
-		"name": "çin lahanası"
-	},
-	"brassicas": {
-		"name": "brassicalar"
-	},
-	"bread": {
-		"name": "ekmek"
-	},
-	"breadfruit": {
-		"name": "ekmek ağacı"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "brokoli"
-	},
-	"broccoli-rabe": {
-		"name": "rapini"
-	},
-	"broccolini": {
-		"name": "bebek brokoli"
-	},
-	"brown-sugar": {
-		"name": "esmer şeker"
-	},
-	"brussels-sprouts": {
-		"name": "brüksel lahanası"
-	},
-	"butter": {
-		"name": "tereyağı"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "lahana",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "yenilebilir kaktüs"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "şeker kamışı"
-	},
-	"cannabis": {
-		"name": "kenevir"
-	},
-	"capsicum": {
-		"name": "kırmızı biber"
-	},
-	"caraway": {
-		"name": "kimyon"
-	},
-	"carrot": {
-		"name": "havuç",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "pudra şekeri"
-	},
-	"castor-sugar": {
-		"name": "pudra şekeri"
-	},
-	"catfish": {
-		"name": "kedibalığı"
-	},
-	"cauliflower": {
-		"name": "karnabahar",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "kırmızı biber"
-	},
-	"celeriac": {
-		"name": "kereviz"
-	},
-	"celery": {
-		"name": "kereviz"
-	},
-	"cereal-grains": {
-		"name": "tam taneli tahıl"
-	},
-	"chard": {
-		"name": "pazı"
-	},
-	"cheese": {
-		"name": "peynir"
-	},
-	"chicory": {
-		"name": "hindiba"
-	},
-	"chilli-peppers": {
-		"name": "acı biber",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "frenk soğanı"
-	},
-	"chocolate": {
-		"name": "çikolata"
-	},
-	"cilantro": {
-		"name": "kişniş"
-	},
-	"cinnamon": {
-		"name": "tarçın"
-	},
-	"clarified-butter": {
-		"name": "sade yağ"
-	},
-	"coconut": {
-		"name": "hindistan cevizi",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "hindistan cevizi sütü"
-	},
-	"cod": {
-		"name": "morina"
-	},
-	"coffee": {
-		"name": "kahve"
-	},
-	"collard-greens": {
-		"name": "kara lahana"
-	},
-	"confectioners-sugar": {
-		"name": "pudra şekeri"
-	},
-	"coriander": {
-		"name": "kişniş"
-	},
-	"corn": {
-		"name": "mısır",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "mısır şurubu"
-	},
-	"cottonseed-oil": {
-		"name": "pamuk yağı"
-	},
-	"courgette": {
-		"name": "dolmalık kabak"
-	},
-	"cream-of-tartar": {
-		"name": "krem tartar"
-	},
-	"cucumber": {
-		"name": "salatalık",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "kimyon"
-	},
-	"daikon": {
-		"name": "beyaz turp",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "süt ürünleri ve süt yerine geçen ürünler"
-	},
-	"dandelion": {
-		"name": "karahindiba"
-	},
-	"demerara-sugar": {
-		"name": "esmer şeker"
-	},
-	"dough": {
-		"name": "hamur"
-	},
-	"edible-cactus": {
-		"name": "yenilebilir kaktüs"
-	},
-	"eggplant": {
-		"name": "patlıcan",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "yumurta",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "hindiba",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "yağlar"
-	},
-	"fava-beans": {
-		"name": "fava fasulyesi"
-	},
-	"fiddlehead": {
-		"name": "eğrelti otu filizi"
-	},
-	"fiddlehead-fern": {
-		"name": "eğrelti otu filizi",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "balık"
-	},
-	"five-spice-powder": {
-		"name": "beşli baharat"
-	},
-	"flour": {
-		"name": "un"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fruktoz"
-	},
-	"fruit": {
-		"name": "meyve"
-	},
-	"fruit-sugar": {
-		"name": "meyve şekeri"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "sarımsak",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "saf yağ"
-	},
-	"giblets": {
-		"name": "sakatatlar"
-	},
-	"ginger": {
-		"name": "zencefil"
-	},
-	"grains": {
-		"name": "tahıllar"
-	},
-	"granulated-sugar": {
-		"name": "toz şeker"
-	},
-	"grape-seed-oil": {
-		"name": "üzüm çekirdeği yağı"
-	},
-	"green-onion": {
-		"name": "taze soğan",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "kenevir"
-	},
-	"herbs": {
-		"name": "otlar"
-	},
-	"honey": {
-		"name": "bal"
-	},
-	"isomalt": {
-		"name": "izomalt"
-	},
-	"jackfruit": {
-		"name": "jak meyvesi",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "reçel"
-	},
-	"jellies": {
-		"name": "jöleler"
-	},
-	"jerusalem-artichoke": {
-		"name": "yerelması"
-	},
-	"jicama": {
-		"name": "meksika turpu"
-	},
-	"kale": {
-		"name": "lahana"
-	},
-	"kohlrabi": {
-		"name": "alabaş"
-	},
-	"kumara": {
-		"name": "tatlı patates"
-	},
-	"leavening-agents": {
-		"name": "mayalama maddeleri"
-	},
-	"leek": {
-		"name": "pırasa",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "baklagiller"
-	},
-	"lemongrass": {
-		"name": "limon otu"
-	},
-	"lentils": {
-		"name": "mercimek"
-	},
-	"lettuce": {
-		"name": "marul"
-	},
-	"liver": {
-		"name": "karaciğer",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "mısır"
-	},
-	"maple-syrup": {
-		"name": "akçaağaç şurubu"
-	},
-	"meat": {
-		"name": "et"
-	},
-	"milk": {
-		"name": "süt"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mantar",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "midye"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "muskat"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "besin mayası"
-	},
-	"nuts": {
-		"name": "kuruyemişler"
-	},
-	"octopuses": {
-		"name": "ahtapotlar",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "yağ"
-	},
-	"okra": {
-		"name": "bamya"
-	},
-	"olive": {
-		"name": "zeytin"
-	},
-	"olive-oil": {
-		"name": "zeytin yağı"
-	},
-	"onion": {
-		"name": "soğan"
-	},
-	"onion-family": {
-		"name": "soğan ailesi"
-	},
-	"orange-blossom-water": {
-		"name": "portakal çiçeği suyu"
-	},
-	"oranges": {
-		"name": "portakal",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "kekik"
-	},
-	"oysters": {
-		"name": "istiridye"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "kırmızı biber"
-	},
-	"parsley": {
-		"name": "maydanoz"
-	},
-	"parsnip": {
-		"name": "yaban havucu",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "armut",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "bezelye"
-	},
-	"pepper": {
-		"name": "biber",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "ananas",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "yemeklik muz",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "haşhaş tohumu"
-	},
-	"potato": {
-		"name": "patates",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "kümes hayvanları"
-	},
-	"powdered-sugar": {
-		"name": "pudra şekeri"
-	},
-	"pumpkin": {
-		"name": "balkabağı",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "kabak çekirdeği"
-	},
-	"radish": {
-		"name": "turp",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "kesme şeker"
-	},
-	"refined-sugar": {
-		"name": "rafine şeker"
-	},
-	"rice": {
-		"name": "pirinç"
-	},
-	"rice-flour": {
-		"name": "pirinç unu"
-	},
-	"rock-sugar": {
-		"name": "kide şekeri"
-	},
-	"rum": {
-		"name": "rom"
-	},
-	"salmon": {
-		"name": "somon"
-	},
-	"salt": {
-		"name": "tuz"
-	},
-	"salt-cod": {
-		"name": "tuzlu morina"
-	},
-	"scallion": {
-		"name": "taze soğan",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "deniz ürünleri"
-	},
-	"seeds": {
-		"name": "tohumlar"
-	},
-	"sesame-seeds": {
-		"name": "susam"
-	},
-	"shallot": {
-		"name": "arpacık soğan",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "çemçe balığı"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "karbonat"
-	},
-	"soybean": {
-		"name": "soya fasulyesi"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "baharatlar"
-	},
-	"spinach": {
-		"name": "ıspanak"
-	},
-	"spring-onion": {
-		"name": "yeşil soğan",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "kabak",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "kabak ailesi"
-	},
-	"stockfish": {
-		"name": "kurutulmuş balık"
-	},
-	"sugar": {
-		"name": "şeker"
-	},
-	"sunchoke": {
-		"name": "yer elması",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "ay çekirdeği"
-	},
-	"superfine-sugar": {
-		"name": "pudra şekeri"
-	},
-	"sweet-potato": {
-		"name": "tatlı patates",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "tatlı mısır",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "tatlandırıcı"
-	},
-	"tahini": {
-		"name": "tahin"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "domates",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "alabalık"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "ton balığı"
-	},
-	"turbanado-sugar": {
-		"name": "doğal esmer şeker"
-	},
-	"turnip": {
-		"name": "şalgam",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "rafine edilmemiş şeker"
-	},
-	"vanilla": {
-		"name": "vanilya"
-	},
-	"vegetables": {
-		"name": "sebze"
-	},
-	"watercress": {
-		"name": "su teresi"
-	},
-	"watermelon": {
-		"name": "karpuz",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "beyaz mantar",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "beyaz şeker"
-	},
-	"xanthan-gum": {
-		"name": "ksantan gum"
-	},
-	"yam": {
-		"name": "tatlı patates",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "maya"
-	},
-	"zucchini": {
-		"name": "kabak",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "meşe palamudu kabağı"
+            },
+            "alfalfa-sprouts": {
+                "name": "yonca filizi"
+            },
+            "anchovies": {
+                "name": "hamsi"
+            },
+            "apples": {
+                "name": "elma",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "enginar"
+            },
+            "arugula": {
+                "name": "roka"
+            },
+            "asparagus": {
+                "name": "kuşkonmaz"
+            },
+            "avocado": {
+                "name": "avokado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "domuz pastırması"
+            },
+            "baking-powder": {
+                "name": "kabartma tozu"
+            },
+            "baking-soda": {
+                "name": "karbonat"
+            },
+            "baking-sugar": {
+                "name": "fırınlama şekeri"
+            },
+            "bar-sugar": {
+                "name": "kesme şeker"
+            },
+            "basil": {
+                "name": "fesleğen"
+            },
+            "beans": {
+                "name": "fasulye"
+            },
+            "bell-peppers": {
+                "name": "kırmızı biber",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "böğürtlen"
+            },
+            "bok-choy": {
+                "name": "çin lahanası"
+            },
+            "brassicas": {
+                "name": "brassicalar"
+            },
+            "bread": {
+                "name": "ekmek"
+            },
+            "breadfruit": {
+                "name": "ekmek ağacı"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "brokoli"
+            },
+            "broccoli-rabe": {
+                "name": "rapini"
+            },
+            "broccolini": {
+                "name": "bebek brokoli"
+            },
+            "brown-sugar": {
+                "name": "esmer şeker"
+            },
+            "brussels-sprouts": {
+                "name": "brüksel lahanası"
+            },
+            "butter": {
+                "name": "tereyağı"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "lahana",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "yenilebilir kaktüs"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "şeker kamışı"
+            },
+            "cannabis": {
+                "name": "kenevir"
+            },
+            "capsicum": {
+                "name": "kırmızı biber"
+            },
+            "caraway": {
+                "name": "kimyon"
+            },
+            "carrot": {
+                "name": "havuç",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "pudra şekeri"
+            },
+            "castor-sugar": {
+                "name": "pudra şekeri"
+            },
+            "catfish": {
+                "name": "kedibalığı"
+            },
+            "cauliflower": {
+                "name": "karnabahar",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "kırmızı biber"
+            },
+            "celeriac": {
+                "name": "kereviz"
+            },
+            "celery": {
+                "name": "kereviz"
+            },
+            "cereal-grains": {
+                "name": "tam taneli tahıl"
+            },
+            "chard": {
+                "name": "pazı"
+            },
+            "cheese": {
+                "name": "peynir"
+            },
+            "chicory": {
+                "name": "hindiba"
+            },
+            "chilli-peppers": {
+                "name": "acı biber",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "frenk soğanı"
+            },
+            "chocolate": {
+                "name": "çikolata"
+            },
+            "cilantro": {
+                "name": "kişniş"
+            },
+            "cinnamon": {
+                "name": "tarçın"
+            },
+            "clarified-butter": {
+                "name": "sade yağ"
+            },
+            "coconut": {
+                "name": "hindistan cevizi",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "hindistan cevizi sütü"
+            },
+            "cod": {
+                "name": "morina"
+            },
+            "coffee": {
+                "name": "kahve"
+            },
+            "collard-greens": {
+                "name": "kara lahana"
+            },
+            "confectioners-sugar": {
+                "name": "pudra şekeri"
+            },
+            "coriander": {
+                "name": "kişniş"
+            },
+            "corn": {
+                "name": "mısır",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "mısır şurubu"
+            },
+            "cottonseed-oil": {
+                "name": "pamuk yağı"
+            },
+            "courgette": {
+                "name": "dolmalık kabak"
+            },
+            "cream-of-tartar": {
+                "name": "krem tartar"
+            },
+            "cucumber": {
+                "name": "salatalık",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "kimyon"
+            },
+            "daikon": {
+                "name": "beyaz turp",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "süt ürünleri ve süt yerine geçen ürünler"
+            },
+            "dandelion": {
+                "name": "karahindiba"
+            },
+            "demerara-sugar": {
+                "name": "esmer şeker"
+            },
+            "dough": {
+                "name": "hamur"
+            },
+            "edible-cactus": {
+                "name": "yenilebilir kaktüs"
+            },
+            "eggplant": {
+                "name": "patlıcan",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "yumurta",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "hindiba",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "yağlar"
+            },
+            "fava-beans": {
+                "name": "fava fasulyesi"
+            },
+            "fiddlehead": {
+                "name": "eğrelti otu filizi"
+            },
+            "fiddlehead-fern": {
+                "name": "eğrelti otu filizi",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "balık"
+            },
+            "five-spice-powder": {
+                "name": "beşli baharat"
+            },
+            "flour": {
+                "name": "un"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fruktoz"
+            },
+            "fruit": {
+                "name": "meyve"
+            },
+            "fruit-sugar": {
+                "name": "meyve şekeri"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "sarımsak",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "saf yağ"
+            },
+            "giblets": {
+                "name": "sakatatlar"
+            },
+            "ginger": {
+                "name": "zencefil"
+            },
+            "grains": {
+                "name": "tahıllar"
+            },
+            "granulated-sugar": {
+                "name": "toz şeker"
+            },
+            "grape-seed-oil": {
+                "name": "üzüm çekirdeği yağı"
+            },
+            "green-onion": {
+                "name": "taze soğan",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "kenevir"
+            },
+            "herbs": {
+                "name": "otlar"
+            },
+            "honey": {
+                "name": "bal"
+            },
+            "isomalt": {
+                "name": "izomalt"
+            },
+            "jackfruit": {
+                "name": "jak meyvesi",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "reçel"
+            },
+            "jellies": {
+                "name": "jöleler"
+            },
+            "jerusalem-artichoke": {
+                "name": "yerelması"
+            },
+            "jicama": {
+                "name": "meksika turpu"
+            },
+            "kale": {
+                "name": "lahana"
+            },
+            "kohlrabi": {
+                "name": "alabaş"
+            },
+            "kumara": {
+                "name": "tatlı patates"
+            },
+            "leavening-agents": {
+                "name": "mayalama maddeleri"
+            },
+            "leek": {
+                "name": "pırasa",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "baklagiller"
+            },
+            "lemongrass": {
+                "name": "limon otu"
+            },
+            "lentils": {
+                "name": "mercimek"
+            },
+            "lettuce": {
+                "name": "marul"
+            },
+            "liver": {
+                "name": "karaciğer",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "mısır"
+            },
+            "maple-syrup": {
+                "name": "akçaağaç şurubu"
+            },
+            "meat": {
+                "name": "et"
+            },
+            "milk": {
+                "name": "süt"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mantar",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "midye"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "muskat"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "besin mayası"
+            },
+            "nuts": {
+                "name": "kuruyemişler"
+            },
+            "octopuses": {
+                "name": "ahtapotlar",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "yağ"
+            },
+            "okra": {
+                "name": "bamya"
+            },
+            "olive": {
+                "name": "zeytin"
+            },
+            "olive-oil": {
+                "name": "zeytin yağı"
+            },
+            "onion": {
+                "name": "soğan"
+            },
+            "onion-family": {
+                "name": "soğan ailesi"
+            },
+            "orange-blossom-water": {
+                "name": "portakal çiçeği suyu"
+            },
+            "oranges": {
+                "name": "portakal",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "kekik"
+            },
+            "oysters": {
+                "name": "istiridye"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "kırmızı biber"
+            },
+            "parsley": {
+                "name": "maydanoz"
+            },
+            "parsnip": {
+                "name": "yaban havucu",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "armut",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "bezelye"
+            },
+            "pepper": {
+                "name": "biber",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "ananas",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "yemeklik muz",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "haşhaş tohumu"
+            },
+            "potato": {
+                "name": "patates",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "kümes hayvanları"
+            },
+            "powdered-sugar": {
+                "name": "pudra şekeri"
+            },
+            "pumpkin": {
+                "name": "balkabağı",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "kabak çekirdeği"
+            },
+            "radish": {
+                "name": "turp",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "kesme şeker"
+            },
+            "refined-sugar": {
+                "name": "rafine şeker"
+            },
+            "rice": {
+                "name": "pirinç"
+            },
+            "rice-flour": {
+                "name": "pirinç unu"
+            },
+            "rock-sugar": {
+                "name": "kide şekeri"
+            },
+            "rum": {
+                "name": "rom"
+            },
+            "salmon": {
+                "name": "somon"
+            },
+            "salt": {
+                "name": "tuz"
+            },
+            "salt-cod": {
+                "name": "tuzlu morina"
+            },
+            "scallion": {
+                "name": "taze soğan",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "deniz ürünleri"
+            },
+            "seeds": {
+                "name": "tohumlar"
+            },
+            "sesame-seeds": {
+                "name": "susam"
+            },
+            "shallot": {
+                "name": "arpacık soğan",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "çemçe balığı"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "karbonat"
+            },
+            "soybean": {
+                "name": "soya fasulyesi"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "baharatlar"
+            },
+            "spinach": {
+                "name": "ıspanak"
+            },
+            "spring-onion": {
+                "name": "yeşil soğan",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "kabak",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "kabak ailesi"
+            },
+            "stockfish": {
+                "name": "kurutulmuş balık"
+            },
+            "sugar": {
+                "name": "şeker"
+            },
+            "sunchoke": {
+                "name": "yer elması",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "ay çekirdeği"
+            },
+            "superfine-sugar": {
+                "name": "pudra şekeri"
+            },
+            "sweet-potato": {
+                "name": "tatlı patates",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "tatlı mısır",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "tatlandırıcı"
+            },
+            "tahini": {
+                "name": "tahin"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "domates",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "alabalık"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "ton balığı"
+            },
+            "turbanado-sugar": {
+                "name": "doğal esmer şeker"
+            },
+            "turnip": {
+                "name": "şalgam",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "rafine edilmemiş şeker"
+            },
+            "vanilla": {
+                "name": "vanilya"
+            },
+            "vegetables": {
+                "name": "sebze"
+            },
+            "watercress": {
+                "name": "su teresi"
+            },
+            "watermelon": {
+                "name": "karpuz",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "beyaz mantar",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "beyaz şeker"
+            },
+            "xanthan-gum": {
+                "name": "ksantan gum"
+            },
+            "yam": {
+                "name": "tatlı patates",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "maya"
+            },
+            "zucchini": {
+                "name": "kabak",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Sebze-Meyve": {
+        "foods": {}
+    },
+    "Hububat": {
+        "foods": {}
+    },
+    "Meyveler": {
+        "foods": {}
+    },
+    "Sebzeler": {
+        "foods": {}
+    },
+    "Et": {
+        "foods": {}
+    },
+    "Deniz Ürünleri": {
+        "foods": {}
+    },
+    "İçecekler": {
+        "foods": {}
+    },
+    "Unlu Mamüller": {
+        "foods": {}
+    },
+    "Konserve Ürünleri": {
+        "foods": {}
+    },
+    "Çeşniler": {
+        "foods": {}
+    },
+    "Şekerleme": {
+        "foods": {}
+    },
+    "Süt Ürünleri": {
+        "foods": {}
+    },
+    "Donmuş Gıdalar": {
+        "foods": {}
+    },
+    "Sağlıklı Gıdalar": {
+        "foods": {}
+    },
+    "Ev Halkı": {
+        "foods": {}
+    },
+    "Et Ürünleri": {
+        "foods": {}
+    },
+    "Atıştırmalıklar": {
+        "foods": {}
+    },
+    "Baharatlar": {
+        "foods": {}
+    },
+    "Tatlılar": {
+        "foods": {}
+    },
+    "Alkol": {
+        "foods": {}
+    },
+    "Diğer": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/uk-UA.json
+++ b/mealie/repos/seed/resources/foods/locales/uk-UA.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "гарбуз акорн"
-	},
-	"alfalfa-sprouts": {
-		"name": "люцерна"
-	},
-	"anchovies": {
-		"name": "анчоуси"
-	},
-	"apples": {
-		"name": "яблуки",
-		"plural_name": "яблука"
-	},
-	"artichoke": {
-		"name": "артишок"
-	},
-	"arugula": {
-		"name": "рукола"
-	},
-	"asparagus": {
-		"name": "спаржа"
-	},
-	"avocado": {
-		"name": "авокадо",
-		"plural_name": "авокадо"
-	},
-	"bacon": {
-		"name": "бекон"
-	},
-	"baking-powder": {
-		"name": "харчовий розпушувач"
-	},
-	"baking-soda": {
-		"name": "столова сода"
-	},
-	"baking-sugar": {
-		"name": "цукрова пудра"
-	},
-	"bar-sugar": {
-		"name": "цукрова пудра"
-	},
-	"basil": {
-		"name": "базилік"
-	},
-	"beans": {
-		"name": "боби"
-	},
-	"bell-peppers": {
-		"name": "солодкий перець",
-		"plural_name": "болгарський перець"
-	},
-	"blackberries": {
-		"name": "ожина"
-	},
-	"bok-choy": {
-		"name": "пак чой"
-	},
-	"brassicas": {
-		"name": "капуста"
-	},
-	"bread": {
-		"name": "хліб"
-	},
-	"breadfruit": {
-		"name": "плоди хлібного дерева"
-	},
-	"broccoflower": {
-		"name": "брокофлауер"
-	},
-	"broccoli": {
-		"name": "брокколі"
-	},
-	"broccoli-rabe": {
-		"name": "рапіні"
-	},
-	"broccolini": {
-		"name": "брокколіні"
-	},
-	"brown-sugar": {
-		"name": "коричневий цукор"
-	},
-	"brussels-sprouts": {
-		"name": "брюссельська капуста"
-	},
-	"butter": {
-		"name": "вершкове масло"
-	},
-	"butternut-pumpkin": {
-		"name": "мускатний гарбуз"
-	},
-	"butternut-squash": {
-		"name": "мускатний гарбуз"
-	},
-	"cabbage": {
-		"name": "капуста",
-		"plural_name": "капуста"
-	},
-	"cactus-edible": {
-		"name": "кактус"
-	},
-	"calabrese": {
-		"name": "броколі"
-	},
-	"cane-sugar": {
-		"name": "тростинний цукор"
-	},
-	"cannabis": {
-		"name": "канабіс"
-	},
-	"capsicum": {
-		"name": "перці"
-	},
-	"caraway": {
-		"name": "кмин"
-	},
-	"carrot": {
-		"name": "морква",
-		"plural_name": "морква"
-	},
-	"caster-sugar": {
-		"name": "цукрова пудра"
-	},
-	"castor-sugar": {
-		"name": "цукрова пудра"
-	},
-	"catfish": {
-		"name": "сом"
-	},
-	"cauliflower": {
-		"name": "цвітна капуста",
-		"plural_name": "цвітна капуста"
-	},
-	"cayenne-pepper": {
-		"name": "каєнський перець"
-	},
-	"celeriac": {
-		"name": "корінь селери"
-	},
-	"celery": {
-		"name": "селера"
-	},
-	"cereal-grains": {
-		"name": "висівки"
-	},
-	"chard": {
-		"name": "мангольд"
-	},
-	"cheese": {
-		"name": "сир"
-	},
-	"chicory": {
-		"name": "цикорій"
-	},
-	"chilli-peppers": {
-		"name": "перець чилі",
-		"plural_name": "перець чилі"
-	},
-	"chinese-leaves": {
-		"name": "китайська капуста"
-	},
-	"chives": {
-		"name": "цибуля-трибулька"
-	},
-	"chocolate": {
-		"name": "шоколад"
-	},
-	"cilantro": {
-		"name": "коріандр"
-	},
-	"cinnamon": {
-		"name": "кориця"
-	},
-	"clarified-butter": {
-		"name": "пряжене масло"
-	},
-	"coconut": {
-		"name": "кокос",
-		"plural_name": "кокоси"
-	},
-	"coconut-milk": {
-		"name": "кокосове молоко"
-	},
-	"cod": {
-		"name": "тріска"
-	},
-	"coffee": {
-		"name": "кава"
-	},
-	"collard-greens": {
-		"name": "капуста коллард"
-	},
-	"confectioners-sugar": {
-		"name": "кондитерський цукор"
-	},
-	"coriander": {
-		"name": "коріандр"
-	},
-	"corn": {
-		"name": "кукурудза",
-		"plural_name": "кукурудза"
-	},
-	"corn-syrup": {
-		"name": "кукурудзяний сироп"
-	},
-	"cottonseed-oil": {
-		"name": "бавовняна олія"
-	},
-	"courgette": {
-		"name": "кабачок"
-	},
-	"cream-of-tartar": {
-		"name": "винний камінь"
-	},
-	"cucumber": {
-		"name": "огірок",
-		"plural_name": "огірки"
-	},
-	"cumin": {
-		"name": "кумин"
-	},
-	"daikon": {
-		"name": "дайкон",
-		"plural_name": "дайкони"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "молочні продукти та молочні замінники"
-	},
-	"dandelion": {
-		"name": "кульбаба"
-	},
-	"demerara-sugar": {
-		"name": "демерара"
-	},
-	"dough": {
-		"name": "тісто"
-	},
-	"edible-cactus": {
-		"name": "кактус"
-	},
-	"eggplant": {
-		"name": "баклажан",
-		"plural_name": "баклажани"
-	},
-	"eggs": {
-		"name": "яйця",
-		"plural_name": "яйця"
-	},
-	"endive": {
-		"name": "ендивій (салатний цикорій)",
-		"plural_name": "салатний цикорій"
-	},
-	"fats": {
-		"name": "жири"
-	},
-	"fava-beans": {
-		"name": "біб кінський"
-	},
-	"fiddlehead": {
-		"name": "рахіси папороті"
-	},
-	"fiddlehead-fern": {
-		"name": "рахіс папороті",
-		"plural_name": "рахіси папороті"
-	},
-	"fish": {
-		"name": "риба"
-	},
-	"five-spice-powder": {
-		"name": "5 спецій"
-	},
-	"flour": {
-		"name": "борошно"
-	},
-	"frisee": {
-		"name": "салат фрізе"
-	},
-	"fructose": {
-		"name": "фруктоза"
-	},
-	"fruit": {
-		"name": "фрукт"
-	},
-	"fruit-sugar": {
-		"name": "фруктоза"
-	},
-	"ful": {
-		"name": "фул"
-	},
-	"garam-masala": {
-		"name": "гарам масала"
-	},
-	"garlic": {
-		"name": "часник",
-		"plural_name": "часник"
-	},
-	"gem-squash": {
-		"name": "гарбуз \"джем\""
-	},
-	"ghee": {
-		"name": "гхі"
-	},
-	"giblets": {
-		"name": "пташині тельбухи"
-	},
-	"ginger": {
-		"name": "імбир"
-	},
-	"grains": {
-		"name": "зерна"
-	},
-	"granulated-sugar": {
-		"name": "гранульований цукор"
-	},
-	"grape-seed-oil": {
-		"name": "олія з виноградних кісточок"
-	},
-	"green-onion": {
-		"name": "зелена цибуля",
-		"plural_name": "зелена цибуля"
-	},
-	"heart-of-palm": {
-		"name": "серцевина пальми",
-		"plural_name": "серцевина пальми"
-	},
-	"hemp": {
-		"name": "коноплі"
-	},
-	"herbs": {
-		"name": "трави"
-	},
-	"honey": {
-		"name": "мед"
-	},
-	"isomalt": {
-		"name": "ізомальт"
-	},
-	"jackfruit": {
-		"name": "джекфрут",
-		"plural_name": "джекфрукти"
-	},
-	"jaggery": {
-		"name": "цукор джаггері"
-	},
-	"jams": {
-		"name": "джеми"
-	},
-	"jellies": {
-		"name": "желе"
-	},
-	"jerusalem-artichoke": {
-		"name": "топінамбур"
-	},
-	"jicama": {
-		"name": "хікама"
-	},
-	"kale": {
-		"name": "капуста кейл"
-	},
-	"kohlrabi": {
-		"name": "кольрабі"
-	},
-	"kumara": {
-		"name": "батат"
-	},
-	"leavening-agents": {
-		"name": "харчовий розпушувач"
-	},
-	"leek": {
-		"name": "цибуля-порей",
-		"plural_name": "цибуля-порей"
-	},
-	"legumes": {
-		"name": "бобові"
-	},
-	"lemongrass": {
-		"name": "лемонграс"
-	},
-	"lentils": {
-		"name": "сочевиця"
-	},
-	"lettuce": {
-		"name": "салат"
-	},
-	"liver": {
-		"name": "печінка",
-		"plural_name": "печінки"
-	},
-	"maize": {
-		"name": "маіс"
-	},
-	"maple-syrup": {
-		"name": "кленовий сироп"
-	},
-	"meat": {
-		"name": "м’ясо"
-	},
-	"milk": {
-		"name": "молоко"
-	},
-	"mortadella": {
-		"name": "мортадела"
-	},
-	"mushroom": {
-		"name": "гриби",
-		"plural_name": "гриби"
-	},
-	"mussels": {
-		"name": "мідії"
-	},
-	"nanaimo-bar-mix": {
-		"name": "суміш для тістечок \"Нанаімо\""
-	},
-	"nori": {
-		"name": "норі"
-	},
-	"nutmeg": {
-		"name": "мускатний горіх"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "харчові дріжджі"
-	},
-	"nuts": {
-		"name": "горіхи"
-	},
-	"octopuses": {
-		"name": "восьминоги",
-		"plural_name": "восьминоги"
-	},
-	"oils": {
-		"name": "олії"
-	},
-	"okra": {
-		"name": "бамія"
-	},
-	"olive": {
-		"name": "оливка"
-	},
-	"olive-oil": {
-		"name": "оливкова олія"
-	},
-	"onion": {
-		"name": "цибуля"
-	},
-	"onion-family": {
-		"name": "цибулеві"
-	},
-	"orange-blossom-water": {
-		"name": "апельсинова квіткова вода"
-	},
-	"oranges": {
-		"name": "апельсини",
-		"plural_name": "апельсини"
-	},
-	"oregano": {
-		"name": "орегано"
-	},
-	"oysters": {
-		"name": "устриці"
-	},
-	"panch-puran": {
-		"name": "спеціі Панч Пурeн"
-	},
-	"paprika": {
-		"name": "паприка"
-	},
-	"parsley": {
-		"name": "петрушка"
-	},
-	"parsnip": {
-		"name": "пастернак",
-		"plural_name": "пастернаки"
-	},
-	"pear": {
-		"name": "груша",
-		"plural_name": "груші"
-	},
-	"peas": {
-		"name": "горох"
-	},
-	"pepper": {
-		"name": "перець",
-		"plural_name": "перці"
-	},
-	"pineapple": {
-		"name": "ананас",
-		"plural_name": "ананаси"
-	},
-	"plantain": {
-		"name": "плантан",
-		"plural_name": "плантани"
-	},
-	"poppy-seeds": {
-		"name": "макове насіння"
-	},
-	"potato": {
-		"name": "картопля",
-		"plural_name": "картоплини"
-	},
-	"poultry": {
-		"name": "птиця"
-	},
-	"powdered-sugar": {
-		"name": "цукрова пудра"
-	},
-	"pumpkin": {
-		"name": "гарбуз",
-		"plural_name": "гарбузи"
-	},
-	"pumpkin-seeds": {
-		"name": "гарбузове насіння"
-	},
-	"radish": {
-		"name": "редис",
-		"plural_name": "редиски"
-	},
-	"raw-sugar": {
-		"name": "цукор сирець"
-	},
-	"refined-sugar": {
-		"name": "рафінований цукор"
-	},
-	"rice": {
-		"name": "рис"
-	},
-	"rice-flour": {
-		"name": "рисове борошно"
-	},
-	"rock-sugar": {
-		"name": "кандований цукор"
-	},
-	"rum": {
-		"name": "ром"
-	},
-	"salmon": {
-		"name": "лосось"
-	},
-	"salt": {
-		"name": "сіль"
-	},
-	"salt-cod": {
-		"name": "солона тріска"
-	},
-	"scallion": {
-		"name": "зелена цибуля",
-		"plural_name": "зелена цибуля"
-	},
-	"seafood": {
-		"name": "морепродукти"
-	},
-	"seeds": {
-		"name": "насіння"
-	},
-	"sesame-seeds": {
-		"name": "насіння кунжуту"
-	},
-	"shallot": {
-		"name": "цибуля шалот",
-		"plural_name": "цибуля шалот"
-	},
-	"skate": {
-		"name": "скат"
-	},
-	"soda": {
-		"name": "сода"
-	},
-	"soda-baking": {
-		"name": "харчова сода"
-	},
-	"soybean": {
-		"name": "соєві боби"
-	},
-	"spaghetti-squash": {
-		"name": "гарбуз спагеті",
-		"plural_name": "гарбуз спагеті"
-	},
-	"speck": {
-		"name": "шпек"
-	},
-	"spices": {
-		"name": "спеції"
-	},
-	"spinach": {
-		"name": "шпинат"
-	},
-	"spring-onion": {
-		"name": "зелена цибуля",
-		"plural_name": "зелена цибуля"
-	},
-	"squash": {
-		"name": "гарбуз",
-		"plural_name": "гарбузи"
-	},
-	"squash-family": {
-		"name": "гарбузові"
-	},
-	"stockfish": {
-		"name": "в'ялена риба"
-	},
-	"sugar": {
-		"name": "цукор"
-	},
-	"sunchoke": {
-		"name": "топінамбур",
-		"plural_name": "топінамбури"
-	},
-	"sunflower-seeds": {
-		"name": "насіння соняшника"
-	},
-	"superfine-sugar": {
-		"name": "цукрова пудра"
-	},
-	"sweet-potato": {
-		"name": "батат",
-		"plural_name": "батати"
-	},
-	"sweetcorn": {
-		"name": "солодка кукурудза",
-		"plural_name": "солодка кукурудза"
-	},
-	"sweeteners": {
-		"name": "підсолоджувачі"
-	},
-	"tahini": {
-		"name": "тахіні"
-	},
-	"taro": {
-		"name": "таро",
-		"plural_name": "таро"
-	},
-	"teff": {
-		"name": "тефф"
-	},
-	"tomato": {
-		"name": "помідор",
-		"plural_name": "помідори"
-	},
-	"trout": {
-		"name": "форель"
-	},
-	"tubers": {
-		"name": "бульби",
-		"plural_name": "бульби"
-	},
-	"tuna": {
-		"name": "тунець"
-	},
-	"turbanado-sugar": {
-		"name": "цукор турбінадо"
-	},
-	"turnip": {
-		"name": "ріпа",
-		"plural_name": "ріпи"
-	},
-	"unrefined-sugar": {
-		"name": "нерафінований цукор"
-	},
-	"vanilla": {
-		"name": "ваніль"
-	},
-	"vegetables": {
-		"name": "овочі"
-	},
-	"watercress": {
-		"name": "настурція лікарська"
-	},
-	"watermelon": {
-		"name": "кавун",
-		"plural_name": "кавуни"
-	},
-	"white-mushroom": {
-		"name": "білий гриб",
-		"plural_name": "білі гриби"
-	},
-	"white-sugar": {
-		"name": "білий цукор"
-	},
-	"xanthan-gum": {
-		"name": "ксантанова камедь"
-	},
-	"yam": {
-		"name": "ямс",
-		"plural_name": "ямс"
-	},
-	"yeast": {
-		"name": "дріжджі"
-	},
-	"zucchini": {
-		"name": "цукіні",
-		"plural_name": "цукіні"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "гарбуз акорн"
+            },
+            "alfalfa-sprouts": {
+                "name": "люцерна"
+            },
+            "anchovies": {
+                "name": "анчоуси"
+            },
+            "apples": {
+                "name": "яблуки",
+                "plural_name": "яблука"
+            },
+            "artichoke": {
+                "name": "артишок"
+            },
+            "arugula": {
+                "name": "рукола"
+            },
+            "asparagus": {
+                "name": "спаржа"
+            },
+            "avocado": {
+                "name": "авокадо",
+                "plural_name": "авокадо"
+            },
+            "bacon": {
+                "name": "бекон"
+            },
+            "baking-powder": {
+                "name": "харчовий розпушувач"
+            },
+            "baking-soda": {
+                "name": "столова сода"
+            },
+            "baking-sugar": {
+                "name": "цукрова пудра"
+            },
+            "bar-sugar": {
+                "name": "цукрова пудра"
+            },
+            "basil": {
+                "name": "базилік"
+            },
+            "beans": {
+                "name": "боби"
+            },
+            "bell-peppers": {
+                "name": "солодкий перець",
+                "plural_name": "болгарський перець"
+            },
+            "blackberries": {
+                "name": "ожина"
+            },
+            "bok-choy": {
+                "name": "пак чой"
+            },
+            "brassicas": {
+                "name": "капуста"
+            },
+            "bread": {
+                "name": "хліб"
+            },
+            "breadfruit": {
+                "name": "плоди хлібного дерева"
+            },
+            "broccoflower": {
+                "name": "брокофлауер"
+            },
+            "broccoli": {
+                "name": "брокколі"
+            },
+            "broccoli-rabe": {
+                "name": "рапіні"
+            },
+            "broccolini": {
+                "name": "брокколіні"
+            },
+            "brown-sugar": {
+                "name": "коричневий цукор"
+            },
+            "brussels-sprouts": {
+                "name": "брюссельська капуста"
+            },
+            "butter": {
+                "name": "вершкове масло"
+            },
+            "butternut-pumpkin": {
+                "name": "мускатний гарбуз"
+            },
+            "butternut-squash": {
+                "name": "мускатний гарбуз"
+            },
+            "cabbage": {
+                "name": "капуста",
+                "plural_name": "капуста"
+            },
+            "cactus-edible": {
+                "name": "кактус"
+            },
+            "calabrese": {
+                "name": "броколі"
+            },
+            "cane-sugar": {
+                "name": "тростинний цукор"
+            },
+            "cannabis": {
+                "name": "канабіс"
+            },
+            "capsicum": {
+                "name": "перці"
+            },
+            "caraway": {
+                "name": "кмин"
+            },
+            "carrot": {
+                "name": "морква",
+                "plural_name": "морква"
+            },
+            "caster-sugar": {
+                "name": "цукрова пудра"
+            },
+            "castor-sugar": {
+                "name": "цукрова пудра"
+            },
+            "catfish": {
+                "name": "сом"
+            },
+            "cauliflower": {
+                "name": "цвітна капуста",
+                "plural_name": "цвітна капуста"
+            },
+            "cayenne-pepper": {
+                "name": "каєнський перець"
+            },
+            "celeriac": {
+                "name": "корінь селери"
+            },
+            "celery": {
+                "name": "селера"
+            },
+            "cereal-grains": {
+                "name": "висівки"
+            },
+            "chard": {
+                "name": "мангольд"
+            },
+            "cheese": {
+                "name": "сир"
+            },
+            "chicory": {
+                "name": "цикорій"
+            },
+            "chilli-peppers": {
+                "name": "перець чилі",
+                "plural_name": "перець чилі"
+            },
+            "chinese-leaves": {
+                "name": "китайська капуста"
+            },
+            "chives": {
+                "name": "цибуля-трибулька"
+            },
+            "chocolate": {
+                "name": "шоколад"
+            },
+            "cilantro": {
+                "name": "коріандр"
+            },
+            "cinnamon": {
+                "name": "кориця"
+            },
+            "clarified-butter": {
+                "name": "пряжене масло"
+            },
+            "coconut": {
+                "name": "кокос",
+                "plural_name": "кокоси"
+            },
+            "coconut-milk": {
+                "name": "кокосове молоко"
+            },
+            "cod": {
+                "name": "тріска"
+            },
+            "coffee": {
+                "name": "кава"
+            },
+            "collard-greens": {
+                "name": "капуста коллард"
+            },
+            "confectioners-sugar": {
+                "name": "кондитерський цукор"
+            },
+            "coriander": {
+                "name": "коріандр"
+            },
+            "corn": {
+                "name": "кукурудза",
+                "plural_name": "кукурудза"
+            },
+            "corn-syrup": {
+                "name": "кукурудзяний сироп"
+            },
+            "cottonseed-oil": {
+                "name": "бавовняна олія"
+            },
+            "courgette": {
+                "name": "кабачок"
+            },
+            "cream-of-tartar": {
+                "name": "винний камінь"
+            },
+            "cucumber": {
+                "name": "огірок",
+                "plural_name": "огірки"
+            },
+            "cumin": {
+                "name": "кумин"
+            },
+            "daikon": {
+                "name": "дайкон",
+                "plural_name": "дайкони"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "молочні продукти та молочні замінники"
+            },
+            "dandelion": {
+                "name": "кульбаба"
+            },
+            "demerara-sugar": {
+                "name": "демерара"
+            },
+            "dough": {
+                "name": "тісто"
+            },
+            "edible-cactus": {
+                "name": "кактус"
+            },
+            "eggplant": {
+                "name": "баклажан",
+                "plural_name": "баклажани"
+            },
+            "eggs": {
+                "name": "яйця",
+                "plural_name": "яйця"
+            },
+            "endive": {
+                "name": "ендивій (салатний цикорій)",
+                "plural_name": "салатний цикорій"
+            },
+            "fats": {
+                "name": "жири"
+            },
+            "fava-beans": {
+                "name": "біб кінський"
+            },
+            "fiddlehead": {
+                "name": "рахіси папороті"
+            },
+            "fiddlehead-fern": {
+                "name": "рахіс папороті",
+                "plural_name": "рахіси папороті"
+            },
+            "fish": {
+                "name": "риба"
+            },
+            "five-spice-powder": {
+                "name": "5 спецій"
+            },
+            "flour": {
+                "name": "борошно"
+            },
+            "frisee": {
+                "name": "салат фрізе"
+            },
+            "fructose": {
+                "name": "фруктоза"
+            },
+            "fruit": {
+                "name": "фрукт"
+            },
+            "fruit-sugar": {
+                "name": "фруктоза"
+            },
+            "ful": {
+                "name": "фул"
+            },
+            "garam-masala": {
+                "name": "гарам масала"
+            },
+            "garlic": {
+                "name": "часник",
+                "plural_name": "часник"
+            },
+            "gem-squash": {
+                "name": "гарбуз \"джем\""
+            },
+            "ghee": {
+                "name": "гхі"
+            },
+            "giblets": {
+                "name": "пташині тельбухи"
+            },
+            "ginger": {
+                "name": "імбир"
+            },
+            "grains": {
+                "name": "зерна"
+            },
+            "granulated-sugar": {
+                "name": "гранульований цукор"
+            },
+            "grape-seed-oil": {
+                "name": "олія з виноградних кісточок"
+            },
+            "green-onion": {
+                "name": "зелена цибуля",
+                "plural_name": "зелена цибуля"
+            },
+            "heart-of-palm": {
+                "name": "серцевина пальми",
+                "plural_name": "серцевина пальми"
+            },
+            "hemp": {
+                "name": "коноплі"
+            },
+            "herbs": {
+                "name": "трави"
+            },
+            "honey": {
+                "name": "мед"
+            },
+            "isomalt": {
+                "name": "ізомальт"
+            },
+            "jackfruit": {
+                "name": "джекфрут",
+                "plural_name": "джекфрукти"
+            },
+            "jaggery": {
+                "name": "цукор джаггері"
+            },
+            "jams": {
+                "name": "джеми"
+            },
+            "jellies": {
+                "name": "желе"
+            },
+            "jerusalem-artichoke": {
+                "name": "топінамбур"
+            },
+            "jicama": {
+                "name": "хікама"
+            },
+            "kale": {
+                "name": "капуста кейл"
+            },
+            "kohlrabi": {
+                "name": "кольрабі"
+            },
+            "kumara": {
+                "name": "батат"
+            },
+            "leavening-agents": {
+                "name": "харчовий розпушувач"
+            },
+            "leek": {
+                "name": "цибуля-порей",
+                "plural_name": "цибуля-порей"
+            },
+            "legumes": {
+                "name": "бобові"
+            },
+            "lemongrass": {
+                "name": "лемонграс"
+            },
+            "lentils": {
+                "name": "сочевиця"
+            },
+            "lettuce": {
+                "name": "салат"
+            },
+            "liver": {
+                "name": "печінка",
+                "plural_name": "печінки"
+            },
+            "maize": {
+                "name": "маіс"
+            },
+            "maple-syrup": {
+                "name": "кленовий сироп"
+            },
+            "meat": {
+                "name": "м’ясо"
+            },
+            "milk": {
+                "name": "молоко"
+            },
+            "mortadella": {
+                "name": "мортадела"
+            },
+            "mushroom": {
+                "name": "гриби",
+                "plural_name": "гриби"
+            },
+            "mussels": {
+                "name": "мідії"
+            },
+            "nanaimo-bar-mix": {
+                "name": "суміш для тістечок \"Нанаімо\""
+            },
+            "nori": {
+                "name": "норі"
+            },
+            "nutmeg": {
+                "name": "мускатний горіх"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "харчові дріжджі"
+            },
+            "nuts": {
+                "name": "горіхи"
+            },
+            "octopuses": {
+                "name": "восьминоги",
+                "plural_name": "восьминоги"
+            },
+            "oils": {
+                "name": "олії"
+            },
+            "okra": {
+                "name": "бамія"
+            },
+            "olive": {
+                "name": "оливка"
+            },
+            "olive-oil": {
+                "name": "оливкова олія"
+            },
+            "onion": {
+                "name": "цибуля"
+            },
+            "onion-family": {
+                "name": "цибулеві"
+            },
+            "orange-blossom-water": {
+                "name": "апельсинова квіткова вода"
+            },
+            "oranges": {
+                "name": "апельсини",
+                "plural_name": "апельсини"
+            },
+            "oregano": {
+                "name": "орегано"
+            },
+            "oysters": {
+                "name": "устриці"
+            },
+            "panch-puran": {
+                "name": "спеціі Панч Пурeн"
+            },
+            "paprika": {
+                "name": "паприка"
+            },
+            "parsley": {
+                "name": "петрушка"
+            },
+            "parsnip": {
+                "name": "пастернак",
+                "plural_name": "пастернаки"
+            },
+            "pear": {
+                "name": "груша",
+                "plural_name": "груші"
+            },
+            "peas": {
+                "name": "горох"
+            },
+            "pepper": {
+                "name": "перець",
+                "plural_name": "перці"
+            },
+            "pineapple": {
+                "name": "ананас",
+                "plural_name": "ананаси"
+            },
+            "plantain": {
+                "name": "плантан",
+                "plural_name": "плантани"
+            },
+            "poppy-seeds": {
+                "name": "макове насіння"
+            },
+            "potato": {
+                "name": "картопля",
+                "plural_name": "картоплини"
+            },
+            "poultry": {
+                "name": "птиця"
+            },
+            "powdered-sugar": {
+                "name": "цукрова пудра"
+            },
+            "pumpkin": {
+                "name": "гарбуз",
+                "plural_name": "гарбузи"
+            },
+            "pumpkin-seeds": {
+                "name": "гарбузове насіння"
+            },
+            "radish": {
+                "name": "редис",
+                "plural_name": "редиски"
+            },
+            "raw-sugar": {
+                "name": "цукор сирець"
+            },
+            "refined-sugar": {
+                "name": "рафінований цукор"
+            },
+            "rice": {
+                "name": "рис"
+            },
+            "rice-flour": {
+                "name": "рисове борошно"
+            },
+            "rock-sugar": {
+                "name": "кандований цукор"
+            },
+            "rum": {
+                "name": "ром"
+            },
+            "salmon": {
+                "name": "лосось"
+            },
+            "salt": {
+                "name": "сіль"
+            },
+            "salt-cod": {
+                "name": "солона тріска"
+            },
+            "scallion": {
+                "name": "зелена цибуля",
+                "plural_name": "зелена цибуля"
+            },
+            "seafood": {
+                "name": "морепродукти"
+            },
+            "seeds": {
+                "name": "насіння"
+            },
+            "sesame-seeds": {
+                "name": "насіння кунжуту"
+            },
+            "shallot": {
+                "name": "цибуля шалот",
+                "plural_name": "цибуля шалот"
+            },
+            "skate": {
+                "name": "скат"
+            },
+            "soda": {
+                "name": "сода"
+            },
+            "soda-baking": {
+                "name": "харчова сода"
+            },
+            "soybean": {
+                "name": "соєві боби"
+            },
+            "spaghetti-squash": {
+                "name": "гарбуз спагеті",
+                "plural_name": "гарбуз спагеті"
+            },
+            "speck": {
+                "name": "шпек"
+            },
+            "spices": {
+                "name": "спеції"
+            },
+            "spinach": {
+                "name": "шпинат"
+            },
+            "spring-onion": {
+                "name": "зелена цибуля",
+                "plural_name": "зелена цибуля"
+            },
+            "squash": {
+                "name": "гарбуз",
+                "plural_name": "гарбузи"
+            },
+            "squash-family": {
+                "name": "гарбузові"
+            },
+            "stockfish": {
+                "name": "в'ялена риба"
+            },
+            "sugar": {
+                "name": "цукор"
+            },
+            "sunchoke": {
+                "name": "топінамбур",
+                "plural_name": "топінамбури"
+            },
+            "sunflower-seeds": {
+                "name": "насіння соняшника"
+            },
+            "superfine-sugar": {
+                "name": "цукрова пудра"
+            },
+            "sweet-potato": {
+                "name": "батат",
+                "plural_name": "батати"
+            },
+            "sweetcorn": {
+                "name": "солодка кукурудза",
+                "plural_name": "солодка кукурудза"
+            },
+            "sweeteners": {
+                "name": "підсолоджувачі"
+            },
+            "tahini": {
+                "name": "тахіні"
+            },
+            "taro": {
+                "name": "таро",
+                "plural_name": "таро"
+            },
+            "teff": {
+                "name": "тефф"
+            },
+            "tomato": {
+                "name": "помідор",
+                "plural_name": "помідори"
+            },
+            "trout": {
+                "name": "форель"
+            },
+            "tubers": {
+                "name": "бульби",
+                "plural_name": "бульби"
+            },
+            "tuna": {
+                "name": "тунець"
+            },
+            "turbanado-sugar": {
+                "name": "цукор турбінадо"
+            },
+            "turnip": {
+                "name": "ріпа",
+                "plural_name": "ріпи"
+            },
+            "unrefined-sugar": {
+                "name": "нерафінований цукор"
+            },
+            "vanilla": {
+                "name": "ваніль"
+            },
+            "vegetables": {
+                "name": "овочі"
+            },
+            "watercress": {
+                "name": "настурція лікарська"
+            },
+            "watermelon": {
+                "name": "кавун",
+                "plural_name": "кавуни"
+            },
+            "white-mushroom": {
+                "name": "білий гриб",
+                "plural_name": "білі гриби"
+            },
+            "white-sugar": {
+                "name": "білий цукор"
+            },
+            "xanthan-gum": {
+                "name": "ксантанова камедь"
+            },
+            "yam": {
+                "name": "ямс",
+                "plural_name": "ямс"
+            },
+            "yeast": {
+                "name": "дріжджі"
+            },
+            "zucchini": {
+                "name": "цукіні",
+                "plural_name": "цукіні"
+            }
+        }
+    },
+    "Продукти": {
+        "foods": {}
+    },
+    "Зерна": {
+        "foods": {}
+    },
+    "Фрукти": {
+        "foods": {}
+    },
+    "Овочі": {
+        "foods": {}
+    },
+    "М’ясо": {
+        "foods": {}
+    },
+    "Морепродукти": {
+        "foods": {}
+    },
+    "Напої": {
+        "foods": {}
+    },
+    "Печені страви": {
+        "foods": {}
+    },
+    "Консерви": {
+        "foods": {}
+    },
+    "Приправи": {
+        "foods": {}
+    },
+    "Солодощі": {
+        "foods": {}
+    },
+    "Молочні продукти": {
+        "foods": {}
+    },
+    "Заморожені продукти": {
+        "foods": {}
+    },
+    "Здорова їжа": {
+        "foods": {}
+    },
+    "Сім'я": {
+        "foods": {}
+    },
+    "М'ясні Продукти": {
+        "foods": {}
+    },
+    "Закуски": {
+        "foods": {}
+    },
+    "Спеції": {
+        "foods": {}
+    },
+    "Cолодощі": {
+        "foods": {}
+    },
+    "Алкоголь": {
+        "foods": {}
+    },
+    "Інше": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/vi-VN.json
+++ b/mealie/repos/seed/resources/foods/locales/vi-VN.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "anchovies"
-	},
-	"apples": {
-		"name": "apple",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "artichoke"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "asparagus"
-	},
-	"avocado": {
-		"name": "avocado",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "bacon"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "baking soda"
-	},
-	"baking-sugar": {
-		"name": "baking sugar"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "basil"
-	},
-	"beans": {
-		"name": "beans"
-	},
-	"bell-peppers": {
-		"name": "bell peppers",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "blackberries"
-	},
-	"bok-choy": {
-		"name": "bok choy"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "bread"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "broccoli"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "brown sugar"
-	},
-	"brussels-sprouts": {
-		"name": "brussels sprouts"
-	},
-	"butter": {
-		"name": "butter"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "cabbage",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "cane sugar"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "carrot",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "catfish"
-	},
-	"cauliflower": {
-		"name": "cauliflower",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "celery"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "cheese"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "chocolate"
-	},
-	"cilantro": {
-		"name": "cilantro"
-	},
-	"cinnamon": {
-		"name": "cinnamon"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "coconut",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "coconut milk"
-	},
-	"cod": {
-		"name": "cod"
-	},
-	"coffee": {
-		"name": "coffee"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "coriander"
-	},
-	"corn": {
-		"name": "corn",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "corn syrup"
-	},
-	"cottonseed-oil": {
-		"name": "cottonseed oil"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "cucumber",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "cumin"
-	},
-	"daikon": {
-		"name": "daikon",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "dandelion"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "dough"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "eggplant",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "egg",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "fats"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "fish"
-	},
-	"five-spice-powder": {
-		"name": "five spice powder"
-	},
-	"flour": {
-		"name": "flour"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "fruit"
-	},
-	"fruit-sugar": {
-		"name": "fruit sugar"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "garlic",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "giblets"
-	},
-	"ginger": {
-		"name": "ginger"
-	},
-	"grains": {
-		"name": "grains"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "grape seed oil"
-	},
-	"green-onion": {
-		"name": "green onion",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "honey"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "jackfruit",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "jams"
-	},
-	"jellies": {
-		"name": "jellies"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "lettuce"
-	},
-	"liver": {
-		"name": "liver",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "maple syrup"
-	},
-	"meat": {
-		"name": "meat"
-	},
-	"milk": {
-		"name": "milk"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "mushroom",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "mussels"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "nuts"
-	},
-	"octopuses": {
-		"name": "octopus",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "oils"
-	},
-	"okra": {
-		"name": "okra"
-	},
-	"olive": {
-		"name": "olive"
-	},
-	"olive-oil": {
-		"name": "olive oil"
-	},
-	"onion": {
-		"name": "onion"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "orange",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "oysters"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "parsley"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "pear",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "pepper",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "pineapple",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "poppy seeds"
-	},
-	"potato": {
-		"name": "potato",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "poultry"
-	},
-	"powdered-sugar": {
-		"name": "powdered sugar"
-	},
-	"pumpkin": {
-		"name": "pumpkin",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "pumpkin seeds"
-	},
-	"radish": {
-		"name": "radish",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "raw sugar"
-	},
-	"refined-sugar": {
-		"name": "refined sugar"
-	},
-	"rice": {
-		"name": "rice"
-	},
-	"rice-flour": {
-		"name": "rice flour"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "rum"
-	},
-	"salmon": {
-		"name": "salmon"
-	},
-	"salt": {
-		"name": "salt"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "scallion",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "seafood"
-	},
-	"seeds": {
-		"name": "seeds"
-	},
-	"sesame-seeds": {
-		"name": "sesame seeds"
-	},
-	"shallot": {
-		"name": "shallot",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "soda"
-	},
-	"soda-baking": {
-		"name": "soda, baking"
-	},
-	"soybean": {
-		"name": "soybean"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "spices"
-	},
-	"spinach": {
-		"name": "spinach"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "sugar"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "sunflower seeds"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "sweet potato",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "sweetcorn",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "taro",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "tomato",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "trout"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "tuna"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "vanilla"
-	},
-	"vegetables": {
-		"name": "vegetables"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "watermelon",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "white mushroom",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "white sugar"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "yeast"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "anchovies"
+            },
+            "apples": {
+                "name": "apple",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "artichoke"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "asparagus"
+            },
+            "avocado": {
+                "name": "avocado",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "bacon"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "baking soda"
+            },
+            "baking-sugar": {
+                "name": "baking sugar"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "basil"
+            },
+            "beans": {
+                "name": "beans"
+            },
+            "bell-peppers": {
+                "name": "bell peppers",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "blackberries"
+            },
+            "bok-choy": {
+                "name": "bok choy"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "bread"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "broccoli"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "brown sugar"
+            },
+            "brussels-sprouts": {
+                "name": "brussels sprouts"
+            },
+            "butter": {
+                "name": "butter"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "cabbage",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "cane sugar"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "carrot",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "catfish"
+            },
+            "cauliflower": {
+                "name": "cauliflower",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "celery"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "cheese"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "chocolate"
+            },
+            "cilantro": {
+                "name": "cilantro"
+            },
+            "cinnamon": {
+                "name": "cinnamon"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "coconut",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "coconut milk"
+            },
+            "cod": {
+                "name": "cod"
+            },
+            "coffee": {
+                "name": "coffee"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "coriander"
+            },
+            "corn": {
+                "name": "corn",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "corn syrup"
+            },
+            "cottonseed-oil": {
+                "name": "cottonseed oil"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "cucumber",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "cumin"
+            },
+            "daikon": {
+                "name": "daikon",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "dandelion"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "dough"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "eggplant",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "egg",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "fats"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "fish"
+            },
+            "five-spice-powder": {
+                "name": "five spice powder"
+            },
+            "flour": {
+                "name": "flour"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "fruit"
+            },
+            "fruit-sugar": {
+                "name": "fruit sugar"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "garlic",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "giblets"
+            },
+            "ginger": {
+                "name": "ginger"
+            },
+            "grains": {
+                "name": "grains"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "grape seed oil"
+            },
+            "green-onion": {
+                "name": "green onion",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "honey"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "jackfruit",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "jams"
+            },
+            "jellies": {
+                "name": "jellies"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "lettuce"
+            },
+            "liver": {
+                "name": "liver",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "maple syrup"
+            },
+            "meat": {
+                "name": "meat"
+            },
+            "milk": {
+                "name": "milk"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "mushroom",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "mussels"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "nuts"
+            },
+            "octopuses": {
+                "name": "octopus",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "oils"
+            },
+            "okra": {
+                "name": "okra"
+            },
+            "olive": {
+                "name": "olive"
+            },
+            "olive-oil": {
+                "name": "olive oil"
+            },
+            "onion": {
+                "name": "onion"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "orange",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "oysters"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "parsley"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "pear",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "pepper",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "pineapple",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "poppy seeds"
+            },
+            "potato": {
+                "name": "potato",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "poultry"
+            },
+            "powdered-sugar": {
+                "name": "powdered sugar"
+            },
+            "pumpkin": {
+                "name": "pumpkin",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "pumpkin seeds"
+            },
+            "radish": {
+                "name": "radish",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "raw sugar"
+            },
+            "refined-sugar": {
+                "name": "refined sugar"
+            },
+            "rice": {
+                "name": "rice"
+            },
+            "rice-flour": {
+                "name": "rice flour"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "rum"
+            },
+            "salmon": {
+                "name": "salmon"
+            },
+            "salt": {
+                "name": "salt"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "scallion",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "seafood"
+            },
+            "seeds": {
+                "name": "seeds"
+            },
+            "sesame-seeds": {
+                "name": "sesame seeds"
+            },
+            "shallot": {
+                "name": "shallot",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "soda"
+            },
+            "soda-baking": {
+                "name": "soda, baking"
+            },
+            "soybean": {
+                "name": "soybean"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "spices"
+            },
+            "spinach": {
+                "name": "spinach"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "sugar"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "sunflower seeds"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "sweet potato",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "sweetcorn",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "taro",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "tomato",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "trout"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "tuna"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "vanilla"
+            },
+            "vegetables": {
+                "name": "vegetables"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "watermelon",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "white mushroom",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "white sugar"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "yeast"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "Rau củ": {
+        "foods": {}
+    },
+    "Các loại hạt": {
+        "foods": {}
+    },
+    "Trái cây": {
+        "foods": {}
+    },
+    "Thịt": {
+        "foods": {}
+    },
+    "Hải sản": {
+        "foods": {}
+    },
+    "Đồ uống": {
+        "foods": {}
+    },
+    "Bánh": {
+        "foods": {}
+    },
+    "Đồ hộp": {
+        "foods": {}
+    },
+    "Đồ gia vị": {
+        "foods": {}
+    },
+    "Kẹo": {
+        "foods": {}
+    },
+    "Sản phẩm từ sữa": {
+        "foods": {}
+    },
+    "Đồ đông lạnh": {
+        "foods": {}
+    },
+    "Đồ tốt cho sức khỏe": {
+        "foods": {}
+    },
+    "Gia đình": {
+        "foods": {}
+    },
+    "Sản phẩm thịt": {
+        "foods": {}
+    },
+    "Đồ ăn vặt": {
+        "foods": {}
+    },
+    "Gia vị": {
+        "foods": {}
+    },
+    "Đồ ngọt": {
+        "foods": {}
+    },
+    "Cồn": {
+        "foods": {}
+    },
+    "Khác": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/zh-CN.json
+++ b/mealie/repos/seed/resources/foods/locales/zh-CN.json
@@ -1,692 +1,756 @@
 {
-	"acorn-squash": {
-		"name": "橡果南瓜"
-	},
-	"alfalfa-sprouts": {
-		"name": "紫花苜蓿芽"
-	},
-	"anchovies": {
-		"name": "凤尾鱼"
-	},
-	"apples": {
-		"name": "苹果",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "洋蓟"
-	},
-	"arugula": {
-		"name": "芝麻菜"
-	},
-	"asparagus": {
-		"name": "芦笋"
-	},
-	"avocado": {
-		"name": "牛油果",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "培根"
-	},
-	"baking-powder": {
-		"name": "发酵粉"
-	},
-	"baking-soda": {
-		"name": "烘焙用小苏打"
-	},
-	"baking-sugar": {
-		"name": "烘焙用糖"
-	},
-	"bar-sugar": {
-		"name": "bar sugar"
-	},
-	"basil": {
-		"name": "罗勒"
-	},
-	"beans": {
-		"name": "豆子"
-	},
-	"bell-peppers": {
-		"name": "甜椒",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "黑莓"
-	},
-	"bok-choy": {
-		"name": "小白菜"
-	},
-	"brassicas": {
-		"name": "甘蓝"
-	},
-	"bread": {
-		"name": "面包"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "西蓝花"
-	},
-	"broccoli": {
-		"name": "西兰花"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "broccolini"
-	},
-	"brown-sugar": {
-		"name": "红糖"
-	},
-	"brussels-sprouts": {
-		"name": "抱子甘蓝"
-	},
-	"butter": {
-		"name": "黄油"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "奶油南瓜"
-	},
-	"cabbage": {
-		"name": "卷心菜",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "仙人掌 (可食用)"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "蔗糖"
-	},
-	"cannabis": {
-		"name": "cannabis"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "胡萝卜",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "细砂糖"
-	},
-	"castor-sugar": {
-		"name": "castor sugar"
-	},
-	"catfish": {
-		"name": "鲶鱼"
-	},
-	"cauliflower": {
-		"name": "菜花",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "芹菜"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "芝士"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "chilli pepper",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "韭菜"
-	},
-	"chocolate": {
-		"name": "巧克力"
-	},
-	"cilantro": {
-		"name": "欧芹"
-	},
-	"cinnamon": {
-		"name": "肉桂"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "椰子",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "椰奶"
-	},
-	"cod": {
-		"name": "鳕鱼"
-	},
-	"coffee": {
-		"name": "咖啡"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "香菜"
-	},
-	"corn": {
-		"name": "玉米",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "玉米糖浆"
-	},
-	"cottonseed-oil": {
-		"name": "棉花籽油"
-	},
-	"courgette": {
-		"name": "西葫芦"
-	},
-	"cream-of-tartar": {
-		"name": "塔塔酱"
-	},
-	"cucumber": {
-		"name": "黄瓜",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "孜然"
-	},
-	"daikon": {
-		"name": "白萝卜",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "奶制品和奶制品替代品"
-	},
-	"dandelion": {
-		"name": "蒲公英"
-	},
-	"demerara-sugar": {
-		"name": "德麦拉拉蔗糖"
-	},
-	"dough": {
-		"name": "面团"
-	},
-	"edible-cactus": {
-		"name": "可食用仙人掌"
-	},
-	"eggplant": {
-		"name": "茄子",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "蛋",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "脂肪"
-	},
-	"fava-beans": {
-		"name": "蚕豆"
-	},
-	"fiddlehead": {
-		"name": "蕨菜"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "鱼"
-	},
-	"five-spice-powder": {
-		"name": "五香粉"
-	},
-	"flour": {
-		"name": "面粉"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "水果"
-	},
-	"fruit-sugar": {
-		"name": "果糖"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "马萨拉咖哩粉"
-	},
-	"garlic": {
-		"name": "大蒜",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "内脏"
-	},
-	"ginger": {
-		"name": "姜"
-	},
-	"grains": {
-		"name": "谷物"
-	},
-	"granulated-sugar": {
-		"name": "白砂糖"
-	},
-	"grape-seed-oil": {
-		"name": "葡萄籽油"
-	},
-	"green-onion": {
-		"name": "小葱",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "hemp"
-	},
-	"herbs": {
-		"name": "香草"
-	},
-	"honey": {
-		"name": "蜂蜜"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "菠萝蜜",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "果酱"
-	},
-	"jellies": {
-		"name": "果冻"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "羽衣甘蓝"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "韭葱",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "豆类"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "生菜"
-	},
-	"liver": {
-		"name": "肝",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "玉米"
-	},
-	"maple-syrup": {
-		"name": "枫糖浆"
-	},
-	"meat": {
-		"name": "肉类"
-	},
-	"milk": {
-		"name": "牛奶"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "蘑菇",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "青口贝"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "海苔"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "坚果"
-	},
-	"octopuses": {
-		"name": "章鱼",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "油"
-	},
-	"okra": {
-		"name": "秋葵"
-	},
-	"olive": {
-		"name": "橄榄"
-	},
-	"olive-oil": {
-		"name": "橄榄油"
-	},
-	"onion": {
-		"name": "洋葱"
-	},
-	"onion-family": {
-		"name": "葱类"
-	},
-	"orange-blossom-water": {
-		"name": "橙花水"
-	},
-	"oranges": {
-		"name": "橙子",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "牛至"
-	},
-	"oysters": {
-		"name": "生蚝"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "红辣椒"
-	},
-	"parsley": {
-		"name": "香菜"
-	},
-	"parsnip": {
-		"name": "欧防风",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "梨",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "豌豆"
-	},
-	"pepper": {
-		"name": "胡椒",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "菠萝",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "plantain",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "罂粟籽"
-	},
-	"potato": {
-		"name": "马铃薯",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "家禽"
-	},
-	"powdered-sugar": {
-		"name": "糖粉"
-	},
-	"pumpkin": {
-		"name": "南瓜",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "南瓜籽"
-	},
-	"radish": {
-		"name": "萝卜",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "原糖"
-	},
-	"refined-sugar": {
-		"name": "精炼糖"
-	},
-	"rice": {
-		"name": "米饭"
-	},
-	"rice-flour": {
-		"name": "大米粉"
-	},
-	"rock-sugar": {
-		"name": "冰糖"
-	},
-	"rum": {
-		"name": "朗姆酒"
-	},
-	"salmon": {
-		"name": "三文鱼"
-	},
-	"salt": {
-		"name": "盐"
-	},
-	"salt-cod": {
-		"name": "腌鳕鱼"
-	},
-	"scallion": {
-		"name": "香葱",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "海鲜"
-	},
-	"seeds": {
-		"name": "种子"
-	},
-	"sesame-seeds": {
-		"name": "芝麻"
-	},
-	"shallot": {
-		"name": "红葱头",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "苏打"
-	},
-	"soda-baking": {
-		"name": "烘焙用苏打"
-	},
-	"soybean": {
-		"name": "黄豆"
-	},
-	"spaghetti-squash": {
-		"name": "南瓜意面",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "香料"
-	},
-	"spinach": {
-		"name": "菠菜"
-	},
-	"spring-onion": {
-		"name": "小葱",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "南瓜",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "南瓜属植物"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "糖"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "瓜子"
-	},
-	"superfine-sugar": {
-		"name": "特细砂糖"
-	},
-	"sweet-potato": {
-		"name": "红薯",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "甜玉米",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "甜味剂"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "芋头",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "苔麸"
-	},
-	"tomato": {
-		"name": "番茄",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "鳟鱼"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "金枪鱼"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "芜菁",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "香草"
-	},
-	"vegetables": {
-		"name": "蔬菜"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "西瓜",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "白蘑菇",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "白糖"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "酵母"
-	},
-	"zucchini": {
-		"name": "西葫芦",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "橡果南瓜"
+            },
+            "alfalfa-sprouts": {
+                "name": "紫花苜蓿芽"
+            },
+            "anchovies": {
+                "name": "凤尾鱼"
+            },
+            "apples": {
+                "name": "苹果",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "洋蓟"
+            },
+            "arugula": {
+                "name": "芝麻菜"
+            },
+            "asparagus": {
+                "name": "芦笋"
+            },
+            "avocado": {
+                "name": "牛油果",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "培根"
+            },
+            "baking-powder": {
+                "name": "发酵粉"
+            },
+            "baking-soda": {
+                "name": "烘焙用小苏打"
+            },
+            "baking-sugar": {
+                "name": "烘焙用糖"
+            },
+            "bar-sugar": {
+                "name": "bar sugar"
+            },
+            "basil": {
+                "name": "罗勒"
+            },
+            "beans": {
+                "name": "豆子"
+            },
+            "bell-peppers": {
+                "name": "甜椒",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "黑莓"
+            },
+            "bok-choy": {
+                "name": "小白菜"
+            },
+            "brassicas": {
+                "name": "甘蓝"
+            },
+            "bread": {
+                "name": "面包"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "西蓝花"
+            },
+            "broccoli": {
+                "name": "西兰花"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "broccolini"
+            },
+            "brown-sugar": {
+                "name": "红糖"
+            },
+            "brussels-sprouts": {
+                "name": "抱子甘蓝"
+            },
+            "butter": {
+                "name": "黄油"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "奶油南瓜"
+            },
+            "cabbage": {
+                "name": "卷心菜",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "仙人掌 (可食用)"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "蔗糖"
+            },
+            "cannabis": {
+                "name": "cannabis"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "胡萝卜",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "细砂糖"
+            },
+            "castor-sugar": {
+                "name": "castor sugar"
+            },
+            "catfish": {
+                "name": "鲶鱼"
+            },
+            "cauliflower": {
+                "name": "菜花",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "芹菜"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "芝士"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "chilli pepper",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "韭菜"
+            },
+            "chocolate": {
+                "name": "巧克力"
+            },
+            "cilantro": {
+                "name": "欧芹"
+            },
+            "cinnamon": {
+                "name": "肉桂"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "椰子",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "椰奶"
+            },
+            "cod": {
+                "name": "鳕鱼"
+            },
+            "coffee": {
+                "name": "咖啡"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "香菜"
+            },
+            "corn": {
+                "name": "玉米",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "玉米糖浆"
+            },
+            "cottonseed-oil": {
+                "name": "棉花籽油"
+            },
+            "courgette": {
+                "name": "西葫芦"
+            },
+            "cream-of-tartar": {
+                "name": "塔塔酱"
+            },
+            "cucumber": {
+                "name": "黄瓜",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "孜然"
+            },
+            "daikon": {
+                "name": "白萝卜",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "奶制品和奶制品替代品"
+            },
+            "dandelion": {
+                "name": "蒲公英"
+            },
+            "demerara-sugar": {
+                "name": "德麦拉拉蔗糖"
+            },
+            "dough": {
+                "name": "面团"
+            },
+            "edible-cactus": {
+                "name": "可食用仙人掌"
+            },
+            "eggplant": {
+                "name": "茄子",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "蛋",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "脂肪"
+            },
+            "fava-beans": {
+                "name": "蚕豆"
+            },
+            "fiddlehead": {
+                "name": "蕨菜"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "鱼"
+            },
+            "five-spice-powder": {
+                "name": "五香粉"
+            },
+            "flour": {
+                "name": "面粉"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "水果"
+            },
+            "fruit-sugar": {
+                "name": "果糖"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "马萨拉咖哩粉"
+            },
+            "garlic": {
+                "name": "大蒜",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "内脏"
+            },
+            "ginger": {
+                "name": "姜"
+            },
+            "grains": {
+                "name": "谷物"
+            },
+            "granulated-sugar": {
+                "name": "白砂糖"
+            },
+            "grape-seed-oil": {
+                "name": "葡萄籽油"
+            },
+            "green-onion": {
+                "name": "小葱",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "hemp"
+            },
+            "herbs": {
+                "name": "香草"
+            },
+            "honey": {
+                "name": "蜂蜜"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "菠萝蜜",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "果酱"
+            },
+            "jellies": {
+                "name": "果冻"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "羽衣甘蓝"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "韭葱",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "豆类"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "生菜"
+            },
+            "liver": {
+                "name": "肝",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "玉米"
+            },
+            "maple-syrup": {
+                "name": "枫糖浆"
+            },
+            "meat": {
+                "name": "肉类"
+            },
+            "milk": {
+                "name": "牛奶"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "蘑菇",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "青口贝"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "海苔"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "坚果"
+            },
+            "octopuses": {
+                "name": "章鱼",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "油"
+            },
+            "okra": {
+                "name": "秋葵"
+            },
+            "olive": {
+                "name": "橄榄"
+            },
+            "olive-oil": {
+                "name": "橄榄油"
+            },
+            "onion": {
+                "name": "洋葱"
+            },
+            "onion-family": {
+                "name": "葱类"
+            },
+            "orange-blossom-water": {
+                "name": "橙花水"
+            },
+            "oranges": {
+                "name": "橙子",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "牛至"
+            },
+            "oysters": {
+                "name": "生蚝"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "红辣椒"
+            },
+            "parsley": {
+                "name": "香菜"
+            },
+            "parsnip": {
+                "name": "欧防风",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "梨",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "豌豆"
+            },
+            "pepper": {
+                "name": "胡椒",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "菠萝",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "plantain",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "罂粟籽"
+            },
+            "potato": {
+                "name": "马铃薯",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "家禽"
+            },
+            "powdered-sugar": {
+                "name": "糖粉"
+            },
+            "pumpkin": {
+                "name": "南瓜",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "南瓜籽"
+            },
+            "radish": {
+                "name": "萝卜",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "原糖"
+            },
+            "refined-sugar": {
+                "name": "精炼糖"
+            },
+            "rice": {
+                "name": "米饭"
+            },
+            "rice-flour": {
+                "name": "大米粉"
+            },
+            "rock-sugar": {
+                "name": "冰糖"
+            },
+            "rum": {
+                "name": "朗姆酒"
+            },
+            "salmon": {
+                "name": "三文鱼"
+            },
+            "salt": {
+                "name": "盐"
+            },
+            "salt-cod": {
+                "name": "腌鳕鱼"
+            },
+            "scallion": {
+                "name": "香葱",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "海鲜"
+            },
+            "seeds": {
+                "name": "种子"
+            },
+            "sesame-seeds": {
+                "name": "芝麻"
+            },
+            "shallot": {
+                "name": "红葱头",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "苏打"
+            },
+            "soda-baking": {
+                "name": "烘焙用苏打"
+            },
+            "soybean": {
+                "name": "黄豆"
+            },
+            "spaghetti-squash": {
+                "name": "南瓜意面",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "香料"
+            },
+            "spinach": {
+                "name": "菠菜"
+            },
+            "spring-onion": {
+                "name": "小葱",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "南瓜",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "南瓜属植物"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "糖"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "瓜子"
+            },
+            "superfine-sugar": {
+                "name": "特细砂糖"
+            },
+            "sweet-potato": {
+                "name": "红薯",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "甜玉米",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "甜味剂"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "芋头",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "苔麸"
+            },
+            "tomato": {
+                "name": "番茄",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "鳟鱼"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "金枪鱼"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "芜菁",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "香草"
+            },
+            "vegetables": {
+                "name": "蔬菜"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "西瓜",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "白蘑菇",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "白糖"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "酵母"
+            },
+            "zucchini": {
+                "name": "西葫芦",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "农产品": {
+        "foods": {}
+    },
+    "谷物": {
+        "foods": {}
+    },
+    "水果": {
+        "foods": {}
+    },
+    "蔬菜": {
+        "foods": {}
+    },
+    "肉类": {
+        "foods": {}
+    },
+    "海鲜": {
+        "foods": {}
+    },
+    "饮料": {
+        "foods": {}
+    },
+    "烘焙食品": {
+        "foods": {}
+    },
+    "罐头食品": {
+        "foods": {}
+    },
+    "调味品": {
+        "foods": {}
+    },
+    "糖果类": {
+        "foods": {}
+    },
+    "乳制品": {
+        "foods": {}
+    },
+    "冷冻食品": {
+        "foods": {}
+    },
+    "健康食品": {
+        "foods": {}
+    },
+    "家庭": {
+        "foods": {}
+    },
+    "肉制品": {
+        "foods": {}
+    },
+    "零食": {
+        "foods": {}
+    },
+    "甜食": {
+        "foods": {}
+    },
+    "酒类": {
+        "foods": {}
+    },
+    "其它": {
+        "foods": {}
+    }
 }

--- a/mealie/repos/seed/resources/foods/locales/zh-TW.json
+++ b/mealie/repos/seed/resources/foods/locales/zh-TW.json
@@ -1,692 +1,759 @@
 {
-	"acorn-squash": {
-		"name": "acorn squash"
-	},
-	"alfalfa-sprouts": {
-		"name": "alfalfa sprouts"
-	},
-	"anchovies": {
-		"name": "鯷魚"
-	},
-	"apples": {
-		"name": "蘋果",
-		"plural_name": "apples"
-	},
-	"artichoke": {
-		"name": "菜薊"
-	},
-	"arugula": {
-		"name": "arugula"
-	},
-	"asparagus": {
-		"name": "蘆筍"
-	},
-	"avocado": {
-		"name": "酪梨",
-		"plural_name": "avocado"
-	},
-	"bacon": {
-		"name": "培根"
-	},
-	"baking-powder": {
-		"name": "baking powder"
-	},
-	"baking-soda": {
-		"name": "小蘇打粉"
-	},
-	"baking-sugar": {
-		"name": "烘焙糖"
-	},
-	"bar-sugar": {
-		"name": "方糖"
-	},
-	"basil": {
-		"name": "羅勒"
-	},
-	"beans": {
-		"name": "豆子"
-	},
-	"bell-peppers": {
-		"name": "甜椒",
-		"plural_name": "bell peppers"
-	},
-	"blackberries": {
-		"name": "黑莓"
-	},
-	"bok-choy": {
-		"name": "青江菜"
-	},
-	"brassicas": {
-		"name": "brassicas"
-	},
-	"bread": {
-		"name": "麵包"
-	},
-	"breadfruit": {
-		"name": "breadfruit"
-	},
-	"broccoflower": {
-		"name": "broccoflower"
-	},
-	"broccoli": {
-		"name": "花椰菜"
-	},
-	"broccoli-rabe": {
-		"name": "broccoli rabe"
-	},
-	"broccolini": {
-		"name": "綠色花椰菜"
-	},
-	"brown-sugar": {
-		"name": "紅糖"
-	},
-	"brussels-sprouts": {
-		"name": "球芽甘藍"
-	},
-	"butter": {
-		"name": "奶油"
-	},
-	"butternut-pumpkin": {
-		"name": "butternut pumpkin"
-	},
-	"butternut-squash": {
-		"name": "butternut squash"
-	},
-	"cabbage": {
-		"name": "高麗菜",
-		"plural_name": "cabbages"
-	},
-	"cactus-edible": {
-		"name": "cactus, edible"
-	},
-	"calabrese": {
-		"name": "calabrese"
-	},
-	"cane-sugar": {
-		"name": "蔗糖"
-	},
-	"cannabis": {
-		"name": "大麻"
-	},
-	"capsicum": {
-		"name": "capsicum"
-	},
-	"caraway": {
-		"name": "caraway"
-	},
-	"carrot": {
-		"name": "胡蘿蔔",
-		"plural_name": "carrots"
-	},
-	"caster-sugar": {
-		"name": "caster sugar"
-	},
-	"castor-sugar": {
-		"name": "細砂白糖"
-	},
-	"catfish": {
-		"name": "鯰魚"
-	},
-	"cauliflower": {
-		"name": "白花菜",
-		"plural_name": "cauliflowers"
-	},
-	"cayenne-pepper": {
-		"name": "cayenne pepper"
-	},
-	"celeriac": {
-		"name": "celery root"
-	},
-	"celery": {
-		"name": "西芹"
-	},
-	"cereal-grains": {
-		"name": "cereal grains"
-	},
-	"chard": {
-		"name": "chard"
-	},
-	"cheese": {
-		"name": "起司"
-	},
-	"chicory": {
-		"name": "chicory"
-	},
-	"chilli-peppers": {
-		"name": "辣椒",
-		"plural_name": "chilli peppers"
-	},
-	"chinese-leaves": {
-		"name": "chinese leaves"
-	},
-	"chives": {
-		"name": "chives"
-	},
-	"chocolate": {
-		"name": "巧克力"
-	},
-	"cilantro": {
-		"name": "香菜"
-	},
-	"cinnamon": {
-		"name": "肉桂"
-	},
-	"clarified-butter": {
-		"name": "clarified butter"
-	},
-	"coconut": {
-		"name": "椰子",
-		"plural_name": "coconuts"
-	},
-	"coconut-milk": {
-		"name": "椰奶"
-	},
-	"cod": {
-		"name": "鱈魚"
-	},
-	"coffee": {
-		"name": "咖啡"
-	},
-	"collard-greens": {
-		"name": "collard greens"
-	},
-	"confectioners-sugar": {
-		"name": "confectioners' sugar"
-	},
-	"coriander": {
-		"name": "香菜"
-	},
-	"corn": {
-		"name": "玉米",
-		"plural_name": "corns"
-	},
-	"corn-syrup": {
-		"name": "玉米糖漿"
-	},
-	"cottonseed-oil": {
-		"name": "棉籽油"
-	},
-	"courgette": {
-		"name": "courgette"
-	},
-	"cream-of-tartar": {
-		"name": "cream of tartar"
-	},
-	"cucumber": {
-		"name": "黃瓜",
-		"plural_name": "cucumbers"
-	},
-	"cumin": {
-		"name": "孜然"
-	},
-	"daikon": {
-		"name": "白蘿蔔",
-		"plural_name": "daikons"
-	},
-	"dairy-products-and-dairy-substitutes": {
-		"name": "dairy products and dairy substitutes"
-	},
-	"dandelion": {
-		"name": "蒲公英"
-	},
-	"demerara-sugar": {
-		"name": "demerara sugar"
-	},
-	"dough": {
-		"name": "麵團"
-	},
-	"edible-cactus": {
-		"name": "edible cactus"
-	},
-	"eggplant": {
-		"name": "茄子",
-		"plural_name": "eggplants"
-	},
-	"eggs": {
-		"name": "蛋",
-		"plural_name": "eggs"
-	},
-	"endive": {
-		"name": "endive",
-		"plural_name": "endives"
-	},
-	"fats": {
-		"name": "脂肪"
-	},
-	"fava-beans": {
-		"name": "fava beans"
-	},
-	"fiddlehead": {
-		"name": "fiddlehead"
-	},
-	"fiddlehead-fern": {
-		"name": "fiddlehead fern",
-		"plural_name": "fiddlehead ferns"
-	},
-	"fish": {
-		"name": "魚"
-	},
-	"five-spice-powder": {
-		"name": "五香粉"
-	},
-	"flour": {
-		"name": "麵粉"
-	},
-	"frisee": {
-		"name": "frisee"
-	},
-	"fructose": {
-		"name": "fructose"
-	},
-	"fruit": {
-		"name": "水果"
-	},
-	"fruit-sugar": {
-		"name": "果糖"
-	},
-	"ful": {
-		"name": "ful"
-	},
-	"garam-masala": {
-		"name": "garam masala"
-	},
-	"garlic": {
-		"name": "大蒜",
-		"plural_name": "garlics"
-	},
-	"gem-squash": {
-		"name": "gem squash"
-	},
-	"ghee": {
-		"name": "ghee"
-	},
-	"giblets": {
-		"name": "內臟"
-	},
-	"ginger": {
-		"name": "薑"
-	},
-	"grains": {
-		"name": "穀物"
-	},
-	"granulated-sugar": {
-		"name": "granulated sugar"
-	},
-	"grape-seed-oil": {
-		"name": "葡萄籽油"
-	},
-	"green-onion": {
-		"name": "蔥",
-		"plural_name": "green onions"
-	},
-	"heart-of-palm": {
-		"name": "heart of palm",
-		"plural_name": "heart of palms"
-	},
-	"hemp": {
-		"name": "大麻"
-	},
-	"herbs": {
-		"name": "herbs"
-	},
-	"honey": {
-		"name": "蜂蜜"
-	},
-	"isomalt": {
-		"name": "isomalt"
-	},
-	"jackfruit": {
-		"name": "菠蘿蜜",
-		"plural_name": "jackfruits"
-	},
-	"jaggery": {
-		"name": "jaggery"
-	},
-	"jams": {
-		"name": "果醬"
-	},
-	"jellies": {
-		"name": "果凍"
-	},
-	"jerusalem-artichoke": {
-		"name": "jerusalem artichoke"
-	},
-	"jicama": {
-		"name": "jicama"
-	},
-	"kale": {
-		"name": "kale"
-	},
-	"kohlrabi": {
-		"name": "kohlrabi"
-	},
-	"kumara": {
-		"name": "kumara"
-	},
-	"leavening-agents": {
-		"name": "leavening agents"
-	},
-	"leek": {
-		"name": "leek",
-		"plural_name": "leeks"
-	},
-	"legumes": {
-		"name": "legumes"
-	},
-	"lemongrass": {
-		"name": "lemongrass"
-	},
-	"lentils": {
-		"name": "lentils"
-	},
-	"lettuce": {
-		"name": "萵苣"
-	},
-	"liver": {
-		"name": "肝臟",
-		"plural_name": "livers"
-	},
-	"maize": {
-		"name": "maize"
-	},
-	"maple-syrup": {
-		"name": "楓糖漿"
-	},
-	"meat": {
-		"name": "肉類"
-	},
-	"milk": {
-		"name": "牛奶"
-	},
-	"mortadella": {
-		"name": "mortadella"
-	},
-	"mushroom": {
-		"name": "蘑菇",
-		"plural_name": "mushrooms"
-	},
-	"mussels": {
-		"name": "淡菜"
-	},
-	"nanaimo-bar-mix": {
-		"name": "nanaimo bar mix"
-	},
-	"nori": {
-		"name": "nori"
-	},
-	"nutmeg": {
-		"name": "nutmeg"
-	},
-	"nutritional-yeast-flakes": {
-		"name": "nutritional yeast flakes"
-	},
-	"nuts": {
-		"name": "堅果"
-	},
-	"octopuses": {
-		"name": "章魚",
-		"plural_name": "octopuses"
-	},
-	"oils": {
-		"name": "油"
-	},
-	"okra": {
-		"name": "秋葵"
-	},
-	"olive": {
-		"name": "橄欖"
-	},
-	"olive-oil": {
-		"name": "橄欖油"
-	},
-	"onion": {
-		"name": "洋葱"
-	},
-	"onion-family": {
-		"name": "onion family"
-	},
-	"orange-blossom-water": {
-		"name": "orange blossom water"
-	},
-	"oranges": {
-		"name": "橙",
-		"plural_name": "oranges"
-	},
-	"oregano": {
-		"name": "oregano"
-	},
-	"oysters": {
-		"name": "牡蠣"
-	},
-	"panch-puran": {
-		"name": "panch puran"
-	},
-	"paprika": {
-		"name": "paprika"
-	},
-	"parsley": {
-		"name": "香芹"
-	},
-	"parsnip": {
-		"name": "parsnip",
-		"plural_name": "parsnips"
-	},
-	"pear": {
-		"name": "梨子",
-		"plural_name": "pears"
-	},
-	"peas": {
-		"name": "peas"
-	},
-	"pepper": {
-		"name": "胡椒",
-		"plural_name": "peppers"
-	},
-	"pineapple": {
-		"name": "鳳梨",
-		"plural_name": "pineapples"
-	},
-	"plantain": {
-		"name": "芭蕉",
-		"plural_name": "plantains"
-	},
-	"poppy-seeds": {
-		"name": "罌粟子"
-	},
-	"potato": {
-		"name": "馬鈴薯",
-		"plural_name": "potatoes"
-	},
-	"poultry": {
-		"name": "家禽"
-	},
-	"powdered-sugar": {
-		"name": "糖粉"
-	},
-	"pumpkin": {
-		"name": "南瓜",
-		"plural_name": "pumpkins"
-	},
-	"pumpkin-seeds": {
-		"name": "南瓜子"
-	},
-	"radish": {
-		"name": "蘿蔔",
-		"plural_name": "radishes"
-	},
-	"raw-sugar": {
-		"name": "粗糖"
-	},
-	"refined-sugar": {
-		"name": "精糖"
-	},
-	"rice": {
-		"name": "米飯"
-	},
-	"rice-flour": {
-		"name": "米粉"
-	},
-	"rock-sugar": {
-		"name": "rock sugar"
-	},
-	"rum": {
-		"name": "萊姆酒"
-	},
-	"salmon": {
-		"name": "鮭魚"
-	},
-	"salt": {
-		"name": "鹽"
-	},
-	"salt-cod": {
-		"name": "salt cod"
-	},
-	"scallion": {
-		"name": "青蔥",
-		"plural_name": "scallions"
-	},
-	"seafood": {
-		"name": "海鮮"
-	},
-	"seeds": {
-		"name": "種子"
-	},
-	"sesame-seeds": {
-		"name": "芝麻"
-	},
-	"shallot": {
-		"name": "紅蔥頭",
-		"plural_name": "shallots"
-	},
-	"skate": {
-		"name": "skate"
-	},
-	"soda": {
-		"name": "汽水"
-	},
-	"soda-baking": {
-		"name": "小蘇打粉"
-	},
-	"soybean": {
-		"name": "黃豆"
-	},
-	"spaghetti-squash": {
-		"name": "spaghetti squash",
-		"plural_name": "spaghetti squashes"
-	},
-	"speck": {
-		"name": "speck"
-	},
-	"spices": {
-		"name": "香料"
-	},
-	"spinach": {
-		"name": "菠菜"
-	},
-	"spring-onion": {
-		"name": "spring onion",
-		"plural_name": "spring onions"
-	},
-	"squash": {
-		"name": "squash",
-		"plural_name": "squashes"
-	},
-	"squash-family": {
-		"name": "squash family"
-	},
-	"stockfish": {
-		"name": "stockfish"
-	},
-	"sugar": {
-		"name": "糖"
-	},
-	"sunchoke": {
-		"name": "sunchoke",
-		"plural_name": "sunchokes"
-	},
-	"sunflower-seeds": {
-		"name": "瓜子"
-	},
-	"superfine-sugar": {
-		"name": "superfine sugar"
-	},
-	"sweet-potato": {
-		"name": "地瓜",
-		"plural_name": "sweet potatoes"
-	},
-	"sweetcorn": {
-		"name": "甜玉米",
-		"plural_name": "sweetcorns"
-	},
-	"sweeteners": {
-		"name": "sweeteners"
-	},
-	"tahini": {
-		"name": "tahini"
-	},
-	"taro": {
-		"name": "芋頭",
-		"plural_name": "taroes"
-	},
-	"teff": {
-		"name": "teff"
-	},
-	"tomato": {
-		"name": "蕃茄",
-		"plural_name": "tomatoes"
-	},
-	"trout": {
-		"name": "鱒魚"
-	},
-	"tubers": {
-		"name": "tuber",
-		"plural_name": "tubers"
-	},
-	"tuna": {
-		"name": "鮪魚"
-	},
-	"turbanado-sugar": {
-		"name": "turbanado sugar"
-	},
-	"turnip": {
-		"name": "turnip",
-		"plural_name": "turnips"
-	},
-	"unrefined-sugar": {
-		"name": "unrefined sugar"
-	},
-	"vanilla": {
-		"name": "香草"
-	},
-	"vegetables": {
-		"name": "蔬菜"
-	},
-	"watercress": {
-		"name": "watercress"
-	},
-	"watermelon": {
-		"name": "西瓜",
-		"plural_name": "watermelons"
-	},
-	"white-mushroom": {
-		"name": "白蘑菇",
-		"plural_name": "white mushrooms"
-	},
-	"white-sugar": {
-		"name": "白糖"
-	},
-	"xanthan-gum": {
-		"name": "xanthan gum"
-	},
-	"yam": {
-		"name": "yam",
-		"plural_name": "yams"
-	},
-	"yeast": {
-		"name": "酵母"
-	},
-	"zucchini": {
-		"name": "zucchini",
-		"plural_name": "zucchinis"
-	}
+    "": {
+        "foods": {
+            "acorn-squash": {
+                "name": "acorn squash"
+            },
+            "alfalfa-sprouts": {
+                "name": "alfalfa sprouts"
+            },
+            "anchovies": {
+                "name": "鯷魚"
+            },
+            "apples": {
+                "name": "蘋果",
+                "plural_name": "apples"
+            },
+            "artichoke": {
+                "name": "菜薊"
+            },
+            "arugula": {
+                "name": "arugula"
+            },
+            "asparagus": {
+                "name": "蘆筍"
+            },
+            "avocado": {
+                "name": "酪梨",
+                "plural_name": "avocado"
+            },
+            "bacon": {
+                "name": "培根"
+            },
+            "baking-powder": {
+                "name": "baking powder"
+            },
+            "baking-soda": {
+                "name": "小蘇打粉"
+            },
+            "baking-sugar": {
+                "name": "烘焙糖"
+            },
+            "bar-sugar": {
+                "name": "方糖"
+            },
+            "basil": {
+                "name": "羅勒"
+            },
+            "beans": {
+                "name": "豆子"
+            },
+            "bell-peppers": {
+                "name": "甜椒",
+                "plural_name": "bell peppers"
+            },
+            "blackberries": {
+                "name": "黑莓"
+            },
+            "bok-choy": {
+                "name": "青江菜"
+            },
+            "brassicas": {
+                "name": "brassicas"
+            },
+            "bread": {
+                "name": "麵包"
+            },
+            "breadfruit": {
+                "name": "breadfruit"
+            },
+            "broccoflower": {
+                "name": "broccoflower"
+            },
+            "broccoli": {
+                "name": "花椰菜"
+            },
+            "broccoli-rabe": {
+                "name": "broccoli rabe"
+            },
+            "broccolini": {
+                "name": "綠色花椰菜"
+            },
+            "brown-sugar": {
+                "name": "紅糖"
+            },
+            "brussels-sprouts": {
+                "name": "球芽甘藍"
+            },
+            "butter": {
+                "name": "奶油"
+            },
+            "butternut-pumpkin": {
+                "name": "butternut pumpkin"
+            },
+            "butternut-squash": {
+                "name": "butternut squash"
+            },
+            "cabbage": {
+                "name": "高麗菜",
+                "plural_name": "cabbages"
+            },
+            "cactus-edible": {
+                "name": "cactus, edible"
+            },
+            "calabrese": {
+                "name": "calabrese"
+            },
+            "cane-sugar": {
+                "name": "蔗糖"
+            },
+            "cannabis": {
+                "name": "大麻"
+            },
+            "capsicum": {
+                "name": "capsicum"
+            },
+            "caraway": {
+                "name": "caraway"
+            },
+            "carrot": {
+                "name": "胡蘿蔔",
+                "plural_name": "carrots"
+            },
+            "caster-sugar": {
+                "name": "caster sugar"
+            },
+            "castor-sugar": {
+                "name": "細砂白糖"
+            },
+            "catfish": {
+                "name": "鯰魚"
+            },
+            "cauliflower": {
+                "name": "白花菜",
+                "plural_name": "cauliflowers"
+            },
+            "cayenne-pepper": {
+                "name": "cayenne pepper"
+            },
+            "celeriac": {
+                "name": "celery root"
+            },
+            "celery": {
+                "name": "西芹"
+            },
+            "cereal-grains": {
+                "name": "cereal grains"
+            },
+            "chard": {
+                "name": "chard"
+            },
+            "cheese": {
+                "name": "起司"
+            },
+            "chicory": {
+                "name": "chicory"
+            },
+            "chilli-peppers": {
+                "name": "辣椒",
+                "plural_name": "chilli peppers"
+            },
+            "chinese-leaves": {
+                "name": "chinese leaves"
+            },
+            "chives": {
+                "name": "chives"
+            },
+            "chocolate": {
+                "name": "巧克力"
+            },
+            "cilantro": {
+                "name": "香菜"
+            },
+            "cinnamon": {
+                "name": "肉桂"
+            },
+            "clarified-butter": {
+                "name": "clarified butter"
+            },
+            "coconut": {
+                "name": "椰子",
+                "plural_name": "coconuts"
+            },
+            "coconut-milk": {
+                "name": "椰奶"
+            },
+            "cod": {
+                "name": "鱈魚"
+            },
+            "coffee": {
+                "name": "咖啡"
+            },
+            "collard-greens": {
+                "name": "collard greens"
+            },
+            "confectioners-sugar": {
+                "name": "confectioners' sugar"
+            },
+            "coriander": {
+                "name": "香菜"
+            },
+            "corn": {
+                "name": "玉米",
+                "plural_name": "corns"
+            },
+            "corn-syrup": {
+                "name": "玉米糖漿"
+            },
+            "cottonseed-oil": {
+                "name": "棉籽油"
+            },
+            "courgette": {
+                "name": "courgette"
+            },
+            "cream-of-tartar": {
+                "name": "cream of tartar"
+            },
+            "cucumber": {
+                "name": "黃瓜",
+                "plural_name": "cucumbers"
+            },
+            "cumin": {
+                "name": "孜然"
+            },
+            "daikon": {
+                "name": "白蘿蔔",
+                "plural_name": "daikons"
+            },
+            "dairy-products-and-dairy-substitutes": {
+                "name": "dairy products and dairy substitutes"
+            },
+            "dandelion": {
+                "name": "蒲公英"
+            },
+            "demerara-sugar": {
+                "name": "demerara sugar"
+            },
+            "dough": {
+                "name": "麵團"
+            },
+            "edible-cactus": {
+                "name": "edible cactus"
+            },
+            "eggplant": {
+                "name": "茄子",
+                "plural_name": "eggplants"
+            },
+            "eggs": {
+                "name": "蛋",
+                "plural_name": "eggs"
+            },
+            "endive": {
+                "name": "endive",
+                "plural_name": "endives"
+            },
+            "fats": {
+                "name": "脂肪"
+            },
+            "fava-beans": {
+                "name": "fava beans"
+            },
+            "fiddlehead": {
+                "name": "fiddlehead"
+            },
+            "fiddlehead-fern": {
+                "name": "fiddlehead fern",
+                "plural_name": "fiddlehead ferns"
+            },
+            "fish": {
+                "name": "魚"
+            },
+            "five-spice-powder": {
+                "name": "五香粉"
+            },
+            "flour": {
+                "name": "麵粉"
+            },
+            "frisee": {
+                "name": "frisee"
+            },
+            "fructose": {
+                "name": "fructose"
+            },
+            "fruit": {
+                "name": "水果"
+            },
+            "fruit-sugar": {
+                "name": "果糖"
+            },
+            "ful": {
+                "name": "ful"
+            },
+            "garam-masala": {
+                "name": "garam masala"
+            },
+            "garlic": {
+                "name": "大蒜",
+                "plural_name": "garlics"
+            },
+            "gem-squash": {
+                "name": "gem squash"
+            },
+            "ghee": {
+                "name": "ghee"
+            },
+            "giblets": {
+                "name": "內臟"
+            },
+            "ginger": {
+                "name": "薑"
+            },
+            "grains": {
+                "name": "穀物"
+            },
+            "granulated-sugar": {
+                "name": "granulated sugar"
+            },
+            "grape-seed-oil": {
+                "name": "葡萄籽油"
+            },
+            "green-onion": {
+                "name": "蔥",
+                "plural_name": "green onions"
+            },
+            "heart-of-palm": {
+                "name": "heart of palm",
+                "plural_name": "heart of palms"
+            },
+            "hemp": {
+                "name": "大麻"
+            },
+            "herbs": {
+                "name": "herbs"
+            },
+            "honey": {
+                "name": "蜂蜜"
+            },
+            "isomalt": {
+                "name": "isomalt"
+            },
+            "jackfruit": {
+                "name": "菠蘿蜜",
+                "plural_name": "jackfruits"
+            },
+            "jaggery": {
+                "name": "jaggery"
+            },
+            "jams": {
+                "name": "果醬"
+            },
+            "jellies": {
+                "name": "果凍"
+            },
+            "jerusalem-artichoke": {
+                "name": "jerusalem artichoke"
+            },
+            "jicama": {
+                "name": "jicama"
+            },
+            "kale": {
+                "name": "kale"
+            },
+            "kohlrabi": {
+                "name": "kohlrabi"
+            },
+            "kumara": {
+                "name": "kumara"
+            },
+            "leavening-agents": {
+                "name": "leavening agents"
+            },
+            "leek": {
+                "name": "leek",
+                "plural_name": "leeks"
+            },
+            "legumes": {
+                "name": "legumes"
+            },
+            "lemongrass": {
+                "name": "lemongrass"
+            },
+            "lentils": {
+                "name": "lentils"
+            },
+            "lettuce": {
+                "name": "萵苣"
+            },
+            "liver": {
+                "name": "肝臟",
+                "plural_name": "livers"
+            },
+            "maize": {
+                "name": "maize"
+            },
+            "maple-syrup": {
+                "name": "楓糖漿"
+            },
+            "meat": {
+                "name": "肉類"
+            },
+            "milk": {
+                "name": "牛奶"
+            },
+            "mortadella": {
+                "name": "mortadella"
+            },
+            "mushroom": {
+                "name": "蘑菇",
+                "plural_name": "mushrooms"
+            },
+            "mussels": {
+                "name": "淡菜"
+            },
+            "nanaimo-bar-mix": {
+                "name": "nanaimo bar mix"
+            },
+            "nori": {
+                "name": "nori"
+            },
+            "nutmeg": {
+                "name": "nutmeg"
+            },
+            "nutritional-yeast-flakes": {
+                "name": "nutritional yeast flakes"
+            },
+            "nuts": {
+                "name": "堅果"
+            },
+            "octopuses": {
+                "name": "章魚",
+                "plural_name": "octopuses"
+            },
+            "oils": {
+                "name": "油"
+            },
+            "okra": {
+                "name": "秋葵"
+            },
+            "olive": {
+                "name": "橄欖"
+            },
+            "olive-oil": {
+                "name": "橄欖油"
+            },
+            "onion": {
+                "name": "洋葱"
+            },
+            "onion-family": {
+                "name": "onion family"
+            },
+            "orange-blossom-water": {
+                "name": "orange blossom water"
+            },
+            "oranges": {
+                "name": "橙",
+                "plural_name": "oranges"
+            },
+            "oregano": {
+                "name": "oregano"
+            },
+            "oysters": {
+                "name": "牡蠣"
+            },
+            "panch-puran": {
+                "name": "panch puran"
+            },
+            "paprika": {
+                "name": "paprika"
+            },
+            "parsley": {
+                "name": "香芹"
+            },
+            "parsnip": {
+                "name": "parsnip",
+                "plural_name": "parsnips"
+            },
+            "pear": {
+                "name": "梨子",
+                "plural_name": "pears"
+            },
+            "peas": {
+                "name": "peas"
+            },
+            "pepper": {
+                "name": "胡椒",
+                "plural_name": "peppers"
+            },
+            "pineapple": {
+                "name": "鳳梨",
+                "plural_name": "pineapples"
+            },
+            "plantain": {
+                "name": "芭蕉",
+                "plural_name": "plantains"
+            },
+            "poppy-seeds": {
+                "name": "罌粟子"
+            },
+            "potato": {
+                "name": "馬鈴薯",
+                "plural_name": "potatoes"
+            },
+            "poultry": {
+                "name": "家禽"
+            },
+            "powdered-sugar": {
+                "name": "糖粉"
+            },
+            "pumpkin": {
+                "name": "南瓜",
+                "plural_name": "pumpkins"
+            },
+            "pumpkin-seeds": {
+                "name": "南瓜子"
+            },
+            "radish": {
+                "name": "蘿蔔",
+                "plural_name": "radishes"
+            },
+            "raw-sugar": {
+                "name": "粗糖"
+            },
+            "refined-sugar": {
+                "name": "精糖"
+            },
+            "rice": {
+                "name": "米飯"
+            },
+            "rice-flour": {
+                "name": "米粉"
+            },
+            "rock-sugar": {
+                "name": "rock sugar"
+            },
+            "rum": {
+                "name": "萊姆酒"
+            },
+            "salmon": {
+                "name": "鮭魚"
+            },
+            "salt": {
+                "name": "鹽"
+            },
+            "salt-cod": {
+                "name": "salt cod"
+            },
+            "scallion": {
+                "name": "青蔥",
+                "plural_name": "scallions"
+            },
+            "seafood": {
+                "name": "海鮮"
+            },
+            "seeds": {
+                "name": "種子"
+            },
+            "sesame-seeds": {
+                "name": "芝麻"
+            },
+            "shallot": {
+                "name": "紅蔥頭",
+                "plural_name": "shallots"
+            },
+            "skate": {
+                "name": "skate"
+            },
+            "soda": {
+                "name": "汽水"
+            },
+            "soda-baking": {
+                "name": "小蘇打粉"
+            },
+            "soybean": {
+                "name": "黃豆"
+            },
+            "spaghetti-squash": {
+                "name": "spaghetti squash",
+                "plural_name": "spaghetti squashes"
+            },
+            "speck": {
+                "name": "speck"
+            },
+            "spices": {
+                "name": "香料"
+            },
+            "spinach": {
+                "name": "菠菜"
+            },
+            "spring-onion": {
+                "name": "spring onion",
+                "plural_name": "spring onions"
+            },
+            "squash": {
+                "name": "squash",
+                "plural_name": "squashes"
+            },
+            "squash-family": {
+                "name": "squash family"
+            },
+            "stockfish": {
+                "name": "stockfish"
+            },
+            "sugar": {
+                "name": "糖"
+            },
+            "sunchoke": {
+                "name": "sunchoke",
+                "plural_name": "sunchokes"
+            },
+            "sunflower-seeds": {
+                "name": "瓜子"
+            },
+            "superfine-sugar": {
+                "name": "superfine sugar"
+            },
+            "sweet-potato": {
+                "name": "地瓜",
+                "plural_name": "sweet potatoes"
+            },
+            "sweetcorn": {
+                "name": "甜玉米",
+                "plural_name": "sweetcorns"
+            },
+            "sweeteners": {
+                "name": "sweeteners"
+            },
+            "tahini": {
+                "name": "tahini"
+            },
+            "taro": {
+                "name": "芋頭",
+                "plural_name": "taroes"
+            },
+            "teff": {
+                "name": "teff"
+            },
+            "tomato": {
+                "name": "蕃茄",
+                "plural_name": "tomatoes"
+            },
+            "trout": {
+                "name": "鱒魚"
+            },
+            "tubers": {
+                "name": "tuber",
+                "plural_name": "tubers"
+            },
+            "tuna": {
+                "name": "鮪魚"
+            },
+            "turbanado-sugar": {
+                "name": "turbanado sugar"
+            },
+            "turnip": {
+                "name": "turnip",
+                "plural_name": "turnips"
+            },
+            "unrefined-sugar": {
+                "name": "unrefined sugar"
+            },
+            "vanilla": {
+                "name": "香草"
+            },
+            "vegetables": {
+                "name": "蔬菜"
+            },
+            "watercress": {
+                "name": "watercress"
+            },
+            "watermelon": {
+                "name": "西瓜",
+                "plural_name": "watermelons"
+            },
+            "white-mushroom": {
+                "name": "白蘑菇",
+                "plural_name": "white mushrooms"
+            },
+            "white-sugar": {
+                "name": "白糖"
+            },
+            "xanthan-gum": {
+                "name": "xanthan gum"
+            },
+            "yam": {
+                "name": "yam",
+                "plural_name": "yams"
+            },
+            "yeast": {
+                "name": "酵母"
+            },
+            "zucchini": {
+                "name": "zucchini",
+                "plural_name": "zucchinis"
+            }
+        }
+    },
+    "生產": {
+        "foods": {}
+    },
+    "穀物": {
+        "foods": {}
+    },
+    "水果": {
+        "foods": {}
+    },
+    "蔬菜": {
+        "foods": {}
+    },
+    "肉類": {
+        "foods": {}
+    },
+    "海鮮": {
+        "foods": {}
+    },
+    "飲料": {
+        "foods": {}
+    },
+    "烘培食品": {
+        "foods": {}
+    },
+    "罐頭食品": {
+        "foods": {}
+    },
+    "調料": {
+        "foods": {}
+    },
+    "甜品": {
+        "foods": {}
+    },
+    "奶類": {
+        "foods": {}
+    },
+    "冷凍食物": {
+        "foods": {}
+    },
+    "健康食品": {
+        "foods": {}
+    },
+    "家庭": {
+        "foods": {}
+    },
+    "肉類食品": {
+        "foods": {}
+    },
+    "零食": {
+        "foods": {}
+    },
+    "香料": {
+        "foods": {}
+    },
+    "甜食": {
+        "foods": {}
+    },
+    "酒精類": {
+        "foods": {}
+    },
+    "其它": {
+        "foods": {}
+    }
 }

--- a/tests/integration_tests/user_group_tests/test_group_seeder.py
+++ b/tests/integration_tests/user_group_tests/test_group_seeder.py
@@ -12,7 +12,7 @@ def test_seed_invalid_locale(api_client: TestClient, unique_user: TestUser):
 
 
 def test_seed_foods(api_client: TestClient, unique_user: TestUser):
-    CREATED_FOODS = 2694
+    CREATED_FOODS = 2687
     database = unique_user.repos
 
     # Check that the foods was created

--- a/tests/integration_tests/user_group_tests/test_group_seeder.py
+++ b/tests/integration_tests/user_group_tests/test_group_seeder.py
@@ -12,7 +12,7 @@ def test_seed_invalid_locale(api_client: TestClient, unique_user: TestUser):
 
 
 def test_seed_foods(api_client: TestClient, unique_user: TestUser):
-    CREATED_FOODS = 214
+    CREATED_FOODS = 2694
     database = unique_user.repos
 
     # Check that the foods was created
@@ -44,7 +44,7 @@ def test_seed_units(api_client: TestClient, unique_user: TestUser):
 
 
 def test_seed_labels(api_client: TestClient, unique_user: TestUser):
-    CREATED_LABELS = 21
+    CREATED_LABELS = 32
     database = unique_user.repos
 
     # Check that the foods was created

--- a/tests/integration_tests/user_household_tests/test_shopping_list_labels.py
+++ b/tests/integration_tests/user_household_tests/test_shopping_list_labels.py
@@ -99,7 +99,7 @@ def test_new_label_creates_list_labels_in_all_households(
 
 
 def test_seed_label_creates_list_labels(api_client: TestClient, unique_user: TestUser):
-    CREATED_LABELS = 21
+    CREATED_LABELS = 32
     database = unique_user.repos
 
     # create a list with some labels


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

This is based off of the work in PR #3037. @catduckgnaf did a tremendous amount of work creating the new labels and foods, so credit to them. I modified the format of the en-US.json file based on the feedback provided in that thread, primarily to modify the file so that each key was a label and that there was a value called `foods` which is a dictionary where each key is the english name of the food and the value is the attributes of the food, including the translated named of the food. 

- Introduced the new en-US.json file for the foods seeding
- Updated all existing locales for the food file to use the new format
- Updated the label seeding to read from the foods location instead of its own seed file, since the keys in the JSON dictionary are all of the labels
- Updated the foods seeding to read from the updated file, looping over each label and all of the foods associated with each. Each food is now associated with a label during creation as well
- Updated the labels, units, and foods seeding to not create any duplicates, by first querying for all of the current item type and then comparing the name of the new item to see if it already exists. This is a nice QoL change so that clicking "Seed" more than once doesn't leave you with a bunch of duplicate items
- Updated integration tests to verify against the new number of unique labels (32) and foods (2687)
- Updates en-US messages to reflect some of the above changes e.g. duplicate items will not be added during seeding

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

Fixes #1230 
Also based on the work in PR #3037 

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

I updated the en-US.json foods seeding file based on the feedback in PR #3037 by @hay-kot.

All food seeding locale files were updated to use the new format
## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

- Logged into mealie for the first time and selected the option to seed foods for en-US, verified that worked correctly
- For a new install with no labels or foods seeded, went to the group data management page and clicked the "Seed" button for the labels and then for the foods
- For a new install with no labels or foods seeded, went to the group data management page and clicked the "Seed" button for foods and verified they could still be seeded even if the labels were not present
- Tested with some of the other locales such as es-ES and en-GB as well. 
- Updated the integration tests for seeding and verified those ran successfully
