### PR TITLE
fix: Autocomplete Accessibility on Login form

### DIFF
--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -44,6 +44,7 @@
             filled
             rounded
             autofocus
+            autocomplete="username"
             class="rounded-lg"
             name="login"
             :label="$t('user.email-or-username')"
@@ -56,6 +57,7 @@
             :append-icon="passwordIcon"
             filled
             rounded
+            autocomplete="current-password"
             class="rounded-lg"
             name="password"
             :label="$t('user.password')"


### PR DESCRIPTION
## What type of PR is this?
- bug/cleanup

## What this PR does / why we need it:
I recently realized I couldn't use my browser credential autocomplete functionality with the login form.

This PR adds browser/HTML autocomplete attributes primarily for accessibility purposes & password manager autocomplete functionalities.

## Which issue(s) this PR fixes:
Fixes #4836 

## Special notes for your reviewer:
I filed a bug + this PR
