### PR TITLE
dev: remove PR type from PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,20 +20,6 @@
 
  -->
 
-## What type of PR is this?
-
-_(REQUIRED)_
-
-<!--
-  Delete any of the following that do not apply:
- -->
-
-- feature
-- bug
-- documentation
-- cleanup
-- dev (Internal development)
-
 ## What this PR does / why we need it:
 
 _(REQUIRED)_


### PR DESCRIPTION
## What type of PR is this?

- dev (Internal development)

## What this PR does / why we need it:

Removes the duplicate PR type from the PR description since we already have this in the PR title (und the applied label) where it is also checked by our tests.  

## Which issue(s) this PR fixes:

None, just removes some duplicate work to create a PR