### PR TITLE
fix: Show All Recipes in Cookbook Regardless of Sort

### DIFF
--- a/frontend/components/Domain/Cookbook/CookbookPage.vue
+++ b/frontend/components/Domain/Cookbook/CookbookPage.vue
@@ -104,9 +104,12 @@
         }
         const response = await actions.updateOne(editTarget.value);
 
-        // if name changed, redirect to new slug
         if (response?.slug && book.value?.slug !== response?.slug) {
+          // if name changed, redirect to new slug
           router.push(`/g/${route.value.params.groupSlug}/cookbooks/${response?.slug}`);
+        } else {
+          // otherwise reload the page, since the recipe criteria changed
+          router.go(0);
         }
         dialogStates.edit = false;
         editTarget.value = null;

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -219,16 +219,20 @@ export default defineComponent({
     const router = useRouter();
 
     const queryFilter = computed(() => {
-      const orderBy = props.query?.orderBy || preferences.value.orderBy;
-      const orderByFilter = preferences.value.filterNull && orderBy ? `${orderBy} IS NOT NULL` : null;
+      return props.query.queryFilter || null;
 
-      if (props.query.queryFilter && orderByFilter) {
-        return `(${props.query.queryFilter}) AND ${orderByFilter}`;
-      } else if (props.query.queryFilter) {
-        return props.query.queryFilter;
-      } else {
-        return orderByFilter;
-      }
+      // TODO: allow user to filter out null values when ordering by a value that may be null (such as lastMade)
+
+      // const orderBy = props.query?.orderBy || preferences.value.orderBy;
+      // const orderByFilter = preferences.value.filterNull && orderBy ? `${orderBy} IS NOT NULL` : null;
+
+      // if (props.query.queryFilter && orderByFilter) {
+      //   return `(${props.query.queryFilter}) AND ${orderByFilter}`;
+      // } else if (props.query.queryFilter) {
+      //   return props.query.queryFilter;
+      // } else {
+      //   return orderByFilter;
+      // }
     });
 
     async function fetchRecipes(pageCount = 1) {

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -206,6 +206,7 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
         # Apply options late, so they do not get used for counting
         q = q.options(*RecipeSummary.loader_options())
         try:
+            self.logger.debug(f"Recipe Pagination Query: {pagination_result}")
             data = self.session.execute(q).scalars().unique().all()
         except Exception as e:
             self._log_exception(e)


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Removes old code that filtered out nulls when using the old recipe sort. Also force a refresh if a cookbook is edited (since recipe criteria will have changed).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes part of the issue raised in https://github.com/mealie-recipes/mealie/issues/4789#issuecomment-2599012513

## Special notes for your reviewer:

_(fill-in or delete this section)_

Not sure if all issues related to https://github.com/mealie-recipes/mealie/issues/4789#issuecomment-2599012513 are resolved, but at least half of them are.

## Testing

_(fill-in or delete this section)_

Manually
