### PR TITLE
fix: prevent recipe sharing from different group

### DIFF
--- a/mealie/routes/shared/__init__.py
+++ b/mealie/routes/shared/__init__.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+from fastapi import HTTPException
 from pydantic import UUID4
 
 from mealie.routes._base import BaseUserController, controller
@@ -30,6 +31,11 @@ class RecipeSharedController(BaseUserController):
 
     @router.post("", response_model=RecipeShareToken, status_code=201)
     def create_one(self, data: RecipeShareTokenCreate) -> RecipeShareToken:
+        # check if recipe group id is the same as the user group id
+        recipe = self.repos.recipes.get_one(data.recipe_id)
+        if recipe is None or recipe.group_id != self.group_id:
+            raise HTTPException(status_code=403, detail="Recipe does not belong to user's group")
+
         save_data = RecipeShareTokenSave(**data.model_dump(), group_id=self.group_id)
         return self.mixins.create_one(save_data)
 

--- a/mealie/routes/shared/__init__.py
+++ b/mealie/routes/shared/__init__.py
@@ -32,9 +32,9 @@ class RecipeSharedController(BaseUserController):
     @router.post("", response_model=RecipeShareToken, status_code=201)
     def create_one(self, data: RecipeShareTokenCreate) -> RecipeShareToken:
         # check if recipe group id is the same as the user group id
-        recipe = self.repos.recipes.get_one(data.recipe_id)
+        recipe = self.repos.recipes.get_one(data.recipe_id, "id")
         if recipe is None or recipe.group_id != self.group_id:
-            raise HTTPException(status_code=403, detail="Recipe does not belong to user's group")
+            raise HTTPException(status_code=404, detail="Recipe not found in your group")
 
         save_data = RecipeShareTokenSave(**data.model_dump(), group_id=self.group_id)
         return self.mixins.create_one(save_data)

--- a/tests/integration_tests/user_recipe_tests/test_recipe_share_tokens.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_share_tokens.py
@@ -110,3 +110,12 @@ def test_recipe_share_tokens_delete_one(api_client: TestClient, unique_user: Tes
     token = database.recipe_share_tokens.get_one(token.id)
 
     assert token is None
+
+
+def test_share_recipe_from_different_group(api_client: TestClient, unique_user: TestUser, g2_user: TestUser, slug: str):
+    database = unique_user.repos
+    recipe = database.recipes.get_one(slug)
+    assert recipe
+
+    response = api_client.post(api_routes.shared_recipes, json={"recipeId": str(recipe.id)}, headers=g2_user.token)
+    assert response.status_code == 403

--- a/tests/integration_tests/user_recipe_tests/test_recipe_share_tokens.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_share_tokens.py
@@ -118,4 +118,4 @@ def test_share_recipe_from_different_group(api_client: TestClient, unique_user: 
     assert recipe
 
     response = api_client.post(api_routes.shared_recipes, json={"recipeId": str(recipe.id)}, headers=g2_user.token)
-    assert response.status_code == 403
+    assert response.status_code == 404


### PR DESCRIPTION
## What this PR does / why we need it:

Next part of adressing security vulnerabilities reported in #4593. 
This adresses the an issue in where a user from a different group is able to share a recipe from a foreign group if he is in posession of the recipe id. 

## Which issue(s) this PR fixes:

Adresses an vulnerability reported in #4593 

## Testing

Added tests that cover this scenario
