### PR TITLE
fix: update recipe time row direction on small screens

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInfoCard.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInfoCard.vue
@@ -15,9 +15,9 @@
           <v-divider class="my-2" />
           <SafeMarkdown :source="recipe.description" />
           <v-divider v-if="recipe.description" />
-          <v-container class="d-flex flex-row flex-wrap justify-center align-center">
+          <v-container class="d-flex flex-row flex-wrap justify-center">
             <div class="mx-6">
-              <v-row no-gutters class="mb-1">
+              <v-row no-gutters>
                 <v-col v-if="recipe.recipeYieldQuantity || recipe.recipeYield" cols="12" class="d-flex flex-wrap justify-center">
                   <RecipeYield
                     :yield-quantity="recipe.recipeYieldQuantity"

--- a/frontend/components/Domain/Recipe/RecipeTimeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeTimeCard.vue
@@ -12,15 +12,19 @@
     <v-divider v-if="validateTotalTime && (validatePrepTime || validatePerformTime)" class="my-2" />
     <!-- Prep Time & Perform Time -->
     <div v-if="validatePrepTime || validatePerformTime" class="time-card-flex mx-auto">
-      <v-row no-gutters class="d-flex justify-center align-center" style="width: 100%;" :style="fontSize">
-        <div v-if="validatePrepTime" class="d-flex flex-no-wrap">
+      <v-row
+        no-gutters
+        class="d-flex justify-center align-center" :class="{'flex-column': $vuetify.breakpoint.smAndDown}"
+        style="width: 100%;" :style="fontSize"
+      >
+        <div v-if="validatePrepTime" class="d-flex flex-no-wrap my-1">
           <v-icon :large="!small" :dense="small" left color="primary">
             {{ $globals.icons.knfife }}
           </v-icon>
           <p class="my-0"><span class="font-weight-bold">{{ validatePrepTime.name }}</span><br>{{ validatePrepTime.value }}</p>
         </div>
         <v-divider v-if="validatePrepTime && validatePerformTime" vertical class="mx-4" />
-        <div v-if="validatePerformTime" class="d-flex flex-no-wrap">
+        <div v-if="validatePerformTime" class="d-flex flex-no-wrap my-1">
           <v-icon :large="!small" :dense="small" left color="primary">
             {{ $globals.icons.potSteam }}
           </v-icon>


### PR DESCRIPTION
## What this PR does / why we need it:

A minimal update that when on mobile makes the two secondary recipe times stack and removes the vertical divider.
Also removes some not functioning classes and updates a few margins. 

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

There was some talk about the sizing of the new Recipe Info Card elements in Discord. I haven't found an satisfactory solution for this so pushing it for now.

## Testing

Manual
