### PR TITLE
fix: Remove `br` encoding from scraper

### DIFF
--- a/mealie/services/scraper/user_agents_manager.py
+++ b/mealie/services/scraper/user_agents_manager.py
@@ -29,7 +29,7 @@ class UserAgentsManager:
             "User-Agent": user_agent,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
             "Accept-Language": "en-US,en;q=0.5",
-            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Encoding": "gzip, deflate",
             "Connection": "keep-alive",
             "Upgrade-Insecure-Requests": "1",
             "Sec-Fetch-Dest": "document",


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Removes the `br` encoding from the `Accepted-Encoding` header in our recipe scraper, since we don't actually support it. See: https://www.python-httpx.org/quickstart/#binary-response-content

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5113
Fixes https://github.com/mealie-recipes/mealie/issues/5119
Fixes https://github.com/mealie-recipes/mealie/issues/5124

## Special notes for your reviewer:

_(fill-in or delete this section)_

Introduced in https://github.com/mealie-recipes/mealie/pull/5091

## Testing

_(fill-in or delete this section)_

Manually using: https://altonbrown.com/recipes/mojo-verde
