### PR TITLE
dev: chown commandhistory to correct user during devcontainer creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
   ],
   // Use 'onCreateCommand' to run commands at the end of container creation.
   // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "sudo chown -R vscode:vscode /workspaces/mealie/frontend/node_modules && task setup",
+  "onCreateCommand": "sudo chown -R vscode:vscode /workspaces/mealie/frontend/node_modules /home/vscode/commandhistory && task setup",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
   "features": {


### PR DESCRIPTION
## What this PR does / why we need it:
the /home/vscode/commandhistory directory in the devcontainer is currently owned by root, which prevents bash from creating and writing to .bash_history file when running as vscode user. This PR adds that path to the chown command run during container creation.

## Which issue(s) this PR fixes:

Fixes #4956 

## Testing

Added this to my local devcontainer.json and rebuilt it. Folder has correct owner, and bash error no longer appears.
