### PR TITLE
feat: OIDC: Call userinfo if no claims found in id token

### DIFF
--- a/mealie/core/exceptions.py
+++ b/mealie/core/exceptions.py
@@ -43,3 +43,6 @@ def mealie_registered_exceptions(t: Translator) -> dict:
 
 
 class UserLockedOut(Exception): ...
+
+
+class MissingClaimException(Exception): ...

--- a/tests/unit_tests/core/security/providers/test_openid_provider.py
+++ b/tests/unit_tests/core/security/providers/test_openid_provider.py
@@ -1,8 +1,10 @@
-import pytest
-from pytest import MonkeyPatch, Session
 import logging
 
+import pytest
+from pytest import MonkeyPatch, Session
+
 from mealie.core.config import get_app_settings
+from mealie.core.exceptions import MissingClaimException
 from mealie.core.security.providers.openid_provider import OpenIDProvider
 from mealie.repos.all_repositories import get_repositories
 from tests.utils.factories import random_email, random_string
@@ -12,13 +14,15 @@ from tests.utils.fixture_schemas import TestUser
 def test_no_claims():
     auth_provider = OpenIDProvider(None, None)
 
-    assert auth_provider.authenticate() is None
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
 
 
 def test_empty_claims():
     auth_provider = OpenIDProvider(None, {})
 
-    assert auth_provider.authenticate() is None
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
 
 
 def test_empty_required_claims():
@@ -30,14 +34,16 @@ def test_empty_required_claims():
     }
     auth_provider = OpenIDProvider(None, data)
 
-    assert auth_provider.authenticate() is None
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
 
 
 def test_missing_claims():
     data = {"preferred_username": "dude1"}
     auth_provider = OpenIDProvider(None, data)
 
-    assert auth_provider.authenticate() is None
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
 
 
 def test_missing_groups_claim(monkeypatch: MonkeyPatch):
@@ -51,7 +57,8 @@ def test_missing_groups_claim(monkeypatch: MonkeyPatch):
     }
     auth_provider = OpenIDProvider(None, data)
 
-    assert auth_provider.authenticate() is None
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
 
 
 def test_missing_user_group(monkeypatch: MonkeyPatch):


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

Some IdPs don't put user claims into the ID token for enhanced security and instead will return the necessary claims from the UserInfo endpoint. There is usually some setting you can change in the IdP to allow sending the claims in the ID token, so this isn't really an issue. However, it makes sense for Mealie to follow this convention and to pull the user info from the UserInfo endpoint. In order to keep compatibility with existing installs (though it shouldn't be breaking), I've decided to add this as a fallback mechanism. If we can't find the claims we need in the ID token, then we will make the necessary call to the UserInfo endpoint of the IdP to obtain them.

## Which issue(s) this PR fixes:

N/A


## Testing

Tested manually with Authelia 4.38 and 4.39 as well as Authentik, both with and without the option to include claims in the ID token.
Unfortunately, it seems we cannot set up an E2E test for this as the mock OAuth server we use doesn't allow for returning mock data from the UserInfo endpoint
