### PR TITLE
fix: update admin scripts paths in docs

### DIFF
--- a/docs/docs/documentation/getting-started/faq.md
+++ b/docs/docs/documentation/getting-started/faq.md
@@ -148,7 +148,7 @@
     ```shell
     docker exec -it mealie bash
 
-    python /opt/mealie/lib/python3.12/site-packages/reset_locked_users.py
+    python /opt/mealie/lib64/python3.12/site-packages/mealie/scripts/reset_locked_users.py
     ```
 
 
@@ -161,7 +161,7 @@
     ```shell
     docker exec -it mealie bash
 
-    python /opt/mealie/lib/python3.12/site-packages/make_admin.py
+    python /opt/mealie/lib64/python3.12/site-packages/mealie/scripts/make_admin.py
     ```
 
 
@@ -174,7 +174,7 @@
     ```shell
     docker exec -it mealie bash
 
-    python /opt/mealie/lib/python3.12/site-packages/mealie/scripts/change_password.py
+    python /opt/mealie/lib64/python3.12/site-packages/mealie/scripts/change_password.py
     ```
 
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the paths to the admin scripts in the docs. 

## Which issue(s) this PR fixes:

-  fixes #5261