### PR TITLE
fix: Pre-download NLTK during Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -141,6 +141,11 @@ RUN mkdir -p /run/secrets
 # Copy venv into image. It contains a fully-installed mealie backend and frontend.
 COPY --from=venv-builder $VENV_PATH $VENV_PATH
 
+# install nltk data for the ingredient parser
+ENV NLTK_DATA="/nltk_data/"
+RUN mkdir -p $NLTK_DATA
+RUN python -m nltk.downloader -d $NLTK_DATA averaged_perceptron_tagger_eng
+
 VOLUME [ "$MEALIE_HOME/data/" ]
 ENV APP_PORT=9000
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The new ingredient parser repo requires [NLTK](https://www.nltk.org/) to work. When it needs NLTK, it checks if it exists, and if not it downloads it to `/nltk_data`. Some users run into permission errors when creating `/nltk_data`, so this PR creates it at build time and fetches the data files (which may marginally speed up the first access time, not 100% sure about that).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5242

## Testing

_(fill-in or delete this section)_

~~Couldn't reproduce the permission issue reported in https://github.com/mealie-recipes/mealie/issues/5242, but I built the prod image locally and confirmed that the folder creation/download work as expected, so this should be fixed.~~ multiple people on the original issue have confirmed this works (thank you all!)