### PR TITLE
fix: build pull request image only in mealie repo

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -47,7 +47,7 @@ jobs:
 
   publish-image:
     name: "Publish PR Image"
-    if: contains(github.event.pull_request.labels.*.name, 'build-image')
+    if: contains(github.event.pull_request.labels.*.name, 'build-image') && github.repository == 'mealie-recipes/mealie'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What this PR does / why we need it:

This restricts the building of the PR image to only PRs that come from the mealie repo as the required dockerhub secrets won't exist outside of this repo. (See [this](https://github.com/mealie-recipes/mealie/actions/runs/14338110381/job/40193080205?pr=5184) failing run. 

There might be some way around that in pushing PR images only to the ghcr. 

## Which issue(s) this PR fixes:

None.

## Special notes for your reviewer:

Just a quick bandage to fix failing tests at #5184. Will revisit this when i have a bit more time to implement a more robust solution. 
