### PR TITLE
feat: add the selected recipe servings and yields in the content of the recipe post action

### DIFF
--- a/frontend/composables/use-group-recipe-actions.ts
+++ b/frontend/composables/use-group-recipe-actions.ts
@@ -4,6 +4,7 @@ import { useUserApi } from "~/composables/api";
 import { GroupRecipeActionOut, GroupRecipeActionType } from "~/lib/api/types/household";
 import { RequestResponse } from "~/lib/api/types/non-generated";
 import { Recipe } from "~/lib/api/types/recipe";
+import { useScaledAmount } from "~/composables/recipes/use-scaled-amount";
 
 const groupRecipeActions = ref<GroupRecipeActionOut[] | null>(null);
 const loading = ref(false);
@@ -69,7 +70,7 @@ export const useGroupRecipeActions = function (
         window.open(url, "_blank")?.focus();
         return;
       case "post":
-        return await api.groupRecipeActions.triggerAction(action.id, recipe.slug || "");
+        return await api.groupRecipeActions.triggerAction(action.id, recipe.slug || "", useScaledAmount(recipe.recipeServings || 1, recipeScale).scaledAmount);
       default:
         break;
     }

--- a/frontend/composables/use-group-recipe-actions.ts
+++ b/frontend/composables/use-group-recipe-actions.ts
@@ -46,10 +46,7 @@ export const useGroupRecipeActions = function (
     return groupRecipeActions.value;
   });
 
-  function parseRecipeActionUrl(url: string, recipe: Recipe, recipeScale: number): string {
-    const recipeServings = (recipe.recipeServings || 1) * recipeScale;
-    const recipeYieldQuantity = (recipe.recipeYieldQuantity || 1) * recipeScale;
-
+  function parseRecipeActionUrl(url: string, recipe: Recipe, recipeServings: number, recipeYieldQuantity: number): string {
     /* eslint-disable no-template-curly-in-string */
     return url
       .replace("${url}", window.location.href)
@@ -62,18 +59,28 @@ export const useGroupRecipeActions = function (
   };
 
   async function execute(action: GroupRecipeActionOut, recipe: Recipe, recipeScale: number): Promise<void | RequestResponse<unknown>> {
-    const url = parseRecipeActionUrl(action.url, recipe, recipeScale);
+    const [recipeServings, recipeYieldQuantity] = calculateRecipeServingsAndYieldQuantity(recipe, recipeScale);
+    const url = parseRecipeActionUrl(action.url, recipe, recipeServings, recipeYieldQuantity);
 
     switch (action.actionType) {
       case "link":
         window.open(url, "_blank")?.focus();
         return;
       case "post":
-        return await api.groupRecipeActions.triggerAction(action.id, recipe.slug || "");
+        return await api.groupRecipeActions.triggerAction(
+          action.id,
+          recipe.slug || "",
+          recipeServings,
+          recipeYieldQuantity
+        );
       default:
         break;
     }
   };
+
+  function calculateRecipeServingsAndYieldQuantity(recipe: Recipe, recipeScale: number): [number, number] {
+    return [(recipe.recipeServings || 1) * recipeScale, (recipe.recipeYieldQuantity || 1) * recipeScale];
+  }
 
   if (!groupRecipeActions.value && !loading.value) {
     refreshGroupRecipeActions();

--- a/frontend/composables/use-group-recipe-actions.ts
+++ b/frontend/composables/use-group-recipe-actions.ts
@@ -46,7 +46,10 @@ export const useGroupRecipeActions = function (
     return groupRecipeActions.value;
   });
 
-  function parseRecipeActionUrl(url: string, recipe: Recipe, recipeServings: number, recipeYieldQuantity: number): string {
+  function parseRecipeActionUrl(url: string, recipe: Recipe, recipeScale: number): string {
+    const recipeServings = (recipe.recipeServings || 1) * recipeScale;
+    const recipeYieldQuantity = (recipe.recipeYieldQuantity || 1) * recipeScale;
+
     /* eslint-disable no-template-curly-in-string */
     return url
       .replace("${url}", window.location.href)
@@ -59,28 +62,18 @@ export const useGroupRecipeActions = function (
   };
 
   async function execute(action: GroupRecipeActionOut, recipe: Recipe, recipeScale: number): Promise<void | RequestResponse<unknown>> {
-    const [recipeServings, recipeYieldQuantity] = calculateRecipeServingsAndYieldQuantity(recipe, recipeScale);
-    const url = parseRecipeActionUrl(action.url, recipe, recipeServings, recipeYieldQuantity);
+    const url = parseRecipeActionUrl(action.url, recipe, recipeScale);
 
     switch (action.actionType) {
       case "link":
         window.open(url, "_blank")?.focus();
         return;
       case "post":
-        return await api.groupRecipeActions.triggerAction(
-          action.id,
-          recipe.slug || "",
-          recipeServings,
-          recipeYieldQuantity
-        );
+        return await api.groupRecipeActions.triggerAction(action.id, recipe.slug || "");
       default:
         break;
     }
   };
-
-  function calculateRecipeServingsAndYieldQuantity(recipe: Recipe, recipeScale: number): [number, number] {
-    return [(recipe.recipeServings || 1) * recipeScale, (recipe.recipeYieldQuantity || 1) * recipeScale];
-  }
 
   if (!groupRecipeActions.value && !loading.value) {
     refreshGroupRecipeActions();

--- a/frontend/lib/api/user/group-recipe-actions.ts
+++ b/frontend/lib/api/user/group-recipe-actions.ts
@@ -6,14 +6,14 @@ const prefix = "/api";
 const routes = {
     groupRecipeActions: `${prefix}/households/recipe-actions`,
     groupRecipeActionsId: (id: string | number) => `${prefix}/households/recipe-actions/${id}`,
-    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}`,
+    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string, scaledAmount: number) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}/${scaledAmount}`,
   };
 
   export class GroupRecipeActionsAPI extends BaseCRUDAPI<CreateGroupRecipeAction, GroupRecipeActionOut> {
     baseRoute = routes.groupRecipeActions;
     itemRoute = routes.groupRecipeActionsId;
 
-    async triggerAction(id: string | number, recipeSlug: string) {
-      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug), {});
+    async triggerAction(id: string | number, recipeSlug: string, scaledAmount: number) {
+      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug, scaledAmount), {});
     }
   }

--- a/frontend/lib/api/user/group-recipe-actions.ts
+++ b/frontend/lib/api/user/group-recipe-actions.ts
@@ -6,14 +6,14 @@ const prefix = "/api";
 const routes = {
     groupRecipeActions: `${prefix}/households/recipe-actions`,
     groupRecipeActionsId: (id: string | number) => `${prefix}/households/recipe-actions/${id}`,
-    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string, servings: number, yield_quantity: number) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}/${servings}/${yield_quantity}`,
+    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}`,
   };
 
   export class GroupRecipeActionsAPI extends BaseCRUDAPI<CreateGroupRecipeAction, GroupRecipeActionOut> {
     baseRoute = routes.groupRecipeActions;
     itemRoute = routes.groupRecipeActionsId;
 
-    async triggerAction(id: string | number, recipeSlug: string, servings: number, yield_quantity: number) {
-      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug, servings, yield_quantity), {});
+    async triggerAction(id: string | number, recipeSlug: string) {
+      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug), {});
     }
   }

--- a/frontend/lib/api/user/group-recipe-actions.ts
+++ b/frontend/lib/api/user/group-recipe-actions.ts
@@ -6,7 +6,7 @@ const prefix = "/api";
 const routes = {
     groupRecipeActions: `${prefix}/households/recipe-actions`,
     groupRecipeActionsId: (id: string | number) => `${prefix}/households/recipe-actions/${id}`,
-    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string, scaledAmount: number) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}/${scaledAmount}`,
+    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}`,
   };
 
   export class GroupRecipeActionsAPI extends BaseCRUDAPI<CreateGroupRecipeAction, GroupRecipeActionOut> {
@@ -14,6 +14,6 @@ const routes = {
     itemRoute = routes.groupRecipeActionsId;
 
     async triggerAction(id: string | number, recipeSlug: string, scaledAmount: number) {
-      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug, scaledAmount), {});
+      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug), {scaledAmount});
     }
   }

--- a/frontend/lib/api/user/group-recipe-actions.ts
+++ b/frontend/lib/api/user/group-recipe-actions.ts
@@ -6,14 +6,14 @@ const prefix = "/api";
 const routes = {
     groupRecipeActions: `${prefix}/households/recipe-actions`,
     groupRecipeActionsId: (id: string | number) => `${prefix}/households/recipe-actions/${id}`,
-    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}`,
+    groupRecipeActionsIdTriggerRecipeSlug: (id: string | number, recipeSlug: string, servings: number, yield_quantity: number) => `${prefix}/households/recipe-actions/${id}/trigger/${recipeSlug}/${servings}/${yield_quantity}`,
   };
 
   export class GroupRecipeActionsAPI extends BaseCRUDAPI<CreateGroupRecipeAction, GroupRecipeActionOut> {
     baseRoute = routes.groupRecipeActions;
     itemRoute = routes.groupRecipeActionsId;
 
-    async triggerAction(id: string | number, recipeSlug: string) {
-      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug), {});
+    async triggerAction(id: string | number, recipeSlug: string, servings: number, yield_quantity: number) {
+      return await this.requests.post(routes.groupRecipeActionsIdTriggerRecipeSlug(id, recipeSlug, servings, yield_quantity), {});
     }
   }

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 import requests
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import UUID4
 
@@ -67,8 +67,10 @@ class GroupRecipeActionController(BaseUserController):
     # ==================================================================================================================
     # Actions
 
-    @router.post("/{item_id}/trigger/{recipe_slug}/{scaled_amount}", status_code=202)
-    def trigger_action(self, item_id: UUID4, recipe_slug: str, scaled_amount: float, bg_tasks: BackgroundTasks) -> None:
+    @router.post("/{item_id}/trigger/{recipe_slug}", status_code=202)
+    def trigger_action(
+        self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks, scaled_amount: float = Body(..., embed=True)
+    ) -> None:
         recipe_action = self.repos.group_recipe_actions.get_one(item_id)
         if not recipe_action:
             raise HTTPException(
@@ -93,12 +95,10 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
-        payload = GroupRecipeActionPayload(
-            action=recipe_action, content=recipe, scaled_amount=scaled_amount
-        ).model_dump()
+        payload = GroupRecipeActionPayload(action=recipe_action, content=recipe, scaled_amount=scaled_amount)
         bg_tasks.add_task(
             task_action,
             url=recipe_action.url,
-            json=jsonable_encoder(payload),
+            json=jsonable_encoder(payload.model_dump()),
             timeout=15,
         )

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -67,8 +67,10 @@ class GroupRecipeActionController(BaseUserController):
     # ==================================================================================================================
     # Actions
 
-    @router.post("/{item_id}/trigger/{recipe_slug}", status_code=202)
-    def trigger_action(self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks) -> None:
+    @router.post("/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}", status_code=202)
+    def trigger_action(
+        self, item_id: UUID4, recipe_slug: str, servings: int, yield_quantity: int, bg_tasks: BackgroundTasks
+    ) -> None:
         recipe_action = self.repos.group_recipe_actions.get_one(item_id)
         if not recipe_action:
             raise HTTPException(
@@ -93,6 +95,8 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
+        recipe.recipe_servings = servings
+        recipe.recipe_yield_quantity = yield_quantity
         payload = GroupRecipeActionPayload(action=recipe_action, content=recipe)
         bg_tasks.add_task(
             task_action,

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -93,8 +93,9 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
-        payload = GroupRecipeActionPayload(action=recipe_action, content=recipe).model_dump()
-        payload["scaled_amount"] = scaled_amount
+        payload = GroupRecipeActionPayload(
+            action=recipe_action, content=recipe, scaled_amount=scaled_amount
+        ).model_dump()
         bg_tasks.add_task(
             task_action,
             url=recipe_action.url,

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -67,8 +67,8 @@ class GroupRecipeActionController(BaseUserController):
     # ==================================================================================================================
     # Actions
 
-    @router.post("/{item_id}/trigger/{recipe_slug}", status_code=202)
-    def trigger_action(self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks) -> None:
+    @router.post("/{item_id}/trigger/{recipe_slug}/{scaled_amount}", status_code=202)
+    def trigger_action(self, item_id: UUID4, recipe_slug: str, scaled_amount: float, bg_tasks: BackgroundTasks) -> None:
         recipe_action = self.repos.group_recipe_actions.get_one(item_id)
         if not recipe_action:
             raise HTTPException(
@@ -93,6 +93,7 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
+        recipe.scaled_amount = scaled_amount
         payload = GroupRecipeActionPayload(action=recipe_action, content=recipe)
         bg_tasks.add_task(
             task_action,

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -93,11 +93,11 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
-        recipe.scaled_amount = scaled_amount
-        payload = GroupRecipeActionPayload(action=recipe_action, content=recipe)
+        payload = GroupRecipeActionPayload(action=recipe_action, content=recipe).model_dump()
+        payload["scaled_amount"] = scaled_amount
         bg_tasks.add_task(
             task_action,
             url=recipe_action.url,
-            json=jsonable_encoder(payload.model_dump()),
+            json=jsonable_encoder(payload),
             timeout=15,
         )

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -67,10 +67,8 @@ class GroupRecipeActionController(BaseUserController):
     # ==================================================================================================================
     # Actions
 
-    @router.post("/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}", status_code=202)
-    def trigger_action(
-        self, item_id: UUID4, recipe_slug: str, servings: int, yield_quantity: int, bg_tasks: BackgroundTasks
-    ) -> None:
+    @router.post("/{item_id}/trigger/{recipe_slug}", status_code=202)
+    def trigger_action(self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks) -> None:
         recipe_action = self.repos.group_recipe_actions.get_one(item_id)
         if not recipe_action:
             raise HTTPException(
@@ -95,8 +93,6 @@ class GroupRecipeActionController(BaseUserController):
                 detail=ErrorResponse.respond(message="Not found."),
             ) from e
 
-        recipe.recipe_servings = servings
-        recipe.recipe_yield_quantity = yield_quantity
         payload = GroupRecipeActionPayload(action=recipe_action, content=recipe)
         bg_tasks.add_task(
             task_action,

--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -69,7 +69,7 @@ class GroupRecipeActionController(BaseUserController):
 
     @router.post("/{item_id}/trigger/{recipe_slug}", status_code=202)
     def trigger_action(
-        self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks, scaled_amount: float = Body(..., embed=True)
+        self, item_id: UUID4, recipe_slug: str, bg_tasks: BackgroundTasks, scaled_amount: float = Body(1, embed=True)
     ) -> None:
         recipe_action = self.repos.group_recipe_actions.get_one(item_id)
         if not recipe_action:

--- a/mealie/schema/household/group_recipe_action.py
+++ b/mealie/schema/household/group_recipe_action.py
@@ -44,3 +44,4 @@ class GroupRecipeActionPagination(PaginationBase):
 class GroupRecipeActionPayload(MealieModel):
     action: GroupRecipeActionOut
     content: Any
+    scaled_amount: float | None = None

--- a/mealie/schema/household/group_recipe_action.py
+++ b/mealie/schema/household/group_recipe_action.py
@@ -44,4 +44,4 @@ class GroupRecipeActionPagination(PaginationBase):
 class GroupRecipeActionPayload(MealieModel):
     action: GroupRecipeActionOut
     content: Any
-    scaled_amount: float | None = None
+    scaled_amount: float

--- a/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
+++ b/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
@@ -171,7 +171,7 @@ def test_group_recipe_actions_trigger_post(
         recipe_slug = recipe.slug
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug, 1, 1),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug),
         headers=unique_user.token,
     )
 
@@ -187,7 +187,7 @@ def test_group_recipe_actions_trigger_invalid_type(api_client: TestClient, uniqu
     recipe = unique_user.repos.recipes.create(new_recipe(unique_user))
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id, 1, 1),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id),
         headers=unique_user.token,
     )
 

--- a/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
+++ b/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
@@ -171,7 +171,7 @@ def test_group_recipe_actions_trigger_post(
         recipe_slug = recipe.slug
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug, 1.0),
         headers=unique_user.token,
     )
 
@@ -187,7 +187,7 @@ def test_group_recipe_actions_trigger_invalid_type(api_client: TestClient, uniqu
     recipe = unique_user.repos.recipes.create(new_recipe(unique_user))
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id, 1.0),
         headers=unique_user.token,
     )
 

--- a/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
+++ b/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
@@ -171,8 +171,9 @@ def test_group_recipe_actions_trigger_post(
         recipe_slug = recipe.slug
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug, 1.0),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug),
         headers=unique_user.token,
+        json={"scaled_amount": 1.0},
     )
 
     if missing_action or missing_recipe:
@@ -187,8 +188,9 @@ def test_group_recipe_actions_trigger_invalid_type(api_client: TestClient, uniqu
     recipe = unique_user.repos.recipes.create(new_recipe(unique_user))
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id, 1.0),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id),
         headers=unique_user.token,
+        json={"scaled_amount": 1.0},
     )
 
     assert response.status_code == 400

--- a/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
+++ b/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
@@ -171,7 +171,7 @@ def test_group_recipe_actions_trigger_post(
         recipe_slug = recipe.slug
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(action_id, recipe_slug, 1, 1),
         headers=unique_user.token,
     )
 
@@ -187,7 +187,7 @@ def test_group_recipe_actions_trigger_invalid_type(api_client: TestClient, uniqu
     recipe = unique_user.repos.recipes.create(new_recipe(unique_user))
 
     response = api_client.post(
-        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id),
+        api_routes.households_recipe_actions_item_id_trigger_recipe_slug(recipe_action.id, recipe.id, 1, 1),
         headers=unique_user.token,
     )
 

--- a/tests/utils/api_routes/__init__.py
+++ b/tests/utils/api_routes/__init__.py
@@ -365,9 +365,9 @@ def households_recipe_actions_item_id(item_id):
     return f"{prefix}/households/recipe-actions/{item_id}"
 
 
-def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug, servings, yield_quantity):
-    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}`"""
-    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}"
+def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug):
+    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}`"""
+    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}"
 
 
 def households_self_recipes_recipe_slug(recipe_slug):

--- a/tests/utils/api_routes/__init__.py
+++ b/tests/utils/api_routes/__init__.py
@@ -365,9 +365,9 @@ def households_recipe_actions_item_id(item_id):
     return f"{prefix}/households/recipe-actions/{item_id}"
 
 
-def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug):
-    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}`"""
-    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}"
+def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug, scaled_amount):
+    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{scaled_amount}`"""
+    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{scaled_amount}"
 
 
 def households_self_recipes_recipe_slug(recipe_slug):

--- a/tests/utils/api_routes/__init__.py
+++ b/tests/utils/api_routes/__init__.py
@@ -365,9 +365,9 @@ def households_recipe_actions_item_id(item_id):
     return f"{prefix}/households/recipe-actions/{item_id}"
 
 
-def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug, scaled_amount):
-    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{scaled_amount}`"""
-    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{scaled_amount}"
+def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug):
+    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}`"""
+    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}"
 
 
 def households_self_recipes_recipe_slug(recipe_slug):

--- a/tests/utils/api_routes/__init__.py
+++ b/tests/utils/api_routes/__init__.py
@@ -365,9 +365,9 @@ def households_recipe_actions_item_id(item_id):
     return f"{prefix}/households/recipe-actions/{item_id}"
 
 
-def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug):
-    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}`"""
-    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}"
+def households_recipe_actions_item_id_trigger_recipe_slug(item_id, recipe_slug, servings, yield_quantity):
+    """`/api/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}`"""
+    return f"{prefix}/households/recipe-actions/{item_id}/trigger/{recipe_slug}/{servings}/{yield_quantity}"
 
 
 def households_self_recipes_recipe_slug(recipe_slug):


### PR DESCRIPTION
## What this PR does / why we need it:

This change allows the `post` recipe action to send information about the selected recipe `servings` and `yieldQuantity` in the body.

## Which issue(s) this PR fixes:

1st for https://github.com/felixschndr/mealie-bring-api/issues/15

## Special notes for your reviewer:

Previous discussion regarding this: https://github.com/mealie-recipes/mealie/discussions/3610#discussioncomment-12524763

Since I am unfamiliar with the codebase I'd like to get some feedback and proposed changes if I (unintentionally) dit not comply with coding styles.

## Testing

Took a debugger to see that the data was set correctly. 
I am unsure whether it is possible to check the type script side of things or how I can build a docker container to run locally.
