### PR TITLE
chore: Relax Stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,12 +16,13 @@ jobs:
         with:
           stale-issue-label: 'stale'
           exempt-issue-labels: 'pinned,security,early-stages,bug: confirmed,feedback,task'
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          days-before-issue-stale: 30
-          days-before-issue-close: 5
+          stale-issue-message: 'This issue has been automatically marked as stale because it has been open 90 days with no activity.'
+          days-before-issue-stale: 90
+          # This stops an issue from ever getting closed automatically.
+          days-before-issue-close: -1
           stale-pr-label: 'stale'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
-          days-before-pr-stale: 45
+          stale-pr-message: 'This PR has been automatically marked as stale because it has been open 90 days with no activity.'
+          days-before-pr-stale: 90
           # This stops a PR from ever getting closed automatically.
           days-before-pr-close: -1
           # If an issue/PR has a milestone, it's exempt from being marked as stale.


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Relaxes stalebot rules:
- both issues and PRs are stale after 90 days (up from 30 and 45 days, respectively)
- issues are no longer auto-closed

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A