### PR TITLE
fix: #5511, list item state doesn't change when offline

### DIFF
--- a/frontend/composables/use-shopping-list-item-actions.ts
+++ b/frontend/composables/use-shopping-list-item-actions.ts
@@ -89,9 +89,31 @@ export function useShoppingListItemActions(shoppingListId: string) {
     return true;
   }
 
+  function mergeListItemsByLatest(
+    list1: ShoppingListItemOut[],
+    list2: ShoppingListItemOut[]
+  ) {
+    const mergedList = [...list1];
+    list2.forEach((list2Item) => {
+      const confictingItem = mergedList.find((item) => item.id === list2Item.id)
+      if (confictingItem &&
+        list2Item.updatedAt && confictingItem.updatedAt &&
+        list2Item.updatedAt > confictingItem.updatedAt) {
+        mergedList.splice(mergedList.indexOf(confictingItem), 1, list2Item)
+      } else if (!confictingItem) {
+        mergedList.push(list2Item)
+      }
+    })
+    return mergedList
+  }
+
   async function getList() {
     const response = await api.shopping.lists.getOne(shoppingListId);
-    return response.data;
+    if (response.data) {
+      const createAndUpdateQueues = mergeListItemsByLatest(queue.update, queue.create);
+      response.data.listItems = mergeListItemsByLatest(response.data.listItems ?? [], createAndUpdateQueues);
+    }
+    return response.data
   }
 
   function createItem(item: ShoppingListItemOut) {
@@ -188,7 +210,7 @@ export function useShoppingListItemActions(shoppingListId: string) {
   }
 
   async function process() {
-    if(queueEmpty.value) {
+    if (queueEmpty.value) {
       queue.lastUpdate = Date.now();
       return;
     }

--- a/frontend/composables/use-shopping-list-item-actions.ts
+++ b/frontend/composables/use-shopping-list-item-actions.ts
@@ -109,7 +109,7 @@ export function useShoppingListItemActions(shoppingListId: string) {
 
   async function getList() {
     const response = await api.shopping.lists.getOne(shoppingListId);
-    if (response.data) {
+    if (window.$nuxt.isOffline && response.data) {
       const createAndUpdateQueues = mergeListItemsByLatest(queue.update, queue.create);
       response.data.listItems = mergeListItemsByLatest(response.data.listItems ?? [], createAndUpdateQueues);
     }

--- a/frontend/composables/use-shopping-list-item-actions.ts
+++ b/frontend/composables/use-shopping-list-item-actions.ts
@@ -95,12 +95,12 @@ export function useShoppingListItemActions(shoppingListId: string) {
   ) {
     const mergedList = [...list1];
     list2.forEach((list2Item) => {
-      const confictingItem = mergedList.find((item) => item.id === list2Item.id)
-      if (confictingItem &&
-        list2Item.updatedAt && confictingItem.updatedAt &&
-        list2Item.updatedAt > confictingItem.updatedAt) {
-        mergedList.splice(mergedList.indexOf(confictingItem), 1, list2Item)
-      } else if (!confictingItem) {
+      const conflictingItem = mergedList.find((item) => item.id === list2Item.id)
+      if (conflictingItem &&
+        list2Item.updatedAt && conflictingItem.updatedAt &&
+        list2Item.updatedAt > conflictingItem.updatedAt) {
+        mergedList.splice(mergedList.indexOf(conflictingItem), 1, list2Item)
+      } else if (!conflictingItem) {
         mergedList.push(list2Item)
       }
     })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mealie",
-"version": "2.8.0",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/frontend/pages/shopping-lists/_id.vue
+++ b/frontend/pages/shopping-lists/_id.vue
@@ -878,10 +878,9 @@ export default defineComponent({
 
         // make sure the item is at the end of the list with the other checked items
         item.position = shoppingList.value.listItems.length;
-
-        // set a temporary updatedAt timestamp prior to refresh so it appears at the top of the checked items
-        item.updatedAt = new Date().toISOString();
       }
+      // set a temporary updatedAt timestamp prior to refresh so it appears at the top of the checked items
+      item.updatedAt = new Date().toISOString();
 
       // make updates reflect immediately
       if (shoppingList.value.listItems) {


### PR DESCRIPTION

<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

* Merge pending local state changes with server state before updating UI
* Local state changes will overwrite server state where the updatedAt property is larger

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

https://github.com/mealie-recipes/mealie/issues/5511

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

Not sure if the check for updatedAt is required? It might be that we always want local state to overwrite server state, because local state will always be newer ( I think ) 

I don't think I have broken anything by updating the updatedAt property every time, without checking the isChecked, but worth considering, since I'm not very familiar with the code base. The reason I did that was because I found there was a case where if you 
* Checked an item while online
* Went offline 
* Unchecked the same item,
Then the updatedAt times were equal, and so the local state didnt overwrite server state. 
 

## Testing

<!--
  Describe how you tested this change.
-->

* Ran steps to reproduce in the issue, and confirmed the this fixes the issue
* Generally tested out shopping list functionality in online and offline modes
