### PR TITLE
fix: handle recipe-scraper returning a int causing clean_time to return None

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -2,6 +2,7 @@ import contextlib
 import functools
 import html
 import json
+import numbers
 import operator
 import re
 import typing
@@ -412,6 +413,9 @@ def clean_time(time_entry: str | timedelta | None, translator: Translator) -> No
         return None
 
     match time_entry:
+        case numbers.Number:
+            time_delta = timedelta(minutes=time_entry)
+            return pretty_print_timedelta(time_delta, translator)
         case str(time_entry):
             if not time_entry.strip():
                 return None

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -35,6 +35,9 @@ MATCH_MULTI_SPACE = re.compile(r" +")
 MATCH_ERRONEOUS_WHITE_SPACE = re.compile(r"\n\s*\n")
 """ Matches multiple new lines and removes erroneous white space """
 
+N = typing.TypeVar("N", bound=numbers.Number)
+""" Reusable TypeVar for refrencing inhereters of Number """
+
 
 def clean(recipe_data: Recipe | dict, translator: Translator, url=None) -> Recipe:
     """Main entrypoint to clean a recipe extracted from the web
@@ -393,7 +396,7 @@ def clean_yield(yields: str | list[str] | None) -> tuple[float, float, str]:
     return servings_qty, yld_qty, yld_str
 
 
-def clean_time(time_entry: str | timedelta | None, translator: Translator) -> None | str:
+def clean_time(time_entry: str | timedelta | N | None, translator: Translator) -> None | str:
     """_summary_
 
     Supported Structures:

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -35,9 +35,6 @@ MATCH_MULTI_SPACE = re.compile(r" +")
 MATCH_ERRONEOUS_WHITE_SPACE = re.compile(r"\n\s*\n")
 """ Matches multiple new lines and removes erroneous white space """
 
-N = typing.TypeVar("N", bound=numbers.Number)
-""" Reusable TypeVar for refrencing inhereters of Number """
-
 
 def clean(recipe_data: Recipe | dict, translator: Translator, url=None) -> Recipe:
     """Main entrypoint to clean a recipe extracted from the web
@@ -396,7 +393,7 @@ def clean_yield(yields: str | list[str] | None) -> tuple[float, float, str]:
     return servings_qty, yld_qty, yld_str
 
 
-def clean_time(time_entry: str | timedelta | N | None, translator: Translator) -> None | str:
+def clean_time(time_entry: str | timedelta | int | float | None, translator: Translator) -> None | str:
     """_summary_
 
     Supported Structures:
@@ -417,7 +414,8 @@ def clean_time(time_entry: str | timedelta | N | None, translator: Translator) -
 
     match time_entry:
         case numbers.Number():
-            time_delta = timedelta(minutes=time_entry)
+            # type checked by case statement
+            time_delta = timedelta(minutes=time_entry)  # type: ignore
             return pretty_print_timedelta(time_delta, translator)
         case str(time_entry):
             if not time_entry.strip():

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -402,6 +402,7 @@ def clean_time(time_entry: str | timedelta | int | float | None, translator: Tra
         - `"PT1H30M"` - returns "1 hour 30 minutes"
         - `timedelta(hours=1, minutes=30)` - returns "1 hour 30 minutes"
         - `{"minValue": "PT1H30M"}` - returns "1 hour 30 minutes"
+        - `30` - as a `int` or `float` assumed to be in minutes, returns "30 minutes"
 
     Raises:
         TypeError: if the type is not supported a TypeError is raised

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -416,7 +416,7 @@ def clean_time(time_entry: str | timedelta | N | None, translator: Translator) -
         return None
 
     match time_entry:
-        case numbers.Number:
+        case numbers.Number():
             time_delta = timedelta(minutes=time_entry)
             return pretty_print_timedelta(time_delta, translator)
         case str(time_entry):
@@ -438,7 +438,9 @@ def clean_time(time_entry: str | timedelta | N | None, translator: Translator) -
             # TODO: Not sure what to do here
             return str(time_entry)
         case _:
-            logger.warning("[SCRAPER] Unexpected type or structure for variable time_entry")
+            logger.warning(
+                "[SCRAPER] Unexpected type(%s) or structure for variable time_entry: %s", type(time_entry), time_entry
+            )
             return None
 
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

This PR adds another case to the `clean_time` function to handle the `schemaOrg` parser from `recipie-scrapers` returning a int/float as it parses the ISO 8601 durations itsel now

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Fixes [#5232](https://github.com/mealie-recipes/mealie/issues/5232)

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Testing

Currently running the pytests right now, which is why this is in draft

<!--
  Describe how you tested this change.
-->
