### PR TITLE
fix: Fixing the OpenAPI Spec and the Call to delete a shared recipe.

### DIFF
--- a/mealie/routes/shared/__init__.py
+++ b/mealie/routes/shared/__init__.py
@@ -46,5 +46,5 @@ class RecipeSharedController(BaseUserController):
         return self.mixins.get_one(item_id)
 
     @router.delete("/{item_id}")
-    def delete_one(self, item_id: UUID4 | None = None) -> None:
+    def delete_one(self, item_id: UUID4) -> None:
         return self.mixins.delete_one(item_id)


### PR DESCRIPTION
## What this PR does / why we need it:

This change fixes the function `delete_one(self, item_id)` in `RecipeSharedController`. 

The `item_id` was able to take in Null. A delete item should not be able to take `None` as the id. This is evident by the underlying call to the `self.mixins.delete_one(item_id)` function, which doesn't accept `None`. 

This bug also breaks the OpenAPI spec when generating Swift code ( which is how I found it ).

## Which issue(s) this PR fixes:

Fixes #5531 
