### PR TITLE
fix: pwa share target

### DIFF
--- a/frontend/middleware/pwa-share-target-redirect.global.ts
+++ b/frontend/middleware/pwa-share-target-redirect.global.ts
@@ -1,0 +1,10 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if (to.path === "/r/create/url") {
+    const { user } = useMealieAuth();
+    const groupSlug = user.value?.groupSlug;
+    if (!groupSlug) {
+      return navigateTo("/login", { redirectCode: 301 });
+    }
+    return navigateTo(`/g/${groupSlug}${to.fullPath}`, { redirectCode: 301 });
+  }
+});


### PR DESCRIPTION
## What this PR does / why we need it:

fixes the pwa share target. 
the link is missing the g/_groupslug_/ at the front of it because we don't know which group the logged in user belongs to. I added a global middleware that redirects anything that goes to `/r/create/url` to the users group e.g. `/g/home/create/url`.
When the user is not logged in they get redirected to the login page.

## Which issue(s) this PR fixes:

- fixes #5556 

## Special notes for your reviewer:

instead of a global middleware which runs on every route we could also add a `r/[...].vue` page and run the middleware on this. Found this solution a bit cleaner because we are not adding another route to the pages folder, but happy to change it.

## Testing
Works as expected in dev mode
will again build another pr-image to check if there are any dev mode quirks with this. ~~so don't merge yet!~~

Tested in prod working 🥳