### PR TITLE
fix: mealplanner day title card height & alignment

### DIFF
--- a/frontend/pages/household/mealplan/planner/view.vue
+++ b/frontend/pages/household/mealplan/planner/view.vue
@@ -38,82 +38,68 @@
   </v-container>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import type { MealsByDate } from "./types";
 import type { ReadPlanEntry } from "~/lib/api/types/meal-plan";
 import GroupMealPlanDayContextMenu from "~/components/Domain/Household/GroupMealPlanDayContextMenu.vue";
 import RecipeCardMobile from "~/components/Domain/Recipe/RecipeCardMobile.vue";
 import type { RecipeSummary } from "~/lib/api/types/recipe";
 
-export default defineNuxtComponent({
-  components: {
-    GroupMealPlanDayContextMenu,
-    RecipeCardMobile,
-  },
-  props: {
-    mealplans: {
-      type: Array as () => MealsByDate[],
-      required: true,
-    },
-  },
-  setup(props) {
-    type DaySection = {
-      title: string;
-      meals: ReadPlanEntry[];
+const props = defineProps<{
+  mealplans: MealsByDate[];
+}>();
+
+type DaySection = {
+  title: string;
+  meals: ReadPlanEntry[];
+};
+
+type Days = {
+  date: Date;
+  sections: DaySection[];
+  recipes: RecipeSummary[];
+};
+
+const i18n = useI18n();
+
+const plan = computed<Days[]>(() => {
+  return props.mealplans.reduce((acc, day) => {
+    const out: Days = {
+      date: day.date,
+      sections: [
+        { title: i18n.t("meal-plan.breakfast"), meals: [] },
+        { title: i18n.t("meal-plan.lunch"), meals: [] },
+        { title: i18n.t("meal-plan.dinner"), meals: [] },
+        { title: i18n.t("meal-plan.side"), meals: [] },
+      ],
+      recipes: [],
     };
 
-    type Days = {
-      date: Date;
-      sections: DaySection[];
-      recipes: RecipeSummary[];
-    };
+    for (const meal of day.meals) {
+      if (meal.entryType === "breakfast") {
+        out.sections[0].meals.push(meal);
+      }
+      else if (meal.entryType === "lunch") {
+        out.sections[1].meals.push(meal);
+      }
+      else if (meal.entryType === "dinner") {
+        out.sections[2].meals.push(meal);
+      }
+      else if (meal.entryType === "side") {
+        out.sections[3].meals.push(meal);
+      }
 
-    const i18n = useI18n();
+      if (meal.recipe) {
+        out.recipes.push(meal.recipe);
+      }
+    }
 
-    const plan = computed<Days[]>(() => {
-      return props.mealplans.reduce((acc, day) => {
-        const out: Days = {
-          date: day.date,
-          sections: [
-            { title: i18n.t("meal-plan.breakfast"), meals: [] },
-            { title: i18n.t("meal-plan.lunch"), meals: [] },
-            { title: i18n.t("meal-plan.dinner"), meals: [] },
-            { title: i18n.t("meal-plan.side"), meals: [] },
-          ],
-          recipes: [],
-        };
+    // Drop empty sections
+    out.sections = out.sections.filter(section => section.meals.length > 0);
 
-        for (const meal of day.meals) {
-          if (meal.entryType === "breakfast") {
-            out.sections[0].meals.push(meal);
-          }
-          else if (meal.entryType === "lunch") {
-            out.sections[1].meals.push(meal);
-          }
-          else if (meal.entryType === "dinner") {
-            out.sections[2].meals.push(meal);
-          }
-          else if (meal.entryType === "side") {
-            out.sections[3].meals.push(meal);
-          }
+    acc.push(out);
 
-          if (meal.recipe) {
-            out.recipes.push(meal.recipe);
-          }
-        }
-
-        // Drop empty sections
-        out.sections = out.sections.filter(section => section.meals.length > 0);
-
-        acc.push(out);
-
-        return acc;
-      }, [] as Days[]);
-    });
-
-    return {
-      plan,
-    };
-  },
+    return acc;
+  }, [] as Days[]);
 });
 </script>

--- a/frontend/pages/household/mealplan/planner/view.vue
+++ b/frontend/pages/household/mealplan/planner/view.vue
@@ -6,11 +6,11 @@
         <v-card class="mb-2 border-left-primary rounded-sm px-2">
           <v-container class="px-0 d-flex align-center" height="56px">
             <v-row no-gutters style="width: 100%;">
-                <v-col cols="10" class="d-flex align-center">
-                  <p class="pl-2 my-1">
-                    {{ $d(day.date, "short") }}
-                  </p>
-                </v-col>
+              <v-col cols="10" class="d-flex align-center">
+                <p class="pl-2 my-1">
+                  {{ $d(day.date, "short") }}
+                </p>
+              </v-col>
               <v-col class="d-flex align-center" cols="2">
                 <GroupMealPlanDayContextMenu v-if="day.recipes.length" :recipes="day.recipes" />
               </v-col>

--- a/frontend/pages/household/mealplan/planner/view.vue
+++ b/frontend/pages/household/mealplan/planner/view.vue
@@ -4,14 +4,14 @@
       <v-col v-for="(day, index) in plan" :key="index" cols="12" sm="12" md="4" lg="4" xl="2"
         class="col-borders my-1 d-flex flex-column">
         <v-card class="mb-2 border-left-primary rounded-sm px-2">
-          <v-container class="px-0">
+          <v-container class="px-0 d-flex align-center" height="56px">
             <v-row no-gutters style="width: 100%;">
-              <v-col cols="10">
-                <p class="pl-2 my-1">
-                  {{ $d(day.date, "short") }}
-                </p>
-              </v-col>
-              <v-col class="d-flex justify-top" cols="2">
+                <v-col cols="10" class="d-flex align-center">
+                  <p class="pl-2 my-1">
+                    {{ $d(day.date, "short") }}
+                  </p>
+                </v-col>
+              <v-col class="d-flex align-center" cols="2">
                 <GroupMealPlanDayContextMenu v-if="day.recipes.length" :recipes="day.recipes" />
               </v-col>
             </v-row>


### PR DESCRIPTION
## What this PR does / why we need it:

normalizes height of the meal planner title card component and centers the elements vertically.
Also converted it to script setup (last commit). 

## Which issue(s) this PR fixes:

None, came up on discord.

## Testing

local