### PR TITLE
fix: register create group flow

### DIFF
--- a/frontend/pages/register/index.vue
+++ b/frontend/pages/register/index.vue
@@ -78,7 +78,7 @@
                 dark
                 hover
                 width="300px"
-                @click="initial.joinGroup"
+                @click="initial.createGroup"
               >
                 <v-card-title class="d-flex align-center justify-center py-3">
                   <v-icon


### PR DESCRIPTION
## What this PR does / why we need it:

Registration to a new group was broken because both buttons updated the state to joinGroup. So it was not possible to create a new group via the register flow. 
This updates it to the intended behaviour. 

## Which issue(s) this PR fixes:

None, found by me during usage. 

## Special notes for your reviewer:

None

## Testing

Local
