### PR TITLE
feat: Open recipes in new tab for mobile view

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCardMobile.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardMobile.vue
@@ -7,116 +7,127 @@
         :style="{ cursor }"
         hover
         height="100%"
-        :to="$attrs.selected ? undefined : recipeRoute"
         @click="$emit('selected')"
       >
-        <v-img
-          v-if="vertical"
-          class="rounded-sm"
-          cover
+        <a
+          :href="recipeRoute"
+          target="_blank"
+          rel="noopener noreferrer"
+          style="
+           text-decoration: none;
+           color: inherit;
+           display: block;
+           height: 100%;
+           "
         >
-          <RecipeCardImage
-            :icon-size="100"
-            :slug="slug"
-            :recipe-id="recipeId"
-            size="small"
-            :image-version="image"
-            :height="height"
-          />
-        </v-img>
-        <v-list-item
-          lines="two"
-          class="py-0"
-          :class="vertical ? 'px-2' : 'px-0'"
-          item-props
-          height="100%"
-          density="compact"
-        >
-          <template #prepend>
-            <slot
-              v-if="!vertical"
-              name="avatar"
-            >
-              <RecipeCardImage
-                :icon-size="100"
-                :slug="slug"
-                :recipe-id="recipeId"
-                :image-version="image"
-                size="small"
-                width="125"
-                :height="height"
-              />
-            </slot>
-          </template>
-          <div class="pl-4 d-flex flex-column justify-space-between align-stretch pr-2">
-            <v-list-item-title class="mt-3 mb-1 text-top text-truncate w-100">
-              {{ name }}
-            </v-list-item-title>
-            <v-list-item-subtitle class="ma-0 text-top">
-              <SafeMarkdown v-if="description" :source="description" />
-              <p v-else>
-                <br>
-                <br>
-                <br>
-              </p>
-            </v-list-item-subtitle>
-            <div
-              class="d-flex flex-nowrap justify-start ma-0 pt-2 pb-0"
-              style="overflow-x: hidden; overflow-y: hidden; white-space: nowrap;"
-            >
-              <RecipeChips
-                :truncate="true"
-                :items="tags"
-                :title="false"
-                :limit="2"
-                small
-                url-prefix="tags"
-                v-bind="$attrs"
-              />
+          <v-img
+            v-if="vertical"
+            class="rounded-sm"
+            cover
+          >
+            <RecipeCardImage
+              :icon-size="100"
+              :slug="slug"
+              :recipe-id="recipeId"
+              size="small"
+              :image-version="image"
+              :height="height"
+            />
+          </v-img>
+          <v-list-item
+            lines="two"
+            class="py-0"
+            :class="vertical ? 'px-2' : 'px-0'"
+            item-props
+            height="100%"
+            density="compact"
+          >
+            <template #prepend>
+              <slot
+                v-if="!vertical"
+                name="avatar"
+              >
+                <RecipeCardImage
+                  :icon-size="100"
+                  :slug="slug"
+                  :recipe-id="recipeId"
+                  :image-version="image"
+                  size="small"
+                  width="125"
+                  :height="height"
+                />
+              </slot>
+            </template>
+            <div class="pl-4 d-flex flex-column justify-space-between align-stretch pr-2">
+              <v-list-item-title class="mt-3 mb-1 text-top text-truncate w-100">
+                {{ name }}
+              </v-list-item-title>
+              <v-list-item-subtitle class="ma-0 text-top">
+                <SafeMarkdown v-if="description" :source="description" />
+                <p v-else>
+                  <br>
+                  <br>
+                  <br>
+                </p>
+              </v-list-item-subtitle>
+              <div
+                class="d-flex flex-nowrap justify-start ma-0 pt-2 pb-0"
+                style="overflow-x: hidden; overflow-y: hidden; white-space: nowrap;"
+              >
+                <RecipeChips
+                  :truncate="true"
+                  :items="tags"
+                  :title="false"
+                  :limit="2"
+                  small
+                  url-prefix="tags"
+                  v-bind="$attrs"
+                />
+              </div>
             </div>
-          </div>
-          <slot name="actions">
-            <v-card-actions class="w-100 my-0 px-1 py-0">
-              <RecipeFavoriteBadge
-                v-if="isOwnGroup && showRecipeContent"
-                :recipe-id="recipeId"
-                show-always
-                class="ma-0 pa-0"
-              />
-              <div v-else class="my-0 px-1 py-0" /> <!-- Empty div to keep the layout consistent -->
-              <RecipeRating
-                v-if="showRecipeContent"
-                :class="[{ 'pb-2': !isOwnGroup }, 'ml-n2']"
-                :value="rating"
-                :recipe-id="recipeId"
-                :slug="slug"
-                small
-              />
+            <slot name="actions">
+              <v-card-actions class="w-100 my-0 px-1 py-0">
+                <RecipeFavoriteBadge
+                  v-if="isOwnGroup && showRecipeContent"
+                  :recipe-id="recipeId"
+                  show-always
+                  class="ma-0 pa-0"
+                />
+                <div v-else class="my-0 px-1 py-0" /> <!-- Empty div to keep the layout consistent -->
+                <RecipeRating
+                  v-if="showRecipeContent"
+                  :class="[{ 'pb-2': !isOwnGroup }, 'ml-n2']"
+                  :value="rating"
+                  :recipe-id="recipeId"
+                  :slug="slug"
+                  small
+                />
 
-              <!-- If we're not logged-in, no items display, so we hide this menu -->
-              <!-- We also add padding to the v-rating above to compensate -->
-              <RecipeContextMenu
-                v-if="isOwnGroup && showRecipeContent"
-                :slug="slug"
-                :menu-icon="$globals.icons.dotsHorizontal"
-                :name="name"
-                :recipe-id="recipeId"
-                class="ml-auto"
-                :use-items="{
-                  delete: false,
-                  edit: false,
-                  download: true,
-                  mealplanner: true,
-                  shoppingList: true,
-                  print: false,
-                  printPreferences: false,
-                  share: true,
-                }"
-                @deleted="$emit('delete', slug)"
-              />
-            </v-card-actions>
-            </slot>
-        </v-list-item>
+                <!-- If we're not logged-in, no items display, so we hide this menu -->
+                <!-- We also add padding to the v-rating above to compensate -->
+                <RecipeContextMenu
+                  v-if="isOwnGroup && showRecipeContent"
+                  :slug="slug"
+                  :menu-icon="$globals.icons.dotsHorizontal"
+                  :name="name"
+                  :recipe-id="recipeId"
+                  class="ml-auto"
+                  :use-items="{
+                    delete: false,
+                    edit: false,
+                    download: true,
+                    mealplanner: true,
+                    shoppingList: true,
+                    print: false,
+                    printPreferences: false,
+                    share: true,
+                  }"
+                  @deleted="$emit('delete', slug)"
+                />
+              </v-card-actions>
+              </slot>
+          </v-list-item>
+        </a>
         <slot />
       </v-card>
     </v-expand-transition>


### PR DESCRIPTION
## What this PR does / why we need it:

This PR addresses issue #5350. There may be older, closed issues about the same UX problem that I didn't find. Please be referred to the aforementioned issue for details. In a nutshell, though: When scrolling through lists of recipes and looking at them in detail, you are always taken back to the top of the list when going back to the list from a detailed view. That is fine for small numbers of recipes, but it is frustrating when browsing large libraries. On a computer, we can right click and then open a recipe in a new tab. That way, one tab can remain open on the recipe list page while the details can be viewed in another tab, thus not losing the position in the list. Unfortunately, the same cannot be done on any of the many mobile devices that I tried. It is not possible to long-press and then open a recipe in a new tab. Thus, this PR causes recipes in the recipe list to open in new tabs on mobile.

- The mobile recipe card's content is wrapped in an anchor tag pointing to the detail page and the `to` attribute is removed. The component still looks the same. Most of the changes pertain to whitespace due to adjusted indentations.

For the reasons mentioned above, I think it makes sense to always open recipe detail views in new tabs on mobile.

## Which issue(s) this PR fixes:

- #5350 

## Special notes for your reviewer:

I was considering to make this optional and configurable on a per-user basis, but I have to admit to not knowing the frontend's tech stack well enough to do that. I hope it would be simple but I would need advice and help if that were desired.

Any feedback you can give is appreciated! If this change is not desirable, please let me know. Me and my family consider the current behaviour rather frustrating and would very much like to see this change, or a change to a similar effect, introduced in mainline mealie.

Thank you very much for mealie in general and for considering this PR in particular.

I recommend not showing changes due to whitespace when viewing this PR's diff. You can follow [this link](https://github.com/mealie-recipes/mealie/pull/5601/files?diff=unified&w=1) to get to such a view.

## Testing

I built the production docker image locally with my changes and accessed a locally hosted instance both from a computer and from a phone. When clicked, recipes in the mobile view opened in new tabs while ones clicked in the desktop view did not. The mobile recipe cards still look the same as before in my tests.