### PR TITLE
fix: recipe timeline visuals (nuxt 3)

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeTimeline.vue
+++ b/frontend/components/Domain/Recipe/RecipeTimeline.vue
@@ -69,7 +69,8 @@
       :style="maxHeight ? `max-height: ${maxHeight}; overflow-y: auto;` : ''"
     >
       <v-timeline
-        :dense="$vuetify.display.smAndDown"
+        :density="$vuetify.display.smAndDown ? ($vuetify.display.xs ? 'compact' : 'comfortable') : undefined"
+        justify="center"
         class="timeline"
       >
         <RecipeTimelineItem
@@ -78,6 +79,7 @@
           :event="event"
           :recipe="recipes.get(event.recipeId)"
           :show-recipe-cards="showRecipeCards"
+          :width="$vuetify.display.smAndDown ? '100%' : undefined"
           @update="updateTimelineEvent(index)"
           @delete="deleteTimelineEvent(index)"
         />


### PR DESCRIPTION
## What this PR does / why we need it:

The timeline used an deprecated `dense` prop for the v-timeline that is not included in the v3 version of the component. 
Changed it to use `density` and updated the timeline items to use the full width on smaller screens. 

## Which issue(s) this PR fixes:

- fixes #5607 

## Special notes for your reviewer:

The timeline is not perfectly aligned in the center, i don't exactly know why. Hasn't bothered me too much but if there is an easy fix for that we might want to include it. 

## Testing

Local
