### PR TITLE
fix: truncate slugs when too long

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -7,7 +7,6 @@ from uuid import UUID
 import sqlalchemy as sa
 from fastapi import HTTPException
 from pydantic import UUID4
-from slugify import slugify
 from sqlalchemy import orm
 from sqlalchemy.exc import IntegrityError
 
@@ -22,7 +21,7 @@ from mealie.db.models.users.user_to_recipe import UserToRecipe
 from mealie.db.models.users.users import User
 from mealie.schema.cookbook.cookbook import ReadCookBook
 from mealie.schema.recipe import Recipe
-from mealie.schema.recipe.recipe import RecipeCategory, RecipePagination, RecipeSummary
+from mealie.schema.recipe.recipe import RecipeCategory, RecipePagination, RecipeSummary, create_recipe_slug
 from mealie.schema.recipe.recipe_ingredient import IngredientFood
 from mealie.schema.recipe.recipe_suggestion import RecipeSuggestionQuery, RecipeSuggestionResponseItem
 from mealie.schema.recipe.recipe_tool import RecipeToolOut
@@ -98,7 +97,7 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
             except IntegrityError:
                 self.session.rollback()
                 document.name = f"{original_name} ({i})"
-                document.slug = slugify(document.name)
+                document.slug = create_recipe_slug(document.name)
 
                 if i >= max_retries:
                     raise

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -36,6 +36,22 @@ from .recipe_step import RecipeStep
 app_dirs = get_app_dirs()
 
 
+def create_recipe_slug(name: str, max_length: int = 250) -> str:
+    """Generate a slug from a recipe name, truncating to a reasonable length.
+
+    Args:
+        name: The recipe name to create a slug from
+        max_length: Maximum length for the slug (default: 250)
+
+    Returns:
+        A truncated slug string
+    """
+    generated_slug = slugify(name)
+    if len(generated_slug) > max_length:
+        generated_slug = generated_slug[:max_length]
+    return generated_slug
+
+
 class RecipeTag(MealieModel):
     id: UUID4 | None = None
     group_id: UUID4 | None = None
@@ -229,7 +245,7 @@ class Recipe(RecipeSummary):
         if not info.data.get("name"):
             return slug
 
-        return slugify(info.data["name"])
+        return create_recipe_slug(info.data["name"])
 
     @field_validator("recipe_ingredient", mode="before")
     def validate_ingredients(recipe_ingredient):

--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -9,7 +9,6 @@ from uuid import UUID, uuid4
 from zipfile import ZipFile
 
 from fastapi import UploadFile
-from slugify import slugify
 
 from mealie.core import exceptions
 from mealie.core.config import get_app_settings
@@ -21,7 +20,7 @@ from mealie.repos.repository_factory import AllRepositories
 from mealie.repos.repository_generic import RepositoryGeneric
 from mealie.schema.household.household import HouseholdInDB, HouseholdRecipeUpdate
 from mealie.schema.openai.recipe import OpenAIRecipe
-from mealie.schema.recipe.recipe import CreateRecipe, Recipe
+from mealie.schema.recipe.recipe import CreateRecipe, Recipe, create_recipe_slug
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient
 from mealie.schema.recipe.recipe_notes import RecipeNote
 from mealie.schema.recipe.recipe_settings import RecipeSettings
@@ -332,7 +331,7 @@ class RecipeService(RecipeServiceBase):
 
         new_name = dup_data.name if dup_data.name else old_recipe.name or ""
         new_recipe.id = uuid4()
-        new_recipe.slug = slugify(new_name)
+        new_recipe.slug = create_recipe_slug(new_name)
         new_recipe.image = cache.cache_key.new_key() if old_recipe.image else None
         new_recipe.recipe_instructions = (
             None
@@ -447,7 +446,7 @@ class OpenAIRecipeService(RecipeServiceBase):
             group_id=self.user.group_id,
             household_id=self.household.id,
             name=openai_recipe.name,
-            slug=slugify(openai_recipe.name),
+            slug=create_recipe_slug(openai_recipe.name),
             description=openai_recipe.description,
             recipe_yield=openai_recipe.recipe_yield,
             total_time=openai_recipe.total_time,


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes an issue where the generated slug would be too long for the constructed file path. In reality we shouldn't be using slug names for file paths, but that's load bearing code by now 😓 

## Which issue(s) this PR fixes:

Fixes #5321

## Testing

Automated Testing