### PR TITLE
fix: load from env if available vs file

### DIFF
--- a/dev/code-generation/gen_ts_locales.py
+++ b/dev/code-generation/gen_ts_locales.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,7 +14,7 @@ from mealie.schema._mealie import MealieModel
 
 BASE = pathlib.Path(__file__).parent.parent.parent
 
-API_KEY = dotenv.get_key(BASE / ".env", "CROWDIN_API_KEY")
+API_KEY = dotenv.get_key(BASE / ".env", "CROWDIN_API_KEY") or os.environ.get("CROWDIN_API_KEY", "")
 
 
 @dataclass


### PR DESCRIPTION
## What this PR does / why we need it:

Loads env from both a file and the local env if available. This fixes the action that runs in CI and requires access to the actual env.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->
