### PR TITLE
fix: Recipe Timeline Not Filtering

### DIFF
--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -219,10 +219,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
 
   async getAllTimelineEvents(page = 1, perPage = -1, params = {} as any) {
     return await this.requests.get<PaginationData<RecipeTimelineEventOut>>(
-      routes.recipesTimelineEvent,
-      {
-        params: { page, perPage, ...params },
-      },
+      routes.recipesTimelineEvent, { page, perPage, ...params },
     );
   }
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The frontend was calling the recipe timeline API wrong by adding an erroneous `params` key, causing all params to be ignored. I double checked and no other API is doing this, just this one.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5646

## Testing

_(fill-in or delete this section)_

Manually adjusting filters and such, as well as checking individual recipes.
