### PR TITLE
fix: Restore Servings To Print View

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/components/Domain/Recipe/RecipePrintView.vue
@@ -23,18 +23,17 @@
               </v-icon>
               {{ recipe.name }}
             </v-card-title>
-            <div v-if="recipeYield"
-                 class="d-flex justify-space-between align-center px-4 pb-2"
+            <div
+              v-if="recipeYield"
+              class="d-flex justify-space-between align-center pb-6"
             >
-              <v-chip :size="$vuetify.display.smAndDown ? 'small' : undefined"
-                      label
-              >
+              <div>
                 <v-icon start>
                   {{ $globals.icons.potSteam }}
                 </v-icon>
                 <!-- eslint-disable-next-line vue/no-v-html -->
                 <span v-html="recipeYield" />
-              </v-chip>
+              </div>
             </div>
             <v-row class="d-flex justify-start">
               <RecipeTimeCard :prep-time="recipe.prepTime"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Converts the servings to a normal div instead of a chip in print view:
<img width="552" height="155" alt="image" src="https://github.com/user-attachments/assets/a225a250-4542-4fb3-9f6e-de77853b7bab" />

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

I double-checked all scenarios (servings only, yield only, both, neither) and it behaves as expected.