### PR TITLE
fix: set correct github tag in init py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build Package
     uses: ./.github/workflows/build-package.yml
     with:
-      tag: release
+      tag: ${{ github.event.release.tag_name }}
 
   publish:
     permissions:


### PR DESCRIPTION
## What this PR does / why we need it:

sets the correct tag name in the __init__.py file instead of a generic 'release'. 

## Which issue(s) this PR fixes:

- fixes #5676 

## Special notes for your reviewer:

Don't look at the blame on how it got there 🙈

## Testing

Will be tested with the next release
