### PR TITLE
fix: style of recipe actions to be compliant with design schema

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -125,11 +125,6 @@
         </v-list-item>
         <div v-if="useItems.recipeActions && recipeActions && recipeActions.length">
           <v-divider />
-          <v-list-item disabled>
-            <v-list-item-title>
-              {{ $t("recipe.recipe-actions") }}
-            </v-list-item-title>
-          </v-list-item>
           <v-list-item
             v-for="(action, index) in recipeActions"
             :key="index"
@@ -137,7 +132,7 @@
           >
             <template #prepend>
               <v-icon color="undefined">
-                {{ $globals.icons.primary }}
+                {{ $globals.icons.linkVariantPlus }}
               </v-icon>
             </template>
             <v-list-item-title>

--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -125,25 +125,25 @@
         </v-list-item>
         <div v-if="useItems.recipeActions && recipeActions && recipeActions.length">
           <v-divider />
-          <v-list-group @click.stop>
-            <template #activator="{ props }">
-              <v-list-item-title v-bind="props">
-                {{ $t("recipe.recipe-actions") }}
-              </v-list-item-title>
+          <v-list-item disabled>
+            <v-list-item-title>
+              {{ $t("recipe.recipe-actions") }}
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item
+            v-for="(action, index) in recipeActions"
+            :key="index"
+            @click="executeRecipeAction(action)"
+          >
+            <template #prepend>
+              <v-icon color="undefined">
+                {{ $globals.icons.primary }}
+              </v-icon>
             </template>
-            <v-list density="compact" class="ma-0 pa-0">
-              <v-list-item
-                v-for="(action, index) in recipeActions"
-                :key="index"
-                class="pl-6"
-                @click="executeRecipeAction(action)"
-              >
-                <v-list-item-title>
-                  {{ action.title }}
-                </v-list-item-title>
-              </v-list-item>
-            </v-list>
-          </v-list-group>
+            <v-list-item-title>
+              {{ action.title }}
+            </v-list-item-title>
+          </v-list-item>
         </div>
       </v-list>
     </v-menu>

--- a/frontend/lib/icons/icons.ts
+++ b/frontend/lib/icons/icons.ts
@@ -151,6 +151,7 @@ import {
   mdiKnife,
   mdiCookie,
   mdiBellPlus,
+  mdiLinkVariantPlus,
 } from "@mdi/js";
 
 export const icons = {
@@ -236,6 +237,7 @@ export const icons = {
   informationOutline: mdiInformationOutline,
   informationVariant: mdiInformationVariant,
   link: mdiLink,
+  linkVariantPlus: mdiLinkVariantPlus,
   lock: mdiLock,
   logout: mdiLogout,
   menu: mdiMenu,

--- a/frontend/pages/group/data/recipe-actions.vue
+++ b/frontend/pages/group/data/recipe-actions.vue
@@ -4,7 +4,7 @@
     <BaseDialog
       v-model="state.createDialog"
       :title="$t('data-pages.recipe-actions.new-recipe-action')"
-      :icon="$globals.icons.primary"
+      :icon="$globals.icons.linkVariantPlus"
       can-submit
       @submit="createAction"
     >
@@ -34,7 +34,7 @@
     <!-- Edit Dialog -->
     <BaseDialog
       v-model="state.editDialog"
-      :icon="$globals.icons.primary"
+      :icon="$globals.icons.linkVariantPlus"
       :title="$t('data-pages.recipe-actions.edit-recipe-action')"
       :submit-text="$t('general.save')"
       can-submit
@@ -115,7 +115,7 @@
 
     <!-- Data Table -->
     <BaseCardSectionTitle
-      :icon="$globals.icons.primary"
+      :icon="$globals.icons.linkVariantPlus"
       section
       :title="$t('data-pages.recipe-actions.recipe-actions-data')"
     />


### PR DESCRIPTION
## What this PR does / why we need it:

The design of the recipe actions in the three dot menu did not look good (not like the other points) and it was unclear that is is possible to click on the text to show the actions. This fixes it:
- The menu for actions is always visible now (if there is at least one recipe action 
- The text is aligned properly
- Removed the header
- The actions have an icon (always the same, the same one as in `/group/data/recipe-actions`), changed that icon as discussed below to `mdiLinkVariantPlus` 

------


Old design:
<img width="314" height="365" alt="image" src="https://github.com/user-attachments/assets/862eb953-abf4-47f1-a63b-bf5ebd20ed2e" />
<img width="315" height="443" alt="image" src="https://github.com/user-attachments/assets/28d5eaab-821f-47c2-99af-f686b6ba8f18" />



New design:
<img width="267" height="465" alt="image" src="https://github.com/user-attachments/assets/0ca4f844-9173-4061-88f4-bc1cc0e40a0d" />

<img width="343" height="205" alt="image" src="https://github.com/user-attachments/assets/19db06c2-468c-42d8-a67a-69ff0f4f1645" />


the menu is always visible now (if there is at least one recipe action and the text is aligned properly

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/issues/5734



## Testing

`task ui:test` runs successfully