### PR TITLE
fix: Mealplan Regressions

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -277,8 +277,8 @@ export default defineNuxtComponent({
     const newMealdateString = computed(() => {
       // Format the date to YYYY-MM-DD in the same timezone as newMealdate
       const year = state.newMealdate.getFullYear();
-      const month = String(state.newMealdate.getMonth() + 1).padStart(2, '0');
-      const day = String(state.newMealdate.getDate()).padStart(2, '0');
+      const month = String(state.newMealdate.getMonth() + 1).padStart(2, "0");
+      const day = String(state.newMealdate.getDate()).padStart(2, "0");
       return `${year}-${month}-${day}`;
     });
 

--- a/frontend/components/Domain/Recipe/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu.vue
@@ -269,13 +269,17 @@ export default defineNuxtComponent({
       recipeName: props.name,
       loading: false,
       menuItems: [] as ContextMenuItem[],
-      newMealdate: new Date(Date.now() - new Date().getTimezoneOffset() * 60000),
+      newMealdate: new Date(),
       newMealType: "dinner" as PlanEntryType,
       pickerMenu: false,
     });
 
     const newMealdateString = computed(() => {
-      return state.newMealdate.toISOString().substring(0, 10);
+      // Format the date to YYYY-MM-DD in the same timezone as newMealdate
+      const year = state.newMealdate.getFullYear();
+      const month = String(state.newMealdate.getMonth() + 1).padStart(2, '0');
+      const day = String(state.newMealdate.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
     });
 
     const i18n = useI18n();

--- a/frontend/pages/household/mealplan/planner.vue
+++ b/frontend/pages/household/mealplan/planner.vue
@@ -5,7 +5,6 @@
       :close-on-content-click="false"
       transition="scale-transition"
       offset-y
-      max-width="290px"
       min-width="auto"
     >
       <template #activator="{ props }">
@@ -20,29 +19,27 @@
           {{ $d(weekRange.start, "short") }} - {{ $d(weekRange.end, "short") }}
         </v-btn>
       </template>
-      <v-date-picker
-        v-model="state.range"
-        hide-header
-        :multiple="'range'"
-        :first-day-of-week="firstDayOfWeek"
-        :local="$i18n.locale"
-      >
-        <v-text-field
-          v-model="numberOfDays"
-          type="number"
-          :label="$t('meal-plan.numberOfDays-label')"
-          :hint="$t('meal-plan.numberOfDays-hint')"
-          persistent-hint
+
+      <v-card>
+        <v-date-picker
+          v-model="state.range"
+          hide-header
+          :multiple="'range'"
+          :first-day-of-week="firstDayOfWeek"
+          :local="$i18n.locale"
         />
-        <v-spacer />
-        <v-btn
-          variant="text"
-          color="primary"
-          @click="state.picker = false"
-        >
-          {{ $t("general.ok") }}
-        </v-btn>
-      </v-date-picker>
+
+        <v-card-text>
+          <v-text-field
+            v-model="numberOfDays"
+            class="mt-0 pt-0"
+            type="number"
+            :label="$t('meal-plan.numberOfDays-label')"
+            :hint="$t('meal-plan.numberOfDays-hint')"
+            persistent-hint
+          />
+        </v-card-text>
+      </v-card>
     </v-menu>
 
     <div class="d-flex flex-wrap align-center justify-space-between mb-2">

--- a/frontend/pages/household/mealplan/planner.vue
+++ b/frontend/pages/household/mealplan/planner.vue
@@ -32,7 +32,6 @@
         <v-card-text>
           <v-text-field
             v-model="numberOfDays"
-            class="mt-0 pt-0"
             type="number"
             :label="$t('meal-plan.numberOfDays-label')"
             :hint="$t('meal-plan.numberOfDays-hint')"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes two mealplan regressions:
- `v-date-picker` no longer accepts content inside the date picker tags, so I moved the default range selector outside of it. I also had to fix a few visual issues with this. I also removed the "OK" button because everything is reactive anyway so it's updated instantly.
- Selecting the date when adding a recipe to the meal plan now correctly reflects the date the user inputted. This was a timezone issue (if the current date in your local time did not match UTC, we used UTC).

New picker with restored field:
<img width="351" height="514" alt="image" src="https://github.com/user-attachments/assets/95fffbb0-ad56-4566-9e58-c33cc8183fad" />


## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5742
Fixes https://github.com/mealie-recipes/mealie/issues/5747

## Special notes for your reviewer:

_(fill-in or delete this section)_

I double-checked to see if we used the deprecated `v-date-picker` content anywhere else, but I confirmed it was only this specific date picker that did this.

## Testing

_(fill-in or delete this section)_

A lot of local timezone switching.
