### PR TITLE
fix: multiple regressions on data management page

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeDataTable.vue
+++ b/frontend/components/Domain/Recipe/RecipeDataTable.vue
@@ -9,6 +9,7 @@
     :items-per-page="15"
     class="elevation-0"
     :loading="loading"
+    return-object
   >
     <template #[`item.name`]="{ item }">
       <a

--- a/frontend/components/Domain/Recipe/RecipeDataTable.vue
+++ b/frontend/components/Domain/Recipe/RecipeDataTable.vue
@@ -3,7 +3,7 @@
     v-model="selected"
     item-key="id"
     show-select
-    :sort-by="[{ key: 'dateAdded', order: 'desc' }]"
+    :sort-by="sortBy"
     :headers="headers"
     :items="recipes"
     :items-per-page="15"
@@ -117,7 +117,7 @@ export default defineNuxtComponent({
       },
     },
   },
-  emits: ["click"],
+  emits: ["click", "update:modelValue"],
   setup(props, context) {
     const i18n = useI18n();
     const $auth = useMealieAuth();
@@ -127,6 +127,9 @@ export default defineNuxtComponent({
       get: () => props.modelValue,
       set: value => context.emit(INPUT_EVENT, value),
     });
+
+    // Initialize sort state with default sorting by dateAdded descending
+    const sortBy = ref([{ key: "dateAdded", order: "desc" }]);
 
     const headers = computed(() => {
       const hdrs: Array<{ title: string; value: string; align?: string; sortable?: boolean }> = [];
@@ -206,6 +209,7 @@ export default defineNuxtComponent({
 
     return {
       selected,
+      sortBy,
       groupSlug,
       headers,
       formatDate,

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -126,7 +126,7 @@
     <!-- Alias Sub-Dialog -->
     <RecipeDataAliasManagerDialog
       v-if="editTarget"
-      :value="aliasManagerDialog"
+      v-model="aliasManagerDialog"
       :data="editTarget"
       @submit="updateFoodAlias"
       @cancel="aliasManagerDialog = false"
@@ -540,6 +540,7 @@ export default defineNuxtComponent({
 
     const aliasManagerDialog = ref(false);
     function aliasManagerEventHandler() {
+      console.log("Opening alias manager dialog");
       aliasManagerDialog.value = true;
     }
 

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -540,7 +540,6 @@ export default defineNuxtComponent({
 
     const aliasManagerDialog = ref(false);
     function aliasManagerEventHandler() {
-      console.log("Opening alias manager dialog");
       aliasManagerDialog.value = true;
     }
 

--- a/frontend/pages/group/data/tags.vue
+++ b/frontend/pages/group/data/tags.vue
@@ -44,6 +44,7 @@
       :title="$t('general.confirm')"
       :icon="$globals.icons.alertCircle"
       color="error"
+      can-confirm
       @confirm="deleteTag"
     >
       <v-card-text>

--- a/frontend/pages/group/data/tools.vue
+++ b/frontend/pages/group/data/tools.vue
@@ -52,6 +52,7 @@
       :title="$t('general.confirm')"
       :icon="$globals.icons.alertCircle"
       color="error"
+      can-confirm
       @confirm="deleteTool"
     >
       <v-card-text>

--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -19,30 +19,16 @@
           v-model="fromUnit"
           return-object
           :items="store"
-          item-title="id"
+          item-title="name"
           :label="$t('data-pages.units.source-unit')"
-        >
-          <template #chip="{ item }">
-            {{ item.raw.name }}
-          </template>
-          <template #item="{ item }">
-            {{ item.raw.name }}
-          </template>
-        </v-autocomplete>
+        />
         <v-autocomplete
           v-model="toUnit"
           return-object
           :items="store"
-          item-title="id"
+          item-title="name"
           :label="$t('data-pages.units.target-unit')"
-        >
-          <template #chip="{ item }">
-            {{ item.raw.name }}
-          </template>
-          <template #item="{ item }">
-            {{ item.raw.name }}
-          </template>
-        </v-autocomplete>
+        />
 
         <template v-if="canMerge && fromUnit && toUnit">
           <div class="text-center">


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes multiple regressions on the data management page. Pretty simple fixes for all of them. 
List of the issues:
- The alias management dialog used :value instead of v-model, which made the dialog not pop up when its value was set to true
- delete dialog for tags and tools was missing `can-confirm` prop
- setting sort state of the recipe table to a variable so that it will not be directly overwritten by any changes (e.g. a selection event)
- returning the recipe object when selecting a recipe on the recipe table instead of just the recipe id so that actions can use the slug of the object
- removed unnecessairy stuff on unit merging that lead to all units being rendered in a single row

## Which issue(s) this PR fixes:

- fixes #5752 
- fixes #5731 
- fixes #5732 
- fixes #5712
- fixes #5707

## Special notes for your reviewer:

None

## Testing

Local in dev