### PR TITLE
feat: change recipe sorting default to alphabetical order instead of `created_at`

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeExplorerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage.vue
@@ -300,8 +300,8 @@ export default defineNuxtComponent({
 
     const queryDefaults = {
       search: "",
-      orderBy: "created_at",
-      orderDirection: "desc" as "asc" | "desc",
+      orderBy: "name",
+      orderDirection: "asc",
       requireAllCategories: false,
       requireAllTags: false,
       requireAllTools: false,


### PR DESCRIPTION
## What this PR does / why we need it:

This PR changes the default sorting from when the newest recipe was created to an alphabetical order. This is much more intuitive (in my opinion) as

- The list of recipes is a list. I expect lists to be sorted by number/name
- Sorting by the newest recipe is not senseful, since the user probably cooked that recipe lately since he added it to mealie afterwards. In this case he wouldn't want to re-cook it now. _I don't know if this sounds senseful, but I think alphabetical is just the logical ordering_

Before:
<img width="1557" height="490" alt="image" src="https://github.com/user-attachments/assets/726b92a1-54ac-4532-a9eb-7227883d77b5" />


After:
<img width="1610" height="579" alt="image" src="https://github.com/user-attachments/assets/d5d3323c-a7c6-499a-a25f-644eae7cc6b1" />


## Which issue(s) this PR fixes:

-

