### PR TITLE
fix: remove v-lazy from RecipeCard

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeCard.vue
@@ -1,6 +1,5 @@
 <template>
   <!-- Wrap v-hover with a div to provide a proper DOM element for the transition -->
-  <v-lazy>
     <div>
       <v-hover
         v-slot="{ isHovering, props }"
@@ -99,7 +98,6 @@
         </v-card>
       </v-hover>
     </div>
-  </v-lazy>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
each v-lazy creates a new IntersectionObserver, tanking the performance. there's still some more work to do around fetching the recipes. locally, it takes 35 ms for API to send the response, but somehow that turns into almost 800 ms of JS 'computations' (that's on production build)

<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

_(REQUIRED)_

this change vastly improves loading speed of recipes list

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

_(REQUIRED)_

(mostly) fixes https://github.com/mealie-recipes/mealie/issues/5206

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->
