### PR TITLE
fix: tags & tools edit confirm

### DIFF
--- a/frontend/pages/group/data/tags.vue
+++ b/frontend/pages/group/data/tags.vue
@@ -26,6 +26,7 @@
       :icon="$globals.icons.tags"
       :title="$t('data-pages.tags.edit-tag')"
       :submit-text="$t('general.save')"
+      can-confirm
       @submit="editSaveTag"
     >
       <v-card-text v-if="editTarget">

--- a/frontend/pages/group/data/tools.vue
+++ b/frontend/pages/group/data/tools.vue
@@ -30,6 +30,7 @@
       :icon="$globals.icons.potSteam"
       :title="$t('data-pages.tools.edit-tool')"
       :submit-text="$t('general.save')"
+      can-confirm
       @submit="editSaveTool"
     >
       <v-card-text v-if="editTarget">
@@ -41,6 +42,7 @@
           <v-checkbox
             v-model="editTarget.onHand"
             :label="$t('tool.on-hand')"
+            hide-details
           />
         </div>
       </v-card-text>


### PR DESCRIPTION
## What this PR does / why we need it:

The edit dialog is missing the can confirm prop on the tools and tags on the data management page. 

## Which issue(s) this PR fixes:

- fixes #5859 

## Testing

Local
