### PR TITLE
fix: change libldap-2.5 to libldap2 in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,7 +132,7 @@ RUN apt-get update \
     gosu \
     iproute2 \
     libldap-common \
-    libldap-2.5 \
+    libldap2 \
     && rm -rf /var/lib/apt/lists/*
 
 # create directory used for Docker Secrets


### PR DESCRIPTION
## What this PR does / why we need it:

`python:3.12-slim` now uses Debian 13 Trixie as base image, which by now do not include `libldap-2.5` package. Even though docker build passes, mealie crashes on startup. Using the suggested `libldap2`, the build succeeds and mealie operates fine.

Logs, for reference:
```
usermod: no changes
Switching to dedicated user

        User uid:    911
        User gid:    911

Traceback (most recent call last):
  File "/opt/mealie/bin/mealie", line 3, in <module>
    from mealie.main import main
  File "/opt/mealie/lib/python3.12/site-packages/mealie/main.py", line 3, in <module>
    from mealie.app import settings
  File "/opt/mealie/lib/python3.12/site-packages/mealie/app.py", line 23, in <module>
    from mealie.routes import router, spa, utility_routes
  File "/opt/mealie/lib/python3.12/site-packages/mealie/routes/__init__.py", line 3, in <module>
    from . import (
  File "/opt/mealie/lib/python3.12/site-packages/mealie/routes/admin/__init__.py", line 3, in <module>
    from . import (
  File "/opt/mealie/lib/python3.12/site-packages/mealie/routes/admin/admin_backups.py", line 9, in <module>
    from mealie.core.security import create_file_token
  File "/opt/mealie/lib/python3.12/site-packages/mealie/core/security/__init__.py", line 1, in <module>
    from .security import *
  File "/opt/mealie/lib/python3.12/site-packages/mealie/core/security/security.py", line 11, in <module>
    from mealie.core.security.providers.auth_provider import AuthProvider
  File "/opt/mealie/lib/python3.12/site-packages/mealie/core/security/providers/__init__.py", line 3, in <module>
    from .ldap_provider import *
  File "/opt/mealie/lib/python3.12/site-packages/mealie/core/security/providers/ldap_provider.py", line 3, in <module>
    import ldap
  File "/opt/mealie/lib/python3.12/site-packages/ldap/__init__.py", line 34, in <module>
    import _ldap
ImportError: libldap.so.2: cannot open shared object file: No such file or directory
```

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/issues/5947

