### PR TITLE
dev: Pin Docker Digest And Add to Renovate

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 ###############################################
 # Frontend Build
 ###############################################
-FROM node:20 AS frontend-builder
+FROM node:20@sha256:452293f0e5c9b7075829f2cd0dbd5fcae44d89cf5508b84a17bbe0857dc1a654 \
+    AS frontend-builder
 
 WORKDIR /frontend
 
@@ -20,7 +21,8 @@ RUN yarn generate
 ###############################################
 # Base Image - Python
 ###############################################
-FROM python:3.12-slim AS python-base
+FROM python:3.12-slim@sha256:2267adc248a477c1f1a852a07a5a224d42abe54c28aafa572efa157dfb001bba \
+    AS python-base
 
 ENV MEALIE_HOME="/app"
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
-    "poetry"
+    "poetry",
+    "dockerfile"
   ],
   "extends": [
     "config:base"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Pins our prod Docker images to their digests, avoiding breaking changes [like these](https://github.com/mealie-recipes/mealie/issues/5947). 

Renovate can automatically update these for us, so I've added that config as well. More info: https://docs.renovatebot.com/docker/#digest-pinning

## Which issue(s) this PR fixes:

_(REQUIRED)_

Closes https://github.com/mealie-recipes/mealie/issues/5948

## Testing

_(fill-in or delete this section)_

E2E tests