### PR TITLE
fix: Missing Items On Admin Pages

### DIFF
--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -99,6 +99,7 @@
           :headers="headers"
           :items="backups.imports || []"
           class="elevation-0"
+          :items-per-page="-1"
           hide-default-footer
           disable-pagination
           :search="search"

--- a/frontend/pages/admin/manage/groups/index.vue
+++ b/frontend/pages/admin/manage/groups/index.vue
@@ -47,6 +47,7 @@
         :items="groups || []"
         item-key="id"
         class="elevation-0"
+        :items-per-page="-1"
         hide-default-footer
         disable-pagination
         :search="search"

--- a/frontend/pages/admin/manage/households/index.vue
+++ b/frontend/pages/admin/manage/households/index.vue
@@ -66,6 +66,7 @@
         :items="households"
         item-key="id"
         class="elevation-0"
+        :items-per-page="-1"
         hide-default-footer
         disable-pagination
         :search="search"

--- a/frontend/pages/admin/manage/users/index.vue
+++ b/frontend/pages/admin/manage/users/index.vue
@@ -56,6 +56,7 @@
         item-key="id"
         class="elevation-0"
         elevation="0"
+        :items-per-page="-1"
         hide-default-footer
         disable-pagination
         :search="search"

--- a/frontend/pages/household/members.vue
+++ b/frontend/pages/household/members.vue
@@ -33,6 +33,7 @@
       :items="members || []"
       item-key="id"
       class="elevation-0"
+      :items-per-page="-1"
       hide-default-footer
       disable-pagination
     >


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sets the `items-per-page` prop on data tables which have pagination disabled to `-1` so all items are displayed. Without this we only show the first 10.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, raised on Discord, also mentioned in this discussion: https://github.com/mealie-recipes/mealie/discussions/5983

## Testing

_(fill-in or delete this section)_

Manually