### PR TITLE
fix: Update variable name in RecipeCard.vue to enable household ratings to appear on recipes

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeCard.vue
@@ -57,7 +57,7 @@
 
               <RecipeRating
                 class="ml-n2"
-                :value="rating"
+                :model-value="rating"
                 :recipe-id="recipeId"
                 :slug="slug"
                 small


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes issue raised [here](https://github.com/mealie-recipes/mealie/issues/5863) where household ratings were not appearing when the user had not rated a recipe.

This seemed to be caused by an incorrect variable name in the recipecard.vue. This PR updates the variable to enable household ratings to show for recipes where the user has not rated the recipe themselves.

## Which issue(s) this PR fixes:
Fixes #5863 where household ratings were not appearing when the user had not rated a recipe.

## Testing
Tested on a copy of my main server to ensure I had household ratings from other users.