### PR TITLE
fix: Increase AXIOS timeout

### DIFF
--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -18,6 +18,7 @@ import type {
   RecipeTimelineEventUpdate,
 } from "~/lib/api/types/recipe";
 import type { ApiRequestInstance, PaginationData } from "~/lib/api/types/non-generated";
+const AXIOS_TIMEOUT = process.env.OPENAI_REQUEST_TIMEOUT || 120000;
 
 export type Parser = "nlp" | "brute" | "openai";
 
@@ -169,7 +170,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
       apiRoute = `${apiRoute}?translateLanguage=${translateLanguage}`;
     }
 
-    return await this.requests.post<string>(apiRoute, formData, { timeout: 120000 });
+    return await this.requests.post<string>(apiRoute, formData, { timeout: AXIOS_TIMEOUT });
   }
 
   async parseIngredients(parser: Parser, ingredients: Array<string>) {

--- a/frontend/plugins/axios.ts
+++ b/frontend/plugins/axios.ts
@@ -1,11 +1,13 @@
 import axios from "axios";
 import { alert } from "~/composables/use-toast";
+const AXIOS_TIMEOUT = process.env.OPENAI_REQUEST_TIMEOUT || 10000;
+
 
 export default defineNuxtPlugin(() => {
   const tokenName = useRuntimeConfig().public.AUTH_TOKEN;
   const axiosInstance = axios.create({
     baseURL: "/", // api calls already pass with /api
-    timeout: 10000,
+    timeout: AXIOS_TIMEOUT,
     headers: {
       Authorization: "Bearer " + useCookie(tokenName).value,
     },


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

Forces Axios to use the OPENAI_REQUEST_TIMEOUT variable declared in the docker-compose.yaml file. Defaults to a set value if OPENAI_REQUEST_TIMEOUT is not set.

- axios.ts modified to declare a constant value of AXIOS_TIMEOUT, which reads the OPENAI_REQUEST_TIMEOUT value from docker-compose.yaml or uses a set value if not declared. Changed axiosInstance timeout to use this constant value
- recipe.ts modified to declare a constant value of AXIOS_TIMEOUT, which reads the OPENAI_REQUEST_TIMEOUT value from docker-compose.yaml or uses a set value if not declared. Changed createOneFromImages timeout to use this constant value.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Fixes #5719
Fixes https://github.com/mealie-recipes/mealie/issues/5910

