### PR TITLE
fix: Simplify AutoForm and fix select

### DIFF
--- a/frontend/components/global/AutoForm.vue
+++ b/frontend/components/global/AutoForm.vue
@@ -106,15 +106,7 @@
           persistent-hint
           lazy-validation
           @blur="emitBlur"
-        >
-          <template #item="{ item }">
-            <v-list-item
-              v-bind="props"
-              :title="item.raw.text"
-              :subtitle="item.raw.description"
-            />
-          </template>
-        </v-select>
+        />
 
         <!-- Color Picker -->
         <div

--- a/frontend/types/auto-forms.ts
+++ b/frontend/types/auto-forms.ts
@@ -4,7 +4,6 @@ type FormFieldType = "text" | "textarea" | "list" | "select" | "object" | "boole
 
 export interface FormSelectOption {
   text: string;
-  description?: string;
 }
 
 export interface FormField {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Removes the `description` field from the `AutoForm` select type and simplifies the component. https://github.com/mealie-recipes/mealie/issues/5906 seems broken even after it was "fixed" in https://github.com/mealie-recipes/mealie/pull/5919.

This option wasn't used anywhere in the app anyway, so if we want to use it later down the line we can re-implement it.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5906 (again)

## Testing

_(fill-in or delete this section)_

![2025-08-23_14h40_57](https://github.com/user-attachments/assets/e3f38a7c-74f6-4f90-8d63-05e985e5cdc9)
