### PR TITLE
fix: Remove Temperature from OpenAI Integration

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -131,7 +131,7 @@ For custom mapping variables (e.g. OPENAI_CUSTOM_HEADERS) you should pass values
 | OPENAI_ENABLE_IMAGE_SERVICES                      |  True   | Whether to enable OpenAI image services, such as creating recipes via image. Leave this enabled unless your custom model doesn't support it, or you want to reduce costs     |
 | OPENAI_WORKERS                                    |    2    | Number of OpenAI workers per request. Higher values may increase processing speed, but will incur additional API costs                                                       |
 | OPENAI_SEND_DATABASE_DATA                         |  True   | Whether to send Mealie data to OpenAI to improve request accuracy. This will incur additional API costs                                                                      |
-| OPENAI_REQUEST_TIMEOUT                            |   60    | The number of seconds to wait for an OpenAI request to complete before cancelling the request. Leave this empty unless you're running into timeout issues on slower hardware |
+| OPENAI_REQUEST_TIMEOUT                            |   300   | The number of seconds to wait for an OpenAI request to complete before cancelling the request. Leave this empty unless you're running into timeout issues on slower hardware |
 
 ### Theming
 

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -398,7 +398,7 @@ class AppSettings(AppLoggingSettings):
     Sending database data may increase accuracy in certain requests,
     but will incur additional API costs
     """
-    OPENAI_REQUEST_TIMEOUT: int = 60
+    OPENAI_REQUEST_TIMEOUT: int = 300
     """
     The number of seconds to wait for an OpenAI request to complete before cancelling the request
     """

--- a/mealie/services/openai/openai.py
+++ b/mealie/services/openai/openai.py
@@ -135,9 +135,7 @@ class OpenAIService(BaseService):
             )
         return "\n".join(content_parts)
 
-    async def _get_raw_response(
-        self, prompt: str, content: list[dict], temperature=0.2, force_json_response=True
-    ) -> ChatCompletion:
+    async def _get_raw_response(self, prompt: str, content: list[dict], force_json_response=True) -> ChatCompletion:
         client = self.get_client()
         return await client.chat.completions.create(
             messages=[
@@ -151,7 +149,6 @@ class OpenAIService(BaseService):
                 },
             ],
             model=self.model,
-            temperature=temperature,
             response_format={"type": "json_object"} if force_json_response else NOT_GIVEN,
         )
 
@@ -161,7 +158,6 @@ class OpenAIService(BaseService):
         message: str,
         *,
         images: list[OpenAIImageBase] | None = None,
-        temperature=0.2,
         force_json_response=True,
     ) -> str | None:
         """Send data to OpenAI and return the response message content"""
@@ -174,7 +170,7 @@ class OpenAIService(BaseService):
             for image in images or []:
                 user_messages.append(image.build_message())
 
-            response = await self._get_raw_response(prompt, user_messages, temperature, force_json_response)
+            response = await self._get_raw_response(prompt, user_messages, force_json_response)
             if not response.choices:
                 return None
             return response.choices[0].message.content


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The `temperature` param is used in the OpenAI spec to adjust how "random" the output of the LLM response is. Currently we set this to "0.2" to keep it basically static. Annoyingly, not only does GPT-5 not support this, but the API will throw an error if it's passed and tell you to use the default of 1.0.

This PR removes the temperature parameter entirely. It seems like OpenAI is moving away from it generally anyway, and while it was very useful back with older models (e.g. GPT-3) it's not really as necessary anymore since responses are generally far more consistent.

I also increased the default timeout to 5 minutes, since now that we support sending multiple images in a request it takes a lot longer (if multiple images are provided). The frontend currently still times out after 10 seconds but [there's another PR to fix this](https://github.com/mealie-recipes/mealie/pull/6016).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6019

## Special notes for your reviewer:

_(fill-in or delete this section)_

After this is merged I'm going to try switching my prod instance over to GPT 5 and see how it fares vs 4o. If it's good for recipe stuff I'll probably change the default (it's cheaper, too).

Kind of silly that OpenAI chooses to return an error rather than ignore the param. I'm sure we're not the only ones burned by this change.

## Testing

_(fill-in or delete this section)_

Switched to GPT-5 and ran some parsing and some recipe extraction.