### PR TITLE
fix: Remove Frontend Timeout

### DIFF
--- a/frontend/plugins/axios.ts
+++ b/frontend/plugins/axios.ts
@@ -4,8 +4,8 @@ import { alert } from "~/composables/use-toast";
 export default defineNuxtPlugin(() => {
   const tokenName = useRuntimeConfig().public.AUTH_TOKEN;
   const axiosInstance = axios.create({
+    // timeout removed to allow backend to handle timeouts
     baseURL: "/", // api calls already pass with /api
-    timeout: 10000,
     headers: {
       Authorization: "Bearer " + useCookie(tokenName).value,
     },


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Removes the frontend timeout. Having a timeout causes issues with communicating with the backend, so this lets the backend manage the timeout instead of both the frontend and the backend.

I double checked and there are zero network requests made by the app using this config that aren't to the backend.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5719
Fixes https://github.com/mealie-recipes/mealie/issues/5910

## Testing

_(fill-in or delete this section)_

Manually tested a long running OpenAI request.