### PR TITLE
fix: Handle missing OIDC groups claim

### DIFF
--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -138,7 +138,7 @@ async def oauth_callback(request: Request, response: Response, session: Session 
         try:
             logger.debug("[OIDC] Claims not present in the ID token, pulling user info")
             userinfo = await client.userinfo(token=token)
-            auth_provider = OpenIDProvider(session, userinfo)
+            auth_provider = OpenIDProvider(session, userinfo, use_default_groups=True)
             auth = auth_provider.authenticate()
         except MissingClaimException:
             auth = None

--- a/tests/unit_tests/core/security/providers/test_openid_provider.py
+++ b/tests/unit_tests/core/security/providers/test_openid_provider.py
@@ -61,6 +61,49 @@ def test_missing_groups_claim(monkeypatch: MonkeyPatch):
         auth_provider.authenticate()
 
 
+def test_missing_groups_claim_admin(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("OIDC_ADMIN_GROUP", "mealie_admin")
+    get_app_settings.cache_clear()
+
+    data = {
+        "preferred_username": "dude1",
+        "email": "email@email.com",
+        "name": "Firstname Lastname",
+    }
+    auth_provider = OpenIDProvider(None, data)
+
+    with pytest.raises(MissingClaimException):
+        auth_provider.authenticate()
+
+
+def test_missing_groups_claim_with_default(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("OIDC_USER_GROUP", "mealie_user")
+    get_app_settings.cache_clear()
+
+    data = {
+        "preferred_username": "dude1",
+        "email": "email@email.com",
+        "name": "Firstname Lastname",
+    }
+    auth_provider = OpenIDProvider(None, data, True)
+
+    assert auth_provider.authenticate() is None
+
+
+def test_missing_groups_claim_admin_group_with_default(monkeypatch: MonkeyPatch, unique_user: TestUser):
+    monkeypatch.setenv("OIDC_ADMIN_GROUP", "mealie_admin")
+    get_app_settings.cache_clear()
+
+    data = {
+        "preferred_username": "dude1",
+        "email": unique_user.email,
+        "name": "Firstname Lastname",
+    }
+    auth_provider = OpenIDProvider(unique_user.repos.session, data, True)
+
+    assert auth_provider.authenticate() is not None
+
+
 def test_missing_user_group(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("OIDC_USER_GROUP", "mealie_user")
     get_app_settings.cache_clear()


### PR DESCRIPTION
Modifies the behaviour of OpenIDProvider to insert an empty groups list when the groups claim is not present in the token's claims. This handles the behaviour of some IdPs that omit including empty claims. This behaviour only gets triggered after the userinfo endpoint is queried in order to not break some existing workflows (access token is missing claims but userinfo endpoint includes those claims).

## What this PR does / why we need it:

This PR fixes the handling of OIDC responses from some IdPs like keycloak, who omit empty claims.

## Which issue(s) this PR fixes:

Fixes #6053
Closes #5974
