### PR TITLE
fix: Fix RecipeLastMade dialog date picker being off by a day

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeLastMade.vue
+++ b/frontend/components/Domain/Recipe/RecipeLastMade.vue
@@ -119,6 +119,7 @@
 
 <script setup lang="ts">
 import { whenever } from "@vueuse/core";
+import { formatISO } from "date-fns";
 import { useUserApi } from "~/composables/api";
 import { alert } from "~/composables/use-toast";
 import { useHouseholdSelf } from "~/composables/use-households";
@@ -148,7 +149,7 @@ const newTimelineEventImageName = ref<string>("");
 const newTimelineEventImagePreviewUrl = ref<string>();
 const newTimelineEventTimestamp = ref<Date>(new Date());
 const newTimelineEventTimestampString = computed(() => {
-  return newTimelineEventTimestamp.value.toISOString().substring(0, 10);
+  return formatISO(newTimelineEventTimestamp.value, { representation: "date" });
 });
 
 const lastMade = ref(props.recipe.lastMade);
@@ -169,7 +170,7 @@ whenever(
   () => madeThisDialog.value,
   () => {
     // Set timestamp to now
-    newTimelineEventTimestamp.value = new Date(Date.now() - new Date().getTimezoneOffset() * 60000);
+    newTimelineEventTimestamp.value = new Date();
   },
 );
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

This PR fixes a bug in the "I Made This" (i.e. 'Add to Timeline') dialog on the recipe page, where selecting a date in the popup calendar would put an incorrect date string into the text field, as described in https://github.com/mealie-recipes/mealie/issues/5818.

The root cause was some date manipulation in `RecipeLastMade.vue`, in addition to time zones, as Michael supposed in https://github.com/mealie-recipes/mealie/issues/5818#issuecomment-3124729197.
I'll point out more details to the fixes with inline comments.

Here are two short videos showing the buggy behavior before and the fixed behavior in this PR:

_Before (tested on Mealie Demo at 2025-09-01 20:45 JST):_ 

https://github.com/user-attachments/assets/8c4868b5-8b84-4851-acb2-3255d283ff61

_After:_

https://github.com/user-attachments/assets/3962b207-b092-48e8-8b03-368ea98253b1


## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

Fixed https://github.com/mealie-recipes/mealie/issues/5818

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

I tested this change manually by running the dev server and using the dialog, after having first reproduced the issue (as shown in the video above).