### PR TITLE
fix: Shopping list top buttons layout (margin and row wrapping)

### DIFF
--- a/frontend/pages/shopping-lists/[id].vue
+++ b/frontend/pages/shopping-lists/[id].vue
@@ -38,8 +38,8 @@
 
     <BasePageTitle divider>
       <template #header>
-        <v-container>
-          <v-row>
+        <v-container class="px-0">
+          <v-row no-gutters>
             <v-col
               class="text-left"
             >
@@ -62,6 +62,7 @@
             </v-col>
             <v-col class="d-flex justify-end">
               <BaseButtonGroup
+                class="d-flex"
                 :buttons="[
                   {
                     icon: $globals.icons.contentCopy,


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

This PR adjusts the buttons at the top of the shopping list in these two ways:
* Remove additional horizontal padding to make them flush with the rest of the content (especially visible on mobile)
* Adjust the styling of the button group on the top right, so that it breaks to the next line as a group instead of individually on narrow viewports

I noticed these buttons behaving strangely/differently after the v3 update, so I also went back to compare the visuals and behavior with v2.8.0, and will include that in the screenshots and recordings below. In prose:
* in vuetify v2, the `v-container` had a `padding` of `12px`; in vuetify v3, this has changed to `16px`
* the shopping list view uses a `v-container` for the whole page, and an additional nested `v-container` for the top button bar across the whole width of the page.
  * i.e. effectively, in v2.8.0, the buttons had a total inset of `24px` from the viewport edge, whereas on mealie-next, they have a total of `32px` inset.
* additionally, in v2.8.0, the left ("All lists") button was set to "float left", so the whole button bar would basically always stay on one row, but on narrow viewports the right button group would just overlap that button (see videos below)
* in combination, on my iPhone 13 mini, back on v2.x, the layout worked out fine visually and functionally
  * but on mealie-next, the additional padding and removed float behavior means that _some_ of the buttons on the right break to a second row, which makes the layout look quite off

The row-breaking behavior is more noticable when using a UI language where the "All lists" button has a visually longer label, e.g. in Japanese it's "すべてのリスト".

### Screenshots and recordings:

Screenshots showing the horizontal margin situation on mobile:

| v2.8.0 | mealie-next | this PR |
|---|---|---|
| <img width="718" height="1313" alt="CleanShot 2025-09-02 at 20 52 11@2x" src="https://github.com/user-attachments/assets/df37607e-c09e-42d7-aa6c-340dbef4223f" /> | <img width="718" height="1332" alt="CleanShot 2025-09-02 at 20 52 27@2x" src="https://github.com/user-attachments/assets/5b8a4c1d-8ff0-4d2c-ae7a-ba5854e7e609" /> | <img width="720" height="1334" alt="CleanShot 2025-09-02 at 20 58 04@2x" src="https://github.com/user-attachments/assets/be602c8c-f06c-4bbc-af8c-4803884dfa39" /> |

For reference, screenshots on a wider viewport like desktop (the margins are less egregious but the flush alignment is still nice):

| v2.8.0 | mealie-next | this PR |
|---|---|---|
| <img width="2784" height="1916" alt="CleanShot 2025-09-03 at 18 00 33@2x" src="https://github.com/user-attachments/assets/dc6c8180-97ab-4446-8304-986d2daead56" /> | <img width="2784" height="1916" alt="CleanShot 2025-09-03 at 18 00 42@2x" src="https://github.com/user-attachments/assets/6001ce66-836c-4164-a464-9d1780377e6b" /> | <img width="2784" height="1916" alt="CleanShot 2025-09-03 at 18 00 48@2x" src="https://github.com/user-attachments/assets/ac82ccf7-b805-4874-bde0-2fb7b9c6e8f3" /> |

And here short screen recordings showing the row-breaking behavior in action:

| v2.8.0 | mealie-next | this PR |
|---|---|---|
| <video src="https://github.com/user-attachments/assets/f2931e95-e715-4005-8742-d4f3bf956303"></video> | <video src="https://github.com/user-attachments/assets/895b8d6d-bc7e-45b0-ac56-a5ac993b8be3"></video> | <video src="https://private-user-images.githubusercontent.com/1099818/485025072-9df98ba3-6000-4893-b7ec-3d6a168a2466.mp4"></video> |





## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

--
