### PR TITLE
fix: Context Menu Dialogs Not Working

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
@@ -3,6 +3,7 @@
     <v-menu
       offset-y
       start
+      :eager="isMenuContentLoaded"
       :bottom="!menuTop"
       :nudge-bottom="!menuTop ? '5' : '0'"
       :top="menuTop"

--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -191,7 +191,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   [key: string]: any;
-  delete: [slug: string];
+  deleted: [slug: string];
 }>();
 
 const api = useUserApi();
@@ -371,7 +371,7 @@ async function deleteRecipe() {
   if (data?.slug) {
     router.push(`/g/${groupSlug.value}`);
   }
-  emit("delete", props.slug);
+  emit("deleted", props.slug);
 }
 
 const download = useDownloader();


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/pull/6071 fixed some major performance issues with the recipe context menu, but broke the dialogs. Since they're wrapped in a `v-menu`, when the menu closes, the dialogs unmount.

This PR conditionally adds the `eager` attribute to the content which mounts the menu content even if the menu isn't open. It only switches to eager if the menu is opened once, maintaining the performance improvements from https://github.com/mealie-recipes/mealie/pull/6071.

Also fixed an unrelated console warning for an emit we're not even using. Leaving the functionality in case we add it back in (there are several discussions around it).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Reported by user in comment on performance issue: https://github.com/mealie-recipes/mealie/issues/5206#issuecomment-3258126232

## Testing

_(fill-in or delete this section)_

Manually verified it works as expected.