### PR TITLE
fix: Upgrade Vuetify, fix Dev Dependencies, and fix Migration Tree View

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mealie",
-"version": "3.1.2",
+  "version": "3.1.2",
   "private": true,
   "scripts": {
     "dev": "nuxt dev",
@@ -19,10 +19,8 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@nuxt/eslint": "1.2.0",
     "@nuxt/fonts": "^0.11.4",
     "@nuxtjs/i18n": "^9.2.1",
-    "@nuxtjs/proxy": "^2.1.0",
     "@sidebase/nuxt-auth": "0.10.0",
     "@vite-pwa/nuxt": "0.10.6",
     "@vueuse/core": "^12.7.0",
@@ -34,14 +32,14 @@
     "marked": "^15.0.12",
     "next-auth": "~4.21.1",
     "nuxt": "^3.15.4",
-    "typescript": "5.3",
     "vite": "^6.2.0",
-    "vite-plugin-commonjs": "^0.10.4",
     "vue-advanced-cropper": "^2.8.9",
     "vue-draggable-plus": "^0.6.0",
-    "vuetify-nuxt-module": "0.18.3"
+    "vuetify": "^3.9.7",
+    "vuetify-nuxt-module": "^0.18.3"
   },
   "devDependencies": {
+    "@nuxt/eslint": "1.2.0",
     "@nuxt/types": "^2.18.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "@nuxtjs/eslint-module": "^4.1.0",
@@ -56,6 +54,8 @@
     "lint-staged": "^15.4.3",
     "prettier": "^3.5.2",
     "sass-embedded": "^1.85.1",
+    "typescript": "5.3",
+    "vite-plugin-commonjs": "^0.10.4",
     "vitest": "^3.0.7"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/frontend/pages/group/migrations.vue
+++ b/frontend/pages/group/migrations.vue
@@ -36,7 +36,8 @@
           </div>
           {{ content.text }}
           <v-treeview
-            v-if="content.tree"
+            v-if="content.tree && Array.isArray(content.tree)"
+            :key="migrationType"
             density="compact"
             :items="content.tree"
           >
@@ -99,6 +100,19 @@ import type { ReportSummary } from "~/lib/api/types/reports";
 import type { MenuItem } from "~/components/global/BaseOverflowButton.vue";
 import { useUserApi } from "~/composables/api";
 import type { SupportedMigrations } from "~/lib/api/types/group";
+
+interface TreeNode {
+  id?: number;
+  icon: string;
+  title: string;
+  children?: TreeNode[];
+}
+
+interface MigrationContent {
+  text: string;
+  acceptedFileType: string;
+  tree: TreeNode[] | false;
+}
 
 const MIGRATIONS = {
   mealie: "mealie_alpha",
@@ -172,53 +186,47 @@ export default defineNuxtComponent({
         value: MIGRATIONS.tandoor,
       },
     ];
-    const _content = {
+    const _content: Record<string, MigrationContent> = {
       [MIGRATIONS.mealie]: {
         text: i18n.t("migration.mealie-pre-v1.description-long"),
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "mealie.zip",
+            title: "mealie.zip",
             children: [
               {
-                id: 2,
-                name: "recipes",
+                title: "recipes",
                 icon: $globals.icons.folderOutline,
                 children: [
                   {
-                    id: 3,
-                    name: "recipe-name",
+                    title: "recipe-name",
                     icon: $globals.icons.folderOutline,
                     children: [
-                      { id: 4, name: "recipe-name.json", icon: $globals.icons.codeJson },
+                      { title: "recipe-name.json", icon: $globals.icons.codeJson },
                       {
-                        id: 5,
-                        name: "images",
+                        title: "images",
                         icon: $globals.icons.folderOutline,
                         children: [
-                          { id: 6, name: "original.webp", icon: $globals.icons.codeJson },
-                          { id: 7, name: "full.jpg", icon: $globals.icons.fileImage },
-                          { id: 8, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                          { title: "original.webp", icon: $globals.icons.codeJson },
+                          { title: "full.jpg", icon: $globals.icons.fileImage },
+                          { title: "thumb.jpg", icon: $globals.icons.fileImage },
                         ],
                       },
                     ],
                   },
                   {
-                    id: 9,
-                    name: "recipe-name-1",
+                    title: "recipe-name-1",
                     icon: $globals.icons.folderOutline,
                     children: [
-                      { id: 10, name: "recipe-name-1.json", icon: $globals.icons.codeJson },
+                      { title: "recipe-name-1.json", icon: $globals.icons.codeJson },
                       {
-                        id: 11,
-                        name: "images",
+                        title: "images",
                         icon: $globals.icons.folderOutline,
                         children: [
-                          { id: 12, name: "original.webp", icon: $globals.icons.codeJson },
-                          { id: 13, name: "full.jpg", icon: $globals.icons.fileImage },
-                          { id: 14, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                          { title: "original.webp", icon: $globals.icons.codeJson },
+                          { title: "full.jpg", icon: $globals.icons.fileImage },
+                          { title: "thumb.jpg", icon: $globals.icons.fileImage },
                         ],
                       },
                     ],
@@ -234,28 +242,25 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "nextcloud.zip",
+            title: "nextcloud.zip",
             children: [
               {
-                id: 2,
-                name: i18n.t("migration.recipe-1"),
+                title: i18n.t("migration.recipe-1"),
                 icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 3, name: "recipe.json", icon: $globals.icons.codeJson },
-                  { id: 4, name: "full.jpg", icon: $globals.icons.fileImage },
-                  { id: 5, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "full.jpg", icon: $globals.icons.fileImage },
+                  { title: "thumb.jpg", icon: $globals.icons.fileImage },
                 ],
               },
               {
-                id: 6,
-                name: i18n.t("migration.recipe-2"),
+                title: i18n.t("migration.recipe-2"),
                 icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 7, name: "recipe.json", icon: $globals.icons.codeJson },
-                  { id: 8, name: "full.jpg", icon: $globals.icons.fileImage },
-                  { id: 9, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "full.jpg", icon: $globals.icons.fileImage },
+                  { title: "thumb.jpg", icon: $globals.icons.fileImage },
                 ],
               },
             ],
@@ -267,21 +272,19 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "Copy_Me_That_20230306.zip",
+            title: "Copy_Me_That_20230306.zip",
             children: [
               {
-                id: 2,
-                name: "images",
+                title: "images",
                 icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 3, name: "recipe_1_an5zy.jpg", icon: $globals.icons.fileImage },
-                  { id: 4, name: "recipe_2_82el8.jpg", icon: $globals.icons.fileImage },
-                  { id: 5, name: "recipe_3_j75qg.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe_1_an5zy.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe_2_82el8.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe_3_j75qg.jpg", icon: $globals.icons.fileImage },
                 ],
               },
-              { id: 6, name: "recipes.html", icon: $globals.icons.codeJson },
+              { title: "recipes.html", icon: $globals.icons.codeJson },
             ],
           },
         ],
@@ -296,28 +299,25 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "nextcloud.zip",
+            title: "nextcloud.zip",
             children: [
               {
-                id: 2,
-                name: i18n.t("migration.recipe-1"),
+                title: i18n.t("migration.recipe-1"),
                 icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 3, name: "recipe.json", icon: $globals.icons.codeJson },
-                  { id: 4, name: "full.jpg", icon: $globals.icons.fileImage },
-                  { id: 5, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "full.jpg", icon: $globals.icons.fileImage },
+                  { title: "thumb.jpg", icon: $globals.icons.fileImage },
                 ],
               },
               {
-                id: 6,
-                name: i18n.t("migration.recipe-2"),
+                title: i18n.t("migration.recipe-2"),
                 icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 7, name: "recipe.json", icon: $globals.icons.codeJson },
-                  { id: 8, name: "full.jpg", icon: $globals.icons.fileImage },
-                  { id: 9, name: "thumb.jpg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "full.jpg", icon: $globals.icons.fileImage },
+                  { title: "thumb.jpg", icon: $globals.icons.fileImage },
                 ],
               },
             ],
@@ -334,11 +334,10 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "plantoeat-recipes-508318_10-13-2023.zip",
+            title: "plantoeat-recipes-508318_10-13-2023.zip",
             children: [
-              { id: 9, name: "plantoeat-recipes-508318_10-13-2023.csv", icon: $globals.icons.codeJson },
+              { title: "plantoeat-recipes-508318_10-13-2023.csv", icon: $globals.icons.codeJson },
             ],
           },
         ],
@@ -348,16 +347,15 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "recipekeeperhtml.zip",
+            title: "recipekeeperhtml.zip",
             children: [
-              { id: 2, name: "recipes.html", icon: $globals.icons.codeJson },
+              { title: "recipes.html", icon: $globals.icons.codeJson },
               {
-                id: 3, name: "images", icon: $globals.icons.folderOutline,
+                title: "images", icon: $globals.icons.folderOutline,
                 children: [
-                  { id: 4, name: "image1.jpg", icon: $globals.icons.fileImage },
-                  { id: 5, name: "image2.jpg", icon: $globals.icons.fileImage },
+                  { title: "image1.jpg", icon: $globals.icons.fileImage },
+                  { title: "image2.jpg", icon: $globals.icons.fileImage },
                 ],
               },
             ],
@@ -369,35 +367,31 @@ export default defineNuxtComponent({
         acceptedFileType: ".zip",
         tree: [
           {
-            id: 1,
             icon: $globals.icons.zip,
-            name: "tandoor_default_export_full_2023-06-29.zip",
+            title: "tandoor_default_export_full_2023-06-29.zip",
             children: [
               {
-                id: 2,
-                name: "1.zip",
+                title: "1.zip",
                 icon: $globals.icons.zip,
                 children: [
-                  { id: 3, name: "image.jpeg", icon: $globals.icons.fileImage },
-                  { id: 4, name: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "image.jpeg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
                 ],
               },
               {
-                id: 5,
-                name: "2.zip",
+                title: "2.zip",
                 icon: $globals.icons.zip,
                 children: [
-                  { id: 6, name: "image.jpeg", icon: $globals.icons.fileImage },
-                  { id: 7, name: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "image.jpeg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
                 ],
               },
               {
-                id: 8,
-                name: "3.zip",
+                title: "3.zip",
                 icon: $globals.icons.zip,
                 children: [
-                  { id: 9, name: "image.jpeg", icon: $globals.icons.fileImage },
-                  { id: 10, name: "recipe.json", icon: $globals.icons.codeJson },
+                  { title: "image.jpeg", icon: $globals.icons.fileImage },
+                  { title: "recipe.json", icon: $globals.icons.codeJson },
                 ],
               },
             ],
@@ -405,6 +399,29 @@ export default defineNuxtComponent({
         ],
       },
     };
+
+    function addIdToNode(counter: number, node: TreeNode): number {
+      node.id = counter;
+      counter += 1;
+      if (node.children) {
+        node.children.forEach((child: TreeNode) => {
+          counter = addIdToNode(counter, child);
+        });
+      }
+      return counter;
+    }
+
+    for (const key in _content) {
+      const migration = _content[key];
+      if (migration.tree && Array.isArray(migration.tree)) {
+        let counter = 1;
+        migration.tree.forEach((node: TreeNode) => {
+          counter = addIdToNode(counter, node);
+        });
+      }
+    }
+
+    console.log(_content);
 
     function setFileObject(fileObject: File) {
       state.fileObject = fileObject;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2333,13 +2333,6 @@
     vue-i18n "^10.0.5"
     vue-router "^4.5.0"
 
-"@nuxtjs/proxy@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-2.1.0.tgz#fa7715a11d237fa1273503c4e9e137dd1bf5575b"
-  integrity sha512-/qtoeqXgZ4Mg6LRg/gDUZQrFpOlOdHrol/vQYMnKu3aN3bP90UfOUB3QSDghUUK7OISAJ0xp8Ld78aHyCTcKCQ==
-  dependencies:
-    http-proxy-middleware "^1.0.6"
-
 "@oxc-parser/binding-darwin-arm64@0.53.0":
   version "0.53.0"
   resolved "https://registry.yarnpkg.com/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.53.0.tgz#5f0e1672c1e95a7b40eed6808731690fba6c0c77"
@@ -3083,13 +3076,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
-"@types/http-proxy@^1.17.5":
-  version "1.17.16"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.16.tgz#dee360707b35b3cc85afcde89ffeebff7d7f9240"
-  integrity sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -3816,10 +3802,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.13.tgz#87b309a6379c22b926e696893237826f64339b6f"
   integrity sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==
 
-"@vuetify/loader-shared@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@vuetify/loader-shared/-/loader-shared-2.1.0.tgz#29410dce04a78fa9cd40c4d9bc417b8d61ce5103"
-  integrity sha512-dNE6Ceym9ijFsmJKB7YGW0cxs7xbYV8+1LjU6jd4P14xOt/ji4Igtgzt0rJFbxu+ZhAzqz853lhB0z8V9Dy9cQ==
+"@vuetify/loader-shared@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@vuetify/loader-shared/-/loader-shared-2.1.1.tgz#bc3bbf845f910f1b2e0317be9293f42dfc94006d"
+  integrity sha512-jSZTzTYaoiv8iwonFCVZQ0YYX/M+Uyl4ng+C4egMJT0Hcmh9gIxJL89qfZICDeo3g0IhqrvipW2FFKKRDMtVcA==
   dependencies:
     upath "^2.0.1"
 
@@ -5972,11 +5958,6 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter3@^4.0.0:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-
 eventemitter3@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
@@ -6184,7 +6165,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -6647,26 +6628,6 @@ http-proxy-agent@^7.0.2:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
-http-proxy-middleware@^1.0.6:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz#43700d6d9eecb7419bf086a128d0f7205d9eb665"
-  integrity sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==
-  dependencies:
-    "@types/http-proxy" "^1.17.5"
-    http-proxy "^1.18.1"
-    is-glob "^4.0.1"
-    is-plain-obj "^3.0.0"
-    micromatch "^4.0.2"
-
-http-proxy@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
-  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  dependencies:
-    eventemitter3 "^4.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
 http-shutdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/http-shutdown/-/http-shutdown-1.2.2.tgz#41bc78fc767637c4c95179bc492f312c0ae64c5f"
@@ -7046,11 +7007,6 @@ is-path-inside@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-4.0.0.tgz#805aeb62c47c1b12fc3fd13bfb3ed1e7430071db"
   integrity sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==
-
-is-plain-obj@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
-  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-obj@^4.1.0:
   version "4.1.0"
@@ -7797,7 +7753,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.2, micromatch@^4.0.5, micromatch@^4.0.8:
+micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -9267,11 +9223,6 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 requrl@^3.0.2:
   version "3.0.2"
@@ -11100,12 +11051,12 @@ vite-plugin-vue-tracer@^0.1.1:
     pathe "^2.0.3"
     source-map-js "^1.2.1"
 
-vite-plugin-vuetify@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.0.tgz#56767be099fd18a44ec2f9831d49269722e0e538"
-  integrity sha512-4wEAQtZaigPpwbFcZbrKpYwutOsWwWdeXn22B9XHzDPQNxVsKT+K9lKcXZnI5JESO1Iaql48S9rOk8RZZEt+Mw==
+vite-plugin-vuetify@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.2.tgz#8e28dcb5b20f4635d350010547654cf2b4dad373"
+  integrity sha512-I/wd6QS+DO6lHmuGoi1UTyvvBTQ2KDzQZ9oowJQEJ6OcjWfJnscYXx2ptm6S7fJSASuZT8jGRBL3LV4oS3LpaA==
   dependencies:
-    "@vuetify/loader-shared" "^2.1.0"
+    "@vuetify/loader-shared" "^2.1.1"
     debug "^4.3.3"
     upath "^2.0.1"
 
@@ -11237,10 +11188,10 @@ vue@^3.4, vue@^3.5.13:
     "@vue/server-renderer" "3.5.13"
     "@vue/shared" "3.5.13"
 
-vuetify-nuxt-module@0.18.3:
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/vuetify-nuxt-module/-/vuetify-nuxt-module-0.18.3.tgz#7d397a561a7410ccfea289a32646498570542554"
-  integrity sha512-Mv5mcqfqk5dR9oVJiITXn5p4NmDzp57AR2Txf/0iIoAjFlMsDWzTpUvn9ELTzDI3Z0LjiYVqptwxrOlMcju2Wg==
+vuetify-nuxt-module@^0.18.3:
+  version "0.18.7"
+  resolved "https://registry.yarnpkg.com/vuetify-nuxt-module/-/vuetify-nuxt-module-0.18.7.tgz#aa704bd950754064cc6ad214d24d9d782538c183"
+  integrity sha512-AEP5DRuyY5yIk8JzPEhG6NohCkGwf9afn4Mv51YPKGxreqP/KfzL0jooG/HN1cinSo4c+9uRowHllzCsnSN7FA==
   dependencies:
     "@nuxt/kit" "^3.12.4"
     defu "^6.1.4"
@@ -11251,13 +11202,18 @@ vuetify-nuxt-module@0.18.3:
     ufo "^1.5.4"
     unconfig "^0.5.5"
     upath "^2.0.1"
-    vite-plugin-vuetify "^2.0.4"
+    vite-plugin-vuetify "^2.1.0"
     vuetify "^3.7.0"
 
 vuetify@^3.7.0:
   version "3.7.18"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.7.18.tgz#53b7184b8df224c6d2c696b2a62557564710bca1"
   integrity sha512-JDkPIaug4hP9c+K/wxSgmTiLTMjBTYv2ATPvudhkRKuhsoym89aWCXb1CVbs7FRYuRsJEOGojpwpL5rBfDDy9g==
+
+vuetify@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.9.7.tgz#aea996f35111f25dd7e31ab956fbb40911841c24"
+  integrity sha512-Ib8PB3ItcguCol8f0DXLpoGyy7FvoOYW23SEWqXX+in1CSItJZHxUXXGSus94m5JWqYqQrFiwCykbHm7UWPi4Q==
 
 w3c-keyname@^2.2.4:
   version "2.2.8"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Pins/upgrades Vuetify to the newest version, giving us back `v-treeview`. The API changed slightly so I fixed it and also simplified the id generation.

I noticed a bunch of dev deps that should be in dev deps and not the production deps, so I moved those.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5844

## Testing

_(fill-in or delete this section)_

Built the prod image to double check moving deps from deps to devDeps didn't break anything.