### PR TITLE
docs: fix typo starting-dev-server.md

### DIFF
--- a/docs/docs/contributors/developers-guide/starting-dev-server.md
+++ b/docs/docs/contributors/developers-guide/starting-dev-server.md
@@ -45,7 +45,7 @@ Once the prerequisites are installed you can cd into the project base directory 
 === "Linux / macOS"
 
     ```bash
-    # Naviate To The Root Directory
+    # Navigate To The Root Directory
     cd /path/to/project
 
     # Utilize the Taskfile to Install Dependencies


### PR DESCRIPTION

## What this PR does / why we need it:

fix a typo in navigate spelling.

## Which issue(s) this PR fixes:

none, it's just a typo