### PR TITLE
fix: add `breaks` option to markdown rendering, to get old linebreak behaviour

### DIFF
--- a/frontend/components/global/SafeMarkdown.vue
+++ b/frontend/components/global/SafeMarkdown.vue
@@ -39,7 +39,7 @@ export default defineNuxtComponent({
     }
 
     const value = computed(() => {
-      const rawHtml = marked.parse(props.source || "", { async: false });
+      const rawHtml = marked.parse(props.source || "", { async: false, breaks: true });
       return sanitizeMarkdown(rawHtml);
     });
 


### PR DESCRIPTION
## What this PR does / why we need it:

As mentioned in #6084 line breaks in the text of recipe instructions won't be rendered anymore, unless you add the explicit markdown sequences (`br` or `\`). This is a bit of a problem if you have saved your instructions in plaintext, because they will become quite unreadable. This reverts back to the pre-nuxt3 behaviour

## Which issue(s) this PR fixes:

Fixes #6084 

## Testing

I tried if it works. I did not add any unit tests, because it's frontend only
