### PR TITLE
fix: Explorer Page State Not Working On Hitting Back

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
@@ -121,7 +121,7 @@
 
 <script setup lang="ts">
 import RecipeExplorerPageSearchFilters from "./RecipeExplorerPageSearchFilters.vue";
-import { useRecipeExplorerSearch } from "~/composables/use-recipe-explorer-search";
+import { useRecipeExplorerSearch, clearRecipeExplorerSearchState } from "~/composables/use-recipe-explorer-search";
 
 const emit = defineEmits<{
   ready: [];
@@ -153,6 +153,11 @@ defineExpose({
 onMounted(async () => {
   await initialize();
   emit("ready");
+});
+
+onUnmounted(() => {
+  // Clear the cache when component unmounts to ensure fresh state on remount
+  clearRecipeExplorerSearchState(groupSlug.value);
 });
 
 const sortText = computed(() => {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

If you set a filter, click on a recipe, then hit back, the recipe filters don't work anymore until resetting them. This clears the internal state on unmount so hitting back can properly hydrate everything.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A