### PR TITLE
chore(l10n): Maybe-fix Crowdin Sync Label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -86,3 +86,6 @@ autolabeler:
   - label: 'dev'
     title:
       - '/dev:/i'
+  - label: 'l10n'
+    title:
+      - '/l10n/i'

--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -99,7 +99,6 @@ jobs:
             --title "chore(l10n): Crowdin locale sync" \
             --base "$BASE_BRANCH" \
             --head "$BRANCH_NAME" \
-            --label "l10n" \
             --body "## Summary
 
           Automatically generated locale updates from the weekly sync job.


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Maybe fixes the Crowdin sync PRs not getting labeled properly. Testing by modifying the PR title here manually.

## Which issue(s) this PR fixes:

N/A