### PR TITLE
fix: multiple RecipeRating backend calls

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeRating.vue
+++ b/frontend/components/Domain/Recipe/RecipeRating.vue
@@ -13,7 +13,6 @@
         hover
         clearable
         @update:model-value="updateRating(+$event)"
-        @click="updateRating"
       />
       <!-- Group Rating -->
       <v-rating v-else
@@ -83,7 +82,7 @@ export default defineNuxtComponent({
     });
 
     function updateRating(val?: number) {
-      if (!isOwnGroup.value) {
+      if (!isOwnGroup.value || typeof val !== "number" || val === 0) {
         return;
       }
 

--- a/frontend/components/Domain/Recipe/RecipeRating.vue
+++ b/frontend/components/Domain/Recipe/RecipeRating.vue
@@ -82,7 +82,7 @@ export default defineNuxtComponent({
     });
 
     function updateRating(val?: number) {
-      if (!isOwnGroup.value || typeof val !== "number" || val === 0) {
+      if (!isOwnGroup.value || !val) {
         return;
       }
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

This PR fixes the double call that is made when a user rates a recipe as well as the submission of a non-numeric value that results in an error 'Input should be a valid number'

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

Manually, by looking at network requests in the browser's developer tools