### PR TITLE
fix: Re-creating container clears auth

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -128,7 +128,7 @@ export default defineNuxtConfig({
 
   auth: {
     isEnabled: true,
-    // disableServerSideAuth: true,
+    disableServerSideAuth: true,
     originEnvKey: "AUTH_ORIGIN",
     baseURL: "/api",
     provider: {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

When the server is torn down the backend usually returns a 502 error which tells Nuxt to clear the token. This disables server side auth in Nuxt which _should_ fix this.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Seems to work as expected on local prod, we'll see.