### PR TITLE
fix: Remove explicit timeout from OpenAI image API Call

### DIFF
--- a/frontend/lib/api/user/recipes/recipe.ts
+++ b/frontend/lib/api/user/recipes/recipe.ts
@@ -169,7 +169,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
       apiRoute = `${apiRoute}?translateLanguage=${translateLanguage}`;
     }
 
-    return await this.requests.post<string>(apiRoute, formData, { timeout: 120000 });
+    return await this.requests.post<string>(apiRoute, formData);
   }
 
   async parseIngredients(parser: Parser, ingredients: Array<string>) {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Removes a timeout from the frontend OpenAI image API call. This was probably added to attempt to resolve timeout issues we were having before, but have since fixed.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6226