### PR TITLE
fix: Remove constraint on unhashed password being 'LDAP'

### DIFF
--- a/mealie/routes/users/crud.py
+++ b/mealie/routes/users/crud.py
@@ -42,7 +42,7 @@ class UserController(BaseUserController):
     @user_router.put("/password")
     def update_password(self, password_change: ChangePassword):
         """Resets the User Password"""
-        if self.user.password == "LDAP" or self.user.auth_method == AuthMethod.LDAP:
+        if self.user.auth_method == AuthMethod.LDAP:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST, ErrorResponse.respond(self.t("user.ldap-update-password-unavailable"))
             )

--- a/mealie/services/user_services/password_reset_service.py
+++ b/mealie/services/user_services/password_reset_service.py
@@ -21,7 +21,7 @@ class PasswordResetService(BaseService):
             self.logger.error(f"failed to create password reset for {email=}: user doesn't exists")
             # Do not raise exception here as we don't want to confirm to the client that the Email doesn't exists
             return None
-        elif user.password == "LDAP" or user.auth_method == AuthMethod.LDAP:
+        elif user.auth_method == AuthMethod.LDAP:
             self.logger.error(f"failed to create password reset for {email=}: user controlled by LDAP")
             return None
 

--- a/tests/fixtures/fixture_users.py
+++ b/tests/fixtures/fixture_users.py
@@ -337,7 +337,7 @@ def ldap_user():
         user = db.users.create(
             {
                 "username": utils.random_string(10),
-                "password": "mealie_password_not_important",
+                "password": "LDAP",
                 "full_name": utils.random_string(10),
                 "email": utils.random_string(10),
                 "admin": False,


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

When a user is created by LDAP, the password is set to the literal 'LDAP' (unhashed). This is fine because nobody will be able to log in with that password since we always check the hash values instead.

Before we had the AuthMethod on a user, this was all we had to tell if a user was controlled by LDAP, and so we prevented changing the password based on that value. Since we have the AuthMethod now, that check no longer makes sense, and it makes sense to be able to be able to change the auth method back to 'Mealie' and reset the password to be fully "un-controlled" by LDAP.

## Which issue(s) this PR fixes:

Fixes #6203

## Testing

Existing unit tests should cover this. Changed the ldap user fixture to have a password of 'LDAP' to validate.
