### PR TITLE
fix: Remove Double Cookie Refresh

### DIFF
--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -37,11 +37,6 @@ export const useMealieAuth = function () {
     { immediate: true },
   );
 
-  async function signIn(...params: Parameters<typeof auth.signIn>) {
-    await auth.signIn(...params);
-    refreshCookie(useRuntimeConfig().public.AUTH_TOKEN);
-  }
-
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
     const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
@@ -52,7 +47,7 @@ export const useMealieAuth = function () {
   return {
     user,
     loggedIn,
-    signIn,
+    signIn: auth.signIn,
     signOut: auth.signOut,
     signUp: auth.signUp,
     refresh: auth.refresh,


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Some old logic crept in to the new auth handling which resulted in refreshing the cookie immediately after setting it, causing users that already had cookie info to have to login twice. This is easily reproducible by clearing cookies and attempting to login.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A