### PR TITLE
fix: Make Ingredient Parser Dialog Use Full Space

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -6,7 +6,7 @@
     disable-submit-on-enter
     @update:model-value="emit('update:modelValue', $event)"
   >
-    <v-container class="pa-2 ma-0" style="background-color: rgb(var(--v-theme-background));">
+    <v-container fluid class="pa-2 ma-0" style="background-color: rgb(var(--v-theme-background));">
       <div v-if="state.loading.parser" class="my-6">
         <AppLoader waiting-text="" class="my-6" />
       </div>


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Makes sure the ingredient parser uses the full space of the dialog on large screens.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A