### PR TITLE
fix: Stores Not Populating Sometimes

### DIFF
--- a/frontend/composables/partials/use-actions-factory.ts
+++ b/frontend/composables/partials/use-actions-factory.ts
@@ -1,10 +1,11 @@
 import { useAsyncKey } from "../use-utils";
+import type { AsyncData, NuxtError } from "#app";
 import type { BoundT } from "./types";
 import type { BaseCRUDAPI, BaseCRUDAPIReadOnly } from "~/lib/api/base/base-clients";
 import type { QueryValue } from "~/lib/api/base/route";
 
 interface ReadOnlyStoreActions<T extends BoundT> {
-  getAll(page?: number, perPage?: number, params?: any): Ref<T[] | null>;
+  getAll(page?: number, perPage?: number, params?: any): AsyncData<T[] | null, NuxtError<unknown> | null>;
   refresh(page?: number, perPage?: number, params?: any): Promise<void>;
 }
 

--- a/frontend/composables/partials/use-actions-factory.ts
+++ b/frontend/composables/partials/use-actions-factory.ts
@@ -1,4 +1,3 @@
-import { useAsyncKey } from "../use-utils";
 import type { AsyncData, NuxtError } from "#app";
 import type { BoundT } from "./types";
 import type { BaseCRUDAPI, BaseCRUDAPIReadOnly } from "~/lib/api/base/base-clients";
@@ -22,6 +21,7 @@ interface StoreActions<T extends BoundT> extends ReadOnlyStoreActions<T> {
  * a lot of refreshing hooks to be called on operations
  */
 export function useReadOnlyActions<T extends BoundT>(
+  storeKey: string,
   api: BaseCRUDAPIReadOnly<T>,
   allRef: Ref<T[] | null> | null,
   loading: Ref<boolean>,
@@ -30,7 +30,7 @@ export function useReadOnlyActions<T extends BoundT>(
     params.orderBy ??= "name";
     params.orderDirection ??= "asc";
 
-    const allItems = useAsyncData(useAsyncKey(), async () => {
+    const allItems = useAsyncData(storeKey, async () => {
       loading.value = true;
       try {
         const { data } = await api.getAll(page, perPage, params);
@@ -81,6 +81,7 @@ export function useReadOnlyActions<T extends BoundT>(
  * a lot of refreshing hooks to be called on operations
  */
 export function useStoreActions<T extends BoundT>(
+  storeKey: string,
   api: BaseCRUDAPI<unknown, T, unknown>,
   allRef: Ref<T[] | null> | null,
   loading: Ref<boolean>,
@@ -89,7 +90,7 @@ export function useStoreActions<T extends BoundT>(
     params.orderBy ??= "name";
     params.orderDirection ??= "asc";
 
-    const allItems = useAsyncData(useAsyncKey(), async () => {
+    const allItems = useAsyncData(storeKey, async () => {
       loading.value = true;
       try {
         const { data } = await api.getAll(page, perPage, params);

--- a/frontend/composables/partials/use-store-factory.ts
+++ b/frontend/composables/partials/use-store-factory.ts
@@ -22,6 +22,10 @@ export const useReadOnlyStore = function <T extends BoundT>(
   const actions = {
     ...storeActions,
     async refresh() {
+      if (loading.value) {
+        return;
+      }
+
       return await storeActions.refresh(1, -1, params);
     },
     flushStore() {
@@ -29,11 +33,7 @@ export const useReadOnlyStore = function <T extends BoundT>(
     },
   };
 
-  if (!loading.value && !store.value.length) {
-    const result = actions.getAll(1, -1, params);
-    store.value = result.value || [];
-  }
-
+  actions.refresh();
   return { store, actions };
 };
 
@@ -47,6 +47,10 @@ export const useStore = function <T extends BoundT>(
   const actions = {
     ...storeActions,
     async refresh() {
+      if (loading.value) {
+        return;
+      }
+
       return await storeActions.refresh(1, -1, params);
     },
     flushStore() {
@@ -54,10 +58,6 @@ export const useStore = function <T extends BoundT>(
     },
   };
 
-  if (!loading.value && !store.value.length) {
-    const result = actions.getAll(1, -1, params);
-    store.value = result.value || [];
-  }
-
+  actions.refresh();
   return { store, actions };
 };

--- a/frontend/composables/partials/use-store-factory.ts
+++ b/frontend/composables/partials/use-store-factory.ts
@@ -13,12 +13,13 @@ export const useData = function <T extends BoundT>(defaultObject: T) {
 };
 
 export const useReadOnlyStore = function <T extends BoundT>(
+  storeKey: string,
   store: Ref<T[]>,
   loading: Ref<boolean>,
   api: BaseCRUDAPIReadOnly<T>,
   params = {} as Record<string, QueryValue>,
 ) {
-  const storeActions = useReadOnlyActions(api, store, loading);
+  const storeActions = useReadOnlyActions(`${storeKey}-store-readonly`, api, store, loading);
   const actions = {
     ...storeActions,
     async refresh() {
@@ -38,12 +39,13 @@ export const useReadOnlyStore = function <T extends BoundT>(
 };
 
 export const useStore = function <T extends BoundT>(
+  storeKey: string,
   store: Ref<T[]>,
   loading: Ref<boolean>,
   api: BaseCRUDAPI<unknown, T, unknown>,
   params = {} as Record<string, QueryValue>,
 ) {
-  const storeActions = useStoreActions(api, store, loading);
+  const storeActions = useStoreActions(`${storeKey}-store`, api, store, loading);
   const actions = {
     ...storeActions,
     async refresh() {

--- a/frontend/composables/partials/use-store-factory.ts
+++ b/frontend/composables/partials/use-store-factory.ts
@@ -23,10 +23,6 @@ export const useReadOnlyStore = function <T extends BoundT>(
   const actions = {
     ...storeActions,
     async refresh() {
-      if (loading.value) {
-        return;
-      }
-
       return await storeActions.refresh(1, -1, params);
     },
     flushStore() {
@@ -34,7 +30,11 @@ export const useReadOnlyStore = function <T extends BoundT>(
     },
   };
 
-  actions.refresh();
+  // initial hydration
+  if (!loading.value && !store.value.length) {
+    actions.refresh();
+  }
+
   return { store, actions };
 };
 
@@ -49,10 +49,6 @@ export const useStore = function <T extends BoundT>(
   const actions = {
     ...storeActions,
     async refresh() {
-      if (loading.value) {
-        return;
-      }
-
       return await storeActions.refresh(1, -1, params);
     },
     flushStore() {
@@ -60,6 +56,10 @@ export const useStore = function <T extends BoundT>(
     },
   };
 
-  actions.refresh();
+  // initial hydration
+  if (!loading.value && !store.value.length) {
+    actions.refresh();
+  }
+
   return { store, actions };
 };

--- a/frontend/composables/store/use-category-store.ts
+++ b/frontend/composables/store/use-category-store.ts
@@ -17,10 +17,10 @@ export const useCategoryData = function () {
 
 export const useCategoryStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<RecipeCategory>(store, loading, api.categories);
+  return useStore<RecipeCategory>("category", store, loading, api.categories);
 };
 
 export const usePublicCategoryStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<RecipeCategory>(store, publicLoading, api.categories);
+  return useReadOnlyStore<RecipeCategory>("category", store, publicLoading, api.categories);
 };

--- a/frontend/composables/store/use-cookbook-store.ts
+++ b/frontend/composables/store/use-cookbook-store.ts
@@ -9,7 +9,7 @@ const publicLoading = ref(false);
 
 export const useCookbookStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  const store = useStore<ReadCookBook>(cookbooks, loading, api.cookbooks);
+  const store = useStore<ReadCookBook>("cookbook", cookbooks, loading, api.cookbooks);
 
   const updateAll = async function (updateData: UpdateCookBook[]) {
     loading.value = true;
@@ -25,5 +25,5 @@ export const useCookbookStore = function (i18n?: Composer) {
 
 export const usePublicCookbookStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<ReadCookBook>(cookbooks, publicLoading, api.cookbooks);
+  return useReadOnlyStore<ReadCookBook>("cookbook", cookbooks, publicLoading, api.cookbooks);
 };

--- a/frontend/composables/store/use-food-store.ts
+++ b/frontend/composables/store/use-food-store.ts
@@ -18,10 +18,10 @@ export const useFoodData = function () {
 
 export const useFoodStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<IngredientFood>(store, loading, api.foods);
+  return useStore<IngredientFood>("food", store, loading, api.foods);
 };
 
 export const usePublicFoodStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<IngredientFood>(store, publicLoading, api.foods);
+  return useReadOnlyStore<IngredientFood>("food", store, publicLoading, api.foods);
 };

--- a/frontend/composables/store/use-household-store.ts
+++ b/frontend/composables/store/use-household-store.ts
@@ -9,10 +9,10 @@ const publicLoading = ref(false);
 
 export const useHouseholdStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useReadOnlyStore<HouseholdSummary>(store, loading, api.households);
+  return useReadOnlyStore<HouseholdSummary>("household", store, loading, api.households);
 };
 
 export const usePublicHouseholdStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<HouseholdSummary>(store, publicLoading, api.households);
+  return useReadOnlyStore<HouseholdSummary>("household-public", store, publicLoading, api.households);
 };

--- a/frontend/composables/store/use-label-store.ts
+++ b/frontend/composables/store/use-label-store.ts
@@ -17,5 +17,5 @@ export const useLabelData = function () {
 
 export const useLabelStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<MultiPurposeLabelOut>(store, loading, api.multiPurposeLabels);
+  return useStore<MultiPurposeLabelOut>("label", store, loading, api.multiPurposeLabels);
 };

--- a/frontend/composables/store/use-tag-store.ts
+++ b/frontend/composables/store/use-tag-store.ts
@@ -17,10 +17,10 @@ export const useTagData = function () {
 
 export const useTagStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<RecipeTag>(store, loading, api.tags);
+  return useStore<RecipeTag>("tag", store, loading, api.tags);
 };
 
 export const usePublicTagStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<RecipeTag>(store, publicLoading, api.tags);
+  return useReadOnlyStore<RecipeTag>("tag", store, publicLoading, api.tags);
 };

--- a/frontend/composables/store/use-tool-store.ts
+++ b/frontend/composables/store/use-tool-store.ts
@@ -23,10 +23,10 @@ export const useToolData = function () {
 
 export const useToolStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<RecipeTool>(store, loading, api.tools);
+  return useStore<RecipeTool>("tool", store, loading, api.tools);
 };
 
 export const usePublicToolStore = function (groupSlug: string, i18n?: Composer) {
   const api = usePublicExploreApi(groupSlug, i18n).explore;
-  return useReadOnlyStore<RecipeTool>(store, publicLoading, api.tools);
+  return useReadOnlyStore<RecipeTool>("tool", store, publicLoading, api.tools);
 };

--- a/frontend/composables/store/use-unit-store.ts
+++ b/frontend/composables/store/use-unit-store.ts
@@ -18,5 +18,5 @@ export const useUnitData = function () {
 
 export const useUnitStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
-  return useStore<IngredientUnit>(store, loading, api.units);
+  return useStore<IngredientUnit>("unit", store, loading, api.units);
 };

--- a/frontend/composables/store/use-user-store.ts
+++ b/frontend/composables/store/use-user-store.ts
@@ -16,5 +16,5 @@ export const useUserStore = function (i18n?: Composer) {
   const requests = useRequests(i18n);
   const api = new GroupUserAPIReadOnly(requests);
 
-  return useReadOnlyStore<UserSummary>(store, loading, api, { orderBy: "full_name" });
+  return useReadOnlyStore<UserSummary>("user", store, loading, api, { orderBy: "full_name" });
 };

--- a/frontend/composables/use-group-recipe-actions.ts
+++ b/frontend/composables/use-group-recipe-actions.ts
@@ -78,7 +78,7 @@ export const useGroupRecipeActions = function (
   };
 
   const actions = {
-    ...useStoreActions<GroupRecipeActionOut>(api.groupRecipeActions, groupRecipeActions, loading),
+    ...useStoreActions<GroupRecipeActionOut>("group-recipe-actions", api.groupRecipeActions, groupRecipeActions, loading),
     flushStore() {
       groupRecipeActions.value = [];
     },

--- a/frontend/composables/use-utils.ts
+++ b/frontend/composables/use-utils.ts
@@ -8,7 +8,7 @@ export const useToggleDarkMode = () => {
 };
 
 export const useAsyncKey = function () {
-  return String(Date.now());
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 };
 
 export const titleCase = function (str: string) {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sometimes our stores don't populate correctly due to our async usage (especially on first load). This PR fixes some of the hydration logic and eliminates duplicate requests with smarter async keys.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

There's an opportunity for caching here with how the async data stores work, but I didn't want to implement that in this PR since it would require a lot of testing to make sure nothing breaks.

## Testing

_(fill-in or delete this section)_

Clicked around a lot to make sure things are populated correctly. Also did some basic CRUD to make sure refreshes work as expected.