### PR TITLE
docs: Update TOKEN_TIME docs to include max

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -11,7 +11,7 @@
 | DEFAULT_GROUP                 |         Home          | The default group for users                                                                        |
 | DEFAULT_HOUSEHOLD             |        Family         | The default household for users in each group                                                      |
 | BASE_URL                      | http://localhost:8080 | Used for Notifications                                                                             |
-| TOKEN_TIME                    |          48           | The time in hours that a login/auth token is valid                                                 |
+| TOKEN_TIME                    |          48           | The time in hours that a login/auth token is valid. Must be <= 87600 (10 years, in hours).         |
 | API_PORT                      |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker**                |
 | API_DOCS                      |         True          | Turns on/off access to the API documentation locally                                               |
 | TZ                            |          UTC          | Must be set to get correct date/time on the server                                                 |


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Meant to add this in 3.3.0 when I added a maximum token time. More info here: https://github.com/mealie-recipes/mealie/pull/6215

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A