### PR TITLE
fix: Default to "0" qty when creating ingredients everywhere

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientEditor.vue
@@ -127,7 +127,7 @@ function addIngredient(ingredients: Array<string> | null = null) {
         note: x,
         unit: undefined,
         food: undefined,
-        quantity: 1,
+        quantity: 0,
       };
     });
 
@@ -145,7 +145,7 @@ function addIngredient(ingredients: Array<string> | null = null) {
       unit: undefined,
       // @ts-expect-error - prop can be null-type by NoUndefinedField type forces it to be set
       food: undefined,
-      quantity: 1,
+      quantity: 0,
     });
   }
 }
@@ -159,7 +159,7 @@ function insertNewIngredient(dest: number) {
     unit: undefined,
     // @ts-expect-error - prop can be null-type by NoUndefinedField type forces it to be set
     food: undefined,
-    quantity: 1,
+    quantity: 0,
   });
 }
 </script>

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -523,7 +523,7 @@ function insertNewIngredient(index: number) {
     input: "",
     confidence: {},
     ingredient: {
-      quantity: 1.0,
+      quantity: 0,
       referenceId: uuid4(),
     },
   } as ParsedIngredient;


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sets the default qty for new ingredients to "0" everywhere. This was already changed in the main places new ingredients are created, but not all.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6270
Fixes https://github.com/mealie-recipes/mealie/issues/6271