### PR TITLE
fix: Restore recipe meta for non-logged-in users

### DIFF
--- a/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
+++ b/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
@@ -26,13 +26,14 @@ const router = useRouter();
 const slug = route.params.slug as string;
 
 const recipe = ref<Recipe | null>(null);
-if (isOwnGroup.value) {
+function loadRecipe() {
   const { recipe: data } = useRecipe(slug);
   watch(data, (value) => {
     recipe.value = value;
   });
 }
-else {
+
+async function loadPublicRecipe() {
   const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
   const api = usePublicExploreApi(groupSlug.value);
   const { data } = await useAsyncData(useAsyncKey(), async () => {
@@ -45,6 +46,13 @@ else {
     return data;
   });
   recipe.value = data.value;
+}
+
+if (isOwnGroup.value) {
+  loadRecipe();
+}
+else {
+  onMounted(loadPublicRecipe);
 }
 
 whenever(

--- a/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
+++ b/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
@@ -19,7 +19,7 @@ import type { Recipe } from "~/lib/api/types/recipe";
 const $auth = useMealieAuth();
 const { isOwnGroup } = useLoggedInState();
 const route = useRoute();
-const title = ref(route.meta?.title ?? "");
+const title = ref(route.meta?.title as string || "");
 useSeoMeta({ title });
 
 const router = useRouter();

--- a/frontend/pages/g/[groupSlug]/shared/r/[id].vue
+++ b/frontend/pages/g/[groupSlug]/shared/r/[id].vue
@@ -25,7 +25,7 @@ const router = useRouter();
 const recipeId = route.params.id as string;
 const api = usePublicApi();
 
-const title = ref(route.meta?.title ?? "");
+const title = ref(route.meta?.title as string ?? "");
 useSeoMeta({
   title,
 });


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The setup block doesn't support async statements so we never populate the page title for public users (since it relies on `await`). This PR moves that logic to an async function and runs it on mount.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6280

## Testing

_(fill-in or delete this section)_

Double checked both logged-in and non-logged-in and double checked I could still edit when logged in, just to be safe.