### PR TITLE
feat: Add footer nav bar for mobile

### DIFF
--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -91,6 +91,7 @@
         </div>
       </v-scroll-x-transition>
     </v-main>
+    <FooterNav v-if="$vuetify.display.xs" />
   </v-app>
 </template>
 

--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -91,7 +91,7 @@
         </div>
       </v-scroll-x-transition>
     </v-main>
-    <FooterNav v-if="$vuetify.display.xs" />
+    <FooterNav v-if="$vuetify.display.xs && activityPreferences.showFooter" />
   </v-app>
 </template>
 
@@ -99,7 +99,7 @@
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import type { SideBarLink } from "~/types/application-types";
 import { useAppInfo } from "~/composables/api";
-import { useCookbookPreferences } from "~/composables/use-users/preferences";
+import { useCookbookPreferences, useUserActivityPreferences } from "~/composables/use-users/preferences";
 import { useCookbookStore, usePublicCookbookStore } from "~/composables/store/use-cookbook-store";
 import type { ReadCookBook } from "~/lib/api/types/cookbook";
 
@@ -110,6 +110,7 @@ export default defineNuxtComponent({
     const display = useDisplay();
     const $auth = useMealieAuth();
     const { isOwnGroup } = useLoggedInState();
+    const activityPreferences = useUserActivityPreferences();
 
     const route = useRoute();
     const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
@@ -301,6 +302,7 @@ export default defineNuxtComponent({
       isOwnGroup,
       languageDialog,
       sidebar,
+      activityPreferences,
     };
   },
 });

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -6,6 +6,7 @@
     color="primary"
     dark
     class="d-print-none"
+    scroll-behavior="hide"
   >
     <slot />
     <router-link :to="routerLink">

--- a/frontend/components/Layout/LayoutParts/FooterNav.vue
+++ b/frontend/components/Layout/LayoutParts/FooterNav.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-bottom-navigation grow>
+    <template v-for="nav in topLinks" :key="nav.key || nav.title">
+      <v-btn
+        :to="nav.to"
+        :icon="nav.icon"
+        size="3rem"
+        variant="plain"
+      />
+    </template>
+  </v-bottom-navigation>
+</template>
+
+<script lang="ts">
+export default defineNuxtComponent({
+  setup() {
+    const { $globals } = useNuxtApp();
+    const $auth = useMealieAuth();
+
+    const route = useRoute();
+    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+
+    const topLinks = computed<any[]>(() => [
+      {
+        icon: $globals.icons.calendarMultiselect,
+        to: "/household/mealplan/planner/view",
+      },
+      {
+        icon: $globals.icons.silverwareForkKnife,
+        to: `/g/${groupSlug.value}`,
+      },
+      {
+        icon: $globals.icons.formatListCheck,
+        to: "/shopping-lists",
+      },
+    ]);
+
+    return {
+      topLinks,
+    };
+  },
+});
+</script>

--- a/frontend/composables/use-users/preferences.ts
+++ b/frontend/composables/use-users/preferences.ts
@@ -69,6 +69,7 @@ export interface UserRecipeCreatePreferences {
 
 export interface UserActivityPreferences {
   defaultActivity: ActivityKey;
+  showFooter: boolean;
 }
 
 export function useUserMealPlanPreferences(): Ref<UserMealPlanPreferences> {
@@ -127,6 +128,7 @@ export function useUserActivityPreferences(): Ref<UserActivityPreferences> {
     "activity-preferences",
     {
       defaultActivity: ActivityKey.RECIPES,
+      showFooter: true,
     },
     { mergeDefaults: true },
     // we cast to a Ref because by default it will return an optional type ref

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -1076,7 +1076,8 @@
     "forgot-password-text": "Please enter your email address and we will send you a link to reset your password.",
     "changes-reflected-immediately": "Changes to this user will be reflected immediately.",
     "default-activity": "Default Activity",
-    "default-activity-hint": "Select which page you'd like to navigate to upon logging in from this device"
+    "default-activity-hint": "Select which page you'd like to navigate to upon logging in from this device",
+    "show-footer": "Show footer navigation in mobile?"
   },
   "language-dialog": {
     "translated": "translated",

--- a/frontend/pages/user/profile/edit.vue
+++ b/frontend/pages/user/profile/edit.vue
@@ -184,6 +184,11 @@
             persistent-hint
           />
           <v-checkbox
+            v-model="activityPreferences.showFooter"
+            :label="$t('user.show-footer')"
+            color="primary"
+          />
+          <v-checkbox
             v-model="userCopy.advanced"
             :label="$t('profile.show-advanced-description')"
             color="primary"
@@ -223,6 +228,7 @@ import type { VForm } from "~/types/auto-forms";
 import { useUserActivityPreferences } from "~/composables/use-users/preferences";
 import useDefaultActivity from "~/composables/use-default-activity";
 import { ActivityKey } from "~/lib/api/types/activity";
+import type { UserOut } from "~/lib/api/types/user";
 
 export default defineNuxtComponent({
   components: {
@@ -265,7 +271,7 @@ export default defineNuxtComponent({
 
     async function updateUser() {
       if (!userCopy.value?.id) return;
-      const { response } = await api.users.updateOne(userCopy.value.id, userCopy.value);
+      const { response } = await api.users.updateOne(userCopy.value.id, userCopy.value as UserOut);
       if (response?.status === 200) {
         $auth.refresh();
       }
@@ -299,6 +305,7 @@ export default defineNuxtComponent({
       userCopy,
       selectedDefaultActivity,
       activityOptions,
+      activityPreferences,
       password,
       domUpdatePassword,
       passwordsMatch,


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds a footer navbar for mobile. 
This makes it easier for users to quickly navigate between the most common activities. 

The new menu bar:
<img width="557" height="960" alt="image" src="https://github.com/user-attachments/assets/bb726eab-f4a0-4a95-8ead-e22596e5c5f8" />


## Which issue(s) this PR fixes:
N/A

## Special notes for your reviewer:
In the future I want to make the buttons configurable, but I wanted to submit this now that it's usable. 

## Testing
Tested in Firefox.