### PR TITLE
fix: Frontend overwrites token expiration

### DIFF
--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -15,7 +15,8 @@ interface AuthState {
   signIn: (credentials: FormData, options?: { redirect?: boolean }) => Promise<void>;
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
-  getSession: () => Promise<void>;
+  getSession: (refreshTokenCookie?: boolean) => Promise<void>;
+  setToken: (token: string | null) => void;
 }
 
 const authUser = ref<UserOut | null>(null);
@@ -31,14 +32,10 @@ export const useAuthBackend = function (): AuthState {
     tokenCookie.value = token;
   }
 
-  function resetToken() {
-    setToken(null);
-  }
-
   function handleAuthError(error: any, redirect = false) {
     // Only clear token on auth errors, not network errors
     if (error?.response?.status === 401) {
-      resetToken();
+      setToken(null);
       authUser.value = null;
       authStatus.value = "unauthenticated";
       if (redirect) {
@@ -94,7 +91,7 @@ export const useAuthBackend = function (): AuthState {
       console.warn("Logout API call failed:", error);
     }
     finally {
-      resetToken();
+      setToken(null);
       authUser.value = null;
       authStatus.value = "unauthenticated";
       await router.push(callbackUrl || "/login");
@@ -147,5 +144,6 @@ export const useAuthBackend = function (): AuthState {
     signOut,
     refresh,
     getSession,
+    setToken,
   };
 };

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -13,9 +13,10 @@ interface AuthState {
   data: AuthData;
   status: AuthStatus;
   signIn: (credentials: FormData, options?: { redirect?: boolean }) => Promise<void>;
+  oauthSignIn: (params: URLSearchParams) => Promise<void>;
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
-  getSession: (refreshTokenCookie?: boolean) => Promise<void>;
+  getSession: () => Promise<void>;
   setToken: (token: string | null) => void;
 }
 
@@ -98,6 +99,19 @@ export const useAuthBackend = function (): AuthState {
     }
   }
 
+  async function oauthSignIn(params: URLSearchParams): Promise<void> {
+    authStatus.value = "loading";
+
+    try {
+      await $axios.get("/api/auth/oauth/callback", { params });
+      await getSession();
+    }
+    catch (error) {
+      authStatus.value = "unauthenticated";
+      throw error;
+    }
+  }
+
   async function refresh(): Promise<void> {
     if (!tokenCookie.value) return;
 
@@ -145,5 +159,6 @@ export const useAuthBackend = function (): AuthState {
     refresh,
     getSession,
     setToken,
+    oauthSignIn,
   };
 };

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -16,7 +16,6 @@ interface AuthState {
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
   getSession: () => Promise<void>;
-  setToken: (token: string | null) => void;
 }
 
 const authUser = ref<UserOut | null>(null);
@@ -32,10 +31,14 @@ export const useAuthBackend = function (): AuthState {
     tokenCookie.value = token;
   }
 
+  function resetToken() {
+    setToken(null);
+  }
+
   function handleAuthError(error: any, redirect = false) {
     // Only clear token on auth errors, not network errors
     if (error?.response?.status === 401) {
-      setToken(null);
+      resetToken();
       authUser.value = null;
       authStatus.value = "unauthenticated";
       if (redirect) {
@@ -68,14 +71,12 @@ export const useAuthBackend = function (): AuthState {
     authStatus.value = "loading";
 
     try {
-      const response = await $axios.post("/api/auth/token", credentials, {
+      await $axios.post("/api/auth/token", credentials, {
         headers: {
           "Content-Type": "multipart/form-data",
         },
       });
 
-      const { access_token } = response.data;
-      setToken(access_token);
       await getSession();
     }
     catch (error) {
@@ -93,7 +94,7 @@ export const useAuthBackend = function (): AuthState {
       console.warn("Logout API call failed:", error);
     }
     finally {
-      setToken(null);
+      resetToken();
       authUser.value = null;
       authStatus.value = "unauthenticated";
       await router.push(callbackUrl || "/login");
@@ -146,6 +147,5 @@ export const useAuthBackend = function (): AuthState {
     signOut,
     refresh,
     getSession,
-    setToken,
   };
 };

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -4,7 +4,6 @@ import type { UserOut } from "~/lib/api/types/user";
 
 export const useMealieAuth = function () {
   const auth = useAuthBackend();
-  const { $axios } = useNuxtApp();
 
   // User Management
   const lastUser = ref<UserOut | null>(null);
@@ -39,9 +38,7 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
-    auth.setToken(token.access_token);
-    await auth.getSession();
+    await auth.oauthSignIn(params);
   }
 
   return {

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,8 +39,7 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
-    auth.setToken(token.access_token);
+    await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
     await auth.getSession();
   }
 

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,7 +39,8 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
+    const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
+    auth.setToken(token.access_token);
     await auth.getSession();
   }
 

--- a/mealie/lang/messages/en-US.json
+++ b/mealie/lang/messages/en-US.json
@@ -43,7 +43,8 @@
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
         "generic-duplicated": "{name} has been duplicated",
-        "generic-deleted": "{name} has been deleted"
+        "generic-deleted": "{name} has been deleted",
+        "logged-out": "Logged out"
     },
     "datetime": {
         "year": "year|years",


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

After the frontend signs in it sets the token value, but the new token doesn't contain the expiration info so it defaults to a session token. We now periodically check the token every 5 minutes and then the backend will fix the incorrect expiration, but until then it's erroneously set to "session". This PR removes the frontend logic that overwrites the token.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fully fixes https://github.com/mealie-recipes/mealie/issues/6311 (finally)