### PR TITLE
fix: Translate log-out string

### DIFF
--- a/mealie/lang/messages/en-US.json
+++ b/mealie/lang/messages/en-US.json
@@ -43,7 +43,8 @@
         "generic-created-with-url": "{name} has been created, {url}",
         "generic-updated-with-url": "{name} has been updated, {url}",
         "generic-duplicated": "{name} has been duplicated",
-        "generic-deleted": "{name} has been deleted"
+        "generic-deleted": "{name} has been deleted",
+        "logged-out": "Logged out"
     },
     "datetime": {
         "year": "year|years",


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The "log out" string is hardcoded in English. Previously this alert never really worked, but with the auth changes it works now so we need to make sure it can be translated.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A