### PR TITLE
fix: Change 'Units' to 'Unit' in shopping list item editor

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -10,7 +10,7 @@
             v-model="listItem.unit"
             v-model:item-id="listItem.unitId!"
             :items="units"
-            :label="$t('general.units')"
+            :label="$t('general.unit')"
             :icon="$globals.icons.units"
             create
             @create="createAssignUnit"

--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -10,7 +10,7 @@
             v-model="listItem.unit"
             v-model:item-id="listItem.unitId!"
             :items="units"
-            :label="$t('general.unit')"
+            :label="$t('recipe.unit')"
             :icon="$globals.icons.units"
             create
             @create="createAssignUnit"


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes incorrect label "Units" → "Unit" in shopping list item editor.

**Changes:**
- `frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue`: Changed `$t('general.units')` to `$t('general.unit')`

## Which issue(s) this PR fixes:

Fixes #6369

## Testing

- Verified translation keys are correct
- Frontend builds successfully  
- No other similar issues found in codebase