### PR TITLE
fix: Check `x-forwarded-proto` header when determining auth cookie samesite attribute

### DIFF
--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -92,6 +92,11 @@ def get_samesite(request: Request) -> Literal["lax", "none"]:
     if is_https and settings.PRODUCTION:
         return "none"
     else:
+        # TODO: remove this once we resolve pending iframe issues
+        if settings.PRODUCTION:
+            logger.debug("Setting samesite to 'lax' because connection is not HTTPS")
+            logger.debug(f"{request.url.scheme=} | {forwarded_proto=}")
+
         return "lax"
 
 

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -85,7 +85,11 @@ def get_samesite(request: Request) -> Literal["lax", "none"]:
     `samesite="lax"` is the default, which works regardless of HTTP or HTTPS,
     but does not support hosting in iframes.
     """
-    if request.url.scheme == "https" and settings.PRODUCTION:
+
+    forwarded_proto = request.headers.get("x-forwarded-proto", "").lower()
+    is_https = request.url.scheme == "https" or forwarded_proto == "https"
+
+    if is_https and settings.PRODUCTION:
         return "none"
     else:
         return "lax"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Currently we check the url request scheme when determining how to set the `samesite` attribute on the auth cookie. This PR also checks the `x-forwarded-proto` header since it might have originally been `https` but then proxied.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Potential fix for https://github.com/mealie-recipes/mealie/issues/6368, needs additional testing.