### PR TITLE
fix: Use `crossorigin: "use-credentials"` with PWA manifest

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -50,11 +50,11 @@ export default defineNuxtConfig({
         },
       ],
       link: [
-        { "rel": "icon", "type": "image/x-icon", "href": "/favicon.ico", "data-n-head": "ssr" },
-        { "rel": "shortcut icon", "type": "image/png", "href": "/icons/icon-x64.png", "data-n-head": "ssr" },
-        { "rel": "apple-touch-icon", "type": "image/png", "href": "/icons/apple-touch-icon.png", "data-n-head": "ssr" },
-        { "rel": "mask-icon", "href": "/icons/safari-pinned-tab.svg", "data-n-head": "ssr" },
-        { "rel": "manifest", "href": "/manifest.webmanifest", "data-n-head": "ssr" },
+        { rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
+        { rel: "shortcut icon", type: "image/png", href: "/icons/icon-x64.png" },
+        { rel: "apple-touch-icon", type: "image/png", href: "/icons/apple-touch-icon.png" },
+        { rel: "mask-icon", href: "/icons/safari-pinned-tab.svg" },
+        { rel: "manifest", href: "/manifest.webmanifest" },
       ],
     },
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -54,7 +54,7 @@ export default defineNuxtConfig({
         { rel: "shortcut icon", type: "image/png", href: "/icons/icon-x64.png" },
         { rel: "apple-touch-icon", type: "image/png", href: "/icons/apple-touch-icon.png" },
         { rel: "mask-icon", href: "/icons/safari-pinned-tab.svg" },
-        { rel: "manifest", href: "/manifest.webmanifest" },
+        { rel: "manifest", href: "/manifest.webmanifest", crossorigin: "use-credentials" },
       ],
     },
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

See: https://github.com/mealie-recipes/mealie/pull/6419

> This PR fixes an issue where users running Mealie behind an authentication-based reverse proxy (such as Authelia, Traefik Forward Auth, etc.) are unable to install the PWA.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Replaces https://github.com/mealie-recipes/mealie/pull/6419