### PR TITLE
fix: Include contents of purpose field when parsing ingredients

### DIFF
--- a/mealie/services/parser_services/ingredient_parser.py
+++ b/mealie/services/parser_services/ingredient_parser.py
@@ -133,6 +133,9 @@ class NLPParser(ABCIngredientParser):
         if ingredient.comment:
             note_parts.append(ingredient.comment.text)
             confidences.append(ingredient.comment.confidence)
+        if ingredient.purpose:
+            note_parts.append(ingredient.purpose.text)
+            confidences.append(ingredient.purpose.confidence)
 
         # average confidence among all note parts
         confidence = sum(confidences) / len(confidences) if confidences else 0


### PR DESCRIPTION
## What this PR does / why we need it:

When parsing ingredients using the natural language parser, the returned `ParsedIngredient` object has a `purpose` field that captures the purpose of an ingredient (e.g. for garnish). Currently, this field is ignored and any text captured in that field is lost when parsing. 

This PR adds the contents of the `purpose` field to the end of the ingredient notes.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

None

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

This is a pretty basic fix that follows the same pattern as the `comment`, `size` and `preparation` fields of the `ParsedIngredient` object.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

Tested locally with the sentence "3 sprigs of coriander, chopped, for garnish" to demonstrate the "for garnish" is parsed into the ingredient notes.

I don't think there are any specific tests for the natural language parser.

<!--
  Describe how you tested this change.
-->
