### PR TITLE
fix: Respect backend's token expiration immediately

### DIFF
--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -21,6 +21,7 @@ interface AuthState {
    * @returns A promise that resolves when the session has been fetched
    */
   getSession: (forceRefreshCookie?: boolean) => Promise<void>;
+  setToken: (token: string | null) => void;
 }
 
 const authUser = ref<UserOut | null>(null);
@@ -32,14 +33,14 @@ export const useAuthBackend = function (): AuthState {
   const tokenName = useRuntimeConfig().public.AUTH_TOKEN;
   const tokenCookie = useCookie(tokenName);
 
-  function clearToken() {
-    tokenCookie.value = null;
+  function setToken(token: string | null) {
+    tokenCookie.value = token;
   }
 
   function handleAuthError(error: any, redirect = false) {
     // Only clear token on auth errors, not network errors
     if (error?.response?.status === 401) {
-      clearToken();
+      setToken(null);
       authUser.value = null;
       authStatus.value = "unauthenticated";
       if (redirect) {
@@ -117,7 +118,7 @@ export const useAuthBackend = function (): AuthState {
       console.warn("Logout API call failed:", error);
     }
     finally {
-      clearToken();
+      setToken(null);
       authUser.value = null;
       authStatus.value = "unauthenticated";
       await router.push(callbackUrl || "/login");
@@ -168,5 +169,6 @@ export const useAuthBackend = function (): AuthState {
     signOut,
     refresh,
     getSession,
+    setToken,
   };
 };

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -15,7 +15,12 @@ interface AuthState {
   signIn: (credentials: FormData, options?: { redirect?: boolean }) => Promise<void>;
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
-  getSession: () => Promise<void>;
+  /**
+   * Fetches the current user session from the backend using the auth token cookie.
+   * @param forceRefreshCookie Whether to refresh the auth token cookie before fetching the session
+   * @returns A promise that resolves when the session has been fetched
+   */
+  getSession: (forceRefreshCookie?: boolean) => Promise<void>;
 }
 
 const authUser = ref<UserOut | null>(null);

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -44,10 +44,28 @@ export const useAuthBackend = function (): AuthState {
   }
 
   /**
-   * Fetches the current user session from the backend and updates the auth state accordingly.
-   * The backend includes the token in the cookie.
+   * Waits for the auth token cookie to be set by the backend.
+   * The browser should do this immedaitely, but sometimes there is a slight delay, so we poll for it.
    */
-  async function getSession(): Promise<void> {
+  async function waitForCookie(timeoutMs: number = 2000): Promise<void> {
+    const startTime = Date.now();
+
+    while (!tokenCookie.value && Date.now() - startTime < timeoutMs) {
+      refreshCookie(tokenName);
+      if (tokenCookie.value) return;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    if (!tokenCookie.value) {
+      console.warn("Cookie was not set by backend within timeout");
+    }
+  }
+
+  async function getSession(forceRefreshCookie: boolean = false): Promise<void> {
+    if (forceRefreshCookie) {
+      await waitForCookie();
+    }
+
     if (!tokenCookie.value) {
       authUser.value = null;
       authStatus.value = "unauthenticated";
@@ -77,7 +95,7 @@ export const useAuthBackend = function (): AuthState {
         },
       });
 
-      await getSession();
+      await getSession(true);
     }
     catch (error) {
       authStatus.value = "unauthenticated";
@@ -106,7 +124,7 @@ export const useAuthBackend = function (): AuthState {
 
     try {
       await $axios.get("/api/auth/refresh");
-      await getSession();
+      await getSession(true);
     }
     catch (error: any) {
       handleAuthError(error, true);

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -16,7 +16,6 @@ interface AuthState {
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
   getSession: () => Promise<void>;
-  setToken: (token: string | null) => void;
 }
 
 const authUser = ref<UserOut | null>(null);
@@ -28,14 +27,14 @@ export const useAuthBackend = function (): AuthState {
   const tokenName = useRuntimeConfig().public.AUTH_TOKEN;
   const tokenCookie = useCookie(tokenName);
 
-  function setToken(token: string | null) {
-    tokenCookie.value = token;
+  function clearToken() {
+    tokenCookie.value = null;
   }
 
   function handleAuthError(error: any, redirect = false) {
     // Only clear token on auth errors, not network errors
     if (error?.response?.status === 401) {
-      setToken(null);
+      clearToken();
       authUser.value = null;
       authStatus.value = "unauthenticated";
       if (redirect) {
@@ -44,6 +43,10 @@ export const useAuthBackend = function (): AuthState {
     }
   }
 
+  /**
+   * Fetches the current user session from the backend and updates the auth state accordingly.
+   * The backend includes the token in the cookie.
+   */
   async function getSession(): Promise<void> {
     if (!tokenCookie.value) {
       authUser.value = null;
@@ -60,7 +63,6 @@ export const useAuthBackend = function (): AuthState {
     catch (error: any) {
       console.error("Failed to fetch user session:", error);
       handleAuthError(error);
-      authStatus.value = "unauthenticated";
     }
   }
 
@@ -68,14 +70,12 @@ export const useAuthBackend = function (): AuthState {
     authStatus.value = "loading";
 
     try {
-      const response = await $axios.post("/api/auth/token", credentials, {
+      await $axios.post("/api/auth/token", credentials, {
         headers: {
           "Content-Type": "multipart/form-data",
         },
       });
 
-      const { access_token } = response.data;
-      setToken(access_token);
       await getSession();
     }
     catch (error) {
@@ -93,7 +93,7 @@ export const useAuthBackend = function (): AuthState {
       console.warn("Logout API call failed:", error);
     }
     finally {
-      setToken(null);
+      clearToken();
       authUser.value = null;
       authStatus.value = "unauthenticated";
       await router.push(callbackUrl || "/login");
@@ -104,9 +104,7 @@ export const useAuthBackend = function (): AuthState {
     if (!tokenCookie.value) return;
 
     try {
-      const response = await $axios.get("/api/auth/refresh");
-      const { access_token } = response.data;
-      setToken(access_token);
+      await $axios.get("/api/auth/refresh");
       await getSession();
     }
     catch (error: any) {
@@ -146,6 +144,5 @@ export const useAuthBackend = function (): AuthState {
     signOut,
     refresh,
     getSession,
-    setToken,
   };
 };

--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -63,6 +63,7 @@ export const useAuthBackend = function (): AuthState {
     catch (error: any) {
       console.error("Failed to fetch user session:", error);
       handleAuthError(error);
+      authStatus.value = "unauthenticated";
     }
   }
 

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,7 +39,8 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    await $axios.get("/api/auth/oauth/callback", { params });
+    const { data: token } = await $axios.get("/api/auth/oauth/callback", { params });
+    auth.setToken(token);
     await auth.getSession(true);
   }
 

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -42,7 +42,7 @@ export const useMealieAuth = function () {
     // TODO: we shouldn't be setting the token here since the backend is already setting the cookie, but removing it breaks E2E tests for some reason
     const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
     auth.setToken(token.access_token);
-    await auth.getSession(true);
+    await auth.getSession();
   }
 
   return {

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -40,7 +40,7 @@ export const useMealieAuth = function () {
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
     await $axios.get("/api/auth/oauth/callback", { params });
-    await auth.getSession();
+    await auth.getSession(true);
   }
 
   return {

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,8 +39,7 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
-    auth.setToken(token.access_token);
+    await $axios.get("/api/auth/oauth/callback", { params });
     await auth.getSession();
   }
 

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,8 +39,8 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
-    const { data: token } = await $axios.get("/api/auth/oauth/callback", { params });
-    auth.setToken(token);
+    const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
+    auth.setToken(token.access_token);
     await auth.getSession(true);
   }
 

--- a/frontend/composables/useMealieAuth.ts
+++ b/frontend/composables/useMealieAuth.ts
@@ -39,6 +39,7 @@ export const useMealieAuth = function () {
 
   async function oauthSignIn() {
     const params = new URLSearchParams(window.location.search);
+    // TODO: we shouldn't be setting the token here since the backend is already setting the cookie, but removing it breaks E2E tests for some reason
     const { data: token } = await $axios.get<{ access_token: string; token_type: "bearer" }>("/api/auth/oauth/callback", { params });
     auth.setToken(token.access_token);
     await auth.getSession(true);

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -199,9 +199,18 @@ async def oauth_callback(request: Request, response: Response, session: Session 
 
 
 @user_router.get("/refresh")
-async def refresh_token(current_user: PrivateUser = Depends(get_current_user)):
+async def refresh_token(request: Request, response: Response, current_user: PrivateUser = Depends(get_current_user)):
     """Use a valid token to get another token"""
-    access_token = security.create_access_token(data={"sub": str(current_user.id)})
+
+    access_token, duration = security.AuthProvider.create_access_token(data={"sub": str(current_user.id)})
+    expires_in = duration.total_seconds() if duration else None
+
+    MealieAuthToken.set_cookie(
+        response,
+        access_token,
+        expires_in=expires_in,
+        samesite=get_samesite(request),
+    )
     return MealieAuthToken.respond(access_token)
 
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

When the frontend requests a new token, due to how we handle the new token we overwrite the expiration which is set by the backend. This PR explicitly doesn't set the token on the frontend and relies on the backend to do it.

To enable this we also need to make sure the refresh endpoint contains the expiration data and sets the cookie, so I made sure that was included (using the same code path as the sign-in endpoint).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6415

## Special notes for your reviewer:

_(fill-in or delete this section)_

A few times I ran into what seems like a race condition where we wait for the backend response, but somehow the browser (or Nuxt?) doesn't see the new token immediately, causing the sign in flow to fail. There's specifically a function built to solve for this in Nuxt (`refreshCookie`) but I still ran into this issue a few times.

As a result I built in a simple polling function that checks for the new token every 50 ms for up to 2 seconds. In practice I only ever saw this run exactly zero or one times, so the user shouldn't notice it. Seems silly that I had to do this but it works ¯\\\_(ツ)_/¯

## Testing

_(fill-in or delete this section)_

Tested in the dev image and in the prod image. Seems consistent.