### PR TITLE
fix: Set maxAge on frontend auth cookie

### DIFF
--- a/frontend/composables/useAuthBackend.ts
+++ b/frontend/composables/useAuthBackend.ts
@@ -25,8 +25,11 @@ const authStatus = ref<"loading" | "authenticated" | "unauthenticated">("loading
 export const useAuthBackend = function (): AuthState {
   const { $axios } = useNuxtApp();
   const router = useRouter();
-  const tokenName = useRuntimeConfig().public.AUTH_TOKEN;
-  const tokenCookie = useCookie(tokenName);
+
+  const runtimeConfig = useRuntimeConfig();
+  const tokenTimeHours = Number(runtimeConfig.public.TOKEN_TIME) || 48;
+  const tokenName = runtimeConfig.public.AUTH_TOKEN;
+  const tokenCookie = useCookie(tokenName, { maxAge: tokenTimeHours * 60 * 60 });
 
   function setToken(token: string | null) {
     tokenCookie.value = token;

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -72,6 +72,7 @@ export default defineNuxtConfig({
     apiUrl: process.env.API_URL || "http://localhost:9000",
     public: {
       AUTH_TOKEN,
+      TOKEN_TIME: process.env.TOKEN_TIME || "48",
       GLOBAL_MIDDLEWARE: process.env.GLOBAL_MIDDLEWARE || undefined,
       SUB_PATH: process.env.SUB_PATH || "",
       // ==============================================


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sets the `maxAge` on the frontend auth token cookie. This _shouldn't_ matter because the backend sets it correctly, but maybe this fixes issues for some users?

## Which issue(s) this PR fixes:

_(REQUIRED)_

Maybe https://github.com/mealie-recipes/mealie/issues/6516