### PR TITLE
dev: Allow dev server to be accessed on local network

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,5 +56,8 @@
       "dockerDashComposeVersion": "v2"
     }
   },
-  "appPort": 3000
+  "appPort": [
+    "3000:3000",
+    "9000:9000"
+  ]
 }


### PR DESCRIPTION
## What this PR does / why we need it:

This PR allows the dev server to be accessed from the local network when running from the dev container. 
This can be helpful for testing mobile workflows where previously to test those devs would either need to build a docker image or use browser emulation. 

## Which issue(s) this PR fixes:
NA

## Special notes for your reviewer:
NA

## Testing
* Rebuild container
* Start up dev server with task py/task ui
* On a separate device go to `<host machine IP address>:3000` 
* Verify nothing hinky is going on
