### PR TITLE
chore: Update Renovate config to pin versions in pyproject.toml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
         "npm"
       ],
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchManagers": [
+        "pep621"
+      ],
+      "rangeStrategy": "pin"
     }
   ]
 }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Change uv.lock strategy to `pin` instead of `auto`. We're not getting dependency updates right now, this should fix it.

`pin` will convert the ranges in our `pyproject.toml` to pinned versions (e.g. `package==1.0.0`) which makes sense for an application (rather than a library).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A