### PR TITLE
chore: Fail frontend lint if there are warnings

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: "frontend"
 
       - name: Run linter 👀
-        run: yarn lint
+        run: yarn lint --max-warnings=0
         working-directory: "frontend"
 
       - name: Run tests 🧪

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -228,7 +228,7 @@ tasks:
     desc: runs the frontend linter
     dir: frontend
     cmds:
-      - yarn lint
+      - yarn lint --max-warnings=0
 
   ui:test:
     desc: runs the frontend tests

--- a/frontend/components/Domain/Recipe/RecipeAssets.vue
+++ b/frontend/components/Domain/Recipe/RecipeAssets.vue
@@ -92,8 +92,8 @@
               item-value="name"
               class="mr-2"
             >
-              <template #item="{ item, props }">
-                <v-list-item v-bind="props">
+              <template #item="{ item, props: itemProps }">
+                <v-list-item v-bind="itemProps">
                   <template #prepend>
                     <v-icon>{{ item.raw.icon }}</v-icon>
                   </template>


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sets `--max-warnings=0` on eslint so we don't merge PRs with lint warnings. We have already fixed all existing warnings (aside from one which got merged today) so this is just enforcing what we were already doing manually.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A