### PR TITLE
fix: change log rotation size from 10kb to 10mb

### DIFF
--- a/mealie/core/logger/logconf.prod.json
+++ b/mealie/core/logger/logconf.prod.json
@@ -40,7 +40,7 @@
       "level": "DEBUG",
       "formatter": "detailed",
       "filename": "${DATA_DIR}/mealie.log",
-      "maxBytes": 10000,
+      "maxBytes": 10000000,
       "backupCount": 3
     }
   },


### PR DESCRIPTION
## What this PR does / why we need it:

Log rotation is currently set to a very small value. This was likely from me testing in development to make sure the rotation worked and somehow no one has noticed this since then. 

## Which issue(s) this PR fixes:

Closes #6428

## Special notes for your reviewer:

N/A

## Testing

N/A
