### PR TITLE
fix: clear cached store data on logout to prevent user data leakage

### DIFF
--- a/frontend/composables/partials/use-store-factory.ts
+++ b/frontend/composables/partials/use-store-factory.ts
@@ -52,7 +52,7 @@ export const useStore = function <T extends BoundT>(
       return await storeActions.refresh(1, -1, params);
     },
     flushStore() {
-      store = ref([]);
+      store.value = [];
     },
   };
 

--- a/frontend/composables/store/index.ts
+++ b/frontend/composables/store/index.ts
@@ -1,7 +1,31 @@
-export { useCategoryStore, usePublicCategoryStore, useCategoryData } from "./use-category-store";
-export { useFoodStore, usePublicFoodStore, useFoodData } from "./use-food-store";
-export { useHouseholdStore, usePublicHouseholdStore } from "./use-household-store";
-export { useLabelStore, useLabelData } from "./use-label-store";
-export { useTagStore, usePublicTagStore, useTagData } from "./use-tag-store";
-export { useToolStore, usePublicToolStore, useToolData } from "./use-tool-store";
-export { useUnitStore, useUnitData } from "./use-unit-store";
+import { resetCategoryStore } from "./use-category-store";
+import { resetFoodStore } from "./use-food-store";
+import { resetHouseholdStore } from "./use-household-store";
+import { resetLabelStore } from "./use-label-store";
+import { resetTagStore } from "./use-tag-store";
+import { resetToolStore } from "./use-tool-store";
+import { resetUnitStore } from "./use-unit-store";
+import { resetCookbookStore } from "./use-cookbook-store";
+import { resetUserStore } from "./use-user-store";
+
+export { useCategoryStore, usePublicCategoryStore, useCategoryData, resetCategoryStore } from "./use-category-store";
+export { useFoodStore, usePublicFoodStore, useFoodData, resetFoodStore } from "./use-food-store";
+export { useHouseholdStore, usePublicHouseholdStore, resetHouseholdStore } from "./use-household-store";
+export { useLabelStore, useLabelData, resetLabelStore } from "./use-label-store";
+export { useTagStore, usePublicTagStore, useTagData, resetTagStore } from "./use-tag-store";
+export { useToolStore, usePublicToolStore, useToolData, resetToolStore } from "./use-tool-store";
+export { useUnitStore, useUnitData, resetUnitStore } from "./use-unit-store";
+export { useCookbookStore, usePublicCookbookStore, resetCookbookStore } from "./use-cookbook-store";
+export { useUserStore, resetUserStore } from "./use-user-store";
+
+export function clearAllStores() {
+  resetCategoryStore();
+  resetFoodStore();
+  resetHouseholdStore();
+  resetLabelStore();
+  resetTagStore();
+  resetToolStore();
+  resetUnitStore();
+  resetCookbookStore();
+  resetUserStore();
+}

--- a/frontend/composables/store/use-category-store.ts
+++ b/frontend/composables/store/use-category-store.ts
@@ -7,6 +7,12 @@ const store: Ref<RecipeCategory[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetCategoryStore() {
+  store.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useCategoryData = function () {
   return useData<RecipeCategory>({
     id: "",

--- a/frontend/composables/store/use-cookbook-store.ts
+++ b/frontend/composables/store/use-cookbook-store.ts
@@ -7,6 +7,12 @@ const cookbooks: Ref<ReadCookBook[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetCookbookStore() {
+  cookbooks.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useCookbookStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
   const store = useStore<ReadCookBook>("cookbook", cookbooks, loading, api.cookbooks);

--- a/frontend/composables/store/use-food-store.ts
+++ b/frontend/composables/store/use-food-store.ts
@@ -7,6 +7,12 @@ const store: Ref<IngredientFood[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetFoodStore() {
+  store.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useFoodData = function () {
   return useData<IngredientFood>({
     id: "",

--- a/frontend/composables/store/use-household-store.ts
+++ b/frontend/composables/store/use-household-store.ts
@@ -7,6 +7,12 @@ const store: Ref<HouseholdSummary[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetHouseholdStore() {
+  store.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useHouseholdStore = function (i18n?: Composer) {
   const api = useUserApi(i18n);
   return useReadOnlyStore<HouseholdSummary>("household", store, loading, api.households);

--- a/frontend/composables/store/use-label-store.ts
+++ b/frontend/composables/store/use-label-store.ts
@@ -6,6 +6,11 @@ import { useUserApi } from "~/composables/api";
 const store: Ref<MultiPurposeLabelOut[]> = ref([]);
 const loading = ref(false);
 
+export function resetLabelStore() {
+  store.value = [];
+  loading.value = false;
+}
+
 export const useLabelData = function () {
   return useData<MultiPurposeLabelOut>({
     groupId: "",

--- a/frontend/composables/store/use-tag-store.ts
+++ b/frontend/composables/store/use-tag-store.ts
@@ -7,6 +7,12 @@ const store: Ref<RecipeTag[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetTagStore() {
+  store.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useTagData = function () {
   return useData<RecipeTag>({
     id: "",

--- a/frontend/composables/store/use-tool-store.ts
+++ b/frontend/composables/store/use-tool-store.ts
@@ -11,6 +11,12 @@ const store: Ref<RecipeTool[]> = ref([]);
 const loading = ref(false);
 const publicLoading = ref(false);
 
+export function resetToolStore() {
+  store.value = [];
+  loading.value = false;
+  publicLoading.value = false;
+}
+
 export const useToolData = function () {
   return useData<RecipeToolWithOnHand>({
     id: "",

--- a/frontend/composables/store/use-unit-store.ts
+++ b/frontend/composables/store/use-unit-store.ts
@@ -6,6 +6,11 @@ import { useUserApi } from "~/composables/api";
 const store: Ref<IngredientUnit[]> = ref([]);
 const loading = ref(false);
 
+export function resetUnitStore() {
+  store.value = [];
+  loading.value = false;
+}
+
 export const useUnitData = function () {
   return useData<IngredientUnit>({
     id: "",

--- a/frontend/composables/store/use-user-store.ts
+++ b/frontend/composables/store/use-user-store.ts
@@ -7,6 +7,11 @@ import { BaseCRUDAPIReadOnly } from "~/lib/api/base/base-clients";
 const store: Ref<UserSummary[]> = ref([]);
 const loading = ref(false);
 
+export function resetUserStore() {
+  store.value = [];
+  loading.value = false;
+}
+
 class GroupUserAPIReadOnly extends BaseCRUDAPIReadOnly<UserSummary> {
   baseRoute = "/api/groups/members";
   itemRoute = (idOrUsername: string | number) => `/groups/members/${idOrUsername}`;

--- a/frontend/composables/use-auth-backend.ts
+++ b/frontend/composables/use-auth-backend.ts
@@ -1,5 +1,6 @@
 import { ref, computed } from "vue";
 import type { UserOut } from "~/lib/api/types/user";
+import { clearAllStores } from "~/composables/store";
 
 interface AuthData {
   value: UserOut | null;
@@ -101,6 +102,13 @@ export const useAuthBackend = function (): AuthState {
       setToken(null);
       authUser.value = null;
       authStatus.value = "unauthenticated";
+
+      // Clear all cached store data to prevent data leakage between users
+      clearAllStores();
+
+      // Clear Nuxt's useAsyncData cache
+      clearNuxtData();
+
       await router.push(callbackUrl || "/login");
     }
   }


### PR DESCRIPTION
## What this PR does / why we need it:

When users log out and a different user logs in, category and other user-specific data from the previous user was persisting and displaying incorrectly. This was caused by:

1. Module-level refs in store composables that persist across the entire application lifecycle
2. Nuxt's `useAsyncData` cache using static keys without user context
3. The existing `flushStore()` function had a bug - it created a new ref instead of clearing the existing one

**Changes:**
- Fixed `flushStore()` in `use-store-factory.ts` to properly clear the ref value (`store.value = []` instead of `store = ref([])`)
- Added `resetXxxStore()` functions to all 9 store modules (category, tag, food, label, tool, cookbook, household, unit, user)
- Created `clearAllStores()` function in `store/index.ts` that calls all reset functions
- Updated `signOut()` in `use-auth-backend.ts` to call `clearAllStores()` and `clearNuxtData()` on logout

## Which issue(s) this PR fixes:

Fixes #5513

## Testing

To test this fix:
1. Log in as User A and navigate to view categories
2. Log out
3. Log in as User B (different group/household)
4. Verify User B sees their own categories immediately without requiring a hard refresh
5. Repeat switching between users to confirm data is properly cleared each time