### PR TITLE
feat: autofill default credentials on first login

### DIFF
--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -250,6 +250,11 @@ export default defineNuxtComponent({
       const data = await $axios.get<AppStartupInfo>("/api/app/about/startup-info");
       isDemo.value = data.data.isDemo;
       isFirstLogin.value = data.data.isFirstLogin;
+
+      if (data.data.isFirstLogin) {
+        form.email = "changeme@example.com";
+        form.password = "MyPassword";
+      }
     });
 
     whenever(


### PR DESCRIPTION
## What this PR does / why we need it:

Auto-populates the login form with default credentials when the server indicates it's the first login, improving the new user onboarding experience.

- Modified `frontend/pages/login.vue` to set `form.email` and `form.password` when `isFirstLogin` is true
- Users can now click "Login" directly instead of manually entering or copying credentials
- The info banner still displays to explain the situation

## Which issue(s) this PR fixes:

N/A

## Testing

- Start a fresh Mealie instance with default credentials
- Navigate to the login page
- Verify the email and password fields are pre-filled with `changeme@example.com` and `MyPassword`
- Click Login and confirm authentication succeeds