### PR TITLE
fix: Disable submit on enter when editing timeline events

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeTimelineContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeTimelineContextMenu.vue
@@ -5,6 +5,7 @@
       :title="$t('recipe.edit-timeline-event')"
       :icon="$globals.icons.edit"
       can-submit
+      disable-submit-on-enter
       :submit-text="$t('general.save')"
       @submit="submitEdit"
     >


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Disables submitting via "enter" when editing timeline event items. We want this because we want to permit newlines.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/6703