### PR TITLE
fix: Put tooltips behind app bar

### DIFF
--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -149,6 +149,6 @@ export default defineNuxtComponent({
 
 <style scoped>
 .v-toolbar {
-  z-index: 1010 !important;
+  z-index: 2010 !important;
 }
 </style>


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

We set the `AppHeader` to be at `z-index` of `1010`, in order to guarantee that it appears in front of everything else. Except tool tips have a `z-index` of `2000`. This PR sets the `AppHeader` to `2010`.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/2925