### PR TITLE
fix: More lenient postgres override parsing

### DIFF
--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -60,6 +60,14 @@ psql_validation_cases = [
         ],
     ),
     (
+        "unencoded_to_encoded_no_port_url",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://mealie:P@ssword!@#$%%^^&&**()+;'\"'<>?{}[]@postgres/mealie",
+            "postgresql://mealie:P%40ssword%21%40%23%24%25%25%5E%5E%26%26%2A%2A%28%29%2B%3B%27%22%27%3C%3E%3F%7B%7D%5B%5D@postgres/mealie",
+        ],
+    ),
+    (
         "no_encode_needed_password",
         [
             "POSTGRES_PASSWORD",
@@ -73,6 +81,54 @@ psql_validation_cases = [
             "POSTGRES_URL_OVERRIDE",
             "postgresql://mealie:MyPassword@postgres:5432/mealie",
             "postgresql://mealie:MyPassword@postgres:5432/mealie",
+        ],
+    ),
+    (
+        "no_password_url",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://mealie@postgres:5432/mealie",
+            "postgresql://mealie@postgres:5432/mealie",
+        ],
+    ),
+    (
+        "no_password_no_port_url",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://mealie@postgres/mealie",
+            "postgresql://mealie@postgres/mealie",
+        ],
+    ),
+    (
+        "unix_socket_with_empty_password",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://mealie:@/mealie?host=/run/postgresql",
+            "postgresql://mealie:@/mealie?host=/run/postgresql",
+        ],
+    ),
+    (
+        "unix_socket_no_password",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://mealie@/mealie?host=/run/postgresql",
+            "postgresql://mealie@/mealie?host=/run/postgresql",
+        ],
+    ),
+    (
+        "no_credentials_at_all",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql:///mealie?host=/run/postgresql",
+            "postgresql:///mealie?host=/run/postgresql",
+        ],
+    ),
+    (
+        "query_params_with_colon",
+        [
+            "POSTGRES_URL_OVERRIDE",
+            "postgresql://user@host/db?sslmode=require&connect_timeout=10",
+            "postgresql://user@host/db?sslmode=require&connect_timeout=10",
         ],
     ),
 ]

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,6 +1,7 @@
 import json
 import re
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
@@ -174,11 +175,11 @@ def test_smtp_enable_with_bad_data_tls(data: SMTPValidationCase):
 @dataclass(slots=True)
 class EnvVar:
     name: str
-    value: any
+    value: Any
 
 
 class LDAPValidationCase:
-    settings = list[EnvVar]
+    settings: list[EnvVar]
     is_valid: bool
 
     def __init__(
@@ -222,7 +223,7 @@ def test_ldap_settings_validation(data: LDAPValidationCase, monkeypatch: pytest.
 
 
 class OIDCValidationCase:
-    settings = list[EnvVar]
+    settings: list[EnvVar]
     is_valid: bool
 
     def __init__(


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Our manual postgres URL parsing (which encodes passwords) assumes you have certain elements in your postgres URL. This PR makes that more lenient (e.g. if you have no password).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/3573

## Testing

_(fill-in or delete this section)_

Added a bunch of test cases which fail on the old logic.