### PR TITLE
fix: localize text validators message

### DIFF
--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -1428,5 +1428,13 @@
       "is-like": "is like",
       "is-not-like": "is not like"
     }
+  },
+  "validators": {
+    "required": "This Field is Required",
+    "invalid-email": "Email Must Be Valid",
+    "invalid-url": "Must Be A Valid URL",
+    "no-whitespace": "No Whitespace Allowed",
+    "min-length": "Must Be At Least {min} Characters",
+    "max-length": "Must Be At Most {max} Characters"
   }
 }

--- a/frontend/lib/validators/inputs.ts
+++ b/frontend/lib/validators/inputs.ts
@@ -1,22 +1,28 @@
+import { useGlobalI18n } from "~/composables/use-global-i18n";
+
 const EMAIL_REGEX
   = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@(([[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 const URL_REGEX = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
 
 export function required(v: string | undefined | null) {
-  return !!v || "This Field is Required";
+  const i18n = useGlobalI18n();
+  return !!v || i18n.t("validators.required");
 }
 
 export function email(v: string | undefined | null) {
-  return (!!v && EMAIL_REGEX.test(v)) || "Email Must Be Valid";
+  const i18n = useGlobalI18n();
+  return (!!v && EMAIL_REGEX.test(v)) || i18n.t("validators.invalid-email");
 }
 
 export function whitespace(v: string | null | undefined) {
-  return (!!v && v.split(" ").length <= 1) || "No Whitespace Allowed";
+  const i18n = useGlobalI18n();
+  return (!!v && v.split(" ").length <= 1) || i18n.t("validators.no-whitespace");
 }
 
 export function url(v: string | undefined | null) {
-  return (!!v && URL_REGEX.test(v)) || "Must Be A Valid URL";
+  const i18n = useGlobalI18n();
+  return (!!v && URL_REGEX.test(v)) || i18n.t("validators.invalid-url");
 }
 
 export function urlOptional(v: string | undefined | null) {
@@ -24,9 +30,11 @@ export function urlOptional(v: string | undefined | null) {
 }
 
 export function minLength(min: number) {
-  return (v: string | undefined | null) => (!!v && v.length >= min) || `Must Be At Least ${min} Characters`;
+  const i18n = useGlobalI18n();
+  return (v: string | undefined | null) => (!!v && v.length >= min) || i18n.t("validators.min-length", { min });
 }
 
 export function maxLength(max: number) {
-  return (v: string | undefined | null) => !v || v.length <= max || `Must Be At Most ${max} Characters`;
+  const i18n = useGlobalI18n();
+  return (v: string | undefined | null) => !v || v.length <= max || i18n.t("validators.max-length", { max });
 }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Text field validators are not localized in the user's language. Use the global instance and the `useGlobalI18n()` composable to use the corresponding strings.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #6715 
