### PR TITLE
docs: isolate docs dependencies to avoid python-ldap build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --only-group docs
 
       - name: Build docs
         run: uv run mkdocs build -d site

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ pgsql = [
 ]
 
 [dependency-groups]
+docs = [
+    "mkdocs-material==9.7.0",
+]
 dev = [
     "coverage==7.13.0",
     "coveragepy-lcov==0.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -880,6 +880,9 @@ dev = [
     { name = "types-requests" },
     { name = "types-urllib3" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -946,6 +949,7 @@ dev = [
     { name = "types-requests", specifier = "==2.32.4.20250913" },
     { name = "types-urllib3", specifier = "==1.26.25.14" },
 ]
+docs = [{ name = "mkdocs-material", specifier = "==9.7.0" }]
 
 [[package]]
 name = "mergedeep"


### PR DESCRIPTION
## Summary
- Add dedicated `docs` dependency group with only mkdocs-material
- Use `--only-group docs` in docs workflow to avoid installing python-ldap
- python-ldap requires OpenLDAP dev headers which aren't available on CI runners
