### PR TITLE
docs: add --no-project flags to skip mealie installation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --only-group docs
+        run: uv sync --only-group docs --no-install-project
 
       - name: Build docs
-        run: uv run mkdocs build -d site
+        run: uv run --no-project mkdocs build -d site
         working-directory: docs
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Add `--no-install-project` to `uv sync` to skip installing mealie package
- Add `--no-project` to `uv run` to avoid triggering project installation

This prevents uv from trying to build python-ldap which requires OpenLDAP dev headers not available on CI runners.

## Test plan
- [x] Verified locally with `uv sync --only-group docs --no-install-project`
- [x] Verified `uv run --no-project mkdocs build` succeeds