### PR TITLE
fix: Backup selection doesn't work sometimes

### DIFF
--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -238,7 +238,7 @@ export default defineNuxtComponent({
     });
 
     function setSelected(data: { name: string; date: string }) {
-      if (selected.value === null || selected.value === undefined) {
+      if (!data.name) {
         return;
       }
       selected.value = data.name;

--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -37,7 +37,6 @@
                   $t('settings.backup.backup-restore-process-in-the-documentation') }}</a>
               </template>
             </i18n-t>
-            {{ $t('') }}
           </p>
 
           <v-checkbox


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes some weird logic with how backups work on the frontend; sometimes you can attempt to restore from backup and send "undefined" to the backend (instead of the id) which obviously doesn't work.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A