### PR TITLE
fix: add loader for create backup button

### DIFF
--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -81,6 +81,7 @@
         >
           <BaseButton
             class="mr-2"
+            :loading="runningBackup"
             @click="createBackup"
           >
             {{ $t("settings.backup.create-heading") }}
@@ -182,6 +183,7 @@ export default defineNuxtComponent({
     }
 
     async function createBackup() {
+      state.runningBackup = true;
       const { data } = await adminApi.backups.create();
 
       if (data?.error === false) {
@@ -191,6 +193,7 @@ export default defineNuxtComponent({
       else {
         alert.error(i18n.t("settings.backup.error-creating-backup-see-log-file"));
       }
+      state.runningBackup = false;
     }
 
     async function restoreBackup(fileName: string) {
@@ -227,6 +230,7 @@ export default defineNuxtComponent({
       deleteDialog: false,
       createDialog: false,
       importDialog: false,
+      runningBackup: false,
       runningRestore: false,
       search: "",
       headers: [


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The “Create backup” button does not change state when pressed, which can be confusing for the user. Adding the “loading” state prevents the task from being submitted twice and provides visual feedback.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A