### PR TITLE
fix: Only fetch recipes with a household id

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearchFilters.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearchFilters.vue
@@ -101,4 +101,14 @@ const { store: tags } = isOwnGroup.value ? useTagStore() : usePublicTagStore(gro
 const { store: tools } = isOwnGroup.value ? useToolStore() : usePublicToolStore(groupSlug.value);
 const { store: foods } = isOwnGroup.value ? useFoodStore() : usePublicFoodStore(groupSlug.value);
 const { store: households } = isOwnGroup.value ? useHouseholdStore() : usePublicHouseholdStore(groupSlug.value);
+
+watch(
+  households,
+  () => {
+    // if exactly one household exists, then we shouldn't be filtering by household
+    if (households.value.length == 1) {
+      selectedHouseholds.value = [];
+    }
+  },
+);
 </script>

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -82,7 +82,7 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
         try:
             if isinstance(self.model.household_id, AssociationProxyInstance):
                 q.filter(self.model.household_id.is_not(None))
-        except AttributeError:
+        except (AttributeError, NotImplementedError):
             pass
 
         if with_options:

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import UUID4, BaseModel
 from sqlalchemy import ColumnElement, Select, case, delete, func, nulls_first, nulls_last, select
+from sqlalchemy.ext.associationproxy import AssociationProxyInstance
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import sqltypes
@@ -77,6 +78,13 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
 
     def _query(self, override_schema: type[MealieModel] | None = None, with_options=True):
         q = select(self.model)
+
+        try:
+            if isinstance(self.model.household_id, AssociationProxyInstance):
+                q.filter(self.model.household_id.is_not(None))
+        except AttributeError:
+            pass
+
         if with_options:
             schema = override_schema or self.schema
             return q.options(*schema.loader_options())
@@ -87,6 +95,7 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
         dct = {}
         if self.group_id:
             dct["group_id"] = self.group_id
+
         if self.household_id:
             dct["household_id"] = self.household_id
 

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -214,7 +214,7 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
     ) -> RecipePagination:
         # Copy this, because calling methods (e.g. tests) might rely on it not getting mutated
         pagination_result = pagination.model_copy()
-        q = sa.select(self.model)
+        q = sa.select(self.model).filter(self.model.household_id.is_not(None))
 
         fltr = self._filter_builder()
         q = q.filter_by(**fltr)
@@ -334,7 +334,9 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
         return fltr
 
     def get_random(self, limit=1) -> list[Recipe]:
-        stmt = sa.select(RecipeModel).order_by(sa.func.random()).limit(limit)  # Postgres and SQLite specific
+        stmt = (
+            sa.select(RecipeModel).filter(RecipeModel.household_id.is_not(None)).order_by(sa.func.random()).limit(limit)
+        )  # Postgres and SQLite specific
         if self.group_id:
             stmt = stmt.filter(RecipeModel.group_id == self.group_id)
         if self.household_id:
@@ -405,7 +407,7 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
         ingredients_alias = orm.aliased(RecipeIngredientModel)
         tools_alias = orm.aliased(Tool)
 
-        q = sa.select(self.model)
+        q = sa.select(self.model).filter_by(self.model.household_id.is_not(None))
         fltr = self._filter_builder()
         q = q.filter_by(**fltr)
 

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -21,7 +21,7 @@ from mealie.db.models.users.user_to_recipe import UserToRecipe
 from mealie.db.models.users.users import User
 from mealie.schema.cookbook.cookbook import ReadCookBook
 from mealie.schema.recipe import Recipe
-from mealie.schema.recipe.recipe import RecipeCategory, RecipePagination, RecipeSummary, create_recipe_slug
+from mealie.schema.recipe.recipe import RecipePagination, RecipeSummary, create_recipe_slug
 from mealie.schema.recipe.recipe_ingredient import IngredientFood
 from mealie.schema.recipe.recipe_suggestion import RecipeSuggestionQuery, RecipeSuggestionResponseItem
 from mealie.schema.recipe.recipe_tool import RecipeToolOut
@@ -270,24 +270,6 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
             total_pages=total_pages,
             items=items,
         )
-
-    def get_by_categories(self, categories: list[RecipeCategory]) -> list[RecipeSummary]:
-        """
-        get_by_categories returns all the Recipes that contain every category provided in the list
-        """
-
-        ids = [x.id for x in categories]
-        stmt = (
-            sa.select(RecipeModel)
-            .join(RecipeModel.recipe_category)
-            .filter(RecipeModel.recipe_category.any(Category.id.in_(ids)))
-        )
-        if self.group_id:
-            stmt = stmt.filter(RecipeModel.group_id == self.group_id)
-        if self.household_id:
-            stmt = stmt.filter(RecipeModel.household_id == self.household_id)
-
-        return [RecipeSummary.model_validate(x) for x in self.session.execute(stmt).unique().scalars().all()]
 
     def _build_recipe_filter(
         self,

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -389,7 +389,7 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
         ingredients_alias = orm.aliased(RecipeIngredientModel)
         tools_alias = orm.aliased(Tool)
 
-        q = sa.select(self.model).filter_by(self.model.household_id.is_not(None))
+        q = sa.select(self.model).filter(self.model.household_id.is_not(None))
         fltr = self._filter_builder()
         q = q.filter_by(**fltr)
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

There are a few open issues around orphaning recipes from users (e.g. when [deleting a user](https://github.com/mealie-recipes/mealie/issues/3171)). This PR doesn't address that problem, but it does address one of the major symptoms which can sometimes block users from seeing any recipes on the main page.

This PR adds a few safeguards:
1. If only one household exists, make sure we're not filtering by a household on the frontend (the filter is hidden, so it should also be cleared)
2. When fetching recipes (or any object with similar properties, such as cookbooks), only fetch recipes with a `household_id` (recipes should _never_ not have a `household_id`, but it can happen due to other bugs, such as the one linked above).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/5957

## Testing

_(fill-in or delete this section)_

Broke my local db and confirmed the issue was reproducible, then confirmed it works fine after this fix.
