### PR TITLE
feat: add proxy authentication provider

### DIFF
--- a/frontend/app/pages/login.vue
+++ b/frontend/app/pages/login.vue
@@ -276,6 +276,14 @@ whenever(
   { immediate: true },
 );
 
+whenever(
+  () => $appInfo.proxyAuthEnabled && !isDirectLogin(),
+  () => {
+      authenticate({ isproxyAuthRequest: true });
+    },
+  { immediate: true },
+);
+
 const loggingIn = ref(false);
 const oidcLoggingIn = ref(false);
 
@@ -320,16 +328,17 @@ async function oidcAuthenticate(callback = false) {
   }
 }
 
-async function authenticate() {
-  if (form.email.length === 0 || form.password.length === 0) {
-    alert.error(i18n.t("user.please-enter-your-email-and-password"));
-    return;
-  }
+async function authenticate({ isproxyAuthRequest } = { isproxyAuthRequest: false}) {
+  if (!isproxyAuthRequest)
+    if (form.email.length === 0 || form.password.length === 0) {
+      alert.error(i18n.t("user.please-enter-your-email-and-password"));
+      return;
+    }
 
   loggingIn.value = true;
   const formData = new FormData();
-  formData.append("username", form.email);
-  formData.append("password", form.password);
+  formData.append("username", isproxyAuthRequest ? "proxy" : form.email);
+  formData.append("password", isproxyAuthRequest ? "proxy" : form.password);
   formData.append("remember_me", String(form.remember));
 
   try {

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -90,6 +90,8 @@ async def lifespan_fn(_: FastAPI) -> AsyncGenerator[None, None]:
     logger.info(settings.OIDC_FEATURE)
     logger.info("-------==OPENAI==-------")
     logger.info(settings.OPENAI_FEATURE)
+    logger.info("-------==PROXY_AUTH==-------")
+    logger.info(settings.PROXY_AUTH_FEATURE)
     logger.info("------------------------")
 
     yield

--- a/mealie/core/security/providers/__init__.py
+++ b/mealie/core/security/providers/__init__.py
@@ -2,3 +2,4 @@ from .auth_provider import *
 from .credentials_provider import *
 from .ldap_provider import *
 from .openid_provider import *
+from .proxy_provider import *

--- a/mealie/core/security/providers/proxy_provider.py
+++ b/mealie/core/security/providers/proxy_provider.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+
+from sqlalchemy.orm.session import Session
+from starlette.datastructures import Headers
+
+from mealie.core import root_logger
+from mealie.core.config import get_app_settings
+from mealie.core.security.providers.credentials_provider import CredentialsProvider
+from mealie.schema.user.auth import CredentialsRequest
+
+
+class ProxyProvider(CredentialsProvider):
+    """Authentication provider that authenticates a user using the header(s) forwarded from a trusted proxy"""
+
+    _logger = root_logger.get_logger("proxy_provider")
+
+    def __init__(self, session: Session, data: CredentialsRequest) -> None:
+        # Extra attributes necessary for forward auth that are not included in AuthProvider protocol nor passed
+        # to get_auth_provider. Instead, we assign these later in the /auth/token route where we have access to
+        # the Request object.
+        self.headers: Headers
+        super().__init__(session, data)
+
+    def authenticate(self) -> tuple[str, timedelta] | None:
+        """Attempt to authenticate a user with the username supplied in the
+        `REMOTE-USER` header (or the header specified by settings.REMOTE_USER_HEADER)."""
+        # When proxy auth is enabled, we need to still also support authentication with the Mealie backend.
+        # First we look to see if the required user header is set. If the required header is not set,
+        # we fallback to authenticating using the credentials provided in the login form. If the required
+        # header IS set, we attempt to match the value of this header with an existing mealie user.
+        # If we fail to find an existing user, we fallback to authenticating with the Mealie backend.
+
+        settings = get_app_settings()
+        remote_user = self.headers.get(settings.REMOTE_USER_HEADER, None)
+
+        if not remote_user:
+            self._logger.debug(
+                f"Required header {settings.REMOTE_USER_HEADER} not found. Falling back to internal auth."
+            )
+            return super().authenticate()
+
+        user = self.try_get_user(remote_user)
+
+        if not user:
+            # For now, there is no option to automatically provision new users, i.e.
+            # users who have not been previously registered as internal users. Though
+            # this could be added fairly trivially.
+            self._logger.debug(f"Failed to find existing user for remote user: {remote_user}")
+            return super().authenticate()
+
+        return self.get_access_token(user, False)

--- a/mealie/core/security/security.py
+++ b/mealie/core/security/security.py
@@ -11,6 +11,7 @@ from mealie.core.security.hasher import get_hasher
 from mealie.core.security.providers.auth_provider import AuthProvider
 from mealie.core.security.providers.credentials_provider import CredentialsProvider
 from mealie.core.security.providers.ldap_provider import LDAPProvider
+from mealie.core.security.providers.proxy_provider import ProxyProvider
 from mealie.schema.user.auth import CredentialsRequest, CredentialsRequestForm
 
 ALGORITHM = "HS256"
@@ -24,6 +25,9 @@ def get_auth_provider(session: Session, data: CredentialsRequestForm) -> AuthPro
     credentials_request = CredentialsRequest(**data.__dict__)
     if settings.LDAP_ENABLED:
         return LDAPProvider(session, credentials_request)
+
+    if settings.PROXY_AUTH_READY:
+        return ProxyProvider(session, credentials_request)
 
     return CredentialsProvider(session, credentials_request)
 

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -385,6 +385,33 @@ class AppSettings(AppLoggingSettings):
         return self.OIDC_FEATURE.enabled
 
     # ===============================================
+    # Proxy Auth configuration
+
+    PROXY_AUTH_ENABLED: bool = False
+    REMOTE_USER_HEADER: str = "Remote-User"
+    REMOTE_EMAIL_HEADER: str | None = None
+
+    # For now, this only supports specifying a set of particular IPs.
+    # In future, it may be desirable to support CIDR notation so that
+    # users can trust an entire subnet, such as 10.0.0.0/24.
+
+    @property
+    def PROXY_AUTH_FEATURE(self) -> FeatureDetails:
+        description = None if self.PROXY_AUTH_ENABLED else "PROXY_AUTH_ENABLED is false"
+
+        if not self.REMOTE_USER_HEADER:
+            description = "REMOTE_USER_HEADER is not set"
+
+        return FeatureDetails(
+            enabled=bool(self.PROXY_AUTH_ENABLED and self.REMOTE_USER_HEADER),
+            description=description,
+        )
+
+    @property
+    def PROXY_AUTH_READY(self) -> bool:
+        return self.PROXY_AUTH_FEATURE.enabled
+
+    # ===============================================
     # OpenAI Configuration
 
     OPENAI_BASE_URL: str | None = None

--- a/mealie/routes/admin/admin_about.py
+++ b/mealie/routes/admin/admin_about.py
@@ -40,6 +40,7 @@ class AdminAboutController(BaseAdminController):
             enable_openai_image_services=settings.OPENAI_ENABLED and settings.OPENAI_ENABLE_IMAGE_SERVICES,
             enable_openai_transcription_services=settings.OPENAI_ENABLED
             and settings.OPENAI_ENABLE_TRANSCRIPTION_SERVICES,
+            proxy_auth_enabled=settings.PROXY_AUTH_ENABLED,
         )
 
     @router.get("/statistics", response_model=AppStatistics)

--- a/mealie/routes/app/app_about.py
+++ b/mealie/routes/app/app_about.py
@@ -46,6 +46,7 @@ def get_app_info(session: Session = Depends(generate_session)):
         enable_openai_transcription_services=settings.OPENAI_ENABLED and settings.OPENAI_ENABLE_TRANSCRIPTION_SERVICES,
         allow_password_login=settings.ALLOW_PASSWORD_LOGIN,
         token_time=settings.TOKEN_TIME,
+        proxy_auth_enabled=settings.PROXY_AUTH_ENABLED,
     )
 
 

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -13,6 +13,7 @@ from mealie.core.config import get_app_settings
 from mealie.core.dependencies import get_current_user
 from mealie.core.exceptions import MissingClaimException, UserLockedOut
 from mealie.core.security.providers.openid_provider import OpenIDProvider
+from mealie.core.security.providers.proxy_provider import ProxyProvider
 from mealie.core.security.security import get_auth_provider
 from mealie.db.db_setup import generate_session
 from mealie.lang import get_locale_provider
@@ -71,6 +72,10 @@ def get_token(request: Request, data: CredentialsRequestForm = Depends(), sessio
 
     try:
         auth_provider = get_auth_provider(session, data)
+
+        if isinstance(auth_provider, ProxyProvider):
+            auth_provider.headers = request.headers
+
         auth = auth_provider.authenticate()
     except UserLockedOut as e:
         logger.error(f"User is locked out from {ip}")

--- a/mealie/schema/admin/about.py
+++ b/mealie/schema/admin/about.py
@@ -25,6 +25,7 @@ class AppInfo(MealieModel):
     enable_openai_image_services: bool
     enable_openai_transcription_services: bool
     token_time: int
+    proxy_auth_enabled: bool
 
 
 class AppTheme(MealieModel):
@@ -66,6 +67,7 @@ class AdminAboutInfo(AppInfo):
     default_household: str
     build_id: str
     recipe_scraper_version: str
+    proxy_auth_enabled: bool
 
 
 class CheckAppConfig(MealieModel):

--- a/tests/e2e/docker/docker-compose-forward-auth.yml
+++ b/tests/e2e/docker/docker-compose-forward-auth.yml
@@ -1,0 +1,42 @@
+networks:
+  default:
+    driver: bridge
+    name: forward_auth_test
+
+services:
+
+   mealie:
+    container_name: mealie
+    image: mealie:e2e-forward-auth
+    build:
+      context: ../../../
+      target: production
+      dockerfile: ./docker/Dockerfile
+    restart: always
+    volumes:
+      - mealie-data:/app/data/
+    environment:
+      ALLOW_SIGNUP: True
+      DB_ENGINE: sqlite
+
+      PROXY_AUTH_ENABLED: true
+    networks:
+      - default
+
+   traefik:
+    container_name: traefik
+    image: traefik:v3.3.6
+    command:
+      - "--configFile=/etc/traefik/traefik_config.yml"
+      - "--accesslog=true"
+    ports:
+      - 127.0.0.1:8080:80
+    volumes:
+      - ../traefik:/etc/traefik:ro
+    networks:
+        - default
+
+
+volumes:
+  mealie-data:
+    driver: local

--- a/tests/e2e/traefik/dynamic_config.yml
+++ b/tests/e2e/traefik/dynamic_config.yml
@@ -1,0 +1,22 @@
+http:
+  middlewares:
+    addRemoteUser:
+      headers:
+        customRequestHeaders:
+          # NOTE: DO NOT DO THIS IN A PRODUCTION ENVIRONMENT
+          Remote-User: "john"
+
+  routers:
+    mealie-http:
+      entryPoints:
+        - web
+      service: mealie
+      middlewares:
+        - "addRemoteUser"
+      rule: Host(`mealie.localhost`)
+
+  services:
+    mealie:
+      loadBalancer:
+        servers:
+          - url: http://mealie:9000

--- a/tests/e2e/traefik/traefik_config.yml
+++ b/tests/e2e/traefik/traefik_config.yml
@@ -1,0 +1,10 @@
+# log:
+#   level: DEBUG
+
+entrypoints:
+  web:
+    address: :80
+
+providers:
+  file:
+    filename: "/etc/traefik/dynamic_config.yml"

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -322,4 +322,3 @@ def test_proxy_auth_login_no_header(api_client: TestClient, unique_user: TestUse
     assert response.status_code == 200
 
     get_app_settings.cache_clear()
-

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -258,3 +258,68 @@ def test_ldap_user_login_complex_filter(api_client: TestClient):
     assert data.get("admin") is True
 
     get_app_settings.cache_clear()
+
+
+def test_proxy_auth_login(api_client: TestClient, unique_user: TestUser):
+    app_settings = get_app_settings()
+
+    app_settings.LDAP_AUTH_ENABLED = False
+    app_settings.PROXY_AUTH_ENABLED = True
+
+    # 'testclient` is the default host for Starlette TestClient
+    app_settings.TRUSTED_PROXIES = {"testclient"}
+
+    response = api_client.post(api_routes.auth_token, headers={"Remote-User": unique_user.username})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data is not None
+    assert data.get("access_token") is not None
+
+    response = api_client.get(api_routes.users_self, headers={"Authorization": f"Bearer {data.get('access_token')}"})
+    assert response.status_code == 200
+
+    get_app_settings.cache_clear()
+
+
+def test_proxy_auth_custom_header(api_client: TestClient, unique_user: TestUser):
+    app_settings = get_app_settings()
+
+    app_settings.LDAP_AUTH_ENABLED = False
+    app_settings.PROXY_AUTH_ENABLED = True
+    app_settings.REMOTE_USER_HEADER = "USER"
+    app_settings.TRUSTED_PROXIES = {"testclient"}
+
+    response = api_client.post(api_routes.auth_token, headers={"USER": unique_user.username})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data is not None
+    assert data.get("access_token") is not None
+
+    response = api_client.get(api_routes.users_self, headers={"Authorization": f"Bearer {data.get('access_token')}"})
+    assert response.status_code == 200
+
+    get_app_settings.cache_clear()
+
+
+def test_proxy_auth_login_no_header(api_client: TestClient, unique_user: TestUser):
+    app_settings = get_app_settings()
+
+    app_settings.LDAP_AUTH_ENABLED = False
+    app_settings.PROXY_AUTH_ENABLED = True
+
+    form_data = {"username": unique_user.username, "password": unique_user.password}
+
+    response = api_client.post(api_routes.auth_token, data=form_data)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data is not None
+    assert data.get("access_token") is not None
+
+    response = api_client.get(api_routes.users_self, headers={"Authorization": f"Bearer {data.get('access_token')}"})
+    assert response.status_code == 200
+
+    get_app_settings.cache_clear()
+


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

This pull-request adds support for [proxy authorization](https://www.authelia.com/reference/guides/proxy-authorization/) / [ForwardAuth](https://docs.goauthentik.io/add-secure-apps/providers/proxy/forward_auth/). This authentication method relies on a trusted proxy appropriately setting the REMOTE-USER header in forwarded request.

This is a frequently requested feature and would provide a streamlined user experience for users running a centralised identity-provider with reverse proxy to manage access to private services. 

The approach taken here is based on #2040 but updates the code to use the newer AuthProvider interface. It also focuses on implementing **header-based** auth only. This simplifies the solution since Mealie need not be responsible for, e.g. redirecting users to the IdP if the session has expired. 

**N.B. because mealie [currently runs with --forwaded-allow-ips="*"](https://github.com/mealie-recipes/mealie/blob/7792f0504d02e0030eb5f3f6adab2126429551ea/mealie/app.py#L178), mealie allows any host to set the sensitive headers. We should consider also changing this to be configurable via app settings. Otherwise, users enabling forward auth will need to ensure that the unicorn server is only accessible via a trusted proxy.**

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Related discussions [#801](https://github.com/mealie-recipes/mealie/discussions/801), [#3364](https://github.com/mealie-recipes/mealie/discussions/3664), [#284](https://github.com/mealie-recipes/mealie/discussions/284).

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

Forward Auth requires access to the headers sent with the request to the /auth/token/ endpoint. However, request headers are not part of the AuthProvider interface, nor are they provided to the get_auth_provider function.  For this reason, to avoid modifying the existing interface I have chosen to simply set these on the AuthProvider instance inside the /auth/token route handler iff the AuthProvider in use is the ProxyAuth provider.

## Testing

I have started adding a new e2e test for this feature. However, I am unsure on how to create an internal user
for use in testing during this e2e test.

As such, testing with this setup currently requires completing the registration process at least once, registering a user with username 'john'. This matches the static Remote-User header set in `traefik/dynamic_config.yml`

Once the stack defined in `docker-compose-forward-auth.yml` is up, mealie should be reachable at mealie.localhost:8080. Traefik should then add the static Remote-User header with value john to each request.

I have tested this manually (i.e. without using GitHub Actions) or another automated runner. 
<!--
  Describe how you tested this change.
-->
