### PR TITLE
fix: recipe context menu

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeActionMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeActionMenu.vue
@@ -79,7 +79,7 @@
         @print="$emit('print')"
       />
     </div>
-    <div v-if="open" class="custom-btn-group gapped">
+    <div v-if="open" class="custom-btn-group gapped ma-1">
       <v-btn
         v-for="(btn, index) in editorButtons"
         :key="index"

--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
@@ -10,7 +10,6 @@
       :nudge-top="menuTop ? '5' : '0'"
       allow-overflow
       close-delay="125"
-      :open-on-hover="$vuetify.display.mdAndUp"
       content-class="d-print-none"
       @update:model-value="onMenuToggle"
     >

--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenu.vue
@@ -23,7 +23,6 @@
           :fab="fab"
           v-bind="activatorProps"
           @click.prevent
-          @mouseenter="onHover"
         >
           <v-icon
             :size="!fab ? undefined : 'x-large'"
@@ -125,12 +124,6 @@ const contentProps = computed(() => {
   const { ...rest } = props;
   return rest;
 });
-
-function onHover() {
-  if (!isMenuContentLoaded.value) {
-    isMenuContentLoaded.value = true;
-  }
-}
 
 function onMenuToggle(isOpen: boolean) {
   if (isOpen && !isMenuContentLoaded.value) {

--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -176,6 +176,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   [key: string]: any;
   deleted: [slug: string];
+  print: [];
 }>();
 
 const api = useUserApi();


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

As mentioned in #6449, the recipe context menu does not open on some screens. The hover property has therefore been removed, requiring you to click the button to open the menu.
A warning in the console and  spacing in edit mode has been fixed.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #6449
