### PR TITLE
feat: User profile + settings menu in top right (AppHeader) instead of top/bottom left (AppSidebar)

### DIFF
--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -233,6 +233,13 @@ export default defineNuxtComponent({
         restricted: false,
       },
       {
+        icon: $globals.icons.heart,
+        // TODO: how to hide this for non-logged-in view?
+        to: `/user/${$auth.user.value.id}/favorites`,
+        title: i18n.t("user.favorite-recipes"),
+        restricted: false,
+      },
+      {
         icon: $globals.icons.search,
         to: `/g/${groupSlug.value}/recipes/finder`,
         title: i18n.t("recipe-finder.recipe-finder"),

--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -235,7 +235,7 @@ export default defineNuxtComponent({
       {
         icon: $globals.icons.heart,
         // TODO: how to hide this for non-logged-in view?
-        to: `/user/${$auth.user.value.id}/favorites`,
+        to: `/user/${$auth.user.value?.id ?? ""}/favorites`,
         title: i18n.t("user.favorite-recipes"),
         restricted: false,
       },

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -79,7 +79,6 @@
             <v-list-item :prepend-icon="$vuetify.theme.current.dark ? $globals.icons.weatherSunny : $globals.icons.weatherNight" :title="$vuetify.theme.current.dark ? $t('settings.theme.light-mode') : $t('settings.theme.dark-mode')" @click="toggleDark" />
             <!-- TODO: what was the use case for sidebar settings in logged-out state? -->
             <v-divider v-if="loggedIn" class="my-2" />
-            <v-list-item v-if="loggedIn" :prepend-icon="$globals.icons.cog" :title="$t('profile.user-settings')" to="/user/profile" />
             <v-list-item v-if="canManage" :prepend-icon="$globals.icons.manageData" :title="$t('data-pages.data-management')" to="/group/data" />
             <v-divider v-if="isAdmin" class="my-2" />
             <v-list-item v-if="isAdmin" :prepend-icon="$globals.icons.wrench" :title="$t('settings.admin-settings')" to="/admin/site-settings" />

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -62,17 +62,31 @@
         <LanguageDialog v-model="languageDialog" />
         <v-menu z-index="2020">
           <template #activator="{ props }">
-            <v-btn v-bind="props" icon data-testid="user-menu-button">
+            <v-btn
+              v-if="!xs"
+              v-bind="props"
+              rounded="xl"
+              data-testid="user-menu-button"
+              class="ps-0"
+              height="40px"
+            >
+              <div class="d-flex align-center ga-2">
+                <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
+                <div>
+                  {{ sessionUser.fullName }}
+                </div>
+              </div>
+            </v-btn>
+            <v-btn v-else v-bind="props" icon data-testid="user-menu-button">
               <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
             </v-btn>
           </template>
           <v-list density="comfortable" color="primary" data-testid="user-menu">
-            <v-list-item :title="sessionUser.fullName ?? undefined" :to="userProfileLink">
-              <template #prepend>
-                <!-- TODO: horizontally center avatar with other icons in menu (why isn't it automatically centered?) -->
-                <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
-              </template>
-            </v-list-item>
+            <template v-if="xs">
+              <v-list-subheader :title="sessionUser.fullName ?? undefined" class="justify-center" />
+              <v-divider class="my-2" />
+            </template>
+            <v-list-item :prepend-icon="$globals.icons.user" :title="$t('settings.profile')" :to="userProfileLink" />
             <v-divider class="my-2" />
             <v-list-item :prepend-icon="$globals.icons.translate" :title="$t('sidebar.language')" @click="languageDialog=true" />
             <!-- TODO: prevent menu from closing when toggling light/dark mode -->

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -73,7 +73,6 @@
                 <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
               </template>
             </v-list-item>
-            <v-list-item :prepend-icon="$globals.icons.heart" :title="$t('user.favorite-recipes')" :to="userFavoritesLink" />
             <v-divider class="my-2" />
             <v-list-item :prepend-icon="$globals.icons.translate" :title="$t('sidebar.language')" @click="languageDialog=true" />
             <!-- TODO: prevent menu from closing when toggling light/dark mode -->
@@ -125,7 +124,6 @@ export default defineNuxtComponent({
     const { loggedIn } = useLoggedInState();
     const isAdmin = computed(() => $auth.user.value?.admin);
     const canManage = computed(() => $auth.user.value?.canManage);
-    const userFavoritesLink = computed(() => $auth.user.value ? `/user/${$auth.user.value.id}/favorites` : undefined);
     const userProfileLink = computed(() => $auth.user.value ? "/user/profile" : undefined);
     const route = useRoute();
     const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
@@ -181,7 +179,6 @@ export default defineNuxtComponent({
       sessionUser: $auth.user,
       smAndUp,
       toggleDark,
-      userFavoritesLink,
       userProfileLink,
       xs,
     };

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -87,13 +87,12 @@
               <v-divider class="my-2" />
             </template>
             <v-list-item :prepend-icon="$globals.icons.user" :title="$t('settings.profile')" :to="userProfileLink" />
+            <v-list-item v-if="canManage" :prepend-icon="$globals.icons.manageData" :title="$t('data-pages.data-management')" to="/group/data" />
             <v-divider class="my-2" />
             <v-list-item :prepend-icon="$globals.icons.translate" :title="$t('sidebar.language')" @click="languageDialog=true" />
             <!-- TODO: prevent menu from closing when toggling light/dark mode -->
             <v-list-item :prepend-icon="$vuetify.theme.current.dark ? $globals.icons.weatherSunny : $globals.icons.weatherNight" :title="$vuetify.theme.current.dark ? $t('settings.theme.light-mode') : $t('settings.theme.dark-mode')" @click="toggleDark" />
             <!-- TODO: what was the use case for sidebar settings in logged-out state? -->
-            <v-divider v-if="loggedIn" class="my-2" />
-            <v-list-item v-if="canManage" :prepend-icon="$globals.icons.manageData" :title="$t('data-pages.data-management')" to="/group/data" />
             <v-divider v-if="isAdmin" class="my-2" />
             <v-list-item v-if="isAdmin" :prepend-icon="$globals.icons.wrench" :title="$t('settings.admin-settings')" to="/admin/site-settings" />
             <v-divider class="my-2" />

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -58,17 +58,37 @@
       >
         <v-icon> {{ $globals.icons.search }}</v-icon>
       </v-btn>
-      <v-btn
-        v-if="loggedIn"
-        :variant="smAndUp ? 'text' : undefined"
-        :icon="xs"
-        @click="logout()"
-      >
-        <v-icon :start="smAndUp">
-          {{ $globals.icons.logout }}
-        </v-icon>
-        {{ smAndUp ? $t("user.logout") : "" }}
-      </v-btn>
+      <div v-if="loggedIn && sessionUser" class="mx-1">
+        <LanguageDialog v-model="languageDialog" />
+        <v-menu z-index="2020">
+          <template #activator="{ props }">
+            <v-btn v-bind="props" icon data-testid="user-menu-button">
+              <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
+            </v-btn>
+          </template>
+          <v-list density="comfortable" color="primary" data-testid="user-menu">
+            <v-list-item :title="sessionUser.fullName ?? undefined" :to="userProfileLink">
+              <template #prepend>
+                <!-- TODO: horizontally center avatar with other icons in menu (why isn't it automatically centered?) -->
+                <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
+              </template>
+            </v-list-item>
+            <v-list-item :prepend-icon="$globals.icons.heart" :title="$t('user.favorite-recipes')" :to="userFavoritesLink" />
+            <v-divider class="my-2" />
+            <v-list-item :prepend-icon="$globals.icons.translate" :title="$t('sidebar.language')" @click="languageDialog=true" />
+            <!-- TODO: prevent menu from closing when toggling light/dark mode -->
+            <v-list-item :prepend-icon="$vuetify.theme.current.dark ? $globals.icons.weatherSunny : $globals.icons.weatherNight" :title="$vuetify.theme.current.dark ? $t('settings.theme.light-mode') : $t('settings.theme.dark-mode')" @click="toggleDark" />
+            <!-- TODO: what was the use case for sidebar settings in logged-out state? -->
+            <v-divider v-if="loggedIn" class="my-2" />
+            <v-list-item v-if="loggedIn" :prepend-icon="$globals.icons.cog" :title="$t('profile.user-settings')" to="/user/profile" />
+            <v-list-item v-if="canManage" :prepend-icon="$globals.icons.manageData" :title="$t('data-pages.data-management')" to="/group/data" />
+            <v-divider v-if="isAdmin" class="my-2" />
+            <v-list-item v-if="isAdmin" :prepend-icon="$globals.icons.wrench" :title="$t('settings.admin-settings')" to="/admin/site-settings" />
+            <v-divider class="my-2" />
+            <v-list-item v-if="loggedIn" :prepend-icon="$globals.icons.logout" :title="$t('user.logout')" @click="logout()" />
+          </v-list>
+        </v-menu>
+      </div>
       <v-btn
         v-else
         variant="text"
@@ -87,9 +107,13 @@
 <script lang="ts">
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import RecipeDialogSearch from "~/components/Domain/Recipe/RecipeDialogSearch.vue";
+import UserAvatar from "~/components/Domain/User/UserAvatar.vue";
 
 export default defineNuxtComponent({
-  components: { RecipeDialogSearch },
+  components: {
+    RecipeDialogSearch,
+    UserAvatar,
+  },
   props: {
     menu: {
       type: Boolean,
@@ -99,12 +123,22 @@ export default defineNuxtComponent({
   setup() {
     const $auth = useMealieAuth();
     const { loggedIn } = useLoggedInState();
+    const isAdmin = computed(() => $auth.user.value?.admin);
+    const canManage = computed(() => $auth.user.value?.canManage);
+    const userFavoritesLink = computed(() => $auth.user.value ? `/user/${$auth.user.value.id}/favorites` : undefined);
+    const userProfileLink = computed(() => $auth.user.value ? "/user/profile" : undefined);
     const route = useRoute();
     const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
     const { xs, smAndUp } = useDisplay();
 
     const routerLink = computed(() => groupSlug.value ? `/g/${groupSlug.value}` : "/");
     const domSearchDialog = ref<InstanceType<typeof RecipeDialogSearch> | null>(null);
+
+    const toggleDark = useToggleDarkMode();
+
+    const state = reactive({
+      languageDialog: false,
+    });
 
     function activateSearch() {
       domSearchDialog.value?.open();
@@ -136,18 +170,26 @@ export default defineNuxtComponent({
     }
 
     return {
+      ...toRefs(state),
       activateSearch,
+      canManage,
       domSearchDialog,
-      routerLink,
+      isAdmin,
       loggedIn,
       logout,
-      xs, smAndUp,
+      routerLink,
+      sessionUser: $auth.user,
+      smAndUp,
+      toggleDark,
+      userFavoritesLink,
+      userProfileLink,
+      xs,
     };
   },
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .v-toolbar {
   z-index: 2010 !important;
 }

--- a/frontend/components/Layout/LayoutParts/AppSidebar.vue
+++ b/frontend/components/Layout/LayoutParts/AppSidebar.vue
@@ -1,30 +1,5 @@
 <template>
   <v-navigation-drawer v-model="showDrawer" class="d-flex flex-column d-print-none position-fixed" touchless>
-    <LanguageDialog v-model="languageDialog" />
-    <!-- User Profile -->
-    <template v-if="loggedIn">
-      <v-list-item lines="two" :to="userProfileLink" exact>
-        <div class="d-flex align-center ga-2">
-          <UserAvatar list :user-id="sessionUser.id" :tooltip="false" />
-
-          <div class="d-flex flex-column justify-start">
-            <v-list-item-title class="pr-2 pl-1">
-              {{ sessionUser.fullName }}
-            </v-list-item-title>
-            <v-list-item-subtitle class="opacity-100">
-              <v-btn v-if="isOwnGroup" class="px-2 pa-0" variant="text" :to="userFavoritesLink" size="small">
-                <v-icon start size="small">
-                  {{ $globals.icons.heart }}
-                </v-icon>
-                {{ $t("user.favorite-recipes") }}
-              </v-btn>
-            </v-list-item-subtitle>
-          </div>
-        </div>
-      </v-list-item>
-      <v-divider />
-    </template>
-
     <slot />
 
     <!-- Primary Links -->
@@ -113,48 +88,19 @@
         </template>
       </v-list>
     </template>
-
-    <!-- Bottom Navigation Links -->
-    <template #append>
-      <v-list v-model:selected="bottomSelected" nav density="comfortable">
-        <v-menu location="end bottom" :offset="15">
-          <template #activator="{ props }">
-            <v-list-item v-bind="props" :prepend-icon="$globals.icons.cog" :title="$t('general.settings')" />
-          </template>
-          <v-list density="comfortable" color="primary">
-            <v-list-item :prepend-icon="$globals.icons.translate" :title="$t('sidebar.language')" @click="languageDialog=true" />
-            <v-list-item :prepend-icon="$vuetify.theme.current.dark ? $globals.icons.weatherSunny : $globals.icons.weatherNight" :title="$vuetify.theme.current.dark ? $t('settings.theme.light-mode') : $t('settings.theme.dark-mode')" @click="toggleDark" />
-            <v-divider v-if="loggedIn" class="my-2" />
-            <v-list-item v-if="loggedIn" :prepend-icon="$globals.icons.cog" :title="$t('profile.user-settings')" to="/user/profile" />
-            <v-list-item v-if="canManage" :prepend-icon="$globals.icons.manageData" :title="$t('data-pages.data-management')" to="/group/data" />
-            <v-divider v-if="isAdmin" class="my-2" />
-            <v-list-item v-if="isAdmin" :prepend-icon="$globals.icons.wrench" :title="$t('settings.admin-settings')" to="/admin/site-settings" />
-          </v-list>
-        </v-menu>
-      </v-list>
-    </template>
   </v-navigation-drawer>
 </template>
 
 <script lang="ts">
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import type { SidebarLinks } from "~/types/application-types";
-import UserAvatar from "~/components/Domain/User/UserAvatar.vue";
-import { useToggleDarkMode } from "~/composables/use-utils";
 
 export default defineNuxtComponent({
-  components: {
-    UserAvatar,
-  },
   props: {
     modelValue: {
       type: Boolean,
       required: false,
       default: false,
-    },
-    user: {
-      type: Object,
-      default: null,
     },
     topLink: {
       type: Array as () => SidebarLinks,
@@ -168,23 +114,12 @@ export default defineNuxtComponent({
   },
   emits: ["update:modelValue"],
   setup(props, context) {
-    const $auth = useMealieAuth();
-    const { loggedIn, isOwnGroup } = useLoggedInState();
-    const isAdmin = computed(() => $auth.user.value?.admin);
-    const canManage = computed(() => $auth.user.value?.canManage);
-
-    const userFavoritesLink = computed(() => $auth.user.value ? `/user/${$auth.user.value.id}/favorites` : undefined);
-    const userProfileLink = computed(() => $auth.user.value ? "/user/profile" : undefined);
-
-    const toggleDark = useToggleDarkMode();
+    const { isOwnGroup } = useLoggedInState();
 
     const state = reactive({
       dropDowns: {} as Record<string, boolean>,
       topSelected: null as string[] | null,
       secondarySelected: null as string[] | null,
-      bottomSelected: null as string[] | null,
-      hasOpenedBefore: false as boolean,
-      languageDialog: false as boolean,
     });
     // model to control the drawer
     const showDrawer = computed({
@@ -210,15 +145,8 @@ export default defineNuxtComponent({
 
     return {
       ...toRefs(state),
-      userFavoritesLink,
-      userProfileLink,
       showDrawer,
-      loggedIn,
-      isAdmin,
-      canManage,
       isOwnGroup,
-      sessionUser: $auth.user,
-      toggleDark,
     };
   },
 });
@@ -229,13 +157,5 @@ export default defineNuxtComponent({
   .no-print {
     display: none;
   }
-}
-
-.favorites-link {
-  text-decoration: none;
-}
-
-.favorites-link:hover {
-  text-decoration: underline;
 }
 </style>

--- a/frontend/layouts/admin.vue
+++ b/frontend/layouts/admin.vue
@@ -15,7 +15,6 @@
       v-model="sidebar"
       absolute
       :top-link="topLinks"
-      :user="{ data: true }"
       :secondary-header="$t('sidebar.developer')"
       :secondary-links="developerLinks"
     />

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -11,8 +11,7 @@ test('password login', async ({ page }) => {
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     // skip admin setup page
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
-    await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
 });
 
 test('ldap login', async ({ page }) => {
@@ -25,8 +24,8 @@ test('ldap login', async ({ page }) => {
     await page.getByLabel('Password', { exact: true }).fill(password);
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     await expect(page).toHaveURL(/\/g\/home/);
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).not.toBeVisible();
 });
 
@@ -41,8 +40,8 @@ test('ldap admin login', async ({ page }) => {
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     // skip admin setup page
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).toBeVisible();
 });
 
@@ -63,8 +62,8 @@ test('oidc initial login', async ({ page }) => {
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
     await expect(page).toHaveURL(/\/g\/home/);
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).not.toBeVisible();
 });
 
@@ -105,8 +104,8 @@ test('oidc sequential login', async ({ page }) => {
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
     await expect(page).toHaveURL(/\/g\/home/, { timeout: 15000 });
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await page.getByTestId('user-menu').getByText('Logout').click();
 
     await expect(page).toHaveURL(/\/login\?direct=1/);
@@ -114,8 +113,7 @@ test('oidc sequential login', async ({ page }) => {
     await page.getByPlaceholder('Enter any user/subject').fill(username);
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
-    await page.getByTestId("user-menu-button", { timeout: 15000 }).click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
+    await expect(page.getByTestId("user-menu-button"), { timeout: 15000 }).toContainText(name);
 });
 
 test('settings page verify oidc', async ({ page }) => {
@@ -134,8 +132,8 @@ test('settings page verify oidc', async ({ page }) => {
     await page.getByPlaceholder('Enter any user/subject').fill(username);
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await page.getByTestId('user-menu').getByText('Logout').click();
 
     await expect(page).toHaveURL(/\/login\?direct=1/);
@@ -173,7 +171,7 @@ test('oidc admin user', async ({ page }) => {
     // skip admin setup page
     await expect(page).toHaveURL(/\/admin\/setup/, { timeout: 15000 });
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
+    await expect(page.getByTestId("user-menu-button")).toContainText(name);
     await page.getByTestId("user-menu-button").click();
-    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).toBeVisible();
 });

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -11,7 +11,8 @@ test('password login', async ({ page }) => {
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     // skip admin setup page
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
-    await expect(page.getByRole('navigation')).toContainText(name);
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
 });
 
 test('ldap login', async ({ page }) => {
@@ -24,8 +25,8 @@ test('ldap login', async ({ page }) => {
     await page.getByLabel('Password', { exact: true }).fill(password);
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     await expect(page).toHaveURL(/\/g\/home/);
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByText('Settings', { exact: true }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).not.toBeVisible();
 });
 
@@ -40,8 +41,8 @@ test('ldap admin login', async ({ page }) => {
     await page.getByRole('button', { name: 'Login', exact: true }).click();
     // skip admin setup page
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByText('Settings', { exact: true }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).toBeVisible();
 });
 
@@ -62,12 +63,12 @@ test('oidc initial login', async ({ page }) => {
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
     await expect(page).toHaveURL(/\/g\/home/);
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByText('Settings', { exact: true }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).not.toBeVisible();
 });
 
-test('oidc login with user not in propery group', async ({ page }) => {
+test('oidc login with user not in property group', async ({ page }) => {
     const username = "testUserNoGroup"
     const name = "Test User No Group"
     const claims = {
@@ -104,15 +105,17 @@ test('oidc sequential login', async ({ page }) => {
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
     await expect(page).toHaveURL(/\/g\/home/, { timeout: 15000 });
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByRole('button', { name: 'Logout' }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
+    await page.getByTestId('user-menu').getByText('Logout').click();
 
     await expect(page).toHaveURL(/\/login\?direct=1/);
     await page.getByRole('button', { name: 'Login with OAuth' }).click();
     await page.getByPlaceholder('Enter any user/subject').fill(username);
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
-    await expect(page.getByRole('navigation')).toContainText(name, { timeout: 15000 });
+    await page.getByTestId("user-menu-button", { timeout: 15000 }).click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
 });
 
 test('settings page verify oidc', async ({ page }) => {
@@ -131,8 +134,9 @@ test('settings page verify oidc', async ({ page }) => {
     await page.getByPlaceholder('Enter any user/subject').fill(username);
     await page.getByPlaceholder('Optional claims JSON value,').fill(JSON.stringify(claims));
     await page.getByRole('button', { name: 'Sign-in' }).click();
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByRole('button', { name: 'Logout' }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
+    await page.getByTestId('user-menu').getByText('Logout').click();
 
     await expect(page).toHaveURL(/\/login\?direct=1/);
     await page.getByLabel('Email or Username').click();
@@ -169,7 +173,7 @@ test('oidc admin user', async ({ page }) => {
     // skip admin setup page
     await expect(page).toHaveURL(/\/admin\/setup/, { timeout: 15000 });
     await page.getByRole('link', { name: "I'm already set up, just bring me to the homepage" }).click();
-    await expect(page.getByRole('navigation')).toContainText(name);
-    await page.getByText('Settings', { exact: true }).click();
+    await page.getByTestId("user-menu-button").click();
+    await expect(page.getByTestId("user-menu")).toContainText(name);
     await expect(page.getByText('Admin Settings')).toBeVisible();
 });


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

This PR consolidates the link to the current user's profile and the "settings" submenu into a single profile/account menu, represented by the user's avatar in the top right (i.e. at the end of the AppHeader).
This aligns Mealie's UI more with common conventions found in other apps that have user accounts (e.g. Github, Google, etc.).
This also prevents accidental logout, especially on mobile, where the logout button on the top right was easy to hit by mistake (and there was no confirmation dialog before logging out).

In more detail:
* before this change, there was:
  * the user avatar shown at the top of the left sidebar (link to user profile page and to user favorite recipe's)
  * the settings submenu shown at the bottom of the left sidebar (introduced in https://github.com/mealie-recipes/mealie/pull/6043)
  * a login/logout button shown at the right of the top bar (AppHeader)
* after this change, all three of these are consolidated to a "user menu" at the top right (except for the link to favorite recipes, which is moved to the nav links in the left sidebar)
  * the menu is represented by the user's avatar and user name
  * when clicked, a submenu opens, showing:
    * a link to the profile page (previous on the left sidebar on the top)
    * all items from the "settings" submenu (previously in the left sidebar on the bottom), such as theme and language switching, admin settings, etc.
      * except for the "User Settings" menu, because this linked to the "user profile" page which is now at the top of this menu
    * a logout button (previously directly in the app bar)

### Screenshots

| | Before | After<br>(menu closed) | After<br>(menu open) |
|---|---|---|---|
| Desktop | <img width="2700" height="1910" alt="CleanShot 2026-01-05 at 13 56 11@2x" src="https://github.com/user-attachments/assets/fa8e0752-97f6-4a28-82d9-ae422203d4fe" /> | <img width="2700" height="1910" alt="CleanShot 2026-01-05 at 13 56 44@2x" src="https://github.com/user-attachments/assets/f6580e08-ba8a-42d1-96c1-b5bc21995caa" /> | <img width="2700" height="1910" alt="CleanShot 2026-01-05 at 13 56 52@2x" src="https://github.com/user-attachments/assets/eece7079-06b4-477d-97ff-8caabaea224d" /> |
| Mobile | <img width="780" height="1688" alt="CleanShot 2026-01-05 at 13 58 02@2x" src="https://github.com/user-attachments/assets/8500e800-9309-4587-9738-4bb83002303d" /> | <img width="780" height="1688" alt="CleanShot 2026-01-05 at 13 58 26@2x" src="https://github.com/user-attachments/assets/b638d727-63d7-4ac6-9bf8-8be4e507697b" /> | <img width="780" height="1688" alt="CleanShot 2026-01-05 at 13 58 33@2x" src="https://github.com/user-attachments/assets/fca02dd7-8aca-4715-8bf7-89ea7455157c" /> |



## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

Addresses discussion https://github.com/mealie-recipes/mealie/discussions/5528

## Special notes for your reviewer:

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

There are three things in particular I'd like reviewers to take a look at and/or let me know:
* The sidebar had specific handling for when a user isn't logged in; for example, the language and theme switcher menu items were also shown to logged-out users. I'm not sure what the use cases for this are.
  * Right now, the user menu on the top right is _only_ shown to logged-in users. If logged-out usage is important, please let me know how we should address this here (e.g. use a placeholder icon instead of user avatar for the menu button)
* The AppHeader shows a "login" button when it's viewed in a logged-out state. I've kept this for now, but I'm not sure when this would be actionable (similar to the logged-out sidebar). Shouldn't the UI just redirect to the login page right away when the user isn't logged in? 🤔 
* I have applied PR feedback in additional commits within this PR, partially so that they're easy to adjust or revert based on pending feedback by the core maintainers. If the PR doesn't get merged with a "squash" strategy, I'm happy to squash these manually before merging (or for one of the maintainers to do this for me).

Two minor things I noticed but didn't address in this PR yet (i think these can be addressed in follow-up PRs if desired):
* ~~Inside the new profile menu, the user avatar and the other icons are not horizontally centered (they're left-aligned). This is the default behavior of Vuetify's `v-list`, and I didn't find an obvious way to change this. In fact, `v-list-item` uses pretty hard-coded spacing between the prepend slot and the item's text, making customization of this a bit tricky (and probably not easy to maintain).~~ This is now addressed -- the user avatar is no longer showing inside of the menu
* When you click the theme switcher (dark/light mode), the menu closes (default behavior of the popup menu component). This is the same as it currently does in the "settings" menu in the sidebar. I think it would be nicer if the menu stayed open, to make it easier to toggle back if you don't like the other theme or if you clicked it accidentally (imagine blinding yourself by accidentally switching to light mode at night 🙈).

## Testing


<!--
  Describe how you tested this change.
-->

Manually, running the dev server locally.