### PR TITLE
fix: Make quantity input in shopping list item editor visually consistent with other inputs

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -10,11 +10,8 @@
               :label="$t('form.quantity-label-abbreviated')"
               :min="0"
               :precision="null"
-              variant="plain"
               control-variant="stacked"
               inset
-              density="compact"
-              class="centered-number-input"
               style="width: 100px;"
             />
           </div>
@@ -242,10 +239,3 @@ export default defineNuxtComponent({
   },
 });
 </script>
-
-<style scoped>
-.centered-number-input :deep(.v-field) {
-  display: flex;
-  align-items: center;
-}
-</style>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

This PR makes the styling of the quantity input field in the item edit view on the shopping list more consistent with the other inputs in that form.

In particular on mobile, the quantity input was quite small and hard to tap.

Screenshots:

| | Desktop | Mobile |
|---|---|---|
| Before | <img width="2014" height="1440" alt="CleanShot 2026-01-01 at 13 30 06@2x" src="https://github.com/user-attachments/assets/fb0441a3-6886-455a-a1d1-c56bca41fdc8" /> | <img width="780" height="1688" alt="CleanShot 2026-01-01 at 13 30 33@2x" src="https://github.com/user-attachments/assets/87182b31-6151-4c6c-9890-9e70f0800dfc" /> |
| After | <img width="2582" height="1750" alt="CleanShot 2026-01-01 at 17 36 15@2x" src="https://github.com/user-attachments/assets/8ffbcd89-9f72-47c9-9698-efd25c4dee6d" /> | <img width="780" height="1688" alt="CleanShot 2026-01-01 at 17 35 32@2x" src="https://github.com/user-attachments/assets/8f00cf90-e630-4a13-87d2-5d773e79a3a2" /> |




## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

None.
