### PR TITLE
fix: allow `start` attribute on ordered lists (SafeMarkdown)

### DIFF
--- a/frontend/components/global/SafeMarkdown.vue
+++ b/frontend/components/global/SafeMarkdown.vue
@@ -31,7 +31,7 @@ export default defineNuxtComponent({
         ],
         ALLOWED_ATTR: [
           "href", "src", "alt", "height", "width", "class", "allow", "title", "allowfullscreen", "frameborder",
-          "scrolling", "cite", "datetime", "name", "abbr", "target", "border",
+          "scrolling", "cite", "datetime", "name", "abbr", "target", "border", "start",
         ],
       });
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Lists numbered with a number and a dot (as in Markdown) are always rendered as the first element in instruction titles. The "start" attribute is now allowed in the rendering of `<ol>` tags.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #6817