### PR TITLE
fix: prevent XSS via javascript: URIs in recipe actions

### DIFF
--- a/mealie/schema/household/group_recipe_action.py
+++ b/mealie/schema/household/group_recipe_action.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any
 
-from pydantic import UUID4, ConfigDict
+from pydantic import UUID4, ConfigDict, field_validator
 
 from mealie.schema._mealie import MealieModel
 from mealie.schema.response.pagination import PaginationBase
@@ -21,6 +21,14 @@ class CreateGroupRecipeAction(MealieModel):
     url: str
 
     model_config = ConfigDict(use_enum_values=True)
+
+    @field_validator("url")
+    def validate_url_scheme(url: str) -> str:
+        """Validate that the URL uses a safe scheme to prevent XSS via javascript: URIs."""
+        url_lower = url.lower().strip()
+        if not (url_lower.startswith("http://") or url_lower.startswith("https://")):
+            raise ValueError("URL must use http or https scheme")
+        return url
 
 
 class SaveGroupRecipeAction(CreateGroupRecipeAction):


### PR DESCRIPTION
## Summary

- Add URL scheme validation to recipe actions to only allow http/https schemes
- This prevents stored XSS attacks where malicious users could create recipe actions with `javascript:` URIs that execute when other users click them
- Also blocks other unsafe schemes: `data:`, `file:`, `ftp:`, protocol-relative URLs

## Test plan

- [x] Added parametrized tests covering valid schemes (http, https) and invalid schemes (javascript, data, file, ftp, protocol-relative, schemeless)
- [x] All existing tests pass
- [x] Linter passes