### PR TITLE
feat: Add "sprig" as a unit.

### DIFF
--- a/mealie/repos/seed/resources/units/locales/en-US.json
+++ b/mealie/repos/seed/resources/units/locales/en-US.json
@@ -137,5 +137,11 @@
         "plural_name": "pinches",
         "description": "",
         "abbreviation": ""
+    },
+    "sprig": {
+        "name": "sprig",
+        "plural_name": "sprigs",
+        "description": "",
+        "abbreviation": ""
     }
 }

--- a/tests/integration_tests/user_group_tests/test_group_seeder.py
+++ b/tests/integration_tests/user_group_tests/test_group_seeder.py
@@ -28,7 +28,7 @@ def test_seed_foods(api_client: TestClient, unique_user: TestUser):
 
 
 def test_seed_units(api_client: TestClient, unique_user: TestUser):
-    CREATED_UNITS = 23
+    CREATED_UNITS = 24
     database = unique_user.repos
 
     # Check that the foods was created


### PR DESCRIPTION
## What this PR does / why we need it:

As I suggested in discussion #6918, this adds the unit "sprig", to further completeness of the unit list.

## Which issue(s) this PR fixes:

Discussion #6918 

## Testing

```
user@machine:~/src/mealie/mealie/repos/seed/resources/units/locales$ json5 -v en-US.json
user@machine:~/src/mealie/mealie/repos/seed/resources/units/locales$ echo $?
0
user@machine:~/src/mealie/mealie/repos/seed/resources/units/locales$
```