### PR TITLE
fix: use GITHUB_TOKEN for auto-merge to respect CI checks

### DIFF
--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
- Use `GITHUB_TOKEN` for auto-merge instead of the app token
- App token is exempt from branch protection, causing auto-merge to bypass CI
- Keep app token for approval to satisfy required reviews
