### PR TITLE
dev: Enable CI on merge queues

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,7 +10,7 @@ on:
       - mealie-next
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,7 +51,10 @@ jobs:
 
   publish-image:
     name: "Publish PR Image"
-    if: contains(github.event.pull_request.labels.*.name, 'build-image') && github.repository == 'mealie-recipes/mealie'
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'build-image') &&
+      github.repository == 'mealie-recipes/mealie'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - mealie-next
+  merge_group:
+    types: [checks_requested]
+    branches:
+      - mealie-next
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Enables CI on merge queues. Without this anything sitting in a merge queue will wait indefinitely since we have required status checks which cannot run.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A