### PR TITLE
fix: Remove deprecated warning from shopping list editor

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -56,25 +56,6 @@
                 width="250"
               />
             </div>
-
-            <v-menu
-              v-if="listItem.recipeReferences && listItem.recipeReferences.length > 0"
-              open-on-hover
-              offset-y
-              start
-              top
-            >
-              <template #activator="{ props }">
-                <v-icon class="mt-auto" :icon="$globals.icons.alert" v-bind="props" color="warning">
-                  {{ $globals.icons.alert }}
-                </v-icon>
-              </template>
-              <v-card max-width="350px" class="left-warning-border">
-                <v-card-text>
-                  {{ $t("shopping-list.linked-item-warning") }}
-                </v-card-text>
-              </v-card>
-            </v-menu>
           </div>
           <BaseButton
             v-if="listItem.labelId && listItem.food && listItem.labelId !== listItem.food.labelId"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

This warning hasn't been relevant in a while:
<img width="380" height="152" alt="image" src="https://github.com/user-attachments/assets/605e7149-2f43-4141-8770-4d90b524bb06" />

So this PR removes it. We properly handle scenarios for this now. Also the grammar is wrong.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A