### PR TITLE
dev: Switch to bot token for locale sync

### DIFF
--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -15,10 +15,17 @@ jobs:
   sync-locales:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -105,7 +112,7 @@ jobs:
           - Updated frontend locale files
           - Generated from latest translation sources" \
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: No changes detected
         if: steps.changes.outputs.has_changes == 'false'


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Switches locale sync to use our bot so workflows run

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A