### PR TITLE
dev: Increase locale merge limit to 300 and allow PRs from Mealie bot

### DIFF
--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -43,8 +43,8 @@ jobs:
 
           echo "PR changes: +$ADDITIONS -$DELETIONS (total: $TOTAL lines)"
 
-          if [ "$TOTAL" -gt 200 ]; then
-            echo "::error::PR exceeds 200 line change limit ($TOTAL lines)"
+          if [ "$TOTAL" -gt 400 ]; then
+            echo "::error::PR exceeds 400 line change limit ($TOTAL lines)"
             exit 1
           fi
 

--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -25,8 +25,12 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ "$AUTHOR" != "hay-kot" && "$AUTHOR" != "github-actions[bot]" ]]; then
-            echo "::error::PR author must be hay-kot or github-actions[bot] for auto-merge (got: $AUTHOR)"
+          if [[
+            "$AUTHOR" != "hay-kot" &&
+            "$AUTHOR" != "github-actions[bot]" &&
+            "$AUTHOR" != "mealie-actions[bot]"
+          ]]; then
+            echo "::error::PR author must be hay-kot, github-actions[bot], or mealie-actions[bot] for auto-merge (got: $AUTHOR)"
             exit 1
           fi
           echo "Author validated: $AUTHOR"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Bumps locale merge limit to 300 lines (150 additions + 150 deletions) and allows it to run on bot PRs.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A