### PR TITLE
dev: Switch approver for automated i18n merges

### DIFF
--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -14,13 +14,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'l10n')
 
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.COMMIT_BOT_APP_ID }}
-          private-key: ${{ secrets.COMMIT_BOT_APP_PRIVATE_KEY }}
-
       - name: Validate PR author
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -81,7 +74,7 @@ jobs:
 
       - name: Approve PR
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Switch back to GH actions bot to approve the i18n PRs. We can't have the Mealie bot do it since it also creates the locale PRs.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A