### PR TITLE
dev: Switch to Mealie bot for auto-merging

### DIFF
--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -94,9 +94,16 @@ jobs:
             --approve \
             --body "Auto-approved: l10n PR from trusted author with valid file paths"
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COMMIT_BOT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_BOT_APP_PRIVATE_KEY }}
+
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

We need to use the GH Actions bot to approve the Mealie bot PR, but when the GH Actions bot auto-merges workflows don't run in the merge queue. This PR makes the Mealie bot enable auto-merge.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A