### PR TITLE
fix: #6263 Force user avatar refresh after upload

### DIFF
--- a/frontend/pages/user/profile/edit.vue
+++ b/frontend/pages/user/profile/edit.vue
@@ -4,6 +4,7 @@
       <template #header>
         <div class="d-flex flex-column align-center justify-center">
           <UserAvatar
+            :key="avatarKey"
             :tooltip="false"
             size="96"
             :user-id="userCopy.id!"
@@ -13,7 +14,7 @@
             file-name="profile"
             accept="image/*"
             :url="`/api/users/${userCopy.id}/image`"
-            @uploaded="$auth.refresh()"
+            @uploaded="onAvatarUploaded"
           />
         </div>
       </template>
@@ -285,6 +286,12 @@ export default defineNuxtComponent({
       }
     }
 
+    const avatarKey = ref(0)
+    function onAvatarUploaded() {
+      $auth.refresh();
+      avatarKey.value++
+    }
+
     const state = reactive({
       hideImage: false,
       passwordLoading: false,
@@ -303,6 +310,8 @@ export default defineNuxtComponent({
       domUpdatePassword,
       passwordsMatch,
       validators,
+      avatarKey,
+      onAvatarUploaded,
       $auth,
     };
   },

--- a/frontend/pages/user/profile/edit.vue
+++ b/frontend/pages/user/profile/edit.vue
@@ -286,10 +286,10 @@ export default defineNuxtComponent({
       }
     }
 
-    const avatarKey = ref(0)
+    const avatarKey = ref(0);
     function onAvatarUploaded() {
       $auth.refresh();
-      avatarKey.value++
+      avatarKey.value++;
     }
 
     const state = reactive({


### PR DESCRIPTION


## What this PR does / why we need it:

This pr addresses an issue where the uploaded avatar is only visible after reloading the page due to browser caching.

## Changes made:
- added a key to force a rerender of the UserAvatar component. This is the change with the least impact on other components. 
- added a handler function that increments this key.

## Which issue(s) this PR fixes:
#6263 

## Special notes for your reviewer:

- this is my first contribution, so I picked something small. I'm happy about any feedback or guidance. I choose to increment the key instead of using a UUID or the current Date to make the code easier to debug and read.

## Testing

I ran all tests and verified the change actually works.
