### PR TITLE
fix: Button overflow on main page filters

### DIFF
--- a/frontend/components/Domain/SearchFilter.vue
+++ b/frontend/components/Domain/SearchFilter.vue
@@ -46,6 +46,7 @@
               density="compact"
               variant="outlined"
               color="primary"
+              class="my-1"
             >
               <v-btn value="hasAll">
                 {{ $t('search.has-all') }}
@@ -58,6 +59,7 @@
             <v-btn
               size="small"
               color="accent"
+              class="my-1"
               @click="clearSelection"
             >
               {{ $t("search.clear-selection") }}

--- a/frontend/components/Domain/SearchFilter.vue
+++ b/frontend/components/Domain/SearchFilter.vue
@@ -38,7 +38,7 @@
             clearable
           />
           <div />
-          <div class="d-flex py-4 px-1 align-center">
+          <div class="d-flex flex-wrap py-4 px-1 align-center">
             <v-btn-toggle
               v-if="requireAll != undefined"
               v-model="combinator"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes an overflow issue with languages with longer strings.

Before:
<img width="423" height="195" alt="image" src="https://github.com/user-attachments/assets/550b34de-bc30-4907-927a-7a4c56573a07" />

After:
<img width="450" height="251" alt="image" src="https://github.com/user-attachments/assets/e480617b-a6a3-4e29-be46-485649948087" />

On languages with shorter strings the original layout is preserved:
<img width="473" height="201" alt="image" src="https://github.com/user-attachments/assets/1e407c4c-342a-4927-a6bb-a38b160d9f82" />

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, reported in Discord