### PR TITLE
docs: Typo

### DIFF
--- a/docs/docs/documentation/getting-started/api-usage.md
+++ b/docs/docs/documentation/getting-started/api-usage.md
@@ -96,7 +96,7 @@ You can use placeholders to insert dynamic values as opposed to static values. C
 `$NOW` can optionally be paired with basic offsets. Here is an example of a filter which gives you recipes not made within the past 30 days: <br>
 `lastMade <= "$NOW-30d"`
 
-Supported offsets operations include:
+Supported offset operations include:
 
 - `-` for subtracting a time (i.e. in the past)
 - `+` for adding a time (i.e. in the future)

--- a/docs/docs/documentation/getting-started/api-usage.md
+++ b/docs/docs/documentation/getting-started/api-usage.md
@@ -91,7 +91,7 @@ This filter will find all recipes that have particular slugs: <br>
 `slug IN ["pasta-fagioli", "delicious-ramen"]`
 
 ##### Placeholder Keywords
-You can use placeholders to insert dynamic values as opposed to static values. Currently the only supported placeholder keyword is `$NOW`, to insert the current time.
+You can use placeholders to insert dynamic values as opposed to static values. Currently the only supported placeholder keyword is `$NOW`, to insert the current date/time.
 
 `$NOW` can optionally be paired with basic offsets. Here is an example of a filter which gives you recipes not made within the past 30 days: <br>
 `lastMade <= "$NOW-30d"`


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes a typo and clarifies behavior for `$NOW` slightly.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A