### PR TITLE
fix: OIDC caching

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -219,6 +219,7 @@ export default defineNuxtConfig({
     },
     workbox: {
       navigateFallback: "/",
+      navigateFallbackAllowlist: [/^(?!\/api)/],
       globPatterns: ["**/*.{js,css,html,png,svg,ico}"],
       globIgnores: ["404.html", "200.html"],
       cleanupOutdatedCaches: true,


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

https://github.com/mealie-recipes/mealie/pull/6815 fixed service worker caching, but it's too aggresive and caches backend requests (e.g. auth). This PR limits caching to frontend elements only (i.e. `navigateFallbackAllowlist: [/^(?!\/api)/],`).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Maybefix https://github.com/mealie-recipes/mealie/issues/7007, but need to double check with users.