### PR TITLE
fix: handle numeric recipeCategory from LLM/site to prevent import failure

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -533,6 +533,9 @@ def clean_categories(category: str | list) -> list[str]:
             # ]
             #
             return [cat["name"] for cat in category if "name" in cat]
+        case int() | float():
+            # Handling for numeric values returned as categories
+            return []
         case _:
             raise TypeError(f"Unexpected type for category: {type(category)}, {category}")
 

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
@@ -511,6 +511,11 @@ category_test_cases = (
         ],
         expected=["Dessert", "Lunch"],
     ),
+    CleanerCase(
+        test_id="numeric",
+        input=4,
+        expected=[],
+    ),
 )
 
 


### PR DESCRIPTION
## What this PR does / why we need it:

When `recipeCategory` is an integer (e.g. `4`) instead of a string, the LLM fallback import with RecipeScraperPackage raises `TypeError: Unexpected type for category: <class 'int'>, 4`. This can happen when the LLM or site returns a numeric ID instead of a category name.

- **mealie/services/scraper/cleaner.py**: Add an `int | float` match case in `clean_categories` that returns `[]` (numeric IDs are not valid category names).
- **tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py**: Add a test case for numeric category input.

## Which issue(s) this PR fixes:

Fixes #7011

## Testing

- `task py:test -- tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py -k clean_categories -v`
