### PR TITLE
fix: #6263 remove reserved prefix 

### DIFF
--- a/frontend/components/Domain/Admin/Setup/EndPageContent.vue
+++ b/frontend/components/Domain/Admin/Setup/EndPageContent.vue
@@ -41,8 +41,8 @@
 export default defineNuxtComponent({
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
-    const groupSlug = computed(() => $auth.user.value?.groupSlug);
+    const auth = useMealieAuth();
+    const groupSlug = computed(() => auth.user.value?.groupSlug);
     const { $globals } = useNuxtApp();
 
     const sections = ref([

--- a/frontend/components/Domain/Cookbook/CookbookPage.vue
+++ b/frontend/components/Domain/Cookbook/CookbookPage.vue
@@ -73,11 +73,11 @@ import { useLoggedInState } from "~/composables/use-logged-in-state";
 import type { ReadCookBook } from "~/lib/api/types/cookbook";
 import CookbookEditor from "~/components/Domain/Cookbook/CookbookEditor.vue";
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const { recipes, appendRecipes, assignSorted, removeRecipe, replaceRecipes } = useLazyRecipes(isOwnGroup.value ? null : groupSlug.value);
 const slug = route.params.slug as string;
@@ -88,11 +88,11 @@ const router = useRouter();
 const book = getOne(slug);
 
 const isOwnHousehold = computed(() => {
-  if (!($auth.user.value && book.value?.householdId)) {
+  if (!(auth.user.value && book.value?.householdId)) {
     return false;
   }
 
-  return $auth.user.value.householdId === book.value.householdId;
+  return auth.user.value.householdId === book.value.householdId;
 });
 const canEdit = computed(() => isOwnGroup.value && isOwnHousehold.value);
 

--- a/frontend/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/components/Domain/Recipe/RecipeCard.vue
@@ -130,11 +130,11 @@ defineEmits<{
   delete: [slug: string];
 }>();
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 const showRecipeContent = computed(() => props.recipeId && props.slug);
 const recipeRoute = computed<string>(() => {
   return showRecipeContent.value ? `/g/${groupSlug.value}/r/${props.slug}` : "";

--- a/frontend/components/Domain/Recipe/RecipeCardMobile.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardMobile.vue
@@ -160,11 +160,11 @@ defineEmits<{
   delete: [slug: string];
 }>();
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 const showRecipeContent = computed(() => props.recipeId && props.slug);
 const recipeRoute = computed<string>(() => {
   return showRecipeContent.value ? `/g/${groupSlug.value}/r/${props.slug}` : "";

--- a/frontend/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/components/Domain/Recipe/RecipeCardSection.vue
@@ -219,7 +219,7 @@ const EVENTS = {
   shuffle: "shuffle",
 };
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { $globals } = useNuxtApp();
 const { isOwnGroup } = useLoggedInState();
 const useMobileCards = computed(() => {
@@ -234,7 +234,7 @@ const sortLoading = ref(false);
 const randomSeed = ref(Date.now().toString());
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const page = ref(1);
 const perPage = 32;

--- a/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -202,13 +202,13 @@ const newMealdateString = computed(() => {
 });
 
 const i18n = useI18n();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { $globals } = useNuxtApp();
 const { household } = useHouseholdSelf();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 
 const firstDayOfWeek = computed(() => {
   return household.value?.preferences?.firstDayOfWeek || 0;
@@ -296,12 +296,12 @@ const recipeRefWithScale = computed(() =>
 );
 const isAdminAndNotOwner = computed(() => {
   return (
-    $auth.user.value?.admin
-    && $auth.user.value?.id !== recipeRef.value?.userId
+    auth.user.value?.admin
+    && auth.user.value?.id !== recipeRef.value?.userId
   );
 });
 const canDelete = computed(() => {
-  const user = $auth.user.value;
+  const user = auth.user.value;
   const recipe = recipeRef.value;
   return user && recipe && (user.admin || user.id === recipe.userId);
 });

--- a/frontend/components/Domain/Recipe/RecipeDataTable.vue
+++ b/frontend/components/Domain/Recipe/RecipeDataTable.vue
@@ -110,8 +110,8 @@ defineEmits<{
 const selected = defineModel<Recipe[]>({ default: () => [] });
 
 const i18n = useI18n();
-const $auth = useMealieAuth();
-const groupSlug = $auth.user.value?.groupSlug;
+const auth = useMealieAuth();
+const groupSlug = auth.user.value?.groupSlug;
 const router = useRouter();
 
 // Initialize sort state with default sorting by dateAdded descending

--- a/frontend/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
@@ -217,7 +217,7 @@ const props = withDefaults(defineProps<Props>(), {
 const dialog = defineModel<boolean>({ default: false });
 
 const i18n = useI18n();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const api = useUserApi();
 const preferences = useShoppingListPreferences();
 const ready = ref(false);
@@ -239,9 +239,9 @@ const selectedShoppingList = ref<ShoppingListSummary | null>(null);
 
 watch([dialog, () => preferences.value.viewAllLists], () => {
   if (dialog.value) {
-    currentHouseholdSlug.value = $auth.user.value?.householdSlug || "";
+    currentHouseholdSlug.value = auth.user.value?.householdSlug || "";
     filteredShoppingLists.value = props.shoppingLists.filter(
-      list => preferences.value.viewAllLists || list.userId === $auth.user.value?.id,
+      list => preferences.value.viewAllLists || list.userId === auth.user.value?.id,
     );
 
     if (filteredShoppingLists.value.length === 1 && !state.shoppingListShowAllToggled) {

--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -87,7 +87,7 @@ const emit = defineEmits<{
   selected: [recipe: RecipeSummary];
 }>();
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const loading = ref(false);
 const selectedIndex = ref(-1);
 
@@ -153,7 +153,7 @@ watch(dialog, (val) => {
 });
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 watch(route, close);
 
 function open() {

--- a/frontend/components/Domain/Recipe/RecipeDialogShare.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogShare.vue
@@ -119,10 +119,10 @@ whenever(
 );
 
 const i18n = useI18n();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { household } = useHouseholdSelf();
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const firstDayOfWeek = computed(() => {
   return household.value?.preferences?.firstDayOfWeek || 0;

--- a/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPage.vue
@@ -34,11 +34,11 @@ import { useLazyRecipes } from "~/composables/recipes";
 export default defineNuxtComponent({
   components: { RecipeCardSection, RecipeExplorerPageSearch },
   setup() {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
 
     const { isOwnGroup } = useLoggedInState();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
     const { recipes, appendRecipes, replaceRecipes } = useLazyRecipes(isOwnGroup.value ? null : groupSlug.value);
 

--- a/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
@@ -141,13 +141,13 @@ const emit = defineEmits<{
   ready: [];
 }>();
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const route = useRoute();
 const { $globals } = useNuxtApp();
 const i18n = useI18n();
 const showRandomLoading = ref(false);
 
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const {
   state,

--- a/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearchFilters.vue
+++ b/frontend/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearchFilters.vue
@@ -81,11 +81,11 @@ import {
   usePublicToolStore,
 } from "~/composables/store";
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const route = useRoute();
 
 const { isOwnGroup } = useLoggedInState();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const {
   state,

--- a/frontend/components/Domain/Recipe/RecipeFavoriteBadge.vue
+++ b/frontend/components/Domain/Recipe/RecipeFavoriteBadge.vue
@@ -52,14 +52,14 @@ const isFavorite = computed(() => {
 
 async function toggleFavorite() {
   const api = useUserApi();
-  const $auth = useMealieAuth();
+  const auth = useMealieAuth();
 
-  if (!$auth.user.value) return;
+  if (!auth.user.value) return;
   if (!isFavorite.value) {
-    await api.users.addFavorite($auth.user.value?.id, props.recipeId);
+    await api.users.addFavorite(auth.user.value?.id, props.recipeId);
   }
   else {
-    await api.users.removeFavorite($auth.user.value?.id, props.recipeId);
+    await api.users.removeFavorite(auth.user.value?.id, props.recipeId);
   }
   await refreshUserRatings();
 }

--- a/frontend/components/Domain/Recipe/RecipeIngredientEditor.vue
+++ b/frontend/components/Domain/Recipe/RecipeIngredientEditor.vue
@@ -354,8 +354,8 @@ async function createAssignFood() {
 
 // Recipes
 const route = useRoute();
-const $auth = useMealieAuth();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const auth = useMealieAuth();
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const { isOwnGroup } = useLoggedInState();
 const api = isOwnGroup.value ? useUserApi() : usePublicExploreApi(groupSlug.value).explore;

--- a/frontend/components/Domain/Recipe/RecipeIngredientListItem.vue
+++ b/frontend/components/Domain/Recipe/RecipeIngredientListItem.vue
@@ -44,8 +44,8 @@ const props = withDefaults(defineProps<Props>(), {
   scale: 1,
 });
 const route = useRoute();
-const $auth = useMealieAuth();
-const groupSlug = computed(() => route.params.groupSlug || $auth.user?.value?.groupSlug || "");
+const auth = useMealieAuth();
+const groupSlug = computed(() => route.params.groupSlug || auth.user?.value?.groupSlug || "");
 const { useParsedIngredientText } = useIngredientTextParser();
 
 const parsedIng = computed(() => {

--- a/frontend/components/Domain/Recipe/RecipeLastMade.vue
+++ b/frontend/components/Domain/Recipe/RecipeLastMade.vue
@@ -159,7 +159,7 @@ const madeThisDialog = ref(false);
 const userApi = useUserApi();
 const { household } = useHouseholdSelf();
 const i18n = useI18n();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const domMadeThisForm = ref<VForm>();
 const newTimelineEvent = ref<RecipeTimelineEventIn>({
   subject: "",
@@ -179,7 +179,7 @@ const newTimelineEventTimestampString = computed(() => {
 const lastMade = ref(props.recipe.lastMade);
 const lastMadeReady = ref(false);
 onMounted(async () => {
-  if (!$auth.user?.value?.householdSlug) {
+  if (!auth.user?.value?.householdSlug) {
     lastMade.value = props.recipe.lastMade;
   }
   else {
@@ -255,8 +255,8 @@ async function createTimelineEvent() {
   madeThisFormLoading.value = true;
 
   newTimelineEvent.value.recipeId = props.recipe.id;
-  // Note: $auth.user is now a ref
-  newTimelineEvent.value.subject = i18n.t("recipe.user-made-this", { user: $auth.user.value?.fullName });
+  // Note: auth.user is now a ref
+  newTimelineEvent.value.subject = i18n.t("recipe.user-made-this", { user: auth.user.value?.fullName });
 
   // the user only selects the date, so we set the time to end of day local time
   // we choose the end of day so it always comes after "new recipe" events

--- a/frontend/components/Domain/Recipe/RecipeList.vue
+++ b/frontend/components/Domain/Recipe/RecipeList.vue
@@ -73,10 +73,10 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
 });
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { frac } = useFraction();
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug || $auth.user?.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug || auth.user?.value?.groupSlug || "");
 
 const attrs = computed(() => {
   return props.small

--- a/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
+++ b/frontend/components/Domain/Recipe/RecipeOrganizerPage.vue
@@ -162,9 +162,9 @@ const state = reactive({
   },
 });
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user?.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user?.value?.groupSlug || "");
 
 // =================================================================
 // Context Menu

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -220,11 +220,11 @@ import { useNavigationWarning } from "~/composables/use-navigation-warning";
 const recipe = defineModel<NoUndefinedField<Recipe>>({ required: true });
 
 const display = useDisplay();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const route = useRoute();
 const { isOwnGroup } = useLoggedInState();
 
-const groupSlug = computed(() => (route.params.groupSlug as string) || $auth.user?.value?.groupSlug || "");
+const groupSlug = computed(() => (route.params.groupSlug as string) || auth.user?.value?.groupSlug || "");
 
 const router = useRouter();
 const api = useUserApi();

--- a/frontend/components/Domain/User/UserAvatar.vue
+++ b/frontend/components/Domain/User/UserAvatar.vue
@@ -62,15 +62,15 @@ export default defineNuxtComponent({
       error: false,
     });
 
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { store: users } = useUserStore();
     const user = computed(() => {
       return users.value.find(user => user.id === props.userId);
     });
 
     const imageURL = computed(() => {
-      // Note: $auth.user is a ref now
-      const authUser = $auth.user.value;
+      // Note: auth.user is a ref now
+      const authUser = auth.user.value;
       const key = authUser?.cacheKey ?? "";
       return `/api/media/users/${props.userId}/profile.webp?cacheKey=${key}`;
     });

--- a/frontend/components/Domain/User/UserInviteDialog.vue
+++ b/frontend/components/Domain/User/UserInviteDialog.vue
@@ -102,9 +102,9 @@ export default defineNuxtComponent({
   emits: ["update:modelValue"],
   setup(props, context) {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
 
-    const isAdmin = computed(() => $auth.user.value?.admin);
+    const isAdmin = computed(() => auth.user.value?.admin);
     const token = ref("");
     const selectedGroup = ref<string | null>(null);
     const selectedHousehold = ref<string | null>(null);

--- a/frontend/components/Layout/DefaultLayout.vue
+++ b/frontend/components/Layout/DefaultLayout.vue
@@ -106,11 +106,11 @@ export default defineNuxtComponent({
     const i18n = useI18n();
     const { $appInfo, $globals } = useNuxtApp();
     const display = useDisplay();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { isOwnGroup } = useLoggedInState();
 
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
     const cookbookPreferences = useCookbookPreferences();
     const ownCookbookStore = useCookbookStore(i18n);
@@ -152,7 +152,7 @@ export default defineNuxtComponent({
       };
     }
 
-    const currentUserHouseholdId = computed(() => $auth.user.value?.householdId);
+    const currentUserHouseholdId = computed(() => auth.user.value?.householdId);
     const cookbookLinks = computed<SideBarLink[]>(() => {
       if (!cookbooks.value?.length) {
         return [];
@@ -187,7 +187,7 @@ export default defineNuxtComponent({
       });
 
       links.sort((a, b) => a.title.localeCompare(b.title));
-      if ($auth.user.value && cookbookPreferences.value.hideOtherHouseholds) {
+      if (auth.user.value && cookbookPreferences.value.hideOtherHouseholds) {
         return ownLinks;
       }
       else {

--- a/frontend/components/Layout/LayoutParts/AppHeader.vue
+++ b/frontend/components/Layout/LayoutParts/AppHeader.vue
@@ -97,10 +97,10 @@ export default defineNuxtComponent({
     },
   },
   setup() {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { loggedIn } = useLoggedInState();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
     const { xs, smAndUp } = useDisplay();
 
     const routerLink = computed(() => groupSlug.value ? `/g/${groupSlug.value}` : "/");
@@ -128,7 +128,7 @@ export default defineNuxtComponent({
 
     async function logout() {
       try {
-        await $auth.signOut("/login?direct=1");
+        await auth.signOut("/login?direct=1");
       }
       catch (e) {
         console.error(e);

--- a/frontend/components/Layout/LayoutParts/AppSidebar.vue
+++ b/frontend/components/Layout/LayoutParts/AppSidebar.vue
@@ -168,13 +168,13 @@ export default defineNuxtComponent({
   },
   emits: ["update:modelValue"],
   setup(props, context) {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { loggedIn, isOwnGroup } = useLoggedInState();
-    const isAdmin = computed(() => $auth.user.value?.admin);
-    const canManage = computed(() => $auth.user.value?.canManage);
+    const isAdmin = computed(() => auth.user.value?.admin);
+    const canManage = computed(() => auth.user.value?.canManage);
 
-    const userFavoritesLink = computed(() => $auth.user.value ? `/user/${$auth.user.value.id}/favorites` : undefined);
-    const userProfileLink = computed(() => $auth.user.value ? "/user/profile" : undefined);
+    const userFavoritesLink = computed(() => auth.user.value ? `/user/${auth.user.value.id}/favorites` : undefined);
+    const userProfileLink = computed(() => auth.user.value ? "/user/profile" : undefined);
 
     const toggleDark = useToggleDarkMode();
 
@@ -217,7 +217,7 @@ export default defineNuxtComponent({
       isAdmin,
       canManage,
       isOwnGroup,
-      sessionUser: $auth.user,
+      sessionUser: auth.user,
       toggleDark,
     };
   },

--- a/frontend/components/global/AdvancedOnly.vue
+++ b/frontend/components/global/AdvancedOnly.vue
@@ -9,9 +9,9 @@
  */
 export default defineNuxtComponent({
   setup(_, ctx) {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
 
-    const r = $auth.user.value?.advanced || false;
+    const r = auth.user.value?.advanced || false;
 
     return () => {
       return r ? ctx.slots.default?.() : null;

--- a/frontend/composables/recipe-page/shared-state.ts
+++ b/frontend/composables/recipe-page/shared-state.ts
@@ -165,14 +165,14 @@ export function clearPageState(slug: string) {
 }
 
 /**
- * usePageUser provides a wrapper around $auth that provides a type-safe way to
+ * usePageUser provides a wrapper around auth that provides a type-safe way to
  * access the UserOut type from the context. If no user is logged in then an empty
  * object with all properties set to their zero value is returned.
  */
 export function usePageUser(): { user: UserOut } {
-  const $auth = useMealieAuth();
+  const auth = useMealieAuth();
 
-  if (!$auth.user.value) {
+  if (!auth.user.value) {
     return {
       user: {
         id: "",
@@ -188,5 +188,5 @@ export function usePageUser(): { user: UserOut } {
     };
   }
 
-  return { user: $auth.user.value };
+  return { user: auth.user.value };
 }

--- a/frontend/composables/use-logged-in-state.ts
+++ b/frontend/composables/use-logged-in-state.ts
@@ -1,14 +1,14 @@
 export const useLoggedInState = function () {
-  const $auth = useMealieAuth();
+  const auth = useMealieAuth();
   const route = useRoute();
 
-  const loggedIn = computed(() => $auth.loggedIn.value);
+  const loggedIn = computed(() => auth.loggedIn.value);
   const isOwnGroup = computed(() => {
     if (!route.params.groupSlug) {
       return loggedIn.value;
     }
     else {
-      return loggedIn.value && $auth.user.value?.groupSlug === route.params.groupSlug;
+      return loggedIn.value && auth.user.value?.groupSlug === route.params.groupSlug;
     }
   });
 

--- a/frontend/composables/use-users/user-ratings.ts
+++ b/frontend/composables/use-users/user-ratings.ts
@@ -6,10 +6,10 @@ const loading = ref(false);
 const ready = ref(false);
 
 export const useUserSelfRatings = function () {
-  const $auth = useMealieAuth();
+  const auth = useMealieAuth();
 
   async function refreshUserRatings() {
-    if (!$auth.user.value || loading.value) {
+    if (!auth.user.value || loading.value) {
       return;
     }
 
@@ -27,7 +27,7 @@ export const useUserSelfRatings = function () {
     loading.value = true;
     const api = useUserApi();
 
-    const userId = $auth.user.value?.id || "";
+    const userId = auth.user.value?.id || "";
     await api.users.setRating(userId, slug, rating, isFavorite);
 
     loading.value = false;

--- a/frontend/layouts/error.vue
+++ b/frontend/layouts/error.vue
@@ -64,7 +64,7 @@ export default defineNuxtComponent({
     });
 
     const i18n = useGlobalI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $globals } = useNuxtApp();
     const ready = ref(false);
 
@@ -72,7 +72,7 @@ export default defineNuxtComponent({
     const router = useRouter();
 
     async function insertGroupSlugIntoRoute() {
-      const groupSlug = ref($auth.user.value?.groupSlug);
+      const groupSlug = ref(auth.user.value?.groupSlug);
       if (!groupSlug.value) {
         return;
       }

--- a/frontend/pages/admin/backups.vue
+++ b/frontend/pages/admin/backups.vue
@@ -163,9 +163,9 @@ export default defineNuxtComponent({
     });
 
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 
     const adminApi = useAdminApi();
     const selected = ref("");

--- a/frontend/pages/admin/manage/users/index.vue
+++ b/frontend/pages/admin/manage/users/index.vue
@@ -112,9 +112,9 @@ export default defineNuxtComponent({
     const api = useAdminApi();
     const refUserDialog = ref();
     const inviteDialog = ref();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
 
-    const user = computed(() => $auth.user.value);
+    const user = computed(() => auth.user.value);
 
     const i18n = useI18n();
     const { $globals } = useNuxtApp();
@@ -149,7 +149,7 @@ export default defineNuxtComponent({
       deleteUserMixin(id);
 
       if (isUserOwnAccount.value) {
-        $auth.refresh();
+        auth.refresh();
       }
     }
 

--- a/frontend/pages/admin/setup.vue
+++ b/frontend/pages/admin/setup.vue
@@ -262,11 +262,11 @@ definePageMeta({
 // ================================================================
 // Setup
 const i18n = useI18n();
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const userApi = useUserApi();
 const adminApi = useAdminApi();
 
-const groupSlug = computed(() => $auth.user.value?.groupSlug);
+const groupSlug = computed(() => auth.user.value?.groupSlug);
 const { locale } = useLocales();
 const router = useRouter();
 const isSubmitting = ref(false);
@@ -347,9 +347,9 @@ const currentPage = ref(Pages.LANDING);
 // Page Submission
 
 async function updateUser() {
-  // Note: $auth.user is now a ref
-  const { response } = await userApi.users.updateOne($auth.user.value!.id, {
-    ...$auth.user.value,
+  // Note: auth.user is now a ref
+  const { response } = await userApi.users.updateOne(auth.user.value!.id, {
+    ...auth.user.value,
     email: accountDetails.email.value,
     username: accountDetails.username.value,
     fullName: accountDetails.fullName.value,
@@ -360,7 +360,7 @@ async function updateUser() {
     alert.error(i18n.t("events.something-went-wrong"));
   }
   else {
-    $auth.refresh();
+    auth.refresh();
   }
 }
 
@@ -381,8 +381,8 @@ async function submitRegistration() {
 }
 
 async function updateGroup() {
-  // Note: $auth.user is now a ref
-  const { data } = await userApi.groups.getOne($auth.user.value!.groupId);
+  // Note: auth.user is now a ref
+  const { data } = await userApi.groups.getOne(auth.user.value!.groupId);
   if (!data || !data.preferences) {
     alert.error(i18n.t("events.something-went-wrong"));
     return;
@@ -398,16 +398,16 @@ async function updateGroup() {
     preferences,
   };
 
-  // Note: $auth.user is now a ref
-  const { response } = await userApi.groups.updateOne($auth.user.value!.groupId, payload);
+  // Note: auth.user is now a ref
+  const { response } = await userApi.groups.updateOne(auth.user.value!.groupId, payload);
   if (!response || response.status !== 200) {
     alert.error(i18n.t("events.something-went-wrong"));
   }
 }
 
 async function updateHousehold() {
-  // Note: $auth.user is now a ref
-  const { data } = await adminApi.households.getOne($auth.user.value!.householdId);
+  // Note: auth.user is now a ref
+  const { data } = await adminApi.households.getOne(auth.user.value!.householdId);
   if (!data || !data.preferences) {
     alert.error(i18n.t("events.something-went-wrong"));
     return;
@@ -424,8 +424,8 @@ async function updateHousehold() {
     preferences,
   };
 
-  // Note: $auth.user is now a ref
-  const { response } = await adminApi.households.updateOne($auth.user.value!.householdId, payload);
+  // Note: auth.user is now a ref
+  const { response } = await adminApi.households.updateOne(auth.user.value!.householdId, payload);
   if (!response || response.status !== 200) {
     alert.error(i18n.t("events.something-went-wrong"));
   }

--- a/frontend/pages/g/[groupSlug]/cookbooks/index.vue
+++ b/frontend/pages/g/[groupSlug]/cookbooks/index.vue
@@ -159,7 +159,7 @@ export default defineNuxtComponent({
       title: i18n.t("cookbook.cookbooks"),
     });
 
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { store: allCookbooks, actions, updateAll } = useCookbookStore();
 
     // Make a local reactive copy of myCookbooks
@@ -169,7 +169,7 @@ export default defineNuxtComponent({
       (cookbooks) => {
         myCookbooks.value
           = cookbooks?.filter(
-            cookbook => cookbook.householdId === $auth.user.value?.householdId,
+            cookbook => cookbook.householdId === auth.user.value?.householdId,
           ).sort((a, b) => a.position > b.position) ?? [];
       },
       { immediate: true },

--- a/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
+++ b/frontend/pages/g/[groupSlug]/r/[slug]/index.vue
@@ -16,7 +16,7 @@ import { usePublicExploreApi } from "~/composables/api/api-client";
 import { useRecipe } from "~/composables/recipes";
 import type { Recipe } from "~/lib/api/types/recipe";
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const { isOwnGroup } = useLoggedInState();
 const route = useRoute();
 const title = ref(route.meta?.title as string || "");
@@ -34,7 +34,7 @@ function loadRecipe() {
 }
 
 async function loadPublicRecipe() {
-  const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+  const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
   const api = usePublicExploreApi(groupSlug.value);
   const { data } = await useAsyncData(useAsyncKey(), async () => {
     const { data, error } = await api.explore.recipes.getOne(slug);

--- a/frontend/pages/g/[groupSlug]/r/create.vue
+++ b/frontend/pages/g/[groupSlug]/r/create.vue
@@ -51,7 +51,7 @@ export default defineNuxtComponent({
   middleware: ["group-only"],
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $appInfo, $globals } = useNuxtApp();
 
     useSeoMeta({
@@ -99,7 +99,7 @@ export default defineNuxtComponent({
 
     const route = useRoute();
     const router = useRouter();
-    const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 
     const subpage = computed({
       set(subpage: string) {

--- a/frontend/pages/g/[groupSlug]/r/create/html.vue
+++ b/frontend/pages/g/[groupSlug]/r/create/html.vue
@@ -112,9 +112,9 @@ export default defineNuxtComponent({
       loading: false,
       isEditJSON: false,
     });
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
     const domUrlForm = ref<VForm | null>(null);
 
     const api = useUserApi();

--- a/frontend/pages/g/[groupSlug]/r/create/new.vue
+++ b/frontend/pages/g/[groupSlug]/r/create/new.vue
@@ -53,9 +53,9 @@ export default defineNuxtComponent({
       error: false,
       loading: false,
     });
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
     const api = useUserApi();
     const router = useRouter();

--- a/frontend/pages/g/[groupSlug]/r/create/url.vue
+++ b/frontend/pages/g/[groupSlug]/r/create/url.vue
@@ -144,10 +144,10 @@ export default defineNuxtComponent({
       loading: false,
     });
 
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const api = useUserApi();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
     const router = useRouter();
     const tags = useTagStore();

--- a/frontend/pages/g/[groupSlug]/r/create/zip.vue
+++ b/frontend/pages/g/[groupSlug]/r/create/zip.vue
@@ -47,9 +47,9 @@ export default defineNuxtComponent({
     const state = reactive({
       loading: false,
     });
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
     const api = useUserApi();
     const router = useRouter();

--- a/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -436,7 +436,7 @@ export default defineNuxtComponent({
   setup() {
     const display = useDisplay();
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const route = useRoute();
 
     useSeoMeta({
@@ -445,7 +445,7 @@ export default defineNuxtComponent({
 
     const useMobile = computed(() => display.smAndDown.value);
 
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
     const { isOwnGroup } = useLoggedInState();
     const api = isOwnGroup.value ? useUserApi() : usePublicExploreApi(groupSlug.value).explore;
 

--- a/frontend/pages/g/[groupSlug]/recipes/tools/index.vue
+++ b/frontend/pages/g/[groupSlug]/recipes/tools/index.vue
@@ -30,7 +30,7 @@ export default defineNuxtComponent({
   },
   middleware: ["group-only"],
   setup() {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const toolStore = useToolStore();
     const dialog = ref(false);
     const i18n = useI18n();
@@ -39,7 +39,7 @@ export default defineNuxtComponent({
       title: i18n.t("tool.tools"),
     });
 
-    const userHousehold = computed(() => $auth.user.value?.householdSlug || "");
+    const userHousehold = computed(() => auth.user.value?.householdSlug || "");
     const tools = computed(() => toolStore.store.value.map(tool => (
       {
         ...tool,

--- a/frontend/pages/g/[groupSlug]/shared/r/[id].vue
+++ b/frontend/pages/g/[groupSlug]/shared/r/[id].vue
@@ -17,9 +17,9 @@ definePageMeta({
   layout: "basic",
 });
 
-const $auth = useMealieAuth();
+const auth = useMealieAuth();
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const router = useRouter();
 const recipeId = route.params.id as string;

--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -371,7 +371,7 @@ export default defineNuxtComponent({
   setup() {
     const userApi = useUserApi();
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const tableConfig = {
       hideColumns: true,
       canExport: true,
@@ -424,7 +424,7 @@ export default defineNuxtComponent({
       },
     ];
 
-    const userHousehold = computed(() => $auth.user.value?.householdSlug || "");
+    const userHousehold = computed(() => auth.user.value?.householdSlug || "");
     const foodStore = useFoodStore();
     const foods = computed(() => foodStore.store.value.map((food) => {
       const onHand = food.householdsWithIngredientFood?.includes(userHousehold.value) || false;

--- a/frontend/pages/group/data/recipes.vue
+++ b/frontend/pages/group/data/recipes.vue
@@ -254,14 +254,14 @@ export default defineNuxtComponent({
   scrollToTop: true,
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $globals } = useNuxtApp();
 
     useSeoMeta({
       title: i18n.t("data-pages.recipes.recipe-data"),
     });
 
-    const { getAllRecipes, refreshRecipes } = useRecipes(true, true, false, `householdId=${$auth.user.value?.householdId || ""}`);
+    const { getAllRecipes, refreshRecipes } = useRecipes(true, true, false, `householdId=${auth.user.value?.householdId || ""}`);
     const selected = ref<Recipe[]>([]);
 
     function resetAll() {

--- a/frontend/pages/group/data/tools.vue
+++ b/frontend/pages/group/data/tools.vue
@@ -143,7 +143,7 @@ interface RecipeToolWithOnHand extends RecipeTool {
 export default defineNuxtComponent({
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const tableConfig = {
       hideColumns: true,
       canExport: true,
@@ -175,7 +175,7 @@ export default defineNuxtComponent({
       bulkDeleteDialog: false,
     });
 
-    const userHousehold = computed(() => $auth.user.value?.householdSlug || "");
+    const userHousehold = computed(() => auth.user.value?.householdSlug || "");
     const toolData = useToolData();
     const toolStore = useToolStore();
     const tools = computed(() => toolStore.store.value.map((tools) => {

--- a/frontend/pages/household/mealplan/planner/edit.vue
+++ b/frontend/pages/household/mealplan/planner/edit.vue
@@ -263,7 +263,7 @@ export default defineNuxtComponent({
   },
   setup(props) {
     const api = useUserApi();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { household } = useHouseholdSelf();
     const requiredRule = (value: any) => !!value || "Required.";
 
@@ -343,7 +343,7 @@ export default defineNuxtComponent({
       existing: false,
       id: 0,
       groupId: "",
-      userId: $auth.user.value?.id || "",
+      userId: auth.user.value?.id || "",
     });
 
     const newMealDateString = computed(() => {
@@ -375,7 +375,7 @@ export default defineNuxtComponent({
       newMeal.existing = true;
       newMeal.id = id;
       newMeal.groupId = groupId;
-      newMeal.userId = userId || $auth.user.value?.id || "";
+      newMeal.userId = userId || auth.user.value?.id || "";
 
       state.value.dialog = true;
       dialog.note = !recipeId;

--- a/frontend/pages/household/members.vue
+++ b/frontend/pages/household/members.vue
@@ -125,7 +125,7 @@ export default defineNuxtComponent({
     UserAvatar,
   },
   setup() {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const api = useUserApi();
     const i18n = useI18n();
 
@@ -169,7 +169,7 @@ export default defineNuxtComponent({
       await refreshMembers();
     });
 
-    return { members, headers, setPermissions, sessionUser: $auth.user };
+    return { members, headers, setPermissions, sessionUser: auth.user };
   },
 });
 </script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -14,12 +14,12 @@ export default defineNuxtComponent({
       layout: "blank",
     });
 
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $axios } = useNuxtApp();
     const router = useRouter();
     const activityPreferences = useUserActivityPreferences();
     const { getDefaultActivityRoute } = useDefaultActivity();
-    const groupSlug = computed(() => $auth.user.value?.groupSlug);
+    const groupSlug = computed(() => auth.user.value?.groupSlug);
 
     async function redirectPublicUserToDefaultGroup() {
       const { data } = await $axios.get<AppInfo>("/api/app/about");
@@ -40,7 +40,7 @@ export default defineNuxtComponent({
           activityPreferences.value.defaultActivity,
           groupSlug.value,
         );
-        if (!isDemo && isFirstLogin && $auth.user.value?.admin) {
+        if (!isDemo && isFirstLogin && auth.user.value?.admin) {
           router.push("/admin/setup");
         }
         else if (defaultActivityRoute) {

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -228,10 +228,10 @@ export default defineNuxtComponent({
 
     const router = useRouter();
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $appInfo, $axios } = useNuxtApp();
     const { loggedIn } = useLoggedInState();
-    const groupSlug = computed(() => $auth.user.value?.groupSlug);
+    const groupSlug = computed(() => auth.user.value?.groupSlug);
     const isDemo = ref(false);
     const isFirstLogin = ref(false);
     const activityPreferences = useUserActivityPreferences();
@@ -265,7 +265,7 @@ export default defineNuxtComponent({
           activityPreferences.value.defaultActivity,
           groupSlug.value,
         );
-        if (!isDemo.value && isFirstLogin.value && $auth.user.value?.admin) {
+        if (!isDemo.value && isFirstLogin.value && auth.user.value?.admin) {
           router.push("/admin/setup");
         }
         else if (defaultActivityRoute) {
@@ -284,7 +284,7 @@ export default defineNuxtComponent({
     const { passwordIcon, inputType, togglePasswordShow } = usePasswordField();
 
     whenever(
-      () => $appInfo.enableOidc && $appInfo.oidcRedirect && !isCallback() && !isDirectLogin() /* && !$auth.check().valid */,
+      () => $appInfo.enableOidc && $appInfo.oidcRedirect && !isCallback() && !isDirectLogin() /* && !auth.check().valid */,
       () => oidcAuthenticate(),
       { immediate: true },
     );
@@ -309,7 +309,7 @@ export default defineNuxtComponent({
       if (callback) {
         oidcLoggingIn.value = true;
         try {
-          await $auth.oauthSignIn();
+          await auth.oauthSignIn();
         }
         catch (error) {
           await router.replace("/login?direct=1");
@@ -335,7 +335,7 @@ export default defineNuxtComponent({
       formData.append("remember_me", String(form.remember));
 
       try {
-        await $auth.signIn(formData);
+        await auth.signIn(formData);
       }
       catch (error) {
         console.log(error);

--- a/frontend/pages/shopping-lists/[id].vue
+++ b/frontend/pages/shopping-lists/[id].vue
@@ -353,7 +353,7 @@ export default defineNuxtComponent({
   setup() {
     const { mdAndUp } = useDisplay();
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const preferences = useShoppingListPreferences();
 
     useSeoMeta({
@@ -361,7 +361,7 @@ export default defineNuxtComponent({
     });
 
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug as string || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
     const id = route.params.id as string;
 
     const shoppingListPage = useShoppingListPage(id);

--- a/frontend/pages/shopping-lists/index.vue
+++ b/frontend/pages/shopping-lists/index.vue
@@ -132,7 +132,7 @@ import type { UserOut } from "~/lib/api/types/user";
 
 export default defineNuxtComponent({
   setup() {
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const i18n = useI18n();
     const ready = ref(false);
     const userApi = useUserApi();
@@ -142,7 +142,7 @@ export default defineNuxtComponent({
       title: i18n.t("shopping-list.shopping-list"),
     });
 
-    const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
     const overrideDisableRedirect = ref(false);
     const disableRedirect = computed(() => route.query.disableRedirect === "true" || overrideDisableRedirect.value);
     const preferences = useShoppingListPreferences();
@@ -165,7 +165,7 @@ export default defineNuxtComponent({
         return [];
       }
 
-      return shoppingLists.value.filter(list => preferences.value.viewAllLists || list.userId === $auth.user.value?.id);
+      return shoppingLists.value.filter(list => preferences.value.viewAllLists || list.userId === auth.user.value?.id);
     });
 
     // This has to appear before the shoppingListChoices watcher, otherwise that runs first and the redirect is not disabled

--- a/frontend/pages/user/profile/api-tokens.vue
+++ b/frontend/pages/user/profile/api-tokens.vue
@@ -114,14 +114,14 @@ export default defineNuxtComponent({
   middleware: ["advanced-only"],
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
 
     useSeoMeta({
       title: i18n.t("settings.token.api-tokens"),
     });
 
     const user = computed(() => {
-      return $auth.user.value;
+      return auth.user.value;
     });
 
     const api = useUserApi();
@@ -136,7 +136,7 @@ export default defineNuxtComponent({
       createdToken.value = "";
       loading.value = false;
       name.value = "";
-      $auth.refresh();
+      auth.refresh();
     }
 
     async function createToken(name: string) {
@@ -161,7 +161,7 @@ export default defineNuxtComponent({
 
     async function deleteToken(id: number) {
       const { data } = await api.users.deleteAPIToken(id);
-      $auth.refresh();
+      auth.refresh();
       return data;
     }
 

--- a/frontend/pages/user/profile/edit.vue
+++ b/frontend/pages/user/profile/edit.vue
@@ -13,7 +13,7 @@
             file-name="profile"
             accept="image/*"
             :url="`/api/users/${userCopy.id}/image`"
-            @uploaded="$auth.refresh()"
+            @uploaded="auth.refresh()"
           />
         </div>
       </template>
@@ -231,9 +231,9 @@ export default defineNuxtComponent({
   },
   setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { getDefaultActivityLabels, getActivityLabel, getActivityKey } = useDefaultActivity();
-    const user = computed(() => $auth.user.value);
+    const user = computed(() => auth.user.value);
 
     useSeoMeta({
       title: i18n.t("settings.profile"),
@@ -267,7 +267,7 @@ export default defineNuxtComponent({
       if (!userCopy.value?.id) return;
       const { response } = await api.users.updateOne(userCopy.value.id, userCopy.value);
       if (response?.status === 200) {
-        $auth.refresh();
+        auth.refresh();
       }
     }
 
@@ -303,7 +303,7 @@ export default defineNuxtComponent({
       domUpdatePassword,
       passwordsMatch,
       validators,
-      $auth,
+      auth,
     };
   },
 });

--- a/frontend/pages/user/profile/index.vue
+++ b/frontend/pages/user/profile/index.vue
@@ -294,17 +294,17 @@ export default defineNuxtComponent({
   scrollToTop: true,
   async setup() {
     const i18n = useI18n();
-    const $auth = useMealieAuth();
+    const auth = useMealieAuth();
     const { $appInfo } = useNuxtApp();
     const route = useRoute();
-    const groupSlug = computed(() => route.params.groupSlug || $auth.user.value?.groupSlug || "");
+    const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
 
     useSeoMeta({
       title: i18n.t("settings.profile"),
     });
 
     const user = computed<UserOut | null>(() => {
-      const authUser = $auth.user.value;
+      const authUser = auth.user.value;
       if (!authUser) return null;
 
       // Override canInvite if password login is disabled


### PR DESCRIPTION
## What this PR does / why we need it:

- removes the `$`-prefix from the `auth` property within all vue components.
- fixes bug related to `$`-prefixed state var causing user image upload to not properly refresh

### Additional Info
- `$`-prefixed state vars returned in `setup()` trigger a warning in dev mode, but then are silently omitted/inaccessible to the UI.  This was leading to an issue in  `/user/profile/edit.vue` component where a call to `$auth.refresh()` was throwing an 'accessing 'refresh' on undefined' error.
- Note: #6985  addresses this same issue with an iterative key to force a re-render, though I think the root issue can be fixed by renaming this prop.  This can be considered an alternative, let me know if that strategy is preferable and I'll close this!
 
#### Before
[error-before.webm](https://github.com/user-attachments/assets/8e2b8704-0312-415b-b627-c630ffbf24dd)

#### After
[error-after.webm](https://github.com/user-attachments/assets/e49d935f-a0a3-4bd4-82ae-d4a2ce442e39)


## Which issue(s) this PR fixes:

Fixes #6263

## Testing

- Tested this manually on both a local dev and local production build, using the provided dev containers.  
- The behavior I'm seeing doesn't quite match the original report (the undefined $auth call means the AppButtonUpload's loader never goes away, which isnt visible in the original screenshot). 
