### PR TITLE
feat: Dynamic Placeholders UI

### DIFF
--- a/frontend/assets/main.css
+++ b/frontend/assets/main.css
@@ -16,6 +16,10 @@
   max-width: 950px !important;
 }
 
+.lg-container {
+  max-width: 1100px !important;
+}
+
 .theme--dark.v-application {
   background-color: rgb(var(--v-theme-background, 30, 30, 30)) !important;
 }

--- a/frontend/components/Domain/Household/GroupMealPlanRuleForm.vue
+++ b/frontend/components/Domain/Household/GroupMealPlanRuleForm.vue
@@ -76,7 +76,6 @@ const MEAL_DAY_OPTIONS = [
 ];
 
 function handleQueryFilterInput(value: string | undefined) {
-  console.warn("handleQueryFilterInput called with value:", value);
   queryFilterString.value = value || "";
 }
 

--- a/frontend/components/Domain/Household/GroupMealPlanRuleForm.vue
+++ b/frontend/components/Domain/Household/GroupMealPlanRuleForm.vue
@@ -113,7 +113,7 @@ const fieldDefs: FieldDefinition[] = [
   {
     name: "last_made",
     label: i18n.t("general.last-made"),
-    type: "date",
+    type: "relativeDate",
   },
   {
     name: "created_at",

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -158,34 +158,63 @@
               :model-value="field.value"
               @update:model-value="setFieldValue(field, index, $event!)"
             />
-            <v-menu
+            <div
               v-else-if="field.type === 'date'"
-              v-model="datePickers[index]"
-              :close-on-content-click="false"
-              transition="scale-transition"
-              offset-y
-              max-width="290px"
-              min-width="auto"
+              class="d-flex gap-2 flex-wrap align-end"
+              style="width: 100%;"
             >
-              <template #activator="{ props: activatorProps }">
-                <v-text-field
-                  :model-value="field.value ? $d(new Date(field.value + 'T00:00:00')) : null"
-                  persistent-hint
-                  :prepend-icon="$globals.icons.calendar"
-                  variant="underlined"
-                  color="primary"
-                  v-bind="activatorProps"
-                  readonly
+              <v-switch
+                :model-value="field.fieldConfig.absoluteDate"
+                class="mr-4"
+                hide-details
+                inset
+                color="primary"
+                @update:model-value="toggleAbsoluteDate(field, index, $event)"
+              >
+                <template #label>
+                  <v-icon size="24">
+                    {{ $globals.icons.calendar }}
+                  </v-icon>
+                </template>
+              </v-switch>
+              <v-menu
+                v-if="field.fieldConfig.absoluteDate"
+                v-model="datePickers[index]"
+                :close-on-content-click="false"
+                transition="scale-transition"
+                offset-y
+                max-width="290px"
+                min-width="auto"
+              >
+                <template #activator="{ props: activatorProps }">
+                  <v-text-field
+                    :model-value="$d(safeNewDate(field.value + 'T00:00:00'))"
+                    variant="underlined"
+                    color="primary"
+                    v-bind="activatorProps"
+                    readonly
+                  />
+                </template>
+                <v-date-picker
+                  :model-value="safeNewDate(field.value + 'T00:00:00')"
+                  hide-header
+                  :first-day-of-week="firstDayOfWeek"
+                  :local="$i18n.locale"
+                  @update:model-value="val => setFieldValue(field, index, val ? val.toISOString().slice(0, 10) : '')"
                 />
-              </template>
-              <v-date-picker
-                :model-value="field.value ? new Date(field.value + 'T00:00:00') : null"
-                hide-header
-                :first-day-of-week="firstDayOfWeek"
-                :local="$i18n.locale"
-                @update:model-value="val => setFieldValue(field, index, val ? val.toISOString().slice(0, 10) : '')"
+              </v-menu>
+              <v-number-input
+                v-else
+                :model-value="parseRelativeDateOffset(field.value)"
+                variant="underlined"
+                control-variant="stacked"
+                density="compact"
+                inset
+                :precision="0"
+                class="relative-date-input"
+                @update:model-value="setFieldValue(field, index, $event)"
               />
-            </v-menu>
+            </div>
             <RecipeOrganizerSelector
               v-else-if="field.type === Organizer.Category"
               v-model="field.organizers"
@@ -319,7 +348,13 @@ import { useDebounceFn } from "@vueuse/core";
 import { useHouseholdSelf } from "~/composables/use-households";
 import RecipeOrganizerSelector from "~/components/Domain/Recipe/RecipeOrganizerSelector.vue";
 import { Organizer } from "~/lib/api/types/non-generated";
-import type { LogicalOperator, QueryFilterJSON, QueryFilterJSONPart, RelationalKeyword, RelationalOperator } from "~/lib/api/types/non-generated";
+import type {
+  LogicalOperator,
+  QueryFilterJSON,
+  QueryFilterJSONPart,
+  RelationalKeyword,
+  RelationalOperator,
+} from "~/lib/api/types/non-generated";
 import { useCategoryStore, useFoodStore, useHouseholdStore, useTagStore, useToolStore } from "~/composables/store";
 import { useUserStore } from "~/composables/store/use-user-store";
 import { type Field, type FieldDefinition, type FieldValue, type OrganizerBase, useQueryFilterBuilder } from "~/composables/use-query-filter-builder";
@@ -341,7 +376,14 @@ const emit = defineEmits<{
 }>();
 
 const { household } = useHouseholdSelf();
-const { logOps, relOps, buildQueryFilterString, getFieldFromFieldDef, isOrganizerType } = useQueryFilterBuilder();
+const {
+  logOps,
+  relOps,
+  placeholderKeywords,
+  buildQueryFilterString,
+  getFieldFromFieldDef,
+  isOrganizerType,
+} = useQueryFilterBuilder();
 
 const firstDayOfWeek = computed(() => {
   return household.value?.preferences?.firstDayOfWeek || 0;
@@ -430,7 +472,15 @@ function setRelationalOperatorValue(field: FieldWithId, index: number, value: Re
 
 function setFieldValue(field: FieldWithId, index: number, value: FieldValue) {
   state.datePickers[index] = false;
-  fields.value[index].value = value;
+
+  if (field.type == "date" && !field.fieldConfig.absoluteDate) {
+    // Value is set to an int representing the offset from $NOW
+    const op = value < 0 ? "-" : "+";
+    fields.value[index].value = `$NOW${op}${Math.abs(value)}d`;
+  }
+  else {
+    fields.value[index].value = value;
+  }
 }
 
 function setFieldValues(field: FieldWithId, index: number, values: FieldValue[]) {
@@ -446,6 +496,11 @@ function setFieldOrganizers(field: FieldWithId, index: number, organizers: Organ
 function removeField(index: number) {
   fields.value.splice(index, 1);
   state.datePickers.splice(index, 1);
+}
+
+function toggleAbsoluteDate(field: FieldWithId, index: number, isAbsolute: boolean) {
+  field.fieldConfig.absoluteDate = isAbsolute;
+  setFieldValue(field, index, parseRelativeDateOffset(field.value));
 }
 
 const fieldsUpdater = useDebounceFn((/* newFields: typeof fields.value */) => {
@@ -519,6 +574,11 @@ async function initializeFields() {
       ...getFieldFromFieldDef(fieldDef),
       id: useUid(),
     };
+
+    field.fieldConfig = {
+      absoluteDate: false,
+    };
+
     field.leftParenthesis = part.leftParenthesis || field.leftParenthesis;
     field.rightParenthesis = part.rightParenthesis || field.rightParenthesis;
     field.logicalOperator = part.logicalOperator
@@ -561,10 +621,16 @@ async function initializeFields() {
     }
     else if (field.type === "date") {
       field.value = part.value as string || "";
-      const date = new Date(field.value);
-      if (isNaN(date.getTime())) {
-        error = true;
-        return initFieldsError(`Invalid query filter; invalid date value "${(part.value || "").toString()}"`);
+      if (field.value.startsWith(placeholderKeywords.value["$NOW"].value)) {
+        field.fieldConfig.absoluteDate = false;
+      }
+      else {
+        field.fieldConfig.absoluteDate = true;
+        const date = new Date(field.value);
+        if (isNaN(date.getTime())) {
+          error = true;
+          return initFieldsError(`Invalid query filter; invalid date value "${(part.value || "").toString()}"`);
+        }
       }
     }
     else {
@@ -617,6 +683,64 @@ function buildQueryFilterJSON(): QueryFilterJSON {
   const qfJSON = { parts } as QueryFilterJSON;
   console.debug(`Built query filter JSON: ${JSON.stringify(qfJSON)}`);
   return qfJSON;
+}
+
+function safeNewDate(input: string): Date {
+  const date = new Date(input);
+  if (isNaN(date.getTime())) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today;
+  }
+  return date;
+}
+
+/**
+ * Parse a relative date string offset (e.g. $NOW-30d --> -30)
+ */
+function parseRelativeDateOffset(value: string): number {
+  const defaultVal = -30;
+  if (!value) {
+    return defaultVal;
+  }
+
+  try {
+    if (!value.startsWith(placeholderKeywords.value["$NOW"].value)) {
+      return defaultVal;
+    }
+
+    const remainder = value.slice(placeholderKeywords.value["$NOW"].value.length);
+    let sign = 1;
+    if (remainder.startsWith("-")) {
+      sign = -1;
+    }
+    else if (!remainder.startsWith("+")) {
+      throw new Error("Invalid operator");
+    }
+
+    const baseAmount = parseInt(remainder.slice(1, -1));
+    let multiplier = 1;
+    switch (remainder.slice(-1)) {
+      case "y":
+        multiplier = 365;
+        break;
+      // We intentionally don't support "m" since months are not a static number of days.
+      // If we add months to the UI we can pass it directly to the backend,
+      // but then we'd have to re-write this anyway.
+      case "d":
+        // multiplier already set to 1
+        break;
+
+      default:
+        throw new Error("Invalid unit");
+    }
+
+    return sign * baseAmount * multiplier;
+  }
+  catch (error) {
+    console.warn(`Unable to parse relative date offset from '${value}': ${error}`);
+    return defaultVal;
+  }
 }
 
 const config = computed(() => {
@@ -688,5 +812,14 @@ const config = computed(() => {
 
 .bg-light {
   background-color: rgba(255, 255, 255, var(--bg-opactity));
+}
+
+:deep(.relative-date-input input) {
+  text-align: end;
+  padding-right: 6px;
+}
+
+:deep(.relative-date-input .v-field__field) {
+  align-items: center;
 }
 </style>

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -438,6 +438,9 @@ function setField(index: number, fieldLabel: string) {
 
   // Defaults
   switch (fields.value[index].type) {
+    case "date":
+      fields.value[index].value = safeNewDate("");
+      break;
     case "relativeDate":
       fields.value[index].value = "$NOW-30d";
       break;

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -108,7 +108,7 @@
             <v-select
               v-if="field.type !== 'boolean'"
               :model-value="field.relationalOperatorValue"
-              :items="field.relationalOperatorOptions"
+              :items="field.relationalOperatorChoices"
               item-title="label"
               item-value="value"
               variant="underlined"
@@ -129,9 +129,9 @@
             :class="config.col.class"
           >
             <v-select
-              v-if="field.fieldOptions"
+              v-if="field.fieldChoices"
               :model-value="field.values"
-              :items="field.fieldOptions"
+              :items="field.fieldChoices"
               item-title="label"
               item-value="value"
               multiple
@@ -396,11 +396,11 @@ function setField(index: number, fieldLabel: string) {
     return;
   }
 
-  const resetValue = (fieldDef.type !== fields.value[index].type) || (fieldDef.fieldOptions !== fields.value[index].fieldOptions);
+  const resetValue = (fieldDef.type !== fields.value[index].type) || (fieldDef.fieldChoices !== fields.value[index].fieldChoices);
   const updatedField = { ...fields.value[index], ...fieldDef };
 
   // we have to set this explicitly since it might be undefined
-  updatedField.fieldOptions = fieldDef.fieldOptions;
+  updatedField.fieldChoices = fieldDef.fieldChoices;
 
   fields.value[index] = {
     ...getFieldFromFieldDef(updatedField, resetValue),
@@ -532,7 +532,7 @@ async function initializeFields() {
       state.showAdvanced = true;
     }
 
-    if (field.fieldOptions?.length || isOrganizerType(field.type)) {
+    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
       if (typeof part.value === "string") {
         field.values = part.value ? [part.value] : [];
       }
@@ -601,7 +601,7 @@ function buildQueryFilterJSON(): QueryFilterJSON {
       relationalOperator: field.relationalOperatorValue?.value,
     };
 
-    if (field.fieldOptions?.length || isOrganizerType(field.type)) {
+    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
       part.value = field.values.map(value => value.toString());
     }
     else if (field.type === "boolean") {

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -163,20 +163,37 @@
               class="d-flex gap-2 flex-wrap align-end"
               style="width: 100%;"
             >
-              <v-switch
+              <v-btn-toggle
                 :model-value="field.fieldConfig.absoluteDate"
-                class="mr-4"
-                hide-details
-                inset
-                color="primary"
+                mandatory
+                density="compact"
+                variant="outlined"
+                class="mb-5 mr-2"
                 @update:model-value="toggleAbsoluteDate(field, index, $event)"
               >
-                <template #label>
-                  <v-icon size="24">
-                    {{ $globals.icons.calendar }}
-                  </v-icon>
-                </template>
-              </v-switch>
+                <v-tooltip location="bottom">
+                  <template #activator="{ props: tooltipProps }">
+                    <v-btn
+                      :value="false"
+                      :icon="$globals.icons.clockOutline"
+                      class="px-4"
+                      v-bind="tooltipProps"
+                    />
+                  </template>
+                  <span>{{ $t("query-filter.date.days-relative-to-today") }}</span>
+                </v-tooltip>
+                <v-tooltip location="bottom">
+                  <template #activator="{ props: tooltipProps }">
+                    <v-btn
+                      :value="true"
+                      :icon="$globals.icons.calendar"
+                      class="px-4"
+                      v-bind="tooltipProps"
+                    />
+                  </template>
+                  <span>{{ $t("query-filter.date.fixed-date") }}</span>
+                </v-tooltip>
+              </v-btn-toggle>
               <v-menu
                 v-if="field.fieldConfig.absoluteDate"
                 v-model="datePickers[index]"
@@ -191,6 +208,7 @@
                     :model-value="$d(safeNewDate(field.value + 'T00:00:00'))"
                     variant="underlined"
                     color="primary"
+                    class="date-input"
                     v-bind="activatorProps"
                     readonly
                   />
@@ -203,17 +221,19 @@
                   @update:model-value="val => setFieldValue(field, index, val ? val.toISOString().slice(0, 10) : '')"
                 />
               </v-menu>
-              <v-number-input
-                v-else
-                :model-value="parseRelativeDateOffset(field.value)"
-                variant="underlined"
-                control-variant="stacked"
-                density="compact"
-                inset
-                :precision="0"
-                class="relative-date-input"
-                @update:model-value="setFieldValue(field, index, $event)"
-              />
+              <div v-else class="d-flex" style="flex: 1;">
+                <v-number-input
+                  :model-value="parseRelativeDateOffset(field.value)"
+                  :suffix="$t('general.days')"
+                  variant="underlined"
+                  control-variant="stacked"
+                  density="compact"
+                  inset
+                  :precision="0"
+                  class="date-input"
+                  @update:model-value="setFieldValue(field, index, $event)"
+                />
+              </div>
             </div>
             <RecipeOrganizerSelector
               v-else-if="field.type === Organizer.Category"
@@ -814,12 +834,12 @@ const config = computed(() => {
   background-color: rgba(255, 255, 255, var(--bg-opactity));
 }
 
-:deep(.relative-date-input input) {
+:deep(.date-input input) {
   text-align: end;
   padding-right: 6px;
 }
 
-:deep(.relative-date-input .v-field__field) {
+:deep(.date-input .v-field__field) {
   align-items: center;
 }
 </style>

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -158,84 +158,50 @@
               :model-value="field.value"
               @update:model-value="setFieldValue(field, index, $event!)"
             />
-            <div
+            <v-menu
               v-else-if="field.type === 'date'"
-              class="d-flex gap-2 flex-wrap align-end"
-              style="width: 100%;"
+              v-model="datePickers[index]"
+              :close-on-content-click="false"
+              transition="scale-transition"
+              offset-y
+              max-width="290px"
+              min-width="auto"
             >
-              <v-btn-toggle
-                :model-value="field.fieldConfig.absoluteDate"
-                mandatory
-                density="compact"
-                variant="outlined"
-                class="mb-5 mr-2"
-                @update:model-value="toggleAbsoluteDate(field, index, $event)"
-              >
-                <v-tooltip location="bottom">
-                  <template #activator="{ props: tooltipProps }">
-                    <v-btn
-                      :value="false"
-                      :icon="$globals.icons.clockOutline"
-                      class="px-4"
-                      v-bind="tooltipProps"
-                    />
-                  </template>
-                  <span>{{ $t("query-filter.date.days-relative-to-today") }}</span>
-                </v-tooltip>
-                <v-tooltip location="bottom">
-                  <template #activator="{ props: tooltipProps }">
-                    <v-btn
-                      :value="true"
-                      :icon="$globals.icons.calendar"
-                      class="px-4"
-                      v-bind="tooltipProps"
-                    />
-                  </template>
-                  <span>{{ $t("query-filter.date.fixed-date") }}</span>
-                </v-tooltip>
-              </v-btn-toggle>
-              <v-menu
-                v-if="field.fieldConfig.absoluteDate"
-                v-model="datePickers[index]"
-                :close-on-content-click="false"
-                transition="scale-transition"
-                offset-y
-                max-width="290px"
-                min-width="auto"
-              >
-                <template #activator="{ props: activatorProps }">
-                  <v-text-field
-                    :model-value="$d(safeNewDate(field.value + 'T00:00:00'))"
-                    variant="underlined"
-                    color="primary"
-                    class="date-input"
-                    v-bind="activatorProps"
-                    readonly
-                  />
-                </template>
-                <v-date-picker
-                  :model-value="safeNewDate(field.value + 'T00:00:00')"
-                  hide-header
-                  :first-day-of-week="firstDayOfWeek"
-                  :local="$i18n.locale"
-                  @update:model-value="val => setFieldValue(field, index, val ? val.toISOString().slice(0, 10) : '')"
-                />
-              </v-menu>
-              <div v-else class="d-flex" style="flex: 1;">
-                <v-number-input
-                  :model-value="parseRelativeDateOffset(field.value)"
-                  :suffix="$t('general.days')"
+              <template #activator="{ props: activatorProps }">
+                <v-text-field
+                  :model-value="$d(safeNewDate(field.value + 'T00:00:00'))"
                   variant="underlined"
-                  control-variant="stacked"
-                  density="compact"
-                  inset
-                  :max="0"
-                  :precision="0"
+                  color="primary"
                   class="date-input"
-                  @update:model-value="setFieldValue(field, index, $event)"
+                  v-bind="activatorProps"
+                  readonly
                 />
-              </div>
-            </div>
+              </template>
+              <v-date-picker
+                :model-value="safeNewDate(field.value + 'T00:00:00')"
+                hide-header
+                :first-day-of-week="firstDayOfWeek"
+                :local="$i18n.locale"
+                @update:model-value="val => setFieldValue(field, index, val ? val.toISOString().slice(0, 10) : '')"
+              />
+            </v-menu>
+            <!--
+              Relative dates are assumed to be negative intervals with a unit of days.
+              The input is a *positive*, interpreted internally as a *negative* offset.
+            -->
+            <v-number-input
+              v-else-if="field.type === 'relativeDate'"
+              :model-value="parseRelativeDateOffset(field.value)"
+              :suffix="$t('query-filter.dates.days-ago', parseRelativeDateOffset(field.value))"
+              variant="underlined"
+              control-variant="stacked"
+              density="compact"
+              inset
+              :min="0"
+              :precision="0"
+              class="date-input"
+              @update:model-value="setFieldValue(field, index, $event)"
+            />
             <RecipeOrganizerSelector
               v-else-if="field.type === Organizer.Category"
               v-model="field.organizers"
@@ -400,6 +366,7 @@ const { household } = useHouseholdSelf();
 const {
   logOps,
   relOps,
+  relativeDateRelOps,
   placeholderKeywords,
   buildQueryFilterString,
   getFieldFromFieldDef,
@@ -472,23 +439,8 @@ function setField(index: number, fieldLabel: string) {
 
   // Defaults
   switch (fields.value[index].type) {
-    case "date":
-      switch (fields.value[index].name) {
-        case "last_made":
-          fields.value[index].fieldConfig.absoluteDate = false;
-          break;
-
-        default:
-          fields.value[index].fieldConfig.absoluteDate = true;
-          break;
-      }
-
-      if (fields.value[index].fieldConfig.absoluteDate) {
-        fields.value[index].value = safeNewDate("");
-      }
-      else {
-        fields.value[index].value = "$NOW-30d";
-      }
+    case "relativeDate":
+      fields.value[index].value = "$NOW-30d";
       break;
 
     default:
@@ -513,16 +465,24 @@ function setLogicalOperatorValue(field: FieldWithId, index: number, value: Logic
 }
 
 function setRelationalOperatorValue(field: FieldWithId, index: number, value: RelationalKeyword | RelationalOperator) {
-  fields.value[index].relationalOperatorValue = relOps.value[value];
+  switch (fields.value[index].type) {
+    case "relativeDate":
+      fields.value[index].relationalOperatorValue = relativeDateRelOps.value[value];
+      break;
+
+    default:
+      fields.value[index].relationalOperatorValue = relOps.value[value];
+      break;
+  }
 }
 
 function setFieldValue(field: FieldWithId, index: number, value: FieldValue) {
   state.datePickers[index] = false;
 
-  if (field.type == "date" && !field.fieldConfig.absoluteDate) {
+  if (field.type === "relativeDate") {
     // Value is set to an int representing the offset from $NOW
-    const op = value < 0 ? "-" : "+";
-    fields.value[index].value = `$NOW${op}${Math.abs(value)}d`;
+    // Values are assumed to be negative offsets ('-') with a unit of days ('d')
+    fields.value[index].value = `$NOW-${Math.abs(value)}d`;
   }
   else {
     fields.value[index].value = value;
@@ -542,11 +502,6 @@ function setFieldOrganizers(field: FieldWithId, index: number, organizers: Organ
 function removeField(index: number) {
   fields.value.splice(index, 1);
   state.datePickers.splice(index, 1);
-}
-
-function toggleAbsoluteDate(field: FieldWithId, index: number, isAbsolute: boolean) {
-  field.fieldConfig.absoluteDate = isAbsolute;
-  setFieldValue(field, index, parseRelativeDateOffset(field.value));
 }
 
 const fieldsUpdater = useDebounceFn(() => {
@@ -616,15 +571,25 @@ async function initializeFields() {
       id: useUid(),
     };
 
-    field.fieldConfig = {
-      absoluteDate: false,
-    };
-
     field.leftParenthesis = part.leftParenthesis || field.leftParenthesis;
     field.rightParenthesis = part.rightParenthesis || field.rightParenthesis;
     field.logicalOperator = part.logicalOperator
       ? logOps.value[part.logicalOperator]
       : field.logicalOperator;
+
+    switch (field.type) {
+      case "relativeDate":
+        field.relationalOperatorValue = part.relationalOperator
+          ? relativeDateRelOps.value[part.relationalOperator]
+          : field.relationalOperatorValue;
+        break;
+
+      default:
+        field.relationalOperatorValue = part.relationalOperator
+          ? relOps.value[part.relationalOperator]
+          : field.relationalOperatorValue;
+        break;
+    }
     field.relationalOperatorValue = part.relationalOperator
       ? relOps.value[part.relationalOperator]
       : field.relationalOperatorValue;
@@ -662,16 +627,10 @@ async function initializeFields() {
     }
     else if (field.type === "date") {
       field.value = part.value as string || "";
-      if (field.value.startsWith(placeholderKeywords.value["$NOW"].value)) {
-        field.fieldConfig.absoluteDate = false;
-      }
-      else {
-        field.fieldConfig.absoluteDate = true;
-        const date = new Date(field.value);
-        if (isNaN(date.getTime())) {
-          error = true;
-          return initFieldsError(`Invalid query filter; invalid date value "${(part.value || "").toString()}"`);
-        }
+      const date = new Date(field.value);
+      if (isNaN(date.getTime())) {
+        error = true;
+        return initFieldsError(`Invalid query filter; invalid date value "${(part.value || "").toString()}"`);
       }
     }
     else {
@@ -737,10 +696,12 @@ function safeNewDate(input: string): Date {
 }
 
 /**
- * Parse a relative date string offset (e.g. $NOW-30d --> -30)
+ * Parse a relative date string offset (e.g. $NOW-30d --> 30)
+ *
+ * Currently only values with a negative offset ('-') and a unit of days ('d') are supported
  */
 function parseRelativeDateOffset(value: string): number {
-  const defaultVal = -30;
+  const defaultVal = 30;
   if (!value) {
     return defaultVal;
   }
@@ -751,32 +712,16 @@ function parseRelativeDateOffset(value: string): number {
     }
 
     const remainder = value.slice(placeholderKeywords.value["$NOW"].value.length);
-    let sign = 1;
-    if (remainder.startsWith("-")) {
-      sign = -1;
-    }
-    else if (!remainder.startsWith("+")) {
-      throw new Error("Invalid operator");
+    if (!remainder.startsWith("-")) {
+      throw new Error("Invalid operator (not '-')");
     }
 
-    const baseAmount = parseInt(remainder.slice(1, -1));
-    let multiplier = 1;
-    switch (remainder.slice(-1)) {
-      case "y":
-        multiplier = 365;
-        break;
-      // We intentionally don't support "m" since months are not a static number of days.
-      // If we add months to the UI we can pass it directly to the backend,
-      // but then we'd have to re-write this anyway.
-      case "d":
-        // multiplier already set to 1
-        break;
-
-      default:
-        throw new Error("Invalid unit");
+    if (remainder.slice(-1) !== "d") {
+      throw new Error("Invalid unit (not 'd')");
     }
 
-    return sign * baseAmount * multiplier;
+    // Slice off sign and unit
+    return parseInt(remainder.slice(1, -1));
   }
   catch (error) {
     console.warn(`Unable to parse relative date offset from '${value}': ${error}`);

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -469,6 +469,31 @@ function setField(index: number, fieldLabel: string) {
     ...getFieldFromFieldDef(updatedField, resetValue),
     id: fields.value[index].id, // keep the id
   };
+
+  // Defaults
+  switch (fields.value[index].type) {
+    case "date":
+      switch (fields.value[index].name) {
+        case "last_made":
+          fields.value[index].fieldConfig.absoluteDate = false;
+          break;
+
+        default:
+          fields.value[index].fieldConfig.absoluteDate = true;
+          break;
+      }
+
+      if (fields.value[index].fieldConfig.absoluteDate) {
+        fields.value[index].value = safeNewDate("");
+      }
+      else {
+        fields.value[index].value = "$NOW-30d";
+      }
+      break;
+
+    default:
+      break;
+  }
 }
 
 function setLeftParenthesisValue(field: FieldWithId, index: number, value: string) {

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -524,12 +524,7 @@ function toggleAbsoluteDate(field: FieldWithId, index: number, isAbsolute: boole
   setFieldValue(field, index, parseRelativeDateOffset(field.value));
 }
 
-const fieldsUpdater = useDebounceFn((/* newFields: typeof fields.value */) => {
-  /* newFields.forEach((field, index) => {
-    const updatedField = getFieldFromFieldDef(field);
-    fields.value[index] = updatedField; // recursive!!!
-  }); */
-
+const fieldsUpdater = useDebounceFn(() => {
   const qf = buildQueryFilterString(fields.value, state.showAdvanced);
   if (qf) {
     console.debug(`Set query filter: ${qf}`);

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -229,6 +229,7 @@
                   control-variant="stacked"
                   density="compact"
                   inset
+                  :max="0"
                   :precision="0"
                   class="date-input"
                   @update:model-value="setFieldValue(field, index, $event)"

--- a/frontend/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/components/Domain/QueryFilterBuilder.vue
@@ -365,9 +365,8 @@ const emit = defineEmits<{
 const { household } = useHouseholdSelf();
 const {
   logOps,
-  relOps,
-  relativeDateRelOps,
   placeholderKeywords,
+  getRelOps,
   buildQueryFilterString,
   getFieldFromFieldDef,
   isOrganizerType,
@@ -465,15 +464,8 @@ function setLogicalOperatorValue(field: FieldWithId, index: number, value: Logic
 }
 
 function setRelationalOperatorValue(field: FieldWithId, index: number, value: RelationalKeyword | RelationalOperator) {
-  switch (fields.value[index].type) {
-    case "relativeDate":
-      fields.value[index].relationalOperatorValue = relativeDateRelOps.value[value];
-      break;
-
-    default:
-      fields.value[index].relationalOperatorValue = relOps.value[value];
-      break;
-  }
+  const relOps = getRelOps(field.type);
+  fields.value[index].relationalOperatorValue = relOps.value[value];
 }
 
 function setFieldValue(field: FieldWithId, index: number, value: FieldValue) {
@@ -571,25 +563,16 @@ async function initializeFields() {
       id: useUid(),
     };
 
+    const relOps = getRelOps(field.type);
+
     field.leftParenthesis = part.leftParenthesis || field.leftParenthesis;
     field.rightParenthesis = part.rightParenthesis || field.rightParenthesis;
     field.logicalOperator = part.logicalOperator
       ? logOps.value[part.logicalOperator]
       : field.logicalOperator;
-
-    switch (field.type) {
-      case "relativeDate":
-        field.relationalOperatorValue = part.relationalOperator
-          ? relativeDateRelOps.value[part.relationalOperator]
-          : field.relationalOperatorValue;
-        break;
-
-      default:
-        field.relationalOperatorValue = part.relationalOperator
-          ? relOps.value[part.relationalOperator]
-          : field.relationalOperatorValue;
-        break;
-    }
+    field.relationalOperatorValue = part.relationalOperator
+      ? relOps.value[part.relationalOperator]
+      : field.relationalOperatorValue;
     field.relationalOperatorValue = part.relationalOperator
       ? relOps.value[part.relationalOperator]
       : field.relationalOperatorValue;

--- a/frontend/composables/use-query-filter-builder.ts
+++ b/frontend/composables/use-query-filter-builder.ts
@@ -1,5 +1,5 @@
 import { Organizer } from "~/lib/api/types/non-generated";
-import type { LogicalOperator, RecipeOrganizer, RelationalKeyword, RelationalOperator } from "~/lib/api/types/non-generated";
+import type { LogicalOperator, PlaceholderKeyword, RecipeOrganizer, RelationalKeyword, RelationalOperator } from "~/lib/api/types/non-generated";
 
 export interface FieldLogicalOperator {
   label: string;
@@ -9,6 +9,11 @@ export interface FieldLogicalOperator {
 export interface FieldRelationalOperator {
   label: string;
   value: RelationalKeyword | RelationalOperator;
+}
+
+export interface FieldPlaceholderKeyword {
+  label: string;
+  value: PlaceholderKeyword;
 }
 
 export interface OrganizerBase {
@@ -41,8 +46,12 @@ export interface FieldDefinition {
   label: string;
   type: FieldType;
 
-  // only for select/organizer fields
+  // Select/Organizer
   fieldChoices?: SelectableItem[];
+}
+
+export interface FieldConfig {
+  absoluteDate: boolean;
 }
 
 export interface Field extends FieldDefinition {
@@ -53,9 +62,12 @@ export interface Field extends FieldDefinition {
   relationalOperatorChoices: FieldRelationalOperator[];
   rightParenthesis?: string;
 
-  // only for select/organizer fields
+  // Select/Organizer
   values: FieldValue[];
   organizers: OrganizerBase[];
+
+  // Dates
+  fieldConfig: FieldConfig;
 }
 
 export function useQueryFilterBuilder() {
@@ -161,6 +173,17 @@ export function useQueryFilterBuilder() {
     };
   });
 
+  const placeholderKeywords = computed<Record<PlaceholderKeyword, FieldPlaceholderKeyword>>(() => {
+    const NOW = {
+      label: "Now",
+      value: "$NOW",
+    } as FieldPlaceholderKeyword;
+
+    return {
+      $NOW: NOW,
+    };
+  });
+
   function isOrganizerType(type: FieldType): type is Organizer {
     return (
       type === Organizer.Category
@@ -173,7 +196,15 @@ export function useQueryFilterBuilder() {
   };
 
   function getFieldFromFieldDef(field: Field | FieldDefinition, resetValue = false): Field {
-    const updatedField = { logicalOperator: logOps.value.AND, ...field } as Field;
+    const defaultFieldConfig: FieldConfig = {
+      absoluteDate: false,
+    };
+    const updatedField = {
+      logicalOperator: logOps.value.AND,
+      fieldConfig: defaultFieldConfig,
+      ...field,
+    } as Field;
+
     let operatorChoices: FieldRelationalOperator[];
     if (updatedField.fieldChoices?.length || isOrganizerType(updatedField.type)) {
       operatorChoices = [
@@ -317,6 +348,7 @@ export function useQueryFilterBuilder() {
   return {
     logOps,
     relOps,
+    placeholderKeywords,
     buildQueryFilterString,
     getFieldFromFieldDef,
     isOrganizerType,

--- a/frontend/composables/use-query-filter-builder.ts
+++ b/frontend/composables/use-query-filter-builder.ts
@@ -187,6 +187,16 @@ export function useQueryFilterBuilder() {
     return ops;
   });
 
+  function getRelOps(fieldType: FieldType): typeof relOps | typeof relativeDateRelOps {
+    switch (fieldType) {
+      case "relativeDate":
+        return relativeDateRelOps;
+
+      default:
+        return relOps;
+    }
+  }
+
   function isOrganizerType(type: FieldType): type is Organizer {
     return (
       type === Organizer.Category
@@ -353,9 +363,8 @@ export function useQueryFilterBuilder() {
 
   return {
     logOps,
-    relOps,
-    relativeDateRelOps,
     placeholderKeywords,
+    getRelOps,
     buildQueryFilterString,
     getFieldFromFieldDef,
     isOrganizerType,

--- a/frontend/composables/use-query-filter-builder.ts
+++ b/frontend/composables/use-query-filter-builder.ts
@@ -27,6 +27,7 @@ export type FieldType
     | "number"
     | "boolean"
     | "date"
+    | "relativeDate"
     | RecipeOrganizer;
 
 export type FieldValue
@@ -50,10 +51,6 @@ export interface FieldDefinition {
   fieldChoices?: SelectableItem[];
 }
 
-export interface FieldConfig {
-  absoluteDate: boolean;
-}
-
 export interface Field extends FieldDefinition {
   leftParenthesis?: string;
   logicalOperator?: FieldLogicalOperator;
@@ -65,9 +62,6 @@ export interface Field extends FieldDefinition {
   // Select/Organizer
   values: FieldValue[];
   organizers: OrganizerBase[];
-
-  // Dates
-  fieldConfig: FieldConfig;
 }
 
 export function useQueryFilterBuilder() {
@@ -184,6 +178,15 @@ export function useQueryFilterBuilder() {
     };
   });
 
+  const relativeDateRelOps = computed<Record<RelationalKeyword | RelationalOperator, FieldRelationalOperator>>(() => {
+    const ops = { ...relOps.value };
+
+    ops[">="] = { ...relOps.value[">="], label: i18n.t("query-filter.relational-operators.is-newer-than") };
+    ops["<="] = { ...relOps.value["<="], label: i18n.t("query-filter.relational-operators.is-older-than") };
+
+    return ops;
+  });
+
   function isOrganizerType(type: FieldType): type is Organizer {
     return (
       type === Organizer.Category
@@ -196,12 +199,8 @@ export function useQueryFilterBuilder() {
   };
 
   function getFieldFromFieldDef(field: Field | FieldDefinition, resetValue = false): Field {
-    const defaultFieldConfig: FieldConfig = {
-      absoluteDate: false,
-    };
     const updatedField = {
       logicalOperator: logOps.value.AND,
-      fieldConfig: defaultFieldConfig,
       ...field,
     } as Field;
 
@@ -244,6 +243,13 @@ export function useQueryFilterBuilder() {
             relOps.value[">="],
             relOps.value["<"],
             relOps.value["<="],
+          ];
+          break;
+        case "relativeDate":
+          operatorChoices = [
+            // "<=" is first since "older than" is the most common operator
+            relativeDateRelOps.value["<="],
+            relativeDateRelOps.value[">="],
           ];
           break;
         default:
@@ -348,6 +354,7 @@ export function useQueryFilterBuilder() {
   return {
     logOps,
     relOps,
+    relativeDateRelOps,
     placeholderKeywords,
     buildQueryFilterString,
     getFieldFromFieldDef,

--- a/frontend/composables/use-query-filter-builder.ts
+++ b/frontend/composables/use-query-filter-builder.ts
@@ -42,7 +42,7 @@ export interface FieldDefinition {
   type: FieldType;
 
   // only for select/organizer fields
-  fieldOptions?: SelectableItem[];
+  fieldChoices?: SelectableItem[];
 }
 
 export interface Field extends FieldDefinition {
@@ -50,7 +50,7 @@ export interface Field extends FieldDefinition {
   logicalOperator?: FieldLogicalOperator;
   value: FieldValue;
   relationalOperatorValue: FieldRelationalOperator;
-  relationalOperatorOptions: FieldRelationalOperator[];
+  relationalOperatorChoices: FieldRelationalOperator[];
   rightParenthesis?: string;
 
   // only for select/organizer fields
@@ -174,9 +174,9 @@ export function useQueryFilterBuilder() {
 
   function getFieldFromFieldDef(field: Field | FieldDefinition, resetValue = false): Field {
     const updatedField = { logicalOperator: logOps.value.AND, ...field } as Field;
-    let operatorOptions: FieldRelationalOperator[];
-    if (updatedField.fieldOptions?.length || isOrganizerType(updatedField.type)) {
-      operatorOptions = [
+    let operatorChoices: FieldRelationalOperator[];
+    if (updatedField.fieldChoices?.length || isOrganizerType(updatedField.type)) {
+      operatorChoices = [
         relOps.value["IN"],
         relOps.value["NOT IN"],
         relOps.value["CONTAINS ALL"],
@@ -185,7 +185,7 @@ export function useQueryFilterBuilder() {
     else {
       switch (updatedField.type) {
         case "string":
-          operatorOptions = [
+          operatorChoices = [
             relOps.value["="],
             relOps.value["<>"],
             relOps.value["LIKE"],
@@ -193,7 +193,7 @@ export function useQueryFilterBuilder() {
           ];
           break;
         case "number":
-          operatorOptions = [
+          operatorChoices = [
             relOps.value["="],
             relOps.value["<>"],
             relOps.value[">"],
@@ -203,10 +203,10 @@ export function useQueryFilterBuilder() {
           ];
           break;
         case "boolean":
-          operatorOptions = [relOps.value["="]];
+          operatorChoices = [relOps.value["="]];
           break;
         case "date":
-          operatorOptions = [
+          operatorChoices = [
             relOps.value["="],
             relOps.value["<>"],
             relOps.value[">"],
@@ -216,12 +216,12 @@ export function useQueryFilterBuilder() {
           ];
           break;
         default:
-          operatorOptions = [relOps.value["="], relOps.value["<>"]];
+          operatorChoices = [relOps.value["="], relOps.value["<>"]];
       }
     }
-    updatedField.relationalOperatorOptions = operatorOptions;
-    if (!operatorOptions.includes(updatedField.relationalOperatorValue)) {
-      updatedField.relationalOperatorValue = operatorOptions[0];
+    updatedField.relationalOperatorChoices = operatorChoices;
+    if (!operatorChoices.includes(updatedField.relationalOperatorValue)) {
+      updatedField.relationalOperatorValue = operatorChoices[0];
     }
 
     if (resetValue) {
@@ -271,7 +271,7 @@ export function useQueryFilterBuilder() {
         isValid = false;
       }
 
-      if (field.fieldOptions?.length || isOrganizerType(field.type)) {
+      if (field.fieldChoices?.length || isOrganizerType(field.type)) {
         if (field.values?.length) {
           let val: string;
           if (field.type === "string" || field.type === "date" || isOrganizerType(field.type)) {

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -221,7 +221,8 @@
     "show-advanced": "Show Advanced",
     "add-field": "Add Field",
     "date-created": "Date Created",
-    "date-updated": "Date Updated"
+    "date-updated": "Date Updated",
+    "days": "days"
   },
   "group": {
     "are-you-sure-you-want-to-delete-the-group": "Are you sure you want to delete <b>{groupName}<b/>?",
@@ -1432,6 +1433,10 @@
       "contains-all-of": "contains all of",
       "is-like": "is like",
       "is-not-like": "is not like"
+    },
+    "date": {
+      "days-relative-to-today": "Days relative to today",
+      "fixed-date": "Fixed date"
     }
   },
   "validators": {

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -221,8 +221,7 @@
     "show-advanced": "Show Advanced",
     "add-field": "Add Field",
     "date-created": "Date Created",
-    "date-updated": "Date Updated",
-    "days": "days"
+    "date-updated": "Date Updated"
   },
   "group": {
     "are-you-sure-you-want-to-delete-the-group": "Are you sure you want to delete <b>{groupName}<b/>?",
@@ -1423,7 +1422,9 @@
       "is-greater-than": "is greater than",
       "is-greater-than-or-equal-to": "is greater than or equal to",
       "is-less-than": "is less than",
-      "is-less-than-or-equal-to": "is less than or equal to"
+      "is-less-than-or-equal-to": "is less than or equal to",
+      "is-older-than": "is older than",
+      "is-newer-than": "is newer than"
     },
     "relational-keywords": {
       "is": "is",
@@ -1434,9 +1435,8 @@
       "is-like": "is like",
       "is-not-like": "is not like"
     },
-    "date": {
-      "days-relative-to-today": "Days relative to today",
-      "fixed-date": "Fixed date"
+    "dates": {
+      "days-ago": "days ago|day ago|days ago"
     }
   },
   "validators": {

--- a/frontend/lib/api/types/non-generated.ts
+++ b/frontend/lib/api/types/non-generated.ts
@@ -41,8 +41,9 @@ export enum Organizer {
   User = "users",
 }
 
-export type LogicalOperator = "AND" | "OR";
+export type PlaceholderKeyword = "$NOW";
 export type RelationalKeyword = "IS" | "IS NOT" | "IN" | "NOT IN" | "CONTAINS ALL" | "LIKE" | "NOT LIKE";
+export type LogicalOperator = "AND" | "OR";
 export type RelationalOperator = "=" | "<>" | ">" | "<" | ">=" | "<=";
 
 export interface QueryFilterJSON {

--- a/frontend/pages/g/[groupSlug]/cookbooks/index.vue
+++ b/frontend/pages/g/[groupSlug]/cookbooks/index.vue
@@ -39,7 +39,7 @@
 
     <!-- Cookbook Page -->
     <!-- Page Title -->
-    <v-container max-width="1000">
+    <v-container class="lg-container">
       <BasePageTitle divider>
         <template #header>
           <v-img width="100%" max-height="100" max-width="100" src="/svgs/manage-cookbooks.svg" />

--- a/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -667,7 +667,7 @@ export default defineNuxtComponent({
       {
         name: "last_made",
         label: i18n.t("general.last-made"),
-        type: "date",
+        type: "relativeDate",
       },
     ];
 

--- a/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -664,6 +664,11 @@ export default defineNuxtComponent({
         label: i18n.t("user.users"),
         type: Organizer.User,
       },
+      {
+        name: "last_made",
+        label: i18n.t("general.last-made"),
+        type: "date",
+      },
     ];
 
     function clearQueryFilter() {

--- a/frontend/pages/household/mealplan/settings.vue
+++ b/frontend/pages/household/mealplan/settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="md-container">
+  <v-container class="lg-container">
     <BasePageTitle divider>
       <template #header>
         <v-img

--- a/mealie/services/query_filter/builder.py
+++ b/mealie/services/query_filter/builder.py
@@ -39,6 +39,12 @@ class QueryFilterJSON(MealieModel):
 class QueryFilterBuilderComponent:
     """A single relational statement"""
 
+    raw_value: str | list[str] | None
+    """The raw value parsed from the query filter string, before processing placeholder keywords"""
+
+    value: str | list[str] | None
+    """The value parsed from the query filter string, after processing placeholder keywords"""
+
     @staticmethod
     def strip_quotes_from_string(val: str) -> str:
         if len(val) > 2 and val[0] == '"' and val[-1] == '"':
@@ -76,12 +82,12 @@ class QueryFilterBuilderComponent:
                     f'invalid query string: "{relationship.value}" can only be used with "NULL", not "{value}"'
                 )
 
-            self.value = None
+            self.raw_value = None
         else:
-            self.value = value
+            self.raw_value = value
 
         # process placeholder keywords
-        self.value = PlaceholderKeyword.parse_value(self.value)
+        self.value = PlaceholderKeyword.parse_value(self.raw_value)
 
     def __repr__(self) -> str:
         return f"[{self.attribute_name} {self.relationship.value} {self.value}]"
@@ -138,7 +144,7 @@ class QueryFilterBuilderComponent:
             logical_operator=None,
             attribute_name=self.attribute_name,
             relational_operator=self.relationship,
-            value=self.value,
+            value=self.raw_value,  # we use the raw value to preserve placeholder keywords
         )
 
 

--- a/tests/unit_tests/repository_tests/test_query_filter_builder.py
+++ b/tests/unit_tests/repository_tests/test_query_filter_builder.py
@@ -60,3 +60,17 @@ def test_query_filter_builder_json():
             ),
         ]
     )
+
+
+def test_query_filter_builder_json_uses_raw_value():
+    qf = "last_made <= $NOW-30d"
+    builder = QueryFilterBuilder(qf)
+    assert builder.as_json_model() == QueryFilterJSON(
+        parts=[
+            QueryFilterJSONPart(
+                attribute_name="last_made",
+                relational_operator=RelationalOperator.LTE,
+                value="$NOW-30d",
+            ),
+        ]
+    )


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Follow up to https://github.com/mealie-recipes/mealie/pull/6984 which enabled query filters using relative dates. This adds limited support to the UI.

There's a new internal `FieldType` of `relativeDate`. Currently only `last_made` uses this field type. This is what the UI looks like:

<img width="1091" height="236" alt="image" src="https://github.com/user-attachments/assets/6f7b35ad-b769-4ac2-a527-051b9ebe42cb" />

Where your only two operators are:
<img width="193" height="159" alt="image" src="https://github.com/user-attachments/assets/2fbba942-efb2-4a35-b4b8-7f1eb44e07cc" />

"days ago" is translatable, and supports zero/one/multiple (i.e. `1 day ago`):

<img width="170" height="75" alt="image" src="https://github.com/user-attachments/assets/bef351b1-3a42-4f4f-bb3c-1371338eff09" />
<img width="161" height="63" alt="image" src="https://github.com/user-attachments/assets/e541519d-77a5-4dc8-b8ed-01947f09a513" />

This was added to both meal plan rules and the recipe finder. I didn't add this to cookbooks because I don't think it makes sense for cookbooks to be dynamic.

There are several intentional limitations of this UI:
- Only "negative" displacements are supported (e.g. you cannot set a value of "30 days in the future"; you can _only_ set X days ago, including "0 days ago")
- Only intervals of days are supported (so if you want to do months/years you must convert to days. You cannot do hours/minutes/seconds)
- "older than" includes the day (e.g. "older than 30 days" translates to `date <= $NOW-30d`)
- "newer than" _also_ includes the day (e.g. "newer than 30 days" translates to `date >= $NOW-30d`)
- Fields configured as relative dates _cannot_ use absolute dates, and vice versa (e.g. `created_at` can _only_ reference an _absolute_ date; `last_made` can _only_ reference a _relative_ date)

I tried to support a few more configurations but implementation of this got extremely complicated, so I came up with a simpler approach (which is still kind of complicated under the hood but the UX is _very_ simple). The complexity of the UX was not at all worth the added value of slightly more configuration when 99.99% of users aren't going to care. Users always have the option of setting custom queries via the backend if they really want to.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

Would love some feedback on whether or not this implementation is intuitive. I think it is, but I wrote it 😄

I also made a few layout tweaks to support larger queries. Not really relevant for the new feature, but it was helpful during development and I think it's a marginal improvement so I left it in.

## Testing

_(fill-in or delete this section)_

Created simple Meal Plan rules which were properly respected, including compound queries with multiple date rules. This is mostly taken care of in [the backend PR](https://github.com/mealie-recipes/mealie/pull/6984), though.