### PR TITLE
feat: Add Docker metadata to published images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,14 @@ jobs:
 
       - uses: depot/setup-action@v1
 
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            hkotel/mealie
+            ghcr.io/${{ github.repository }}
+
       - name: Retrieve Python package
         uses: actions/download-artifact@v4
         with:
@@ -57,5 +65,8 @@ jobs:
             hkotel/mealie:${{ inputs.tag }}
             ghcr.io/${{ github.repository }}:${{ inputs.tag }}
             ${{ inputs.tags }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ inputs.tag }}
           build-args: |
             COMMIT=${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,9 @@ jobs:
           images: |
             hkotel/mealie
             ghcr.io/${{ github.repository }}
+          # Overwrite the image.version label with our tag
+          labels: |
+            org.opencontainers.image.version=${{ inputs.tag }}
 
       - name: Retrieve Python package
         uses: actions/download-artifact@v4
@@ -65,8 +68,6 @@ jobs:
             hkotel/mealie:${{ inputs.tag }}
             ghcr.io/${{ github.repository }}:${{ inputs.tag }}
             ${{ inputs.tags }}
-          labels: |
-            ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.version=${{ inputs.tag }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             COMMIT=${{ github.sha }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,7 +111,6 @@ RUN . $VENV_PATH/bin/activate \
 # Production Image
 ###############################################
 FROM python-base AS production
-LABEL org.opencontainers.image.source="https://github.com/mealie-recipes/mealie"
 ENV PRODUCTION=true
 ENV TESTING=false
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Adds some basic Docker metadata labels to our published images. This includes labels like:
- org.opencontainers.image.title
- org.opencontainers.image.created
- etc.

`org.opencontainers.image.created` in particular [resolves some issues with services like unraid](https://github.com/mealie-recipes/mealie/discussions/7006).

See: https://github.com/docker/metadata-action

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, suggested in https://github.com/mealie-recipes/mealie/discussions/7006