### PR TITLE
fix: Search bar width

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -33,9 +33,8 @@
 
         <v-btn
           v-if="$vuetify.display.xs"
+          icon
           size="x-small"
-          class="rounded-circle"
-          light
           @click="dialog = false"
         >
           <v-icon>

--- a/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
+++ b/frontend/components/Domain/Recipe/RecipeDialogSearch.vue
@@ -12,6 +12,7 @@
         dark
         color="primary-lighten-1 top-0 position-relative left-0"
         :rounded="!$vuetify.display.xs"
+        style="width: 100%;"
       >
         <v-text-field
           id="arrow-search"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes the search bar width to match the rest of the modal.

Before:
<img width="1024" height="168" alt="image" src="https://github.com/user-attachments/assets/42f29ae7-4a1a-476c-8961-f70b21d8e2f7" />

After:
<img width="1012" height="151" alt="image" src="https://github.com/user-attachments/assets/42ebee81-dd8f-411c-9968-25db7af04aa0" />

Also fixes the button on smaller screens not actually being a circle.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A