### PR TITLE
feat: Improve recipe filter search ordering

### DIFF
--- a/frontend/components/Domain/SearchFilter.vue
+++ b/frontend/components/Domain/SearchFilter.vue
@@ -147,6 +147,8 @@
 
 <script lang="ts">
 import { watchDebounced } from "@vueuse/core";
+import type { IFuseOptions } from "fuse.js";
+import Fuse from "fuse.js";
 
 export interface SelectableItem {
   id: string;
@@ -182,6 +184,15 @@ export default defineNuxtComponent({
     // Use shallowRef for better performance with arrays
     const debouncedSearch = shallowRef("");
 
+    const fuseOptions: IFuseOptions<SelectableItem> = {
+      keys: ["name"],
+      ignoreLocation: true,
+      shouldSort: true,
+      threshold: 0.3,
+      minMatchCharLength: 1,
+      findAllMatches: false,
+    };
+
     const combinator = computed({
       get: () => (props.requireAll ? "hasAll" : "hasAny"),
       set: (value) => {
@@ -209,19 +220,28 @@ export default defineNuxtComponent({
       (newSearch) => {
         debouncedSearch.value = newSearch;
       },
-      { debounce: 500, maxWait: 1500, immediate: false }, // Increased debounce time
+      { debounce: 500, maxWait: 1500, immediate: false },
     );
+
+    const fuse = computed(() => {
+      return new Fuse(props.items || [], fuseOptions);
+    });
 
     const filtered = computed(() => {
       const items = props.items;
-      const search = debouncedSearch.value;
+      const search = debouncedSearch.value.trim();
 
-      if (!search || search.length < 2) { // Only filter after 2 characters
+      // If no search query or less than 2 characters, return all items
+      if (!search || search.length < 2) {
         return items;
       }
 
-      const searchLower = search.toLowerCase();
-      return items.filter(item => item.name.toLowerCase().includes(searchLower));
+      if (!items || items.length === 0) {
+        return [];
+      }
+
+      const results = fuse.value.search(search);
+      return results.map(result => result.item);
     });
 
     const selectedCount = computed(() => selected.value.length);


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Uses `fuse.js` for searching/ordering filters.

Before:
<img width="418" height="487" alt="image" src="https://github.com/user-attachments/assets/ffe4807c-eb01-4897-ac50-cb00db782ef5" />

After:
<img width="411" height="489" alt="image" src="https://github.com/user-attachments/assets/7983e848-2e4a-4cd1-b19d-23e7a6f73634" />

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7035

## Special notes for your reviewer:

_(fill-in or delete this section)_

I cannot believe how insanely easy this was.