### PR TITLE
fix: Show minimum value for quantity

### DIFF
--- a/frontend/composables/recipes/use-recipe-ingredients.test.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.test.ts
@@ -205,4 +205,34 @@ describe("parseIngredientText", () => {
 
     expect(parseIngredientText(ingredient)).toEqual("2 tablespoons diced onion");
   });
+
+  test("decimal below minimum precision shows < 0.001", () => {
+    const ingredient = createRecipeIngredient({
+      quantity: 0.0001,
+      unit: { id: "1", name: "cup", useAbbreviation: false },
+      food: { id: "1", name: "salt" },
+    });
+
+    expect(parseIngredientText(ingredient)).toEqual("&lt; 0.001 cup salt");
+  });
+
+  test("fraction below minimum denominator shows < 1/10", () => {
+    const ingredient = createRecipeIngredient({
+      quantity: 0.05,
+      unit: { id: "1", name: "cup", fraction: true, useAbbreviation: false },
+      food: { id: "1", name: "salt" },
+    });
+
+    expect(parseIngredientText(ingredient)).toEqual("&lt; <sup>1</sup><span>⁄</span><sub>10</sub> cup salt");
+  });
+
+  test("fraction below minimum denominator without formatting shows < 1/10", () => {
+    const ingredient = createRecipeIngredient({
+      quantity: 0.05,
+      unit: { id: "1", name: "cup", fraction: true, useAbbreviation: false },
+      food: { id: "1", name: "salt" },
+    });
+
+    expect(parseIngredientText(ingredient, 1, false)).toEqual("&lt; 1/10 cup salt");
+  });
 });

--- a/frontend/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.ts
@@ -5,6 +5,9 @@ import type { CreateIngredientFood, CreateIngredientUnit, IngredientFood, Ingred
 
 const { frac } = useFraction();
 
+const FRAC_MIN_DENOM = 10;
+const DECIMAL_PRECISION = 3;
+
 export function sanitizeIngredientHTML(rawHtml: string) {
   return DOMPurify.sanitize(rawHtml, {
     USE_PROFILES: { html: true },
@@ -91,11 +94,19 @@ export function useIngredientTextParser() {
 
     // casting to number is required as sometimes quantity is a string
     if (quantity && Number(quantity) !== 0) {
+      const scaledQuantity = Number((quantity * scale));
+
       if (unit && !unit.fraction) {
-        returnQty = Number((quantity * scale).toPrecision(3)).toString();
+        const minVal = 10 ** -DECIMAL_PRECISION;
+        returnQty = scaledQuantity >= minVal
+          ? Number(scaledQuantity.toPrecision(DECIMAL_PRECISION)).toString()
+          : `< ${minVal}`;
       }
       else {
-        const fraction = frac(quantity * scale, 10, true);
+        const minVal = 1 / FRAC_MIN_DENOM;
+        const isUnderMinVal = !(scaledQuantity >= minVal);
+
+        const fraction = !isUnderMinVal ? frac(scaledQuantity, FRAC_MIN_DENOM, true) : [0, 1, FRAC_MIN_DENOM];
         if (fraction[0] !== undefined && fraction[0] > 0) {
           returnQty += fraction[0];
         }
@@ -104,6 +115,10 @@ export function useIngredientTextParser() {
           returnQty += includeFormating
             ? `<sup>${fraction[1]}</sup><span>&frasl;</span><sub>${fraction[2]}</sub>`
             : ` ${fraction[1]}/${fraction[2]}`;
+        }
+
+        if (isUnderMinVal) {
+          returnQty = `< ${returnQty}`;
         }
       }
     }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

When we have really small quantities (e.g. 0.00001) we don't render anything. This can be very confusing to the user where they see gems such as "tsp sugar" (where it should be 0.00001 tsp sugar). This happens mostly when scaling recipes down.

This PR implements the following logic:
- For fractions smaller than 1/10, show "< 1/10"
- For decimals smaller than 0.0001, show "< 0.0001"
<img width="189" height="153" alt="image" src="https://github.com/user-attachments/assets/cc14cdb1-e812-466f-b1e4-739b05be12e8" />

These values are the same as what they are today, except instead of just disappearing we show these strings.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7074

## Testing

_(fill-in or delete this section)_

Added tests