### PR TITLE
fix: Exclude docs/redoc from frontend route cache

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -219,7 +219,7 @@ export default defineNuxtConfig({
     },
     workbox: {
       navigateFallback: "/",
-      navigateFallbackAllowlist: [/^(?!\/api)/],
+      navigateFallbackAllowlist: [/^(?!\/api|\/docs|\/redoc)/],
       globPatterns: ["**/*.{js,css,html,png,svg,ico}"],
       globIgnores: ["404.html", "200.html"],
       cleanupOutdatedCaches: true,


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Excludes the docs/redoc endpoints from being routed to the frontend.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7081

## Testing

_(fill-in or delete this section)_

Not too sure how to test this one since it's a cache/offline issue, so I'm just going to merge it and hope it works 👍