### PR TITLE
feat: Auto-adjust shopping list item autofocus

### DIFF
--- a/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -30,6 +30,7 @@
             :items="foods"
             :label="$t('shopping-list.food')"
             :icon="$globals.icons.foods"
+            :autofocus="autoFocus === 'food'"
             create
             @create="createAssignFood"
           />
@@ -41,7 +42,7 @@
             :label="$t('shopping-list.note')"
             rows="1"
             auto-grow
-            autofocus
+            :autofocus="autoFocus === 'note'"
             @keypress="handleNoteKeyPress"
           />
         </div>
@@ -165,6 +166,8 @@ export default defineNuxtComponent({
       },
     );
 
+    const autoFocus = !listItem.value.food && listItem.value.note ? "note" : "food";
+
     async function createAssignFood(val: string) {
       // keep UI reactive
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -204,6 +207,7 @@ export default defineNuxtComponent({
 
     return {
       listItem,
+      autoFocus,
       createAssignFood,
       createAssignUnit,
       assignLabelToFood,


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Currently when editing a shopping list item we auto focus on "note". This doesn't really make sense anymore since the primary workflow uses foods rather than notes.

Now when a shopping list item is being edited, auto focus will dynamically choose food or note:
- If there is a note but no food, auto focus on note
- Else, focus on food

This means new items (or items with a food) will focus on food, while items with only a note will focus on note.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, brought up in https://github.com/mealie-recipes/mealie/discussions/7095

## Testing

_(fill-in or delete this section)_

Manually tested all scenarios for new/existing list items.