### PR TITLE
fix: Use raw note text for unparsed ingredients sent to NLP parser

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -373,7 +373,18 @@ async function parseIngredients() {
   try {
     const ingsAsString = props.ingredients
       .filter(ing => !ing.referencedRecipe)
-      .map(ing => parseIngredientText(ing, 1, false) ?? "");
+      .map((ing) => {
+        // If the ingredient has not been parsed into structured data (no food and no unit),
+        // the note field contains the full original ingredient text. Using
+        // parseIngredientText in this case would incorrectly prepend the quantity to the
+        // note, producing strings like "1 1/2 cup apples" instead of "1/2 cup apples".
+        // See: https://github.com/mealie-recipes/mealie/issues/7079
+        const isUnparsed = !ing.food && !ing.unit;
+        if (isUnparsed) {
+          return ing.originalText || ing.note || "";
+        }
+        return parseIngredientText(ing, 1, false) ?? "";
+      });
     const { data, error } = await api.recipes.parseIngredients(parser.value, ingsAsString);
     if (error || !data) {
       throw new Error("Failed to parse ingredients");

--- a/frontend/composables/recipes/use-recipe-ingredients.test.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.test.ts
@@ -235,4 +235,28 @@ describe("parseIngredientText", () => {
 
     expect(parseIngredientText(ingredient, 1, false)).toEqual("&lt; 1/10 cup salt");
   });
+
+  // Regression test for https://github.com/mealie-recipes/mealie/issues/7079
+  // Unparsed ingredients (no food, no unit) store the full text in the note field.
+  // When such an ingredient also has a quantity (e.g. from a forced-quantity setting),
+  // parseIngredientText incorrectly prepends that quantity to the note, producing
+  // strings like "1 1/2 cup apples" instead of the original "1/2 cup apples".
+  // Callers constructing strings for the NLP parser should use the note directly
+  // for unparsed ingredients instead of calling parseIngredientText.
+  test("unparsed ingredient with quantity prepends quantity to note (issue #7079)", () => {
+    const ingredient = createRecipeIngredient({
+      quantity: 1,
+      unit: undefined,
+      food: undefined,
+      note: "1/2 cup apples",
+    });
+
+    // This demonstrates the problematic behavior: parseIngredientText combines
+    // the quantity field with the note, producing "1 1/2 cup apples"
+    const result = parseIngredientText(ingredient, 1, false);
+    expect(result).toEqual("1 1/2 cup apples");
+
+    // The note alone contains the correct text for NLP parsing
+    expect(ingredient.note).toEqual("1/2 cup apples");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #7079

When ingredients have not been parsed into structured data (no food and no unit set), the note field contains the full original ingredient text (e.g. 1/2 cup apples). The parse dialog was using parseIngredientText() to construct the string sent to the NLP parser for all ingredients, including unparsed ones. For unparsed ingredients that also have a quantity value (e.g. from a forced-quantity setting that sets everything to 1), this incorrectly prepended the quantity to the note:

- **Before (broken):** parseIngredientText({quantity: 1, note: '1/2 cup apples'}) produces '1 1/2 cup apples' -- NLP sees 1.5 cups
- **After (fixed):** Unparsed ingredients use originalText or note directly, producing '1/2 cup apples' -- NLP sees 0.5 cup

### Changes

- **RecipePageParseDialog.vue**: When building strings to send to the parser, detect unparsed ingredients (no food AND no unit) and use the raw originalText or note field instead of parseIngredientText(). Already-parsed ingredients (which have structured food/unit data) continue using parseIngredientText() as before.
- **use-recipe-ingredients.test.ts**: Added a regression test documenting the problematic behavior of parseIngredientText() with unparsed ingredients that have a quantity, so future developers understand why the caller-side check is necessary.

### How it works

An ingredient is considered unparsed when both food and unit are falsy. In this state:
- The note field contains the complete ingredient string (e.g. 1/2 cup apples)
- The quantity field may contain a meaningless default value (e.g. 1 from a forced-quantity feature)
- parseIngredientText() would combine them into 1 1/2 cup apples, corrupting the NLP input

The fix bypasses parseIngredientText() for these unparsed ingredients and sends the raw text directly.

## Test plan

- [x] Existing frontend unit tests pass (21/21 in use-recipe-ingredients.test.ts)
- [x] New regression test added documenting the issue
- [ ] Manual test: Import a recipe, set all ingredient quantities to 1 (simulating forced-quantity), run the NLP parser -- quantities should now parse correctly from the note text
- [ ] Manual test: Parse ingredients that already have structured food/unit data -- these should continue working as before