### PR TITLE
fix(deps): update dependency fastapi to v0.133.1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,6 +57,7 @@ _(fill-in or delete this section)_
 ## Testing
 
 _(fill-in or delete this section)_
+
 <!--
   Describe how you tested this change.
 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "apprise==1.9.7",
     "bcrypt==5.0.0",
     "extruct==0.18.0",
-    "fastapi==0.131.0",
+    "fastapi==0.133.1",
     "httpx==0.28.1",
     "lxml==6.0.2",
     "orjson==3.11.7",

--- a/tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py
+++ b/tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py
@@ -217,7 +217,7 @@ def test_preserve_future_made_date(api_client: TestClient, unique_user: TestUser
     future_dt = datetime.now(UTC) + timedelta(days=random_int(1, 10))
     response = api_client.patch(
         api_routes.recipes_slug_last_made(recipe.slug),
-        data=RecipeLastMade(timestamp=future_dt).model_dump_json(),
+        json=RecipeLastMade(timestamp=future_dt).model_dump(mode="json"),
         headers=unique_user.token,
     )
     assert response.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -399,7 +399,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.133.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -408,9 +408,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/32/158cbf685b7d5a26f87131069da286bf10fc9fbf7fc968d169d48a45d689/fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff", size = 369612, upload-time = "2026-02-22T16:38:11.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/6f/0eafed8349eea1fa462238b54a624c8b408cd1ba2795c8e64aa6c34f8ab7/fastapi-0.133.1.tar.gz", hash = "sha256:ed152a45912f102592976fde6cbce7dae1a8a1053da94202e51dd35d184fadd6", size = 378741, upload-time = "2026-02-25T18:18:17.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/94/b58ec24c321acc2ad1327f69b033cadc005e0f26df9a73828c9e9c7db7ce/fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a", size = 103854, upload-time = "2026-02-22T16:38:09.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/a175a7779f3599dfa4adfc97a6ce0e157237b3d7941538604aadaf97bfb6/fastapi-0.133.1-py3-none-any.whl", hash = "sha256:658f34ba334605b1617a65adf2ea6461901bdb9af3a3080d63ff791ecf7dc2e2", size = 109029, upload-time = "2026-02-25T18:18:18.578Z" },
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "extruct", specifier = "==0.18.0" },
-    { name = "fastapi", specifier = "==0.131.0" },
+    { name = "fastapi", specifier = "==0.133.1" },
     { name = "html2text", specifier = "==2025.4.15" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "ingredient-parser-nlp", specifier = "==2.5.0" },


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Upgrades FastAPI and fixes a test which doesn't set the correct content type. This is needed due to a breaking change in `v0.132.0`.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Replaces https://github.com/mealie-recipes/mealie/pull/7127

## Special notes for your reviewer:

_(fill-in or delete this section)_

I checked for other places this might impact the app and there aren't any. The only other time we're doing something like this we're explicitly setting the content type.

## Testing

_(fill-in or delete this section)_

Pytest.

## AI / LLM Assistance

_(REQUIRED)_

Used Copilot to scan for other similar patterns in our tests and in the frontend.