### PR TITLE
fix: data management food edit / create

### DIFF
--- a/frontend/pages/group/data/foods.vue
+++ b/frontend/pages/group/data/foods.vue
@@ -307,6 +307,7 @@ const formItems = computed<AutoFormItems>(() => [
     varName: "labelId",
     type: fieldTypes.SELECT,
     options: labelOptions.value,
+    selectReturnValue: "value",
   },
   {
     label: i18n.t("tool.on-hand"),


### PR DESCRIPTION
## What this PR does / why we need it:

Foods were created and edited by returning the wrong return value (their name instead of their id) which this fixes. 

## Which issue(s) this PR fixes:

- fixes #7147

## Special notes for your reviewer:

None

## Testing

Manual

## AI / LLM Assistance

None