### PR TITLE
Add dietary restriction labels to default seed data

### DIFF
--- a/mealie/repos/seed/resources/labels/locales/en-US.json
+++ b/mealie/repos/seed/resources/labels/locales/en-US.json
@@ -61,5 +61,20 @@
     },
     {
         "name": "Other"
+    },
+    {
+        "name": "Vegan"
+    },
+    {
+        "name": "Vegetarian"
+    },
+    {
+        "name": "Plant-Based"
+    },
+    {
+        "name": "Dairy-Free"
+    },
+    {
+        "name": "Gluten-Free"
     }
 ]


### PR DESCRIPTION
## Summary

Adds five dietary restriction labels to the en-US seed data:

- Vegan
- Vegetarian
- Plant-Based
- Dairy-Free
- Gluten-Free

## Motivation

These are among the most frequently-used shopping list label categories for users who track dietary restrictions. They are absent from the current default label set, which means every user who wants them must create them manually before they can begin labeling items.

Adding them to the seed data reduces friction for new installations and aligns with the existing set of general grocery categories (Produce, Dairy Products, Health Foods, etc.).

## Changes

- `mealie/repos/seed/resources/labels/locales/en-US.json` — five new label entries appended after "Other"

This is a purely additive change to a JSON seed file. No code paths, database schema, or existing labels are affected.

Translations for other locales can follow through the existing Crowdin workflow once this is merged.