### PR TITLE
fix: unparsed ingredients with quantities are poorly formatted when fed to NLP

### DIFF
--- a/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -373,7 +373,7 @@ async function parseIngredients() {
   try {
     const ingsAsString = props.ingredients
       .filter(ing => !ing.referencedRecipe)
-      .map(ing => parseIngredientText(ing, 1, false) ?? "");
+      .map(ing => parseIngredientText(ing, 1, false, true) ?? "");
     const { data, error } = await api.recipes.parseIngredients(parser.value, ingsAsString);
     if (error || !data) {
       throw new Error("Failed to parse ingredients");

--- a/frontend/composables/recipes/use-recipe-ingredients.test.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.test.ts
@@ -5,7 +5,7 @@ import { useLocales } from "../use-locales";
 
 vi.mock("../use-locales");
 
-let parseIngredientText: (ingredient: RecipeIngredient, scale?: number, includeFormating?: boolean) => string;
+let parseIngredientText: (ingredient: RecipeIngredient, scale?: number, includeFormating?: boolean, forParsing?: boolean) => string;
 
 describe("parseIngredientText", () => {
   beforeEach(() => {
@@ -234,5 +234,43 @@ describe("parseIngredientText", () => {
     });
 
     expect(parseIngredientText(ingredient, 1, false)).toEqual("&lt; 1/10 cup salt");
+  });
+
+  test("forParsing: unparsed ingredient with quantity uses note directly", () => {
+    // This tests the fix for issue #7079
+    // When an unparsed ingredient has quantity=1 and note="1/2 cup apples",
+    // forParsing=true should return "1/2 cup apples" (not "1 1/2 cup apples")
+    const ingredient: RecipeIngredient = {
+      quantity: 1,
+      note: "1/2 cup apples",
+      food: undefined,
+      unit: undefined,
+    };
+
+    expect(parseIngredientText(ingredient, 1, false, true)).toEqual("1/2 cup apples");
+  });
+
+  test("forParsing: parsed ingredient with food/unit still formats normally", () => {
+    const ingredient = createRecipeIngredient({
+      quantity: 1,
+      unit: { id: "1", name: "cup", useAbbreviation: false },
+      food: { id: "1", name: "apples" },
+      note: "diced",
+    });
+
+    expect(parseIngredientText(ingredient, 1, false, true)).toEqual("1 cup apples diced");
+  });
+
+  test("forParsing: false (default) still prepends quantity to unparsed ingredient", () => {
+    const ingredient: RecipeIngredient = {
+      quantity: 1,
+      note: "1/2 cup apples",
+      food: undefined,
+      unit: undefined,
+    };
+
+    // Default behavior (forParsing=false or omitted) prepends quantity
+    expect(parseIngredientText(ingredient, 1, false, false)).toEqual("1 1/2 cup apples");
+    expect(parseIngredientText(ingredient, 1, false)).toEqual("1 1/2 cup apples");
   });
 });

--- a/frontend/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/composables/recipes/use-recipe-ingredients.ts
@@ -135,7 +135,13 @@ export function useIngredientTextParser() {
     };
   };
 
-  function parseIngredientText(ingredient: RecipeIngredient, scale = 1, includeFormating = true): string {
+  function parseIngredientText(ingredient: RecipeIngredient, scale = 1, includeFormating = true, forParsing = false): string {
+    // When parsing unparsed ingredients (no food and no unit), use the note directly
+    // to avoid duplicating quantities (e.g., "1 1/2 cup apples" from quantity=1 + note="1/2 cup apples")
+    if (forParsing && !ingredient.food && !ingredient.unit && ingredient.note) {
+      return sanitizeIngredientHTML(ingredient.note);
+    }
+
     const { quantity, unit, name, note } = useParsedIngredientText(ingredient, scale, includeFormating);
 
     const text = `${quantity || ""} ${unit || ""} ${name || ""} ${note || ""}`.replace(/ {2,}/g, " ").trim();


### PR DESCRIPTION
## What this PR does

Fixes #7079

When unparsed ingredients (no food/unit) have a quantity field set and the note contains its own quantity, the `parseIngredientText` function was prepending the quantity field, resulting in incorrect parsing.

### Example of the bug:
- Ingredient has: `quantity=1`, `note="1/2 cup apples"`
- Before fix: sent `"1 1/2 cup apples"` to NLP parser → parses as 1.5 cups
- After fix: sends `"1/2 cup apples"` to NLP parser → parses as 0.5 cups

## How it works

Adds a `forParsing` parameter to `parseIngredientText`. When:
- `forParsing=true` AND
- ingredient is unparsed (no food and no unit) AND  
- ingredient has a note

...the note is returned directly without prepending the quantity.

This preserves existing display behavior while fixing the NLP parsing case.

## Changes

1. **`use-recipe-ingredients.ts`**: Added `forParsing` parameter to `parseIngredientText()`
2. **`RecipePageParseDialog.vue`**: Pass `forParsing=true` when calling parser
3. **Tests**: Added 3 new tests covering the fix

## Testing

Added unit tests:
- `forParsing: unparsed ingredient with quantity uses note directly`
- `forParsing: parsed ingredient with food/unit still formats normally`
- `forParsing: false (default) still prepends quantity to unparsed ingredient`

## Checklist

- [x] Changes are properly tested
- [x] Changes are backwards compatible (default behavior unchanged)
- [x] Code follows project conventions