### PR TITLE
fix: allow unsetting recipe ratings via UI

### DIFF
--- a/frontend/components/Domain/Recipe/RecipeRating.vue
+++ b/frontend/components/Domain/Recipe/RecipeRating.vue
@@ -69,13 +69,15 @@ export default defineNuxtComponent({
     });
 
     // if a user unsets their rating, we don't want to fall back to the group rating since it's out of sync
+    // this also handles showing the user rating input after they clear their rating
     const hideGroupRating = ref(!!userRating.value);
     watch(
       () => userRating.value,
-      () => {
-        if (userRating.value) {
+      (newVal) => {
+        if (newVal) {
           hideGroupRating.value = true;
         }
+        // When rating is cleared (undefined), keep showing user rating input so they can rate again
       },
     );
 
@@ -84,12 +86,18 @@ export default defineNuxtComponent({
     });
 
     function updateRating(val?: number) {
-      if (!isOwnGroup.value || !val) {
+      if (!isOwnGroup.value) {
+        return;
+      }
+
+      // Allow val to be 0 (unset rating) - only return if undefined/null
+      if (val === undefined || val === null) {
         return;
       }
 
       if (!props.emitOnly) {
-        setRating(props.slug, val || 0, null);
+        // Send 0 to clear rating, otherwise send the actual rating
+        setRating(props.slug, val, null);
       }
       context.emit("update:modelValue", val);
     }

--- a/mealie/routes/users/ratings.py
+++ b/mealie/routes/users/ratings.py
@@ -53,23 +53,26 @@ class UserRatingsController(BaseUserController):
 
     @router.post("/{id}/ratings/{slug}")
     def set_rating(self, id: UUID4, slug: str, data: UserRatingUpdate):
-        """Sets the user's rating for a recipe"""
+        """Sets the user's rating for a recipe. Use rating=0 to unset/clear the rating."""
         assert_user_change_allowed(id, self.user, self.user)
 
         recipe = self.get_recipe_or_404(slug)
         user_rating = self.repos.user_ratings.get_by_user_and_recipe(id, recipe.id)
         if not user_rating:
-            self.repos.user_ratings.create(
-                UserRatingCreate(
-                    user_id=id,
-                    recipe_id=recipe.id,
-                    rating=data.rating,
-                    is_favorite=data.is_favorite or False,
+            # Only create if rating is non-zero (0 means clear/no rating)
+            if data.rating is None or data.rating > 0:
+                self.repos.user_ratings.create(
+                    UserRatingCreate(
+                        user_id=id,
+                        recipe_id=recipe.id,
+                        rating=data.rating,
+                        is_favorite=data.is_favorite or False,
+                    )
                 )
-            )
         else:
+            # Handle rating update: 0 clears to None, otherwise update normally
             if data.rating is not None:
-                user_rating.rating = data.rating
+                user_rating.rating = data.rating if data.rating > 0 else None
             if data.is_favorite is not None:
                 user_rating.is_favorite = data.is_favorite
 


### PR DESCRIPTION
## Problem
Fixes #7162

When a recipe has a rating, there was no way to set that rating back to blank/zero through the UI. Clicking the clear button on the rating component had no effect.

## Root Cause
The frontend `updateRating()` function had a check `if (!isOwnGroup.value || !val)` which treated 0 as falsy and rejected it.

## Solution
1. **Frontend (`RecipeRating.vue`)**: 
   - Fixed the condition to only reject `undefined` and `null`, allowing 0
   - Send 0 to backend to signal "clear rating"

2. **Backend (`ratings.py`)**:
   - Handle `rating=0` as a signal to clear the rating to `None` in the database
   - Don't create a new rating record if user clears (rating=0) on an unrated recipe

## Testing
1. Open a recipe page
2. Set a rating (e.g., 4 stars)
3. Click the clear button (X) on the rating component
4. Rating should now be unset/blank
5. The user rating input remains visible so you can rate again

## Changes
- `frontend/components/Domain/Recipe/RecipeRating.vue` - Fixed `updateRating()` to allow val=0
- `mealie/routes/users/ratings.py` - Handle rating=0 to clear rating to None