### PR TITLE
feat: Add enviroment variable to set default locale

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -17,7 +17,7 @@
 | TZ                            |          UTC          | Must be set to get correct date/time on the server                                                                                                      |
 | ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                                                                                        |
 | ALLOW_PASSWORD_LOGIN          |         true          | Whether or not to display the username+password input fields. Keep set to true unless you use OIDC authentication                                       |
-| DEFAULT_LOCALE                |         en-US         | The default locale/language for the frontend when no user preference is set (e.g. `en-US`, `de-DE`, `fr-FR`, `nl-NL`)                                   |
+| DEFAULT_LOCALE                |         auto          | The default locale/language for the frontend. Set to `auto` to detect from browser language, or a specific locale (e.g. `en-US`, `de-DE`, `fr-FR`, `nl-NL`) |
 | LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                                                                                      |
 | LOG_LEVEL                     |         info          | Logging level (e.g. critical, error, warning, info, debug)                                                                                              |
 | DAILY_SCHEDULE_TIME           |         23:45         | The time of day to run daily server tasks, in HH:MM format. Use the server's local time, *not* UTC                                                      |

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -17,6 +17,7 @@
 | TZ                            |          UTC          | Must be set to get correct date/time on the server                                                                                                      |
 | ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                                                                                        |
 | ALLOW_PASSWORD_LOGIN          |         true          | Whether or not to display the username+password input fields. Keep set to true unless you use OIDC authentication                                       |
+| DEFAULT_LOCALE                |         en-US         | The default locale/language for the frontend when no user preference is set (e.g. `en-US`, `de-DE`, `fr-FR`, `nl-NL`)                                   |
 | LOG_CONFIG_OVERRIDE           |                       | Override the config for logging with a custom path                                                                                                      |
 | LOG_LEVEL                     |         info          | Logging level (e.g. critical, error, warning, info, debug)                                                                                              |
 | DAILY_SCHEDULE_TIME           |         23:45         | The time of day to run daily server tasks, in HH:MM format. Use the server's local time, *not* UTC                                                      |

--- a/frontend/components/global/LanguageDialog.vue
+++ b/frontend/components/global/LanguageDialog.vue
@@ -63,9 +63,11 @@ export default defineNuxtComponent({
 
     const { locales: LOCALES, locale, i18n } = useLocales();
 
+    const localeCookie = useCookie("mealie_locale", { maxAge: 365 * 24 * 60 * 60 });
     const selectedLocale = ref(locale.value);
     const onLocaleSelect = (value: string) => {
       if (value && locales.some(l => l.value === value)) {
+        localeCookie.value = value;
         locale.value = value as any;
       }
     };

--- a/frontend/lib/api/types/admin.ts
+++ b/frontend/lib/api/types/admin.ts
@@ -19,6 +19,7 @@ export interface AdminAboutInfo {
   enableOpenai: boolean;
   enableOpenaiImageServices: boolean;
   tokenTime: number;
+  defaultLocale: string;
   versionLatest: string;
   apiPort: number;
   apiDocs: boolean;
@@ -52,6 +53,7 @@ export interface AppInfo {
   enableOpenai: boolean;
   enableOpenaiImageServices: boolean;
   tokenTime: number;
+  defaultLocale: string;
 }
 export interface AppStartupInfo {
   isFirstLogin: boolean;

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -198,11 +198,7 @@ export default defineNuxtConfig({
     types: "composition",
     langDir: "./../lang/locales", // note: we need to up one ../ because the default root of lang dir is the /frontend/i18n, which can not be configured
     defaultLocale: "en-US",
-    detectBrowserLanguage: {
-      useCookie: true,
-      alwaysRedirect: true,
-      fallbackLocale: "en-US",
-    },
+    detectBrowserLanguage: false,
     compilation: {
       strictMessage: false,
       escapeHtml: true,

--- a/frontend/plugins/app-info.client.ts
+++ b/frontend/plugins/app-info.client.ts
@@ -1,9 +1,19 @@
 import axios from "axios";
 import type { AppInfo } from "~/lib/api/types/admin";
 
+const LOCALE_COOKIE = "mealie_locale";
+
 export default defineNuxtPlugin({
   async setup() {
     const { data } = await axios.get<AppInfo>("/api/app/about");
+
+    const localeCookie = useCookie(LOCALE_COOKIE, { maxAge: 365 * 24 * 60 * 60 });
+    const targetLocale = localeCookie.value || data.defaultLocale || "en-US";
+
+    const { $i18n } = useNuxtApp();
+    if ($i18n && targetLocale !== $i18n.locale.value) {
+      await $i18n.setLocale(targetLocale);
+    }
 
     return {
       provide: {

--- a/frontend/plugins/app-info.client.ts
+++ b/frontend/plugins/app-info.client.ts
@@ -1,14 +1,38 @@
 import axios from "axios";
 import type { AppInfo } from "~/lib/api/types/admin";
+import { LOCALES } from "~/composables/use-locales/available-locales";
 
 const LOCALE_COOKIE = "mealie_locale";
+
+function detectBrowserLocale(): string | null {
+  if (typeof navigator === "undefined") return null;
+  const available = LOCALES.map(l => l.value);
+  for (const lang of navigator.languages || [navigator.language]) {
+    // Exact match (e.g. "nl-NL")
+    if (available.includes(lang)) return lang;
+    // Prefix match (e.g. "nl" → "nl-NL")
+    const prefix = lang.split("-")[0];
+    const match = available.find(a => a.startsWith(prefix + "-") || a === prefix);
+    if (match) return match;
+  }
+  return null;
+}
+
+function resolveDefaultLocale(serverDefault: string | undefined): string | null {
+  if (!serverDefault || serverDefault === "auto") {
+    return detectBrowserLocale();
+  }
+  return serverDefault;
+}
 
 export default defineNuxtPlugin({
   async setup() {
     const { data } = await axios.get<AppInfo>("/api/app/about");
 
     const localeCookie = useCookie(LOCALE_COOKIE, { maxAge: 365 * 24 * 60 * 60 });
-    const targetLocale = localeCookie.value || data.defaultLocale || "en-US";
+    const targetLocale = localeCookie.value
+      || resolveDefaultLocale(data.defaultLocale)
+      || "en-US";
 
     const { $i18n } = useNuxtApp();
     if ($i18n && targetLocale !== $i18n.locale.value) {

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -120,6 +120,9 @@ class AppSettings(AppLoggingSettings):
 
     IS_DEMO: bool = False
 
+    DEFAULT_LOCALE: str = "en-US"
+    """The default locale for the frontend when no user preference is set (e.g. en-US, de-DE, fr-FR)"""
+
     HOST_IP: str = "*"
 
     API_HOST: str = "0.0.0.0"

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -120,8 +120,8 @@ class AppSettings(AppLoggingSettings):
 
     IS_DEMO: bool = False
 
-    DEFAULT_LOCALE: str = "en-US"
-    """The default locale for the frontend when no user preference is set (e.g. en-US, de-DE, fr-FR)"""
+    DEFAULT_LOCALE: str = "auto"
+    """The default locale for the frontend. Set to 'auto' to detect from browser, or a specific locale like en-US, de-DE, fr-FR"""
 
     HOST_IP: str = "*"
 

--- a/mealie/routes/app/app_about.py
+++ b/mealie/routes/app/app_about.py
@@ -45,6 +45,7 @@ def get_app_info(session: Session = Depends(generate_session)):
         enable_openai_image_services=settings.OPENAI_ENABLED and settings.OPENAI_ENABLE_IMAGE_SERVICES,
         allow_password_login=settings.ALLOW_PASSWORD_LOGIN,
         token_time=settings.TOKEN_TIME,
+        default_locale=settings.DEFAULT_LOCALE,
     )
 
 

--- a/mealie/schema/admin/about.py
+++ b/mealie/schema/admin/about.py
@@ -24,6 +24,7 @@ class AppInfo(MealieModel):
     enable_openai: bool
     enable_openai_image_services: bool
     token_time: int
+    default_locale: str
 
 
 class AppTheme(MealieModel):


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, then delete that section.

  PLEASE READ:
  -------------------------
  Mealie is moving to a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

This PR adds the ability to set a default language. As all my recipes are in Dutch, and I wanted to enable public access, I wanted to have Mealie in Dutch as well by default.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

I didn't find an issue, but there was this discussion:
https://github.com/mealie-recipes/mealie/discussions/3898

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

I am no Nuxt developer, and use a bit of AI to help me here. I did a manual review, and it made sense to me, but please check if this is the right way.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

I tested by locally building and starting the docker. It opened in my preferred language in private browsing.

<!--
  Describe how you tested this change.
-->

## AI / LLM Assistance

I used Claude Code for the coding, I did the reviewing and testing.

<!--
  Describe to which degree an LLM was used in creating this pull request.
-->
