### PR TITLE
fix: Allow more precise standard quantities in unit data management

### DIFF
--- a/frontend/pages/group/data/units.vue
+++ b/frontend/pages/group/data/units.vue
@@ -287,7 +287,7 @@ const formItems = computed<AutoFormItems>(() => [
     numberInputConfig: {
       min: 0,
       max: undefined,
-      precision: undefined,
+      precision: null,
       controlVariant: "hidden",
     },
   },


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Sets precision to `null` (instead of `undefined`) on the unit data management page for the "standard quantity" field.
It's currently set to `undefined` which defaults to "1" (i.e. whole numbers only). `null` lets users enter an arbitrarily-precise value (e.g. 0.333333333333333333333).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

None