### PR TITLE
fix: Don't continue parsing recipes with errored HTTP status codes

### DIFF
--- a/mealie/services/scraper/recipe_scraper.py
+++ b/mealie/services/scraper/recipe_scraper.py
@@ -44,6 +44,10 @@ class RecipeScraper:
         """
 
         raw_html = html or await safe_scrape_html(url)
+
+        if not raw_html:
+            return None, None
+
         for ScraperClass in self.scrapers:
             scraper = ScraperClass(url, self.translator, raw_html=raw_html)
             if not scraper.can_scrape():

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -70,8 +70,8 @@ async def safe_scrape_html(url: str) -> str:
                 headers=user_agents_manager.get_scrape_headers(user_agent),
                 follow_redirects=True,
             ) as resp:
-                if resp.status_code == status.HTTP_403_FORBIDDEN:
-                    logger.debug(f'403 Forbidden with User-Agent: "{user_agent}"')
+                if resp.status_code >= status.HTTP_400_BAD_REQUEST:
+                    logger.debug(f'Error status code {resp.status_code} with User-Agent: "{user_agent}"')
                     continue
 
                 start_time = time.time()

--- a/tests/integration_tests/user_recipe_tests/test_recipe_create_from_video.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_create_from_video.py
@@ -33,7 +33,7 @@ def video_scraper_setup(monkeypatch: pytest.MonkeyPatch):
 
     # Prevent any real HTTP calls during scraping
     async def mock_safe_scrape_html(url: str) -> str:
-        return ""
+        return "<html></html>"
 
     monkeypatch.setattr(recipe_scraper_module, "safe_scrape_html", mock_safe_scrape_html)
 

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -14,11 +14,11 @@ from bs4 import BeautifulSoup
 from fastapi.testclient import TestClient
 from httpx import Response
 from pytest import MonkeyPatch
-from recipe_scrapers._abstract import AbstractScraper
 from recipe_scrapers._schemaorg import SchemaOrg
 from recipe_scrapers.plugins import SchemaOrgFillPlugin
 from slugify import slugify
 
+import mealie.services.scraper.recipe_scraper as recipe_scraper_module
 from mealie.db.models.recipe import RecipeModel
 from mealie.pkgs.safehttp.transport import AsyncSafeTransport
 from mealie.schema.cookbook.cookbook import SaveCookBook
@@ -102,12 +102,12 @@ def test_create_by_url(
     monkeypatch: MonkeyPatch,
 ):
     for recipe_data in recipe_test_data:
-        # Override init function for AbstractScraper to use the test html instead of calling the url
-        monkeypatch.setattr(
-            AbstractScraper,
-            "__init__",
-            get_init(recipe_data.html_file),
-        )
+        # Prevent any real HTTP calls during scraping
+        async def mock_safe_scrape_html(url: str) -> str:
+            return "<html></html>"
+
+        monkeypatch.setattr(recipe_scraper_module, "safe_scrape_html", mock_safe_scrape_html)
+
         # Override the get_html method of the RecipeScraperOpenGraph to return the test html
         for scraper_cls in DEFAULT_SCRAPER_STRATEGIES:
             monkeypatch.setattr(


### PR DESCRIPTION
## What this PR does / why we need it:

The goal of this PR is to:
1. Consider any HTTP codes higher or equal to 400 as failed when scraping sites using the `safe_scrape_html` function, and
2. To return early from the recipe scraper if the page could not be scraped successfully. This is to ensure that we won't call the other scrapers, including the OpenAI scraper which would incur unnecessary costs.

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/issues/5012

## Testing

I manually tested the changes using a [URL](https://www.seriouseats.com/taiwanese-three-cup-chicken-san-bei-gi-recipe) which consistently returns error responses for me (HTTP 402, to be exact).

_Without_ this change, I could see in the logs that a request to OpenAPI was made after the 402 response:

<img width="1167" height="632" alt="Screenshot 2026-03-12 at 02 27 00" src="https://github.com/user-attachments/assets/8599c9ba-6a4c-4eff-bcd9-9a8bbafe1fc8" />

_With_ this change, no such request is made to OpenAI:

<img width="1233" height="608" alt="Screenshot 2026-03-12 at 02 25 46" src="https://github.com/user-attachments/assets/7e911934-5ca0-42d2-bbe6-4ac01d8a61b5" />

I also tested on a successful [URL](https://cookpad.com/us/recipes/5544853-sous-vide-smoked-beef-ribs) to check that there were no breaking changes.

## AI / LLM Assistance

Not used.
