### PR TITLE
chore: run Ruff with --fix in Pre-commit to auto-fix fixable errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,8 @@ repos:
     # Ruff version.
     rev: v0.15.5
     hooks:
-      - id: ruff
+        # Linter
+      - id: ruff-check
+        args: [ --fix ]
+        # Formatter
       - id: ruff-format


### PR DESCRIPTION
## What this PR does / why we need it:

Run [Ruff](https://github.com/astral-sh/ruff-pre-commit) with `--fix` in Pre-commit to auto-fix fixable errors. It makes it easier and quicker to fix Ruff linting errors.

For example, the screenshot below shows how Ruff found 1 error and fixed it:

<img width="929" height="317" alt="Screenshot 2026-03-12 at 12 10 34" src="https://github.com/user-attachments/assets/98f30447-4139-4a68-ace8-cc21206e9d7c" />

While before, it would only show an error was detected:

<img width="1361" height="247" alt="Screenshot 2026-03-12 at 12 12 43" src="https://github.com/user-attachments/assets/6987780e-c62c-4d3e-b277-e21a1f6e64c1" />

Also changed the [legacy](https://github.com/astral-sh/ruff-pre-commit/blob/main/.pre-commit-hooks.yaml#L24) `ruff` alias for the linter to the new `ruff-check` one. It works exactly the same.

## Which issue(s) this PR fixes:

None.

## Testing

Adding incorrectly linted files and running `git commit` to trigger pre-commit.

## AI / LLM Assistance

None
