### PR TITLE
fix: Add ffmpeg to prod image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,6 +121,7 @@ ENV GIT_COMMIT_HASH=$COMMIT
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl \
+    ffmpeg \
     gosu \
     iproute2 \
     libldap-common \


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

`ffmpeg` is installed during build time but isn't in the final production image. This causes importing via video to fail if there isn't a subtitle track.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, reported in Discord

## Testing

_(fill-in or delete this section)_

Built the prod image and checked a tiktok video without subtitles.

## AI / LLM Assistance

_(REQUIRED)_

None
