### PR TITLE
fix: Use latest python image as base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN yarn generate
 ###############################################
 # Base Image - Python
 ###############################################
-FROM python:3.12-slim@sha256:2267adc248a477c1f1a852a07a5a224d42abe54c28aafa572efa157dfb001bba \
+FROM python:3.12-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9 \
     AS python-base
 
 ENV MEALIE_HOME="/app"


### PR DESCRIPTION
## What this PR does / why we need it:

Use the latest python 3.12-slim as base image to reduce the number of vulnerabilities and get rid of critical ones.

## Which issue(s) this PR fixes:

<img width="868" height="355" alt="image" src="https://github.com/user-attachments/assets/bcd0afe6-71fe-4e81-9ac9-88a4358c43dc" />


## AI / LLM Assistance

Pure hard human work