### PR TITLE
chore: bump l10n auto-merge line limit from 400 to 6000

### DIFF
--- a/.github/workflows/auto-merge-l10n.yml
+++ b/.github/workflows/auto-merge-l10n.yml
@@ -40,8 +40,8 @@ jobs:
 
           echo "PR changes: +$ADDITIONS -$DELETIONS (total: $TOTAL lines)"
 
-          if [ "$TOTAL" -gt 400 ]; then
-            echo "::error::PR exceeds 400 line change limit ($TOTAL lines)"
+          if [ "$TOTAL" -gt 6000 ]; then
+            echo "::error::PR exceeds 6000 line change limit ($TOTAL lines)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Increases the auto-merge line change limit for l10n PRs from 400 to 6000
- Recent Crowdin PRs have reached up to ~5,700 lines (e.g. #7258 with +3,073/-2,663), causing them to be blocked by the old limit
- The file-path validation and author checks remain the primary safety controls; the line limit is a sanity check for truly anomalous PRs