### PR TITLE
feat: recipe version history with diff view and restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,12 @@ dev/code-generation/openapi.json
 .task/*
 .dev.env
 frontend/eslint.config.deprecated.js
+
+# Claude Code
+CLAUDE.md
+
+# Claude Code
+CLAUDE.md
+
+# Claude Code
+CLAUDE.md

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -106,6 +106,13 @@
         v-model="recipe"
         class="px-1 my-4 d-print-none"
       />
+      <RecipeVersionHistory
+        v-if="!isEditMode && !isCookMode && recipe.slug && isOwnGroup"
+        :slug="recipe.slug"
+        :can-edit="isOwnGroup"
+        class="px-1"
+        @restored="() => router.go(0)"
+      />
       <RecipePrintContainer :recipe="recipe" :scale="scale" />
     </v-container>
     <!-- Cook mode displayes two columns with ingredients and instructions side by side, each being scrolled individually, allowing to view both at the same time -->
@@ -214,6 +221,7 @@ import { useUserApi } from "~/composables/api";
 import { uuid4, deepCopy } from "~/composables/use-utils";
 import RecipeDialogBulkAdd from "~/components/Domain/Recipe/RecipeDialogBulkAdd.vue";
 import RecipeNotes from "~/components/Domain/Recipe/RecipeNotes.vue";
+import RecipeVersionHistory from "~/components/Domain/Recipe/RecipeVersionHistory.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import { useNavigationWarning } from "~/composables/use-navigation-warning";
 

--- a/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -106,13 +106,6 @@
         v-model="recipe"
         class="px-1 my-4 d-print-none"
       />
-      <RecipeVersionHistory
-        v-if="!isEditMode && !isCookMode && recipe.slug && isOwnGroup"
-        :slug="recipe.slug"
-        :can-edit="isOwnGroup"
-        class="px-1"
-        @restored="() => router.go(0)"
-      />
       <RecipePrintContainer :recipe="recipe" :scale="scale" />
     </v-container>
     <!-- Cook mode displayes two columns with ingredients and instructions side by side, each being scrolled individually, allowing to view both at the same time -->
@@ -221,7 +214,6 @@ import { useUserApi } from "~/composables/api";
 import { uuid4, deepCopy } from "~/composables/use-utils";
 import RecipeDialogBulkAdd from "~/components/Domain/Recipe/RecipeDialogBulkAdd.vue";
 import RecipeNotes from "~/components/Domain/Recipe/RecipeNotes.vue";
-import RecipeVersionHistory from "~/components/Domain/Recipe/RecipeVersionHistory.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import { useNavigationWarning } from "~/composables/use-navigation-warning";
 

--- a/frontend/components/Domain/Recipe/RecipeTimelineBadge.vue
+++ b/frontend/components/Domain/Recipe/RecipeTimelineBadge.vue
@@ -28,11 +28,33 @@
         :icon="$globals.icons.timelineText"
         width="70%"
       >
-        <RecipeTimeline
-          v-model="showTimeline"
-          :query-filter="timelineAttrs.queryFilter"
-          max-height="60vh"
-        />
+        <v-tabs v-model="activeTab" density="compact" class="mb-2">
+          <v-tab value="timeline">
+            {{ $t('recipe.timeline') }}
+          </v-tab>
+          <v-tab value="versions">
+            {{ $t('recipe.version-history') }}
+          </v-tab>
+        </v-tabs>
+
+        <v-tabs-window v-model="activeTab">
+          <v-tabs-window-item value="timeline">
+            <RecipeTimeline
+              v-model="showTimeline"
+              :query-filter="timelineAttrs.queryFilter"
+              max-height="60vh"
+            />
+          </v-tabs-window-item>
+          <v-tabs-window-item value="versions">
+            <RecipeVersionHistory
+              v-if="slug"
+              :slug="slug"
+              :can-edit="true"
+              inline
+              @restored="showTimeline = false"
+            />
+          </v-tabs-window-item>
+        </v-tabs-window>
       </BaseDialog>
     </template>
     <span>{{ $t('recipe.open-timeline') }}</span>
@@ -41,6 +63,7 @@
 
 <script setup lang="ts">
 import RecipeTimeline from "./RecipeTimeline.vue";
+import RecipeVersionHistory from "./RecipeVersionHistory.vue";
 
 interface Props {
   buttonStyle?: boolean;
@@ -56,6 +79,7 @@ const props = withDefaults(defineProps<Props>(), {
 const i18n = useI18n();
 const { smAndDown } = useDisplay();
 const showTimeline = ref(false);
+const activeTab = ref("timeline");
 
 function toggleTimeline() {
   showTimeline.value = !showTimeline.value;

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -220,7 +220,7 @@
 </template>
 
 <script setup lang="ts">
-import { useRequests } from "~/composables/api/api-client";
+import { useUserApi } from "~/composables/api";
 import { alert } from "~/composables/use-toast";
 
 interface RecipeVersionSummary {
@@ -259,7 +259,7 @@ const emit = defineEmits<{
   (e: "restored"): void;
 }>();
 
-const requests = useRequests();
+const api = useUserApi();
 const i18n = useI18n();
 
 const versions = ref<RecipeVersionSummary[]>([]);
@@ -269,7 +269,7 @@ const diffLoading = ref(false);
 const restoreLoading = ref<string | null>(null);
 
 async function loadVersions() {
-  const { data } = await requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
+  const { data } = await api.recipes.requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
   if (data) {
     versions.value = data;
   }
@@ -284,7 +284,7 @@ async function toggleVersion(version: RecipeVersionSummary) {
 
   expandedVersion.value = version.id;
   diffLoading.value = true;
-  const { data } = await requests.get<RecipeDiff>(`/api/recipes/${props.slug}/versions/${version.id}/diff?compare_to=current`);
+  const { data } = await api.recipes.requests.get<RecipeDiff>(`/api/recipes/${props.slug}/versions/${version.id}/diff?compare_to=current`);
   if (data) {
     currentDiff.value = data;
   }
@@ -293,7 +293,7 @@ async function toggleVersion(version: RecipeVersionSummary) {
 
 async function restoreVersion(version: RecipeVersionSummary) {
   restoreLoading.value = version.id;
-  const { data } = await requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
+  const { data } = await api.recipes.requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
   if (data) {
     alert.success(i18n.t("recipe.version-restored", { version: version.versionNumber }));
     emit("restored");

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -64,6 +64,9 @@
               class="mx-4 mb-2"
             >
               <v-card-text class="pa-3">
+                <div class="text-caption text-grey mb-2">
+                  {{ $t("recipe.version-diff-label") }}
+                </div>
                 <div
                   v-if="isDiffEmpty(currentDiff)"
                   class="text-caption text-grey"

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -220,7 +220,7 @@
 </template>
 
 <script setup lang="ts">
-import { useUserApi } from "~/composables/api";
+import { useRequests } from "~/composables/api/api-client";
 import { alert } from "~/composables/use-toast";
 
 interface RecipeVersionSummary {
@@ -259,7 +259,7 @@ const emit = defineEmits<{
   (e: "restored"): void;
 }>();
 
-const api = useUserApi();
+const requests = useRequests();
 const i18n = useI18n();
 
 const versions = ref<RecipeVersionSummary[]>([]);
@@ -269,7 +269,7 @@ const diffLoading = ref(false);
 const restoreLoading = ref<string | null>(null);
 
 async function loadVersions() {
-  const { data } = await api.requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
+  const { data } = await requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
   if (data) {
     versions.value = data;
   }
@@ -284,7 +284,7 @@ async function toggleVersion(version: RecipeVersionSummary) {
 
   expandedVersion.value = version.id;
   diffLoading.value = true;
-  const { data } = await api.requests.get<RecipeDiff>(`/api/recipes/${props.slug}/versions/${version.id}/diff?compare_to=current`);
+  const { data } = await requests.get<RecipeDiff>(`/api/recipes/${props.slug}/versions/${version.id}/diff?compare_to=current`);
   if (data) {
     currentDiff.value = data;
   }
@@ -293,7 +293,7 @@ async function toggleVersion(version: RecipeVersionSummary) {
 
 async function restoreVersion(version: RecipeVersionSummary) {
   restoreLoading.value = version.id;
-  const { data } = await api.requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
+  const { data } = await requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
   if (data) {
     alert.success(i18n.t("recipe.version-restored", { version: version.versionNumber }));
     emit("restored");

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -35,12 +35,21 @@
           </v-list-item-subtitle>
           <template #append>
             <v-btn
+              size="x-small"
+              variant="text"
+              color="info"
+              class="mr-1"
+              @click.stop="viewFullVersion(version)"
+            >
+              {{ $t("general.view") }}
+            </v-btn>
+            <v-btn
               v-if="canEdit"
               size="x-small"
               variant="text"
               color="primary"
               :loading="restoreLoading === version.id"
-              @click.stop="restoreVersion(version)"
+              @click.stop="confirmRestore(version)"
             >
               {{ $t("general.restore") }}
             </v-btn>
@@ -55,7 +64,6 @@
               class="mx-4 mb-2"
             >
               <v-card-text class="pa-3">
-                <!-- No changes -->
                 <div
                   v-if="isDiffEmpty(currentDiff)"
                   class="text-caption text-grey"
@@ -63,7 +71,6 @@
                   {{ $t("recipe.version-no-changes") }}
                 </div>
 
-                <!-- Field changes -->
                 <div
                   v-for="field in currentDiff.fieldsChanged"
                   :key="field.fieldName"
@@ -87,7 +94,6 @@
                   </div>
                 </div>
 
-                <!-- Ingredients -->
                 <div v-if="currentDiff.ingredientsAdded.length || currentDiff.ingredientsRemoved.length || currentDiff.ingredientsChanged.length">
                   <div class="text-caption font-weight-bold mb-1">
                     {{ $t("recipe.ingredients") }}
@@ -117,7 +123,6 @@
                   </div>
                 </div>
 
-                <!-- Instructions -->
                 <div
                   v-if="currentDiff.instructionsAdded.length || currentDiff.instructionsRemoved.length || currentDiff.instructionsChanged.length"
                   class="mt-2"
@@ -128,14 +133,14 @@
                   <div
                     v-for="ins in currentDiff.instructionsRemoved"
                     :key="'rem-' + ins"
-                    class="text-decoration-line-through text-red-lighten-1 text-body-2 text-truncate"
+                    class="text-decoration-line-through text-red-lighten-1 text-body-2"
                   >
                     - {{ ins }}
                   </div>
                   <div
                     v-for="ins in currentDiff.instructionsAdded"
                     :key="'add-' + ins"
-                    class="text-green-darken-1 text-body-2 text-truncate"
+                    class="text-green-darken-1 text-body-2"
                   >
                     + {{ ins }}
                   </div>
@@ -144,16 +149,15 @@
                     :key="'chg-' + ins.position"
                     class="text-body-2"
                   >
-                    <div class="text-decoration-line-through text-red-lighten-1 text-truncate">
+                    <div class="text-decoration-line-through text-red-lighten-1">
                       {{ ins.oldText }}
                     </div>
-                    <div class="text-green-darken-1 text-truncate">
+                    <div class="text-green-darken-1">
                       {{ ins.newText }}
                     </div>
                   </div>
                 </div>
 
-                <!-- Categories/Tags -->
                 <div
                   v-if="currentDiff.categoriesAdded.length || currentDiff.categoriesRemoved.length"
                   class="mt-2"
@@ -216,6 +220,204 @@
         />
       </template>
     </v-list>
+
+    <!-- Full recipe view dialog -->
+    <v-dialog
+      v-model="viewDialog"
+      width="800"
+      scrollable
+    >
+      <v-card v-if="viewingSnapshot">
+        <v-card-title class="d-flex align-center justify-space-between">
+          <span>
+            v{{ viewingVersion?.versionNumber }} — {{ viewingSnapshot.name }}
+          </span>
+          <v-chip
+            size="small"
+            color="grey"
+          >
+            {{ formatDate(viewingVersion?.createdAt || null) }}
+          </v-chip>
+        </v-card-title>
+        <v-divider />
+        <v-card-text style="max-height: 70vh; overflow-y: auto;">
+          <!-- Description -->
+          <div
+            v-if="viewingSnapshot.description"
+            class="mb-4 text-body-1"
+          >
+            {{ viewingSnapshot.description }}
+          </div>
+
+          <!-- Times -->
+          <div
+            v-if="viewingSnapshot.prep_time || viewingSnapshot.cook_time || viewingSnapshot.total_time"
+            class="mb-4"
+          >
+            <v-chip
+              v-if="viewingSnapshot.prep_time"
+              size="small"
+              class="mr-1"
+            >
+              Prep: {{ viewingSnapshot.prep_time }}
+            </v-chip>
+            <v-chip
+              v-if="viewingSnapshot.cook_time"
+              size="small"
+              class="mr-1"
+            >
+              Cook: {{ viewingSnapshot.cook_time }}
+            </v-chip>
+            <v-chip
+              v-if="viewingSnapshot.total_time"
+              size="small"
+              class="mr-1"
+            >
+              Total: {{ viewingSnapshot.total_time }}
+            </v-chip>
+          </div>
+
+          <!-- Yield -->
+          <div
+            v-if="viewingSnapshot.recipe_yield || viewingSnapshot.recipe_servings"
+            class="mb-4 text-body-2"
+          >
+            <strong>{{ $t("recipe.servings") }}:</strong>
+            {{ viewingSnapshot.recipe_servings || viewingSnapshot.recipe_yield || '' }}
+            {{ viewingSnapshot.recipe_yield && viewingSnapshot.recipe_servings ? `(${viewingSnapshot.recipe_yield})` : '' }}
+          </div>
+
+          <!-- Ingredients -->
+          <div v-if="viewingSnapshot.recipe_ingredient?.length">
+            <h3 class="text-h6 mb-2">
+              {{ $t("recipe.ingredients") }}
+            </h3>
+            <ul class="mb-4">
+              <li
+                v-for="(ing, i) in viewingSnapshot.recipe_ingredient"
+                :key="i"
+                class="text-body-2"
+              >
+                <template v-if="ing.title">
+                  <strong>{{ ing.title }}</strong>
+                </template>
+                <template v-else>
+                  {{ formatIngredient(ing) }}
+                </template>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Instructions -->
+          <div v-if="viewingSnapshot.recipe_instructions?.length">
+            <h3 class="text-h6 mb-2">
+              {{ $t("recipe.instructions") }}
+            </h3>
+            <ol class="mb-4">
+              <li
+                v-for="(step, i) in viewingSnapshot.recipe_instructions"
+                :key="i"
+                class="text-body-2 mb-2"
+              >
+                <template v-if="step.title">
+                  <strong>{{ step.title }}</strong><br>
+                </template>
+                {{ step.text }}
+              </li>
+            </ol>
+          </div>
+
+          <!-- Notes -->
+          <div v-if="viewingSnapshot.notes?.length">
+            <h3 class="text-h6 mb-2">
+              {{ $t("recipe.notes") }}
+            </h3>
+            <div
+              v-for="(note, i) in viewingSnapshot.notes"
+              :key="i"
+              class="mb-2"
+            >
+              <strong v-if="note.title">{{ note.title }}:</strong>
+              {{ note.text }}
+            </div>
+          </div>
+
+          <!-- Categories/Tags -->
+          <div
+            v-if="viewingSnapshot.recipe_category?.length || viewingSnapshot.tags?.length"
+            class="mt-4"
+          >
+            <v-chip
+              v-for="cat in (viewingSnapshot.recipe_category || [])"
+              :key="'cat-' + (cat.name || cat.slug)"
+              size="small"
+              color="primary"
+              class="mr-1 mb-1"
+            >
+              {{ cat.name || cat.slug }}
+            </v-chip>
+            <v-chip
+              v-for="tag in (viewingSnapshot.tags || [])"
+              :key="'tag-' + (tag.name || tag.slug)"
+              size="small"
+              color="secondary"
+              class="mr-1 mb-1"
+            >
+              {{ tag.name || tag.slug }}
+            </v-chip>
+          </div>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            variant="text"
+            @click="viewDialog = false"
+          >
+            {{ $t("general.close") }}
+          </v-btn>
+          <v-btn
+            v-if="canEdit"
+            color="primary"
+            variant="elevated"
+            :loading="restoreLoading === viewingVersion?.id"
+            @click="confirmRestore(viewingVersion!)"
+          >
+            {{ $t("general.restore") }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Restore confirmation dialog -->
+    <v-dialog
+      v-model="restoreDialog"
+      max-width="450"
+    >
+      <v-card>
+        <v-card-title>{{ $t("recipe.version-restore-confirm-title") }}</v-card-title>
+        <v-card-text>
+          {{ $t("recipe.version-restore-confirm", { version: restoreTarget?.versionNumber }) }}
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            variant="text"
+            @click="restoreDialog = false"
+          >
+            {{ $t("general.cancel") }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :loading="restoreLoading === restoreTarget?.id"
+            @click="doRestore"
+          >
+            {{ $t("general.restore") }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -231,6 +433,14 @@ interface RecipeVersionSummary {
   versionNumber: number;
   name: string;
   createdAt: string | null;
+}
+
+interface RecipeVersionFull {
+  id: string;
+  versionNumber: number;
+  name: string;
+  createdAt: string | null;
+  snapshot: string;
 }
 
 interface RecipeDiff {
@@ -268,6 +478,15 @@ const currentDiff = ref<RecipeDiff | null>(null);
 const diffLoading = ref(false);
 const restoreLoading = ref<string | null>(null);
 
+// Full view dialog
+const viewDialog = ref(false);
+const viewingVersion = ref<RecipeVersionSummary | null>(null);
+const viewingSnapshot = ref<any>(null);
+
+// Restore confirmation
+const restoreDialog = ref(false);
+const restoreTarget = ref<RecipeVersionSummary | null>(null);
+
 async function loadVersions() {
   const { data } = await api.recipes.requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
   if (data) {
@@ -291,11 +510,33 @@ async function toggleVersion(version: RecipeVersionSummary) {
   diffLoading.value = false;
 }
 
-async function restoreVersion(version: RecipeVersionSummary) {
-  restoreLoading.value = version.id;
-  const { data } = await api.recipes.requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
+async function viewFullVersion(version: RecipeVersionSummary) {
+  const { data } = await api.recipes.requests.get<RecipeVersionFull>(`/api/recipes/${props.slug}/versions/${version.id}`);
   if (data) {
-    alert.success(i18n.t("recipe.version-restored", { version: version.versionNumber }));
+    viewingVersion.value = version;
+    try {
+      viewingSnapshot.value = JSON.parse(data.snapshot);
+    }
+    catch {
+      viewingSnapshot.value = null;
+    }
+    viewDialog.value = true;
+  }
+}
+
+function confirmRestore(version: RecipeVersionSummary) {
+  restoreTarget.value = version;
+  restoreDialog.value = true;
+}
+
+async function doRestore() {
+  if (!restoreTarget.value) return;
+  restoreLoading.value = restoreTarget.value.id;
+  const { data } = await api.recipes.requests.post<any>(`/api/recipes/${props.slug}/versions/${restoreTarget.value.id}/restore`, {});
+  if (data) {
+    alert.success(i18n.t("recipe.version-restored", { version: restoreTarget.value.versionNumber }));
+    restoreDialog.value = false;
+    viewDialog.value = false;
     emit("restored");
   }
   restoreLoading.value = null;
@@ -321,6 +562,21 @@ function formatDate(dateStr: string | null): string {
   if (!dateStr) return "";
   const d = new Date(dateStr);
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function formatIngredient(ing: any): string {
+  const parts: string[] = [];
+  if (ing.quantity) {
+    const q = ing.quantity;
+    parts.push(q === Math.floor(q) ? String(Math.floor(q)) : String(q));
+  }
+  if (ing.unit?.name) parts.push(ing.unit.name);
+  if (ing.food?.name) parts.push(ing.food.name);
+  if (ing.note) {
+    if (parts.length) parts.push(`- ${ing.note}`);
+    else parts.push(ing.note);
+  }
+  return parts.join(" ") || ing.original_text || "";
 }
 
 onMounted(loadVersions);

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -1,231 +1,221 @@
 <template>
-  <div
-    v-if="versions.length > 0"
-    class="my-4 d-print-none"
-  >
-    <v-expansion-panels variant="accordion">
-      <v-expansion-panel>
-        <v-expansion-panel-title>
-          <div class="d-flex align-center">
-            <v-icon
-              size="small"
+  <div class="d-print-none">
+    <div
+      v-if="versions.length === 0"
+      class="text-center text-grey pa-4"
+    >
+      {{ $t("recipe.version-no-history") }}
+    </div>
+    <v-list
+      v-else
+      density="compact"
+    >
+      <template
+        v-for="(version, idx) in versions"
+        :key="version.id"
+      >
+        <v-list-item
+          :class="{ 'bg-grey-lighten-4': expandedVersion === version.id }"
+          @click="toggleVersion(version)"
+        >
+          <template #prepend>
+            <v-avatar
+              size="28"
+              color="primary"
               class="mr-2"
             >
-              {{ $globals.icons.timelineText }}
-            </v-icon>
-            <span class="text-subtitle-1">
-              {{ $t("recipe.version-history") }} ({{ versions.length }})
-            </span>
-          </div>
-        </v-expansion-panel-title>
-        <v-expansion-panel-text>
-          <v-list density="compact">
-            <template
-              v-for="(version, idx) in versions"
-              :key="version.id"
+              <span class="text-caption text-white">v{{ version.versionNumber }}</span>
+            </v-avatar>
+          </template>
+          <v-list-item-title>
+            {{ version.name }}
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            {{ formatDate(version.createdAt) }}
+          </v-list-item-subtitle>
+          <template #append>
+            <v-btn
+              v-if="canEdit"
+              size="x-small"
+              variant="text"
+              color="primary"
+              :loading="restoreLoading === version.id"
+              @click.stop="restoreVersion(version)"
             >
-              <v-list-item
-                :class="{ 'bg-grey-lighten-4': expandedVersion === version.id }"
-                @click="toggleVersion(version)"
-              >
-                <template #prepend>
-                  <v-avatar
-                    size="28"
-                    color="primary"
-                    class="mr-2"
-                  >
-                    <span class="text-caption text-white">v{{ version.versionNumber }}</span>
-                  </v-avatar>
-                </template>
-                <v-list-item-title>
-                  {{ version.name }}
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  {{ formatDate(version.createdAt) }}
-                </v-list-item-subtitle>
-                <template #append>
-                  <v-btn
-                    v-if="canEdit"
-                    size="x-small"
-                    variant="text"
-                    color="primary"
-                    :loading="restoreLoading === version.id"
-                    @click.stop="restoreVersion(version)"
-                  >
-                    {{ $t("general.restore") }}
-                  </v-btn>
-                </template>
-              </v-list-item>
+              {{ $t("general.restore") }}
+            </v-btn>
+          </template>
+        </v-list-item>
 
-              <!-- Expanded diff view -->
-              <v-expand-transition>
-                <div v-if="expandedVersion === version.id && currentDiff">
-                  <v-card
-                    variant="outlined"
-                    class="mx-4 mb-2"
-                  >
-                    <v-card-text class="pa-3">
-                      <!-- No changes -->
-                      <div
-                        v-if="isDiffEmpty(currentDiff)"
-                        class="text-caption text-grey"
-                      >
-                        {{ $t("recipe.version-no-changes") }}
-                      </div>
-
-                      <!-- Field changes -->
-                      <div
-                        v-for="field in currentDiff.fieldsChanged"
-                        :key="field.fieldName"
-                        class="mb-2"
-                      >
-                        <div class="text-caption font-weight-bold">
-                          {{ field.label }}
-                        </div>
-                        <div class="d-flex align-start" style="gap: 8px">
-                          <span
-                            v-if="field.oldValue"
-                            class="text-decoration-line-through text-red-lighten-1 text-body-2"
-                          >{{ field.oldValue }}</span>
-                          <span
-                            v-if="field.newValue"
-                            class="text-green-darken-1 text-body-2"
-                          >{{ field.newValue }}</span>
-                        </div>
-                      </div>
-
-                      <!-- Ingredients -->
-                      <div v-if="currentDiff.ingredientsAdded.length || currentDiff.ingredientsRemoved.length || currentDiff.ingredientsChanged.length">
-                        <div class="text-caption font-weight-bold mb-1">
-                          {{ $t("recipe.ingredients") }}
-                        </div>
-                        <div
-                          v-for="ing in currentDiff.ingredientsRemoved"
-                          :key="'rem-' + ing"
-                          class="text-decoration-line-through text-red-lighten-1 text-body-2"
-                        >
-                          - {{ ing }}
-                        </div>
-                        <div
-                          v-for="ing in currentDiff.ingredientsAdded"
-                          :key="'add-' + ing"
-                          class="text-green-darken-1 text-body-2"
-                        >
-                          + {{ ing }}
-                        </div>
-                        <div
-                          v-for="ing in currentDiff.ingredientsChanged"
-                          :key="'chg-' + ing.position"
-                          class="text-body-2"
-                        >
-                          <span class="text-decoration-line-through text-red-lighten-1">{{ ing.oldText }}</span>
-                          →
-                          <span class="text-green-darken-1">{{ ing.newText }}</span>
-                        </div>
-                      </div>
-
-                      <!-- Instructions -->
-                      <div
-                        v-if="currentDiff.instructionsAdded.length || currentDiff.instructionsRemoved.length || currentDiff.instructionsChanged.length"
-                        class="mt-2"
-                      >
-                        <div class="text-caption font-weight-bold mb-1">
-                          {{ $t("recipe.instructions") }}
-                        </div>
-                        <div
-                          v-for="ins in currentDiff.instructionsRemoved"
-                          :key="'rem-' + ins"
-                          class="text-decoration-line-through text-red-lighten-1 text-body-2 text-truncate"
-                        >
-                          - {{ ins }}
-                        </div>
-                        <div
-                          v-for="ins in currentDiff.instructionsAdded"
-                          :key="'add-' + ins"
-                          class="text-green-darken-1 text-body-2 text-truncate"
-                        >
-                          + {{ ins }}
-                        </div>
-                        <div
-                          v-for="ins in currentDiff.instructionsChanged"
-                          :key="'chg-' + ins.position"
-                          class="text-body-2"
-                        >
-                          <div class="text-decoration-line-through text-red-lighten-1 text-truncate">
-                            {{ ins.oldText }}
-                          </div>
-                          <div class="text-green-darken-1 text-truncate">
-                            {{ ins.newText }}
-                          </div>
-                        </div>
-                      </div>
-
-                      <!-- Categories/Tags -->
-                      <div
-                        v-if="currentDiff.categoriesAdded.length || currentDiff.categoriesRemoved.length"
-                        class="mt-2"
-                      >
-                        <div class="text-caption font-weight-bold mb-1">
-                          {{ $t("recipe.categories") }}
-                        </div>
-                        <v-chip
-                          v-for="c in currentDiff.categoriesRemoved"
-                          :key="'crem-' + c"
-                          size="x-small"
-                          color="red"
-                          class="mr-1"
-                        >
-                          - {{ c }}
-                        </v-chip>
-                        <v-chip
-                          v-for="c in currentDiff.categoriesAdded"
-                          :key="'cadd-' + c"
-                          size="x-small"
-                          color="green"
-                          class="mr-1"
-                        >
-                          + {{ c }}
-                        </v-chip>
-                      </div>
-                      <div
-                        v-if="currentDiff.tagsAdded.length || currentDiff.tagsRemoved.length"
-                        class="mt-2"
-                      >
-                        <div class="text-caption font-weight-bold mb-1">
-                          {{ $t("recipe.tags") }}
-                        </div>
-                        <v-chip
-                          v-for="t in currentDiff.tagsRemoved"
-                          :key="'trem-' + t"
-                          size="x-small"
-                          color="red"
-                          class="mr-1"
-                        >
-                          - {{ t }}
-                        </v-chip>
-                        <v-chip
-                          v-for="t in currentDiff.tagsAdded"
-                          :key="'tadd-' + t"
-                          size="x-small"
-                          color="green"
-                          class="mr-1"
-                        >
-                          + {{ t }}
-                        </v-chip>
-                      </div>
-                    </v-card-text>
-                  </v-card>
+        <!-- Expanded diff view -->
+        <v-expand-transition>
+          <div v-if="expandedVersion === version.id && currentDiff">
+            <v-card
+              variant="outlined"
+              class="mx-4 mb-2"
+            >
+              <v-card-text class="pa-3">
+                <!-- No changes -->
+                <div
+                  v-if="isDiffEmpty(currentDiff)"
+                  class="text-caption text-grey"
+                >
+                  {{ $t("recipe.version-no-changes") }}
                 </div>
-              </v-expand-transition>
 
-              <v-divider
-                v-if="idx < versions.length - 1"
-              />
-            </template>
-          </v-list>
-        </v-expansion-panel-text>
-      </v-expansion-panel>
-    </v-expansion-panels>
+                <!-- Field changes -->
+                <div
+                  v-for="field in currentDiff.fieldsChanged"
+                  :key="field.fieldName"
+                  class="mb-2"
+                >
+                  <div class="text-caption font-weight-bold">
+                    {{ field.label }}
+                  </div>
+                  <div
+                    class="d-flex align-start"
+                    style="gap: 8px"
+                  >
+                    <span
+                      v-if="field.oldValue"
+                      class="text-decoration-line-through text-red-lighten-1 text-body-2"
+                    >{{ field.oldValue }}</span>
+                    <span
+                      v-if="field.newValue"
+                      class="text-green-darken-1 text-body-2"
+                    >{{ field.newValue }}</span>
+                  </div>
+                </div>
+
+                <!-- Ingredients -->
+                <div v-if="currentDiff.ingredientsAdded.length || currentDiff.ingredientsRemoved.length || currentDiff.ingredientsChanged.length">
+                  <div class="text-caption font-weight-bold mb-1">
+                    {{ $t("recipe.ingredients") }}
+                  </div>
+                  <div
+                    v-for="ing in currentDiff.ingredientsRemoved"
+                    :key="'rem-' + ing"
+                    class="text-decoration-line-through text-red-lighten-1 text-body-2"
+                  >
+                    - {{ ing }}
+                  </div>
+                  <div
+                    v-for="ing in currentDiff.ingredientsAdded"
+                    :key="'add-' + ing"
+                    class="text-green-darken-1 text-body-2"
+                  >
+                    + {{ ing }}
+                  </div>
+                  <div
+                    v-for="ing in currentDiff.ingredientsChanged"
+                    :key="'chg-' + ing.position"
+                    class="text-body-2"
+                  >
+                    <span class="text-decoration-line-through text-red-lighten-1">{{ ing.oldText }}</span>
+                    →
+                    <span class="text-green-darken-1">{{ ing.newText }}</span>
+                  </div>
+                </div>
+
+                <!-- Instructions -->
+                <div
+                  v-if="currentDiff.instructionsAdded.length || currentDiff.instructionsRemoved.length || currentDiff.instructionsChanged.length"
+                  class="mt-2"
+                >
+                  <div class="text-caption font-weight-bold mb-1">
+                    {{ $t("recipe.instructions") }}
+                  </div>
+                  <div
+                    v-for="ins in currentDiff.instructionsRemoved"
+                    :key="'rem-' + ins"
+                    class="text-decoration-line-through text-red-lighten-1 text-body-2 text-truncate"
+                  >
+                    - {{ ins }}
+                  </div>
+                  <div
+                    v-for="ins in currentDiff.instructionsAdded"
+                    :key="'add-' + ins"
+                    class="text-green-darken-1 text-body-2 text-truncate"
+                  >
+                    + {{ ins }}
+                  </div>
+                  <div
+                    v-for="ins in currentDiff.instructionsChanged"
+                    :key="'chg-' + ins.position"
+                    class="text-body-2"
+                  >
+                    <div class="text-decoration-line-through text-red-lighten-1 text-truncate">
+                      {{ ins.oldText }}
+                    </div>
+                    <div class="text-green-darken-1 text-truncate">
+                      {{ ins.newText }}
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Categories/Tags -->
+                <div
+                  v-if="currentDiff.categoriesAdded.length || currentDiff.categoriesRemoved.length"
+                  class="mt-2"
+                >
+                  <div class="text-caption font-weight-bold mb-1">
+                    {{ $t("recipe.categories") }}
+                  </div>
+                  <v-chip
+                    v-for="c in currentDiff.categoriesRemoved"
+                    :key="'crem-' + c"
+                    size="x-small"
+                    color="red"
+                    class="mr-1"
+                  >
+                    - {{ c }}
+                  </v-chip>
+                  <v-chip
+                    v-for="c in currentDiff.categoriesAdded"
+                    :key="'cadd-' + c"
+                    size="x-small"
+                    color="green"
+                    class="mr-1"
+                  >
+                    + {{ c }}
+                  </v-chip>
+                </div>
+                <div
+                  v-if="currentDiff.tagsAdded.length || currentDiff.tagsRemoved.length"
+                  class="mt-2"
+                >
+                  <div class="text-caption font-weight-bold mb-1">
+                    {{ $t("recipe.tags") }}
+                  </div>
+                  <v-chip
+                    v-for="t in currentDiff.tagsRemoved"
+                    :key="'trem-' + t"
+                    size="x-small"
+                    color="red"
+                    class="mr-1"
+                  >
+                    - {{ t }}
+                  </v-chip>
+                  <v-chip
+                    v-for="t in currentDiff.tagsAdded"
+                    :key="'tadd-' + t"
+                    size="x-small"
+                    color="green"
+                    class="mr-1"
+                  >
+                    + {{ t }}
+                  </v-chip>
+                </div>
+              </v-card-text>
+            </v-card>
+          </div>
+        </v-expand-transition>
+
+        <v-divider
+          v-if="idx < versions.length - 1"
+        />
+      </template>
+    </v-list>
   </div>
 </template>
 
@@ -262,6 +252,7 @@ interface RecipeDiff {
 const props = defineProps<{
   slug: string;
   canEdit: boolean;
+  inline?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -333,7 +324,5 @@ function formatDate(dateStr: string | null): string {
 }
 
 onMounted(loadVersions);
-
-// Reload when slug changes (after restore)
 watch(() => props.slug, loadVersions);
 </script>

--- a/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
+++ b/frontend/components/Domain/Recipe/RecipeVersionHistory.vue
@@ -1,0 +1,339 @@
+<template>
+  <div
+    v-if="versions.length > 0"
+    class="my-4 d-print-none"
+  >
+    <v-expansion-panels variant="accordion">
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div class="d-flex align-center">
+            <v-icon
+              size="small"
+              class="mr-2"
+            >
+              {{ $globals.icons.timelineText }}
+            </v-icon>
+            <span class="text-subtitle-1">
+              {{ $t("recipe.version-history") }} ({{ versions.length }})
+            </span>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <v-list density="compact">
+            <template
+              v-for="(version, idx) in versions"
+              :key="version.id"
+            >
+              <v-list-item
+                :class="{ 'bg-grey-lighten-4': expandedVersion === version.id }"
+                @click="toggleVersion(version)"
+              >
+                <template #prepend>
+                  <v-avatar
+                    size="28"
+                    color="primary"
+                    class="mr-2"
+                  >
+                    <span class="text-caption text-white">v{{ version.versionNumber }}</span>
+                  </v-avatar>
+                </template>
+                <v-list-item-title>
+                  {{ version.name }}
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ formatDate(version.createdAt) }}
+                </v-list-item-subtitle>
+                <template #append>
+                  <v-btn
+                    v-if="canEdit"
+                    size="x-small"
+                    variant="text"
+                    color="primary"
+                    :loading="restoreLoading === version.id"
+                    @click.stop="restoreVersion(version)"
+                  >
+                    {{ $t("general.restore") }}
+                  </v-btn>
+                </template>
+              </v-list-item>
+
+              <!-- Expanded diff view -->
+              <v-expand-transition>
+                <div v-if="expandedVersion === version.id && currentDiff">
+                  <v-card
+                    variant="outlined"
+                    class="mx-4 mb-2"
+                  >
+                    <v-card-text class="pa-3">
+                      <!-- No changes -->
+                      <div
+                        v-if="isDiffEmpty(currentDiff)"
+                        class="text-caption text-grey"
+                      >
+                        {{ $t("recipe.version-no-changes") }}
+                      </div>
+
+                      <!-- Field changes -->
+                      <div
+                        v-for="field in currentDiff.fieldsChanged"
+                        :key="field.fieldName"
+                        class="mb-2"
+                      >
+                        <div class="text-caption font-weight-bold">
+                          {{ field.label }}
+                        </div>
+                        <div class="d-flex align-start" style="gap: 8px">
+                          <span
+                            v-if="field.oldValue"
+                            class="text-decoration-line-through text-red-lighten-1 text-body-2"
+                          >{{ field.oldValue }}</span>
+                          <span
+                            v-if="field.newValue"
+                            class="text-green-darken-1 text-body-2"
+                          >{{ field.newValue }}</span>
+                        </div>
+                      </div>
+
+                      <!-- Ingredients -->
+                      <div v-if="currentDiff.ingredientsAdded.length || currentDiff.ingredientsRemoved.length || currentDiff.ingredientsChanged.length">
+                        <div class="text-caption font-weight-bold mb-1">
+                          {{ $t("recipe.ingredients") }}
+                        </div>
+                        <div
+                          v-for="ing in currentDiff.ingredientsRemoved"
+                          :key="'rem-' + ing"
+                          class="text-decoration-line-through text-red-lighten-1 text-body-2"
+                        >
+                          - {{ ing }}
+                        </div>
+                        <div
+                          v-for="ing in currentDiff.ingredientsAdded"
+                          :key="'add-' + ing"
+                          class="text-green-darken-1 text-body-2"
+                        >
+                          + {{ ing }}
+                        </div>
+                        <div
+                          v-for="ing in currentDiff.ingredientsChanged"
+                          :key="'chg-' + ing.position"
+                          class="text-body-2"
+                        >
+                          <span class="text-decoration-line-through text-red-lighten-1">{{ ing.oldText }}</span>
+                          →
+                          <span class="text-green-darken-1">{{ ing.newText }}</span>
+                        </div>
+                      </div>
+
+                      <!-- Instructions -->
+                      <div
+                        v-if="currentDiff.instructionsAdded.length || currentDiff.instructionsRemoved.length || currentDiff.instructionsChanged.length"
+                        class="mt-2"
+                      >
+                        <div class="text-caption font-weight-bold mb-1">
+                          {{ $t("recipe.instructions") }}
+                        </div>
+                        <div
+                          v-for="ins in currentDiff.instructionsRemoved"
+                          :key="'rem-' + ins"
+                          class="text-decoration-line-through text-red-lighten-1 text-body-2 text-truncate"
+                        >
+                          - {{ ins }}
+                        </div>
+                        <div
+                          v-for="ins in currentDiff.instructionsAdded"
+                          :key="'add-' + ins"
+                          class="text-green-darken-1 text-body-2 text-truncate"
+                        >
+                          + {{ ins }}
+                        </div>
+                        <div
+                          v-for="ins in currentDiff.instructionsChanged"
+                          :key="'chg-' + ins.position"
+                          class="text-body-2"
+                        >
+                          <div class="text-decoration-line-through text-red-lighten-1 text-truncate">
+                            {{ ins.oldText }}
+                          </div>
+                          <div class="text-green-darken-1 text-truncate">
+                            {{ ins.newText }}
+                          </div>
+                        </div>
+                      </div>
+
+                      <!-- Categories/Tags -->
+                      <div
+                        v-if="currentDiff.categoriesAdded.length || currentDiff.categoriesRemoved.length"
+                        class="mt-2"
+                      >
+                        <div class="text-caption font-weight-bold mb-1">
+                          {{ $t("recipe.categories") }}
+                        </div>
+                        <v-chip
+                          v-for="c in currentDiff.categoriesRemoved"
+                          :key="'crem-' + c"
+                          size="x-small"
+                          color="red"
+                          class="mr-1"
+                        >
+                          - {{ c }}
+                        </v-chip>
+                        <v-chip
+                          v-for="c in currentDiff.categoriesAdded"
+                          :key="'cadd-' + c"
+                          size="x-small"
+                          color="green"
+                          class="mr-1"
+                        >
+                          + {{ c }}
+                        </v-chip>
+                      </div>
+                      <div
+                        v-if="currentDiff.tagsAdded.length || currentDiff.tagsRemoved.length"
+                        class="mt-2"
+                      >
+                        <div class="text-caption font-weight-bold mb-1">
+                          {{ $t("recipe.tags") }}
+                        </div>
+                        <v-chip
+                          v-for="t in currentDiff.tagsRemoved"
+                          :key="'trem-' + t"
+                          size="x-small"
+                          color="red"
+                          class="mr-1"
+                        >
+                          - {{ t }}
+                        </v-chip>
+                        <v-chip
+                          v-for="t in currentDiff.tagsAdded"
+                          :key="'tadd-' + t"
+                          size="x-small"
+                          color="green"
+                          class="mr-1"
+                        >
+                          + {{ t }}
+                        </v-chip>
+                      </div>
+                    </v-card-text>
+                  </v-card>
+                </div>
+              </v-expand-transition>
+
+              <v-divider
+                v-if="idx < versions.length - 1"
+              />
+            </template>
+          </v-list>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useUserApi } from "~/composables/api";
+import { alert } from "~/composables/use-toast";
+
+interface RecipeVersionSummary {
+  id: string;
+  recipeId: string;
+  userId: string | null;
+  groupId: string;
+  versionNumber: number;
+  name: string;
+  createdAt: string | null;
+}
+
+interface RecipeDiff {
+  versionId: string | null;
+  compareTo: string;
+  fieldsChanged: { fieldName: string; label: string; oldValue: string | null; newValue: string | null }[];
+  ingredientsAdded: string[];
+  ingredientsRemoved: string[];
+  ingredientsChanged: { position: number; oldText: string | null; newText: string | null }[];
+  instructionsAdded: string[];
+  instructionsRemoved: string[];
+  instructionsChanged: { position: number; oldText: string | null; newText: string | null }[];
+  categoriesAdded: string[];
+  categoriesRemoved: string[];
+  tagsAdded: string[];
+  tagsRemoved: string[];
+}
+
+const props = defineProps<{
+  slug: string;
+  canEdit: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "restored"): void;
+}>();
+
+const api = useUserApi();
+const i18n = useI18n();
+
+const versions = ref<RecipeVersionSummary[]>([]);
+const expandedVersion = ref<string | null>(null);
+const currentDiff = ref<RecipeDiff | null>(null);
+const diffLoading = ref(false);
+const restoreLoading = ref<string | null>(null);
+
+async function loadVersions() {
+  const { data } = await api.requests.get<RecipeVersionSummary[]>(`/api/recipes/${props.slug}/versions`);
+  if (data) {
+    versions.value = data;
+  }
+}
+
+async function toggleVersion(version: RecipeVersionSummary) {
+  if (expandedVersion.value === version.id) {
+    expandedVersion.value = null;
+    currentDiff.value = null;
+    return;
+  }
+
+  expandedVersion.value = version.id;
+  diffLoading.value = true;
+  const { data } = await api.requests.get<RecipeDiff>(`/api/recipes/${props.slug}/versions/${version.id}/diff?compare_to=current`);
+  if (data) {
+    currentDiff.value = data;
+  }
+  diffLoading.value = false;
+}
+
+async function restoreVersion(version: RecipeVersionSummary) {
+  restoreLoading.value = version.id;
+  const { data } = await api.requests.post<any>(`/api/recipes/${props.slug}/versions/${version.id}/restore`, {});
+  if (data) {
+    alert.success(i18n.t("recipe.version-restored", { version: version.versionNumber }));
+    emit("restored");
+  }
+  restoreLoading.value = null;
+}
+
+function isDiffEmpty(diff: RecipeDiff): boolean {
+  return (
+    diff.fieldsChanged.length === 0
+    && diff.ingredientsAdded.length === 0
+    && diff.ingredientsRemoved.length === 0
+    && diff.ingredientsChanged.length === 0
+    && diff.instructionsAdded.length === 0
+    && diff.instructionsRemoved.length === 0
+    && diff.instructionsChanged.length === 0
+    && diff.categoriesAdded.length === 0
+    && diff.categoriesRemoved.length === 0
+    && diff.tagsAdded.length === 0
+    && diff.tagsRemoved.length === 0
+  );
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+onMounted(loadVersions);
+
+// Reload when slug changes (after restore)
+watch(() => props.slug, loadVersions);
+</script>

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -714,7 +714,8 @@
     "toggle-recipe": "Toggle Recipe",
     "version-history": "Version History",
     "version-no-changes": "No changes in this version",
-    "version-restored": "Restored to version {version}"
+    "version-restored": "Restored to version {version}",
+    "version-no-history": "No version history yet. Edit the recipe to create the first version."
   },
   "recipe-finder": {
     "recipe-finder": "Recipe Finder",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -715,7 +715,9 @@
     "version-history": "Version History",
     "version-no-changes": "No changes in this version",
     "version-restored": "Restored to version {version}",
-    "version-no-history": "No version history yet. Edit the recipe to create the first version."
+    "version-no-history": "No version history yet. Edit the recipe to create the first version.",
+    "version-restore-confirm-title": "Restore Version",
+    "version-restore-confirm": "This will restore the recipe to version {version}. The current state will be saved as a new version before restoring. Continue?"
   },
   "recipe-finder": {
     "recipe-finder": "Recipe Finder",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -717,7 +717,8 @@
     "version-restored": "Restored to version {version}",
     "version-no-history": "No version history yet. Edit the recipe to create the first version.",
     "version-restore-confirm-title": "Restore Version",
-    "version-restore-confirm": "This will restore the recipe to version {version}. The current state will be saved as a new version before restoring. Continue?"
+    "version-restore-confirm": "This will restore the recipe to version {version}. The current state will be saved as a new version before restoring. Continue?",
+    "version-diff-label": "Changes between this version and the current recipe:"
   },
   "recipe-finder": {
     "recipe-finder": "Recipe Finder",

--- a/frontend/lang/messages/en-US.json
+++ b/frontend/lang/messages/en-US.json
@@ -221,7 +221,8 @@
     "show-advanced": "Show Advanced",
     "add-field": "Add Field",
     "date-created": "Date Created",
-    "date-updated": "Date Updated"
+    "date-updated": "Date Updated",
+    "restore": "Restore"
   },
   "group": {
     "are-you-sure-you-want-to-delete-the-group": "Are you sure you want to delete <b>{groupName}<b/>?",
@@ -710,7 +711,10 @@
     "cover-image": "Cover image",
     "include-linked-recipes": "Include Linked Recipes",
     "include-linked-recipe-ingredients": "Include Linked Recipe Ingredients",
-    "toggle-recipe": "Toggle Recipe"
+    "toggle-recipe": "Toggle Recipe",
+    "version-history": "Version History",
+    "version-no-changes": "No changes in this version",
+    "version-restored": "Restored to version {version}"
   },
   "recipe-finder": {
     "recipe-finder": "Recipe Finder",

--- a/mealie/alembic/versions/2026-03-24-00.00.00_c3d4e5f6a7b8_add_recipe_versions.py
+++ b/mealie/alembic/versions/2026-03-24-00.00.00_c3d4e5f6a7b8_add_recipe_versions.py
@@ -1,0 +1,47 @@
+"""Add recipe_versions table
+
+Revision ID: c3d4e5f6a7b8
+Revises: a39c7f1826e3
+Create Date: 2026-03-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from mealie.db.models._model_utils.guid import GUID
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision: str | None = "a39c7f1826e3"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade():
+    op.create_table(
+        "recipe_versions",
+        sa.Column("id", GUID(), nullable=False),
+        sa.Column("recipe_id", GUID(), nullable=False),
+        sa.Column("user_id", GUID(), nullable=True),
+        sa.Column("group_id", GUID(), nullable=False),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("snapshot", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("update_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["recipe_id"], ["recipes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["group_id"], ["groups.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_recipe_versions_recipe_id", "recipe_versions", ["recipe_id"])
+    op.create_index("ix_recipe_versions_group_id", "recipe_versions", ["group_id"])
+    op.create_index("ix_recipe_versions_recipe_id_version", "recipe_versions", ["recipe_id", "version_number"])
+
+
+def downgrade():
+    op.drop_index("ix_recipe_versions_recipe_id_version", table_name="recipe_versions")
+    op.drop_index("ix_recipe_versions_group_id", table_name="recipe_versions")
+    op.drop_index("ix_recipe_versions_recipe_id", table_name="recipe_versions")
+    op.drop_table("recipe_versions")

--- a/mealie/db/models/recipe/__init__.py
+++ b/mealie/db/models/recipe/__init__.py
@@ -8,6 +8,7 @@ from .note import *
 from .nutrition import *
 from .recipe import *
 from .recipe_timeline import *
+from .recipe_version import *
 from .settings import *
 from .shared import *
 from .tag import *

--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -27,6 +27,7 @@ from .instruction import RecipeInstruction
 from .note import Note
 from .nutrition import Nutrition
 from .recipe_timeline import RecipeTimelineEvent
+from .recipe_version import RecipeVersion
 from .settings import RecipeSettings
 from .shared import RecipeShareTokenModel
 from .tag import recipes_to_tags
@@ -129,6 +130,10 @@ class RecipeModel(SqlAlchemyBase, BaseMixins):
 
     timeline_events: Mapped[list[RecipeTimelineEvent]] = orm.relationship(
         "RecipeTimelineEvent", back_populates="recipe", cascade="all, delete, delete-orphan"
+    )
+    versions: Mapped[list[RecipeVersion]] = orm.relationship(
+        "RecipeVersion", back_populates="recipe", cascade="all, delete, delete-orphan",
+        order_by="RecipeVersion.version_number.desc()",
     )
 
     # Mealie Specific

--- a/mealie/db/models/recipe/recipe_version.py
+++ b/mealie/db/models/recipe/recipe_version.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING, Optional
+
+import sqlalchemy as sa
+import sqlalchemy.orm as orm
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .._model_base import BaseMixins, SqlAlchemyBase
+from .._model_utils.auto_init import auto_init
+from .._model_utils.datetime import NaiveDateTime, get_utc_now
+from .._model_utils.guid import GUID
+
+if TYPE_CHECKING:
+    from ..group import Group
+    from ..users import User
+    from .recipe import RecipeModel
+
+
+class RecipeVersion(SqlAlchemyBase, BaseMixins):
+    __tablename__ = "recipe_versions"
+    __table_args__ = (sa.Index("ix_recipe_versions_recipe_id_version", "recipe_id", "version_number"),)
+
+    id: Mapped[GUID] = mapped_column(GUID, primary_key=True, default=GUID.generate)
+
+    recipe_id: Mapped[GUID] = mapped_column(GUID, sa.ForeignKey("recipes.id", ondelete="CASCADE"), nullable=False, index=True)
+    recipe: Mapped[Optional["RecipeModel"]] = orm.relationship("RecipeModel", back_populates="versions")
+
+    user_id: Mapped[GUID | None] = mapped_column(GUID, sa.ForeignKey("users.id"), nullable=True)
+    user: Mapped[Optional["User"]] = orm.relationship("User", uselist=False)
+
+    group_id: Mapped[GUID] = mapped_column(GUID, sa.ForeignKey("groups.id"), nullable=False, index=True)
+    group: Mapped[Optional["Group"]] = orm.relationship("Group", uselist=False)
+
+    version_number: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    name: Mapped[str] = mapped_column(sa.String, nullable=False)
+    snapshot: Mapped[str] = mapped_column(sa.Text, nullable=False)
+
+    created_at: Mapped[NaiveDateTime | None] = mapped_column(NaiveDateTime, default=get_utc_now)
+
+    @auto_init()
+    def __init__(self, **_) -> None:
+        pass

--- a/mealie/routes/recipe/__init__.py
+++ b/mealie/routes/recipe/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import bulk_actions, comments, exports, recipe_crud_routes, shared_routes, timeline_events
+from . import bulk_actions, comments, exports, recipe_crud_routes, recipe_versions, shared_routes, timeline_events
 
 prefix = "/recipes"
 
@@ -12,3 +12,4 @@ router.include_router(comments.router, prefix=prefix, tags=["Recipe: Comments"])
 router.include_router(bulk_actions.router, prefix=prefix, tags=["Recipe: Bulk Actions"])
 router.include_router(shared_routes.router, prefix=prefix, tags=["Recipe: Shared"])
 router.include_router(timeline_events.router, prefix=prefix, tags=["Recipe: Timeline"])
+router.include_router(recipe_versions.router, prefix=prefix, tags=["Recipe: Versions"])

--- a/mealie/routes/recipe/recipe_versions.py
+++ b/mealie/routes/recipe/recipe_versions.py
@@ -1,0 +1,90 @@
+from functools import cached_property
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import UUID4
+
+from mealie.routes._base import controller
+from mealie.routes._base.routers import UserAPIRouter
+from mealie.routes.recipe._base import BaseRecipeController
+from mealie.schema.recipe.recipe_version import (
+    RecipeDiff,
+    RecipeVersionOut,
+    RecipeVersionPagination,
+    RecipeVersionSummary,
+)
+from mealie.schema.response.pagination import PaginationQuery
+from mealie.services.recipe.recipe_version_service import RecipeVersionService
+
+router = UserAPIRouter()
+
+
+@controller(router)
+class RecipeVersionController(BaseRecipeController):
+    @cached_property
+    def version_service(self) -> RecipeVersionService:
+        return RecipeVersionService(self.repos)
+
+    @router.get("/{slug}/versions", response_model=list[RecipeVersionSummary])
+    def get_recipe_versions(self, slug: str):
+        """List all versions for a recipe."""
+        recipe = self.group_recipes.get_by_slug(self.group_id, slug)
+        if not recipe:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Recipe not found")
+        return self.version_service.get_versions(recipe.id)
+
+    @router.get("/{slug}/versions/{version_id}", response_model=RecipeVersionOut)
+    def get_recipe_version(self, slug: str, version_id: UUID4):
+        """Get a single version with its full snapshot."""
+        version = self.version_service.get_version(version_id)
+        if not version:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Version not found")
+        return version
+
+    @router.get("/{slug}/versions/{version_id}/diff", response_model=RecipeDiff)
+    def get_recipe_version_diff(self, slug: str, version_id: UUID4, compare_to: str = Query(default="current")):
+        """Compute diff between a version and another version or current state.
+
+        compare_to: "current" (default) or a version_id UUID.
+        """
+        recipe = self.group_recipes.get_by_slug(self.group_id, slug)
+        if not recipe:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Recipe not found")
+
+        diff = self.version_service.compute_diff(version_id, compare_to, current_recipe=recipe)
+        if not diff:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Version not found or comparison failed")
+        return diff
+
+    @router.post("/{slug}/versions/{version_id}/restore", response_model=RecipeVersionOut)
+    def restore_recipe_version(self, slug: str, version_id: UUID4):
+        """Restore a recipe to a previous version.
+
+        This creates a new version snapshot (of current state) then applies the old version's data.
+        """
+        import json
+
+        from mealie.schema.recipe.recipe import Recipe
+
+        recipe = self.group_recipes.get_by_slug(self.group_id, slug)
+        if not recipe:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Recipe not found")
+
+        if not self.service.can_update([recipe.slug]):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="You do not have permission to edit this recipe")
+
+        version = self.version_service.get_version(version_id)
+        if not version:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Version not found")
+
+        # Parse the snapshot and apply it as an update
+        snapshot_data = json.loads(version.snapshot)
+
+        # Merge snapshot data into current recipe (keeps id, slug, group_id, user_id, etc.)
+        update_data = recipe.model_dump()
+        update_data.update(snapshot_data)
+        update_recipe = Recipe(**update_data)
+
+        # update_one will create a new version snapshot before applying the restore
+        self.service.update_one(recipe.slug, update_recipe)
+
+        return version

--- a/mealie/schema/recipe/recipe_version.py
+++ b/mealie/schema/recipe/recipe_version.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+from pydantic import UUID4, ConfigDict
+
+from mealie.schema._mealie import MealieModel
+from mealie.schema.response.pagination import PaginationBase
+
+
+class RecipeVersionSummary(MealieModel):
+    """Lightweight version info for listing (no snapshot)."""
+
+    id: UUID4
+    recipe_id: UUID4
+    user_id: UUID4 | None = None
+    group_id: UUID4
+    version_number: int
+    name: str
+    created_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RecipeVersionOut(RecipeVersionSummary):
+    """Full version including the JSON snapshot."""
+
+    snapshot: str
+
+
+class RecipeVersionPagination(PaginationBase):
+    items: list[RecipeVersionSummary]
+
+
+# ─── Diff types ───────────────────────────────────────────
+
+
+class FieldDiff(MealieModel):
+    field_name: str
+    label: str
+    old_value: str | None = None
+    new_value: str | None = None
+
+
+class IngredientDiff(MealieModel):
+    position: int
+    old_text: str | None = None
+    new_text: str | None = None
+
+
+class InstructionDiff(MealieModel):
+    position: int
+    old_text: str | None = None
+    new_text: str | None = None
+
+
+class RecipeDiff(MealieModel):
+    """Structured diff between two recipe versions."""
+
+    version_id: UUID4 | None = None
+    compare_to: str = "current"  # version_id or "current"
+    fields_changed: list[FieldDiff] = []
+    ingredients_added: list[str] = []
+    ingredients_removed: list[str] = []
+    ingredients_changed: list[IngredientDiff] = []
+    instructions_added: list[str] = []
+    instructions_removed: list[str] = []
+    instructions_changed: list[InstructionDiff] = []
+    categories_added: list[str] = []
+    categories_removed: list[str] = []
+    tags_added: list[str] = []
+    tags_removed: list[str] = []

--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -488,6 +488,18 @@ class RecipeService(RecipeServiceBase):
     def update_one(self, slug_or_id: str | UUID, update_data: Recipe) -> Recipe:
         recipe = self._pre_update_check(slug_or_id, update_data)
 
+        # Save a version snapshot of the current state before updating
+        try:
+            from mealie.services.recipe.recipe_version_service import RecipeVersionService
+
+            version_service = RecipeVersionService(self.repos)
+            version_service.save_snapshot(recipe, user_id=self.user.id)
+        except Exception:
+            # Version snapshot failure should not block the update
+            import logging
+
+            logging.getLogger(__name__).warning("Failed to save recipe version snapshot", exc_info=True)
+
         # Resolve sub-recipe references before passing to repository
         update_data = self._resolve_ingredient_sub_recipes(update_data)
 

--- a/mealie/services/recipe/recipe_version_service.py
+++ b/mealie/services/recipe/recipe_version_service.py
@@ -183,6 +183,7 @@ class RecipeVersionService:
             version_number = self._get_next_version_number(recipe.id)
 
             version = RecipeVersion(
+                session=self.session,
                 recipe_id=recipe.id,
                 user_id=user_id,
                 group_id=recipe.group_id,

--- a/mealie/services/recipe/recipe_version_service.py
+++ b/mealie/services/recipe/recipe_version_service.py
@@ -1,0 +1,243 @@
+"""Recipe version history: snapshot creation, diff computation, and restore."""
+
+import json
+import logging
+from typing import Any
+
+from pydantic import UUID4
+from sqlalchemy import func, select
+
+from mealie.db.models.recipe.recipe_version import RecipeVersion
+from mealie.repos.repository_factory import AllRepositories
+from mealie.schema.recipe.recipe import Recipe
+from mealie.schema.recipe.recipe_version import (
+    FieldDiff,
+    IngredientDiff,
+    InstructionDiff,
+    RecipeDiff,
+    RecipeVersionOut,
+    RecipeVersionSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fields to include in the snapshot (exclude volatile/computed/binary fields)
+_SNAPSHOT_FIELDS = {
+    "name",
+    "description",
+    "recipe_yield",
+    "recipe_yield_quantity",
+    "recipe_servings",
+    "total_time",
+    "prep_time",
+    "cook_time",
+    "perform_time",
+    "org_url",
+    "recipe_ingredient",
+    "recipe_instructions",
+    "recipe_category",
+    "tags",
+    "tools",
+    "nutrition",
+    "settings",
+    "notes",
+    "extras",
+}
+
+# Simple fields to diff (display label → field name)
+_SIMPLE_DIFF_FIELDS = {
+    "name": "Name",
+    "description": "Description",
+    "recipe_yield": "Yield",
+    "recipe_yield_quantity": "Yield Quantity",
+    "recipe_servings": "Servings",
+    "total_time": "Total Time",
+    "prep_time": "Prep Time",
+    "cook_time": "Cook Time",
+    "perform_time": "Perform Time",
+    "org_url": "Source URL",
+}
+
+
+def _serialize_recipe(recipe: Recipe) -> str:
+    """Serialize a recipe to a JSON snapshot."""
+    data = recipe.model_dump(mode="json")
+    # Keep only the snapshot fields
+    snapshot = {k: v for k, v in data.items() if k in _SNAPSHOT_FIELDS}
+    return json.dumps(snapshot, default=str, ensure_ascii=False)
+
+
+def _ingredient_to_text(ing: dict) -> str:
+    """Convert an ingredient dict to a human-readable string."""
+    parts = []
+    if ing.get("quantity"):
+        q = ing["quantity"]
+        parts.append(str(int(q)) if q == int(q) else str(q))
+    if ing.get("unit") and ing["unit"].get("name"):
+        parts.append(ing["unit"]["name"])
+    if ing.get("food") and ing["food"].get("name"):
+        parts.append(ing["food"]["name"])
+    if ing.get("note"):
+        if parts:
+            parts.append(f"- {ing['note']}")
+        else:
+            parts.append(ing["note"])
+    if ing.get("title"):
+        return f"[{ing['title']}]"
+    return " ".join(p for p in parts if p).strip() or ing.get("original_text", "")
+
+
+def _instruction_to_text(step: dict) -> str:
+    """Convert an instruction dict to text."""
+    text = step.get("text", "")
+    if step.get("title"):
+        return f"[{step['title']}] {text}"
+    return text
+
+
+def _compute_diff(old_data: dict, new_data: dict) -> RecipeDiff:
+    """Compute a structured diff between two recipe snapshots."""
+    diff = RecipeDiff()
+
+    # 1. Simple field diffs
+    for field, label in _SIMPLE_DIFF_FIELDS.items():
+        old_val = str(old_data.get(field) or "")
+        new_val = str(new_data.get(field) or "")
+        if old_val != new_val:
+            diff.fields_changed.append(FieldDiff(
+                field_name=field,
+                label=label,
+                old_value=old_val or None,
+                new_value=new_val or None,
+            ))
+
+    # 2. Ingredient diffs
+    old_ings = old_data.get("recipe_ingredient") or []
+    new_ings = new_data.get("recipe_ingredient") or []
+    old_texts = [_ingredient_to_text(i) for i in old_ings]
+    new_texts = [_ingredient_to_text(i) for i in new_ings]
+
+    max_len = max(len(old_texts), len(new_texts))
+    for i in range(max_len):
+        old_t = old_texts[i] if i < len(old_texts) else None
+        new_t = new_texts[i] if i < len(new_texts) else None
+        if old_t == new_t:
+            continue
+        if old_t is None:
+            diff.ingredients_added.append(new_t or "")
+        elif new_t is None:
+            diff.ingredients_removed.append(old_t)
+        else:
+            diff.ingredients_changed.append(IngredientDiff(position=i, old_text=old_t, new_text=new_t))
+
+    # 3. Instruction diffs
+    old_steps = old_data.get("recipe_instructions") or []
+    new_steps = new_data.get("recipe_instructions") or []
+    old_step_texts = [_instruction_to_text(s) for s in old_steps]
+    new_step_texts = [_instruction_to_text(s) for s in new_steps]
+
+    max_len = max(len(old_step_texts), len(new_step_texts))
+    for i in range(max_len):
+        old_t = old_step_texts[i] if i < len(old_step_texts) else None
+        new_t = new_step_texts[i] if i < len(new_step_texts) else None
+        if old_t == new_t:
+            continue
+        if old_t is None:
+            diff.instructions_added.append(new_t or "")
+        elif new_t is None:
+            diff.instructions_removed.append(old_t)
+        else:
+            diff.instructions_changed.append(InstructionDiff(position=i, old_text=old_t, new_text=new_t))
+
+    # 4. Category/tag diffs
+    old_cats = {c.get("name", c.get("slug", "")) for c in (old_data.get("recipe_category") or [])}
+    new_cats = {c.get("name", c.get("slug", "")) for c in (new_data.get("recipe_category") or [])}
+    diff.categories_added = sorted(new_cats - old_cats)
+    diff.categories_removed = sorted(old_cats - new_cats)
+
+    old_tags = {t.get("name", t.get("slug", "")) for t in (old_data.get("tags") or [])}
+    new_tags = {t.get("name", t.get("slug", "")) for t in (new_data.get("tags") or [])}
+    diff.tags_added = sorted(new_tags - old_tags)
+    diff.tags_removed = sorted(old_tags - new_tags)
+
+    return diff
+
+
+class RecipeVersionService:
+    def __init__(self, repos: AllRepositories) -> None:
+        self.repos = repos
+        self.session = repos.session
+
+    def _get_next_version_number(self, recipe_id: UUID4) -> int:
+        """Get the next version number for a recipe."""
+        stmt = select(func.coalesce(func.max(RecipeVersion.version_number), 0)).where(
+            RecipeVersion.recipe_id == recipe_id
+        )
+        result = self.session.execute(stmt).scalar()
+        return (result or 0) + 1
+
+    def save_snapshot(self, recipe: Recipe, user_id: UUID4 | None = None) -> RecipeVersion | None:
+        """Create a version snapshot of the current recipe state."""
+        try:
+            snapshot = _serialize_recipe(recipe)
+            version_number = self._get_next_version_number(recipe.id)
+
+            version = RecipeVersion(
+                recipe_id=recipe.id,
+                user_id=user_id,
+                group_id=recipe.group_id,
+                version_number=version_number,
+                name=recipe.name or "",
+                snapshot=snapshot,
+            )
+            self.session.add(version)
+            self.session.commit()
+            self.session.refresh(version)
+
+            logger.info("Saved recipe version %d for '%s'", version_number, recipe.name)
+            return version
+        except Exception:
+            self.session.rollback()
+            logger.exception("Failed to save recipe version for '%s'", recipe.name)
+            return None
+
+    def get_versions(self, recipe_id: UUID4) -> list[RecipeVersionSummary]:
+        """List all versions for a recipe (no snapshots)."""
+        stmt = (
+            select(RecipeVersion)
+            .where(RecipeVersion.recipe_id == recipe_id)
+            .order_by(RecipeVersion.version_number.desc())
+        )
+        results = self.session.execute(stmt).scalars().all()
+        return [RecipeVersionSummary.model_validate(v) for v in results]
+
+    def get_version(self, version_id: UUID4) -> RecipeVersionOut | None:
+        """Get a single version with its snapshot."""
+        stmt = select(RecipeVersion).where(RecipeVersion.id == version_id)
+        result = self.session.execute(stmt).scalar_one_or_none()
+        if result is None:
+            return None
+        return RecipeVersionOut.model_validate(result)
+
+    def compute_diff(self, version_id: UUID4, compare_to: str = "current", current_recipe: Recipe | None = None) -> RecipeDiff | None:
+        """Compute diff between a version and another version or current state."""
+        version = self.get_version(version_id)
+        if version is None:
+            return None
+
+        old_data = json.loads(version.snapshot)
+
+        if compare_to == "current" and current_recipe:
+            new_data = json.loads(_serialize_recipe(current_recipe))
+        elif compare_to != "current":
+            other_version = self.get_version(UUID4(compare_to))
+            if other_version is None:
+                return None
+            new_data = json.loads(other_version.snapshot)
+        else:
+            return None
+
+        diff = _compute_diff(old_data, new_data)
+        diff.version_id = version_id
+        diff.compare_to = compare_to
+        return diff

--- a/mealie/services/recipe/recipe_version_service.py
+++ b/mealie/services/recipe/recipe_version_service.py
@@ -123,48 +123,28 @@ def _compute_diff(old_data: dict, new_data: dict) -> RecipeDiff:
                 new_value=new_val or None,
             ))
 
-    # 2. Ingredient diffs
+    # 2. Ingredient diffs (set-based to handle reordering)
     old_ings = old_data.get("recipe_ingredient") or []
     new_ings = new_data.get("recipe_ingredient") or []
-    old_texts = [_ingredient_to_text(i) or "" for i in old_ings]
-    new_texts = [_ingredient_to_text(i) or "" for i in new_ings]
-    # Filter out empty ingredients from comparison
-    old_texts = [t for t in old_texts if t]
-    new_texts = [t for t in new_texts if t]
+    old_texts = [t for t in (_ingredient_to_text(i) or "" for i in old_ings) if t]
+    new_texts = [t for t in (_ingredient_to_text(i) or "" for i in new_ings) if t]
 
-    max_len = max(len(old_texts), len(new_texts)) if old_texts or new_texts else 0
-    for i in range(max_len):
-        old_t = old_texts[i] if i < len(old_texts) else None
-        new_t = new_texts[i] if i < len(new_texts) else None
-        if old_t == new_t:
-            continue
-        if old_t is None and new_t:
-            diff.ingredients_added.append(new_t)
-        elif new_t is None and old_t:
-            diff.ingredients_removed.append(old_t)
-        elif old_t and new_t:
-            diff.ingredients_changed.append(IngredientDiff(position=i, old_text=old_t, new_text=new_t))
+    old_set = set(old_texts)
+    new_set = set(new_texts)
+    diff.ingredients_removed = sorted(old_set - new_set)
+    diff.ingredients_added = sorted(new_set - old_set)
+    # No "changed" items — ingredients are either present or not
 
-    # 3. Instruction diffs
+    # 3. Instruction diffs (set-based to handle reordering)
     old_steps = old_data.get("recipe_instructions") or []
     new_steps = new_data.get("recipe_instructions") or []
-    old_step_texts = [_instruction_to_text(s) or "" for s in old_steps]
-    new_step_texts = [_instruction_to_text(s) or "" for s in new_steps]
-    old_step_texts = [t for t in old_step_texts if t.strip()]
-    new_step_texts = [t for t in new_step_texts if t.strip()]
+    old_step_texts = [t for t in (_instruction_to_text(s) or "" for s in old_steps) if t.strip()]
+    new_step_texts = [t for t in (_instruction_to_text(s) or "" for s in new_steps) if t.strip()]
 
-    max_len = max(len(old_step_texts), len(new_step_texts)) if old_step_texts or new_step_texts else 0
-    for i in range(max_len):
-        old_t = old_step_texts[i] if i < len(old_step_texts) else None
-        new_t = new_step_texts[i] if i < len(new_step_texts) else None
-        if old_t == new_t:
-            continue
-        if old_t is None and new_t:
-            diff.instructions_added.append(new_t)
-        elif new_t is None and old_t:
-            diff.instructions_removed.append(old_t)
-        elif old_t and new_t:
-            diff.instructions_changed.append(InstructionDiff(position=i, old_text=old_t, new_text=new_t))
+    old_step_set = set(old_step_texts)
+    new_step_set = set(new_step_texts)
+    diff.instructions_removed = sorted(old_step_set - new_step_set)
+    diff.instructions_added = sorted(new_step_set - old_step_set)
 
     # 4. Category/tag diffs
     old_cats = {c.get("name", c.get("slug", "")) for c in (old_data.get("recipe_category") or [])}

--- a/mealie/services/recipe/recipe_version_service.py
+++ b/mealie/services/recipe/recipe_version_service.py
@@ -95,14 +95,26 @@ def _instruction_to_text(step: dict) -> str:
     return text
 
 
+def _normalize_value(val: Any) -> str:
+    """Normalize a value for comparison — treat None, empty, 0, 0.0 as equivalent."""
+    if val is None:
+        return ""
+    if isinstance(val, float) and val == 0.0:
+        return ""
+    if isinstance(val, int) and val == 0:
+        return ""
+    s = str(val).strip()
+    return s if s != "None" else ""
+
+
 def _compute_diff(old_data: dict, new_data: dict) -> RecipeDiff:
     """Compute a structured diff between two recipe snapshots."""
     diff = RecipeDiff()
 
     # 1. Simple field diffs
     for field, label in _SIMPLE_DIFF_FIELDS.items():
-        old_val = str(old_data.get(field) or "")
-        new_val = str(new_data.get(field) or "")
+        old_val = _normalize_value(old_data.get(field))
+        new_val = _normalize_value(new_data.get(field))
         if old_val != new_val:
             diff.fields_changed.append(FieldDiff(
                 field_name=field,
@@ -114,39 +126,44 @@ def _compute_diff(old_data: dict, new_data: dict) -> RecipeDiff:
     # 2. Ingredient diffs
     old_ings = old_data.get("recipe_ingredient") or []
     new_ings = new_data.get("recipe_ingredient") or []
-    old_texts = [_ingredient_to_text(i) for i in old_ings]
-    new_texts = [_ingredient_to_text(i) for i in new_ings]
+    old_texts = [_ingredient_to_text(i) or "" for i in old_ings]
+    new_texts = [_ingredient_to_text(i) or "" for i in new_ings]
+    # Filter out empty ingredients from comparison
+    old_texts = [t for t in old_texts if t]
+    new_texts = [t for t in new_texts if t]
 
-    max_len = max(len(old_texts), len(new_texts))
+    max_len = max(len(old_texts), len(new_texts)) if old_texts or new_texts else 0
     for i in range(max_len):
         old_t = old_texts[i] if i < len(old_texts) else None
         new_t = new_texts[i] if i < len(new_texts) else None
         if old_t == new_t:
             continue
-        if old_t is None:
-            diff.ingredients_added.append(new_t or "")
-        elif new_t is None:
+        if old_t is None and new_t:
+            diff.ingredients_added.append(new_t)
+        elif new_t is None and old_t:
             diff.ingredients_removed.append(old_t)
-        else:
+        elif old_t and new_t:
             diff.ingredients_changed.append(IngredientDiff(position=i, old_text=old_t, new_text=new_t))
 
     # 3. Instruction diffs
     old_steps = old_data.get("recipe_instructions") or []
     new_steps = new_data.get("recipe_instructions") or []
-    old_step_texts = [_instruction_to_text(s) for s in old_steps]
-    new_step_texts = [_instruction_to_text(s) for s in new_steps]
+    old_step_texts = [_instruction_to_text(s) or "" for s in old_steps]
+    new_step_texts = [_instruction_to_text(s) or "" for s in new_steps]
+    old_step_texts = [t for t in old_step_texts if t.strip()]
+    new_step_texts = [t for t in new_step_texts if t.strip()]
 
-    max_len = max(len(old_step_texts), len(new_step_texts))
+    max_len = max(len(old_step_texts), len(new_step_texts)) if old_step_texts or new_step_texts else 0
     for i in range(max_len):
         old_t = old_step_texts[i] if i < len(old_step_texts) else None
         new_t = new_step_texts[i] if i < len(new_step_texts) else None
         if old_t == new_t:
             continue
-        if old_t is None:
-            diff.instructions_added.append(new_t or "")
-        elif new_t is None:
+        if old_t is None and new_t:
+            diff.instructions_added.append(new_t)
+        elif new_t is None and old_t:
             diff.instructions_removed.append(old_t)
-        else:
+        elif old_t and new_t:
             diff.instructions_changed.append(InstructionDiff(position=i, old_text=old_t, new_text=new_t))
 
     # 4. Category/tag diffs


### PR DESCRIPTION
## What this PR does / why we need it:

Adds automatic recipe version history — every time a recipe is saved, a full JSON snapshot of the previous state is stored. Users can view a list of all versions, see structured diffs, view the full recipe at any point in time, and restore any previous version.

- **Automatic snapshots**: Before each recipe update, the current state is serialized to JSON and stored in a new `recipe_versions` table
- **Structured diffs**: Set-based comparison of ingredients, instructions, categories, tags, and simple fields — reordering doesn't show as a change
- **Full recipe view**: Click "View" on any version to see the complete recipe in a dialog
- **Restore**: Click "Restore" to revert to any previous version (creates a new snapshot first)
- **UI location**: Version history is a tab alongside Timeline in the existing history dialog (clock icon)

**Backend files:**
- `mealie/db/models/recipe/recipe_version.py` — SQLAlchemy model
- `mealie/schema/recipe/recipe_version.py` — Pydantic schemas + diff types
- `mealie/services/recipe/recipe_version_service.py` — Snapshot, diff computation, version queries
- `mealie/routes/recipe/recipe_versions.py` — API routes (list, get, diff, restore)
- `mealie/services/recipe/recipe_service.py` — Hook in update_one() to auto-snapshot
- Alembic migration for recipe_versions table

**Frontend files:**
- `frontend/components/Domain/Recipe/RecipeVersionHistory.vue` — Version list, diff view, full recipe dialog, restore confirmation
- `frontend/components/Domain/Recipe/RecipeTimelineBadge.vue` — Added "Version History" tab to timeline dialog

Each version stores ~2-5KB (full recipe JSON). At 50 edits that's ~250KB per recipe. Snapshots include: name, description, ingredients, instructions, nutrition, settings, notes, categories, tags, tools, extras, times, yields. Excludes: comments, timeline events, assets, ratings.

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/discussions/4584

## Special notes for your reviewer:

- Diff uses set-based comparison for ingredients/instructions to avoid false positives from reordering
- Null/empty/zero values are normalized before comparison to prevent phantom diffs
- Restore creates a new version snapshot before applying, so restores are always reversible
- No existing tests are affected — the version snapshot is wrapped in try/except so failures don't block recipe saves

## Testing

- Tested in production for 2 days
- Verified: version creation on edit, diff accuracy, full recipe view, restore flow
- Tested restore round-trip: edit → restore → verify recipe reverted → verify new version created
- Playwright automated UI testing for version list, diff expansion, view dialog, restore confirmation

## AI / LLM Assistance

This PR was developed with significant assistance from Claude Code (Claude Opus 4.6). Claude helped with:
- Architecture design (JSON snapshots vs normalized tables trade-off)
- Backend implementation (model, schema, service, routes, migration)
- Frontend Vue component development
- Diff algorithm design and iteration (positional → set-based)
- Debugging deployment issues (migration chain, session handling)
- All code was reviewed and tested by the PR author