### PR TITLE
fix: Relax URL validation

### DIFF
--- a/frontend/lib/validators/inputs.ts
+++ b/frontend/lib/validators/inputs.ts
@@ -3,8 +3,6 @@ import { useGlobalI18n } from "~/composables/use-global-i18n";
 const EMAIL_REGEX
   = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@(([[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-const URL_REGEX = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
-
 export function required(v: string | undefined | null) {
   const i18n = useGlobalI18n();
   return !!v || i18n.t("validators.required");
@@ -22,7 +20,17 @@ export function whitespace(v: string | null | undefined) {
 
 export function url(v: string | undefined | null) {
   const i18n = useGlobalI18n();
-  return (!!v && URL_REGEX.test(v) && (v.startsWith("http://") || v.startsWith("https://"))) || i18n.t("validators.invalid-url");
+  if (!v) {
+    return i18n.t("validators.invalid-url");
+  }
+
+  try {
+    const parsed = new URL(v);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") || i18n.t("validators.invalid-url");
+  }
+  catch {
+    return i18n.t("validators.invalid-url");
+  }
 }
 
 export function urlOptional(v: string | undefined | null) {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Relaxes URL validation to accept less-traditional URLs (e.g. local docker URLs).

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7303

## AI / LLM Assistance

_(REQUIRED)_

Came up with the fix, double checked for regressions.