### PR TITLE
fix: prevent stale SPA shell after container rebuild

### DIFF
--- a/mealie/routes/spa/__init__.py
+++ b/mealie/routes/spa/__init__.py
@@ -33,14 +33,23 @@ class MetaTag:
 class SPAStaticFiles(StaticFiles):
     async def get_response(self, path: str, scope):
         try:
-            return await super().get_response(path, scope)
+            response = await super().get_response(path, scope)
         except HTTPException as ex:
             if ex.status_code == 404:
-                return await super().get_response("index.html", scope)
+                response = await super().get_response("index.html", scope)
             else:
                 raise ex
-        except Exception as e:
-            raise e
+
+        # Hashed assets (_nuxt/*) are safe to cache forever since new builds produce new filenames.
+        # HTML and other files must not be cached to ensure browsers always load the correct bundle
+        # references after a container rebuild (prevents blank white page on stale index.html).
+        if path.startswith("_nuxt/"):
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        else:
+            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            response.headers["Pragma"] = "no-cache"
+
+        return response
 
 
 __app_settings = get_app_settings()


### PR DESCRIPTION
## What this PR does / why we need it:

After a container rebuild, Nuxt bundle filenames change (content hashing) but browsers serve the cached `index.html` which references the old bundle filenames, resulting in a blank white page. Users have to hard-refresh (Ctrl+Shift+R) or clear cache to fix it. This is more problematic when using Home Assistant with Mealie iframe, the cards need to update url at every Mealie rebuild.

This sets proper cache headers in `SPAStaticFiles.get_response()`:
- `_nuxt/*` assets: `Cache-Control: public, max-age=31536000, immutable` — hashed filenames make these safe to cache forever
- Everything else (HTML shell, manifest, etc.): `Cache-Control: no-cache, no-store, must-revalidate` — browser always fetches fresh HTML with correct bundle references

**Files changed:**
- `mealie/routes/spa/__init__.py` — Added cache header logic to `SPAStaticFiles.get_response()`

The fix is in the Python SPA handler (not `nuxt.config.ts`) because Mealie serves the frontend via FastAPI/Starlette `StaticFiles`, not via Nitro.

## Which issue(s) this PR fixes:

Common user complaint after updates — blank white page until hard refresh. No specific issue number.

## Special notes for your reviewer:

- This is a 1-file, ~10-line change with no new dependencies
- The `else` branch (no-cache) covers HTML, manifest, favicons, etc. — anything that isn't a hashed Nuxt bundle
- PWA service worker (`sw.js`) also gets no-cache, which is correct — it needs to update to pick up new precache manifests

## Testing

Tested in production. Verified with `curl -I`:
```
$ curl -I https://mealie.example.com/
cache-control: no-cache, no-store, must-revalidate
pragma: no-cache

$ curl -I https://mealie.example.com/_nuxt/BjS-zhBo.js
cache-control: public, max-age=31536000, immutable
```

## AI / LLM Assistance

This PR was developed with assistance from Claude Code (Claude Opus 4.6). Claude identified that the fix needed to be in the Python SPA handler (not `nuxt.config.ts`) since Mealie serves the frontend via FastAPI StaticFiles. Implementation and testing were done collaboratively. All code was reviewed and tested by the PR author.