### PR TITLE
fix: Disable SSL verify when scraping sites for recipe data

### DIFF
--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -76,7 +76,10 @@ async def safe_scrape_html(url: str) -> str:
         html_bytes = b""
         response = None
 
-        transport = safehttp.AsyncSafeTransport(impersonate=impersonation)
+        transport = safehttp.AsyncSafeTransport(
+            impersonate=impersonation,
+            verify=False,
+        )
         async with AsyncClient(transport=transport) as client:
             async with client.stream(
                 "GET",

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -78,7 +78,7 @@ async def safe_scrape_html(url: str) -> str:
 
         transport = safehttp.AsyncSafeTransport(
             impersonate=impersonation,
-            verify=False,
+            verify=False,  # disable SSL verification since we can handle untrusted data and some sites don't have certs
         )
         async with AsyncClient(transport=transport) as client:
             async with client.stream(


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Disables SSL verification when scraping sites for recipe data. Since there's no attack vector for fetching malicious HTML this is fine, the only two operations are:
1. Scraping using our recipe scraper or OG tags
2. Sending HTML to an LLM

Neither of which are attack vectors exploitable by insecure sites.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7355

## Testing

_(fill-in or delete this section)_

Tested the example in https://github.com/mealie-recipes/mealie/issues/7355.

## AI / LLM Assistance

_(REQUIRED)_

Double-checked potential security risk with Copilot.