### PR TITLE
dev: Fix autolabel permission to only use pull_request_target

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - mealie-next
-  # pull_request event is required for autolabeler
-  pull_request:
-    types: [opened, labeled, unlabeled, reopened, synchronize]
   # pull_request_target event is required for autolabeler to support PRs from forks
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened, synchronize]
@@ -25,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   auto_label:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

The autolabeler fails on `pull_request` when originating from forks, but works fine on `pull_request_target`. This adds support for `pull_request_target` (and removes `pull_request`).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

Copilot double-checked my work.