### PR TITLE
feat: add filter for recipes with unparsed ingredients

### DIFF
--- a/frontend/app/composables/recipes/use-recipes.ts
+++ b/frontend/app/composables/recipes/use-recipes.ts
@@ -136,8 +136,9 @@ export const useRecipes = (
     }
   })();
 
-  async function refreshRecipes() {
-    const { data } = await api.recipes.getAll(page, perPage, { loadFood, orderBy: "created_at", queryFilter });
+  async function refreshRecipes(queryFilterOverride?: string | null) {
+    const effectiveFilter = queryFilterOverride !== undefined ? queryFilterOverride : queryFilter;
+    const { data } = await api.recipes.getAll(page, perPage, { loadFood, orderBy: "created_at", queryFilter: effectiveFilter });
     if (data) {
       recipes.value = data.items;
     }

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -1185,7 +1185,9 @@
       "export-recipes": "Export Recipes",
       "delete-recipes": "Delete Recipes",
       "source-unit-will-be-deleted": "Source Unit will be deleted",
-      "show-only-unparsed": "Show only recipes with unparsed ingredients"
+      "show-only-unparsed": "Show only recipes with unparsed ingredients",
+      "filter-missing-food": "Unparsed food",
+      "filter-missing-unit": "Unparsed unit"
     },
     "recipe-actions": {
       "recipe-actions-data": "Recipe Actions Data",

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -1184,7 +1184,8 @@
       "categorize-recipes": "Categorize Recipes",
       "export-recipes": "Export Recipes",
       "delete-recipes": "Delete Recipes",
-      "source-unit-will-be-deleted": "Source Unit will be deleted"
+      "source-unit-will-be-deleted": "Source Unit will be deleted",
+      "show-only-unparsed": "Show only recipes with unparsed ingredients"
     },
     "recipe-actions": {
       "recipe-actions-data": "Recipe Actions Data",

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -1185,7 +1185,6 @@
       "export-recipes": "Export Recipes",
       "delete-recipes": "Delete Recipes",
       "source-unit-will-be-deleted": "Source Unit will be deleted",
-      "show-only-unparsed": "Show only recipes with unparsed ingredients",
       "filter-missing-food": "Unparsed food",
       "filter-missing-unit": "Unparsed unit"
     },

--- a/frontend/app/pages/admin/setup.vue
+++ b/frontend/app/pages/admin/setup.vue
@@ -457,13 +457,8 @@ async function seedData() {
     return;
   }
 
-  const tasks = [
-    seedFoods(),
-    seedUnits(),
-    seedLabels(),
-  ];
-
-  await Promise.all(tasks);
+  await seedLabels();
+  await Promise.all([seedFoods(), seedUnits()]);
 }
 
 async function submitCommonSettings() {

--- a/frontend/app/pages/group/data/recipes.vue
+++ b/frontend/app/pages/group/data/recipes.vue
@@ -179,6 +179,14 @@
           {{ $t('general.selected-count', selected.length)
           }}
         </p>
+        <v-spacer />
+        <v-checkbox
+          v-model="showOnlyUnparsed"
+          :label="$t('data-pages.recipes.show-only-unparsed')"
+          hide-details
+          density="compact"
+          class="ml-2"
+        />
       </v-card-actions>
       <v-card>
         <RecipeDataTable
@@ -263,6 +271,14 @@ useSeoMeta({
 
 const { refreshRecipes } = useRecipes(true, true, false, `householdId=${auth.user.value?.householdId || ""}`);
 const selected = ref<Recipe[]>([]);
+const showOnlyUnparsed = ref(false);
+
+watch(showOnlyUnparsed, async (val) => {
+  const baseFilter = `householdId=${auth.user.value?.householdId || ""}`;
+  const filter = val ? `${baseFilter} AND hasUnparsedIngredients = true` : baseFilter;
+  await refreshRecipes(filter);
+  selected.value = [];
+});
 
 function resetAll() {
   selected.value = [];

--- a/frontend/app/pages/group/data/recipes.vue
+++ b/frontend/app/pages/group/data/recipes.vue
@@ -181,8 +181,15 @@
         </p>
         <v-spacer />
         <v-checkbox
-          v-model="showOnlyUnparsed"
-          :label="$t('data-pages.recipes.show-only-unparsed')"
+          v-model="filterMissingFood"
+          :label="$t('data-pages.recipes.filter-missing-food')"
+          hide-details
+          density="compact"
+          class="ml-2"
+        />
+        <v-checkbox
+          v-model="filterMissingUnit"
+          :label="$t('data-pages.recipes.filter-missing-unit')"
           hide-details
           density="compact"
           class="ml-2"
@@ -271,12 +278,19 @@ useSeoMeta({
 
 const { refreshRecipes } = useRecipes(true, true, false, `householdId=${auth.user.value?.householdId || ""}`);
 const selected = ref<Recipe[]>([]);
-const showOnlyUnparsed = ref(false);
+const filterMissingFood = ref(false);
+const filterMissingUnit = ref(false);
 
-watch(showOnlyUnparsed, async (val) => {
+watch([filterMissingFood, filterMissingUnit], async ([missingFood, missingUnit]) => {
   const baseFilter = `householdId=${auth.user.value?.householdId || ""}`;
-  const filter = val ? `${baseFilter} AND hasUnparsedIngredients = true` : baseFilter;
-  await refreshRecipes(filter);
+  const parts: string[] = [baseFilter];
+  if (missingFood) {
+    parts.push("recipeIngredient.foodId IS NULL");
+  }
+  if (missingUnit) {
+    parts.push("recipeIngredient.unitId IS NULL");
+  }
+  await refreshRecipes(parts.join(" AND "));
   selected.value = [];
 });
 

--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict
 from sqlalchemy import event
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.orderinglist import ordering_list
-from sqlalchemy.orm import Mapped, column_property, mapped_column, validates
+from sqlalchemy.orm import Mapped, mapped_column, validates
 from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.orm.session import object_session
 
@@ -298,17 +298,3 @@ def calculate_rating(mapper, connection, target: RecipeModel):
         .filter(UserToRecipe.recipe_id == target.id, UserToRecipe.rating is not None, UserToRecipe.rating > 0)
         .scalar()
     )
-
-
-RecipeModel.has_unparsed_ingredients = column_property(
-    sa.select(sa.func.count(RecipeIngredientModel.id))
-    .where(
-        RecipeIngredientModel.recipe_id == RecipeModel.id,
-        sa.or_(RecipeIngredientModel.food_id.is_(None), RecipeIngredientModel.unit_id.is_(None)),
-        sa.or_(RecipeIngredientModel.title.is_(None), RecipeIngredientModel.title == ""),
-        RecipeIngredientModel.referenced_recipe_id.is_(None),
-    )
-    .correlate(RecipeModel)
-    .scalar_subquery()
-    > 0
-)

--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict
 from sqlalchemy import event
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.orderinglist import ordering_list
-from sqlalchemy.orm import Mapped, mapped_column, validates
+from sqlalchemy.orm import Mapped, column_property, mapped_column, validates
 from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.orm.session import object_session
 
@@ -298,3 +298,17 @@ def calculate_rating(mapper, connection, target: RecipeModel):
         .filter(UserToRecipe.recipe_id == target.id, UserToRecipe.rating is not None, UserToRecipe.rating > 0)
         .scalar()
     )
+
+
+RecipeModel.has_unparsed_ingredients = column_property(
+    sa.select(sa.func.count(RecipeIngredientModel.id))
+    .where(
+        RecipeIngredientModel.recipe_id == RecipeModel.id,
+        sa.or_(RecipeIngredientModel.food_id.is_(None), RecipeIngredientModel.unit_id.is_(None)),
+        sa.or_(RecipeIngredientModel.title.is_(None), RecipeIngredientModel.title == ""),
+        RecipeIngredientModel.referenced_recipe_id.is_(None),
+    )
+    .correlate(RecipeModel)
+    .scalar_subquery()
+    > 0
+)


### PR DESCRIPTION
  ## What this PR does / why we need it:                                                                                                                                                                 
                                                                                                                                                                                                         
  Adds the ability to filter recipes by whether they have unparsed ingredients (ingredients missing a food or unit association). Unparsed ingredients degrade functionality like shopping lists, so users need a way to identify these recipes and proactively improve data quality.                                                                                                                            
                                                                                                                                                                                                         
  - **`mealie/db/models/recipe/recipe.py`** — Adds a `column_property` (`has_unparsed_ingredients`) to `RecipeModel` using a correlated EXISTS subquery. This is a SQL-computed attribute (no physical  column, no migration needed) that integrates with the existing `QueryFilterBuilder` system. An ingredient is considered unparsed if `food_id` or `unit_id` is NULL, excluding section headers and  recipe references.                                                                                                                                                                                     
  - **`frontend/app/composables/recipes/use-recipes.ts`** — Extends `refreshRecipes()` with an optional `queryFilterOverride` parameter to support dynamic re-fetching with different filters.
  - **`frontend/app/pages/group/data/recipes.vue`** — Adds a "Show only recipes with unparsed ingredients" checkbox to Settings > Data Management > Recipes. Toggling it re-fetches recipes server-side  with `hasUnparsedIngredients = true` in the query filter.                                                                                                                                              
  - **`frontend/app/lang/messages/en-US.json`** — Adds the i18n string for the checkbox label.                                                                                                           
                                                                                                                                                                                                         
  The filter is also available via the API for any use case that supports query filters:                                                                                
 `GET /api/recipes?queryFilter=hasUnparsedIngredients=true`                                                                                                                                               
                                                                                                                                                                                                         
  ## Which issue(s) this PR fixes:                                
 Feature Reqs:                                                                                                                                                                                                        
 #6762                                                                                                                                                                                        
 #2235
                                                                                                                                                                                                         
  ## Special notes for your reviewer:                                                                                                                                                                    
   
 The `column_property` approach was chosen over modifying `QueryFilterBuilder` to support virtual column aliases. Since `last_made` and `rating` are both real model columns whose aliases just override  the SQL expression, adding has_unparsed_ingredients` as a `column_property` follows the same pattern with zero changes to the filter infrastructure. The subquery only executes when the attribute is actually queried/filtered on.                                                                                                                                                                         
                                                                  
  ## Testing                                                                                                                                                                                             
   
  - Manual testing against a Docker deployment with seeded data and imported recipes                                                                                                                     
  - Verified the checkbox filters correctly on the Data Management > Recipes page
  - Verified the query filter works via API: `GET /api/recipes?queryFilter=hasUnparsedIngredients=true`                                                                                                  
  - Verified recipes with zero ingredients are not flagged              
  - - Verified recipes with all parsed ingredients are not flagged                                                                                                                                         
  - Verified section headers and recipe-reference ingredients are excluded from the unparsed check                                                                                                       
                                                                                                                                                                                                         
  ## AI / LLM Assistance                                                                                                                                                                                 
                                                                                                                                                                                                         
This PR was developed with significant assistance from an LLM. Used to identify implementation option, implementation and writing this PR. All changes were reviewed and tested by the author (testing completed noted above).
