### PR TITLE
Fix theme-color meta tag not reflecting custom theme

### DIFF
--- a/frontend/app/plugins/theme.ts
+++ b/frontend/app/plugins/theme.ts
@@ -30,6 +30,20 @@ async function fetchTheme(): Promise<ThemeConfig | undefined> {
   }
 }
 
+function updateThemeColorMeta(color: string) {
+  if (import.meta.server) return;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute("content", color);
+  }
+  else {
+    const newMeta = document.createElement("meta");
+    newMeta.name = "theme-color";
+    newMeta.content = color;
+    document.head.appendChild(newMeta);
+  }
+}
+
 export default defineNuxtPlugin(async (nuxtApp) => {
   nuxtApp.hook("vuetify:before-create", async ({ vuetifyOptions }) => {
     let theme = __cachedTheme;
@@ -37,8 +51,13 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       theme = await fetchTheme();
       __cachedTheme = theme;
     }
+    const isDark = nuxtApp.$config.public.useDark;
+    const primaryColor = isDark
+      ? (theme?.darkPrimary ?? "#E58325")
+      : (theme?.lightPrimary ?? "#E58325");
+    updateThemeColorMeta(primaryColor);
     vuetifyOptions.theme = {
-      defaultTheme: nuxtApp.$config.public.useDark ? "dark" : "light",
+      defaultTheme: isDark ? "dark" : "light",
       variations: {
         colors: ["primary", "accent", "secondary", "success", "info", "warning", "error", "background"],
         lighten: 3,


### PR DESCRIPTION
## Summary

When customizing Mealie's theme colors via environment variables or the admin UI, the `<meta name="theme-color">` tag in the HTML stays stuck on the default `#E58325` orange. On mobile browsers like iOS Safari, this creates a jarring mismatch — the browser chrome shows the old orange while the app itself uses the custom color.

The root cause is that `@vite-pwa/nuxt` injects the `theme-color` meta at build time from the static manifest config, but the theme plugin (`frontend/app/plugins/theme.ts`) fetches the actual colors from `/api/app/about/theme` at runtime without updating the meta tag.

This PR adds a small `updateThemeColorMeta()` helper in the theme plugin that runs after the API theme is loaded. It updates the existing `<meta name="theme-color">` element (or creates one if missing) with the correct primary color, respecting whether dark or light mode is active.

## Test plan

- [ ] Set custom `THEME_LIGHT_PRIMARY` (e.g. `#1976d2`) and verify the browser chrome on mobile matches the new color
- [ ] Toggle dark mode and confirm the meta tag updates to `THEME_DARK_PRIMARY`
- [ ] With no custom theme set, confirm the default `#E58325` is still applied

Fixes #4563