### PR TITLE
fix: prevent delete-image dialog from reopening in a loop inside v-menu

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="text-center">
+    <BaseDialog
+      v-model="dialogDeleteImage"
+      :title="$t('recipe.delete-image')"
+      :icon="$globals.icons.alertCircle"
+      color="error"
+      can-delete
+      @delete="deleteImage"
+    >
+      <v-card-text>
+        {{ $t("recipe.delete-image-confirmation") }}
+      </v-card-text>
+    </BaseDialog>
     <v-menu
       v-model="menu"
       offset-y
@@ -37,18 +49,6 @@
               delete
               @click="dialogDeleteImage = true"
             />
-            <BaseDialog
-              v-model="dialogDeleteImage"
-              :title="$t('recipe.delete-image')"
-              :icon="$globals.icons.alertCircle"
-              color="error"
-              can-delete
-              @delete="deleteImage"
-            >
-              <v-card-text>
-                {{ $t("recipe.delete-image-confirmation") }}
-              </v-card-text>
-            </BaseDialog>
           </div>
         </v-card-title>
         <v-card-text class="mt-n5">


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes an infinite loop where clicking the **Delete image** button inside the recipe image menu caused the confirmation dialog to reopen immediately after being dismissed, making it impossible to close.

**Root cause:** `BaseDialog` was rendered as a child of the `v-menu` content. Vuetify teleports the dialog scrim (`v-overlay`) to `<body>`, placing it above the still-open menu. When the user clicked the scrim to dismiss the dialog, the click event leaked back through to the delete button in the menu underneath, immediately re-setting `dialogDeleteImage = true` — repeating indefinitely.

**Fix:**
- `frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue` — moved `BaseDialog` outside the `v-menu` as a sibling at the component root. The `v-model` and `@delete` handler are unchanged; only the placement in the DOM tree changes. With the dialog no longer nested inside the menu overlay, the scrim no longer overlaps the menu content and the click leakthrough cannot occur.

## Which issue(s) this PR fixes:

No existing issue — discovered during manual testing.

## Testing

Manually verified on desktop browser (Chromium):
- Clicking **Delete image** opens the confirmation dialog exactly once
- Dismissing the dialog (Cancel / click outside) closes it without reopening
- Confirming delete calls the API and closes both dialog and menu correctly
- Upload image and get-from-URL flows are unaffected

## AI / LLM Assistance

Claude Code (claude-sonnet-4-6) was used to identify the root cause and implement the fix. The bug diagnosis, code change, and manual verification were done with AI assistance.