### PR TITLE
fix: preserve ingredient section titles when parsing recipe ingredients

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -371,14 +371,18 @@ async function parseIngredients() {
   }
   state.loading.parser = true;
   try {
-    const ingsAsString = props.ingredients
-      .filter(ing => !ing.referencedRecipe)
-      .map(ing => ingredientToParserString(ing));
+    const filteredIngredients = props.ingredients.filter(ing => !ing.referencedRecipe);
+    const ingsAsString = filteredIngredients.map(ing => ingredientToParserString(ing));
     const { data, error } = await api.recipes.parseIngredients(parser.value, ingsAsString);
     if (error || !data) {
       throw new Error("Failed to parse ingredients");
     }
-    parsedIngs.value = data;
+
+    // Restore section titles from original ingredients — the parser doesn't return them
+    data.forEach((parsed, index) => {
+      parsed.ingredient.title = filteredIngredients[index]?.title || "";
+    });
+
     const parsed = data ?? [];
     const recipeRefs = props.ingredients.filter(ing => ing.referencedRecipe).map(ing => ({
       input: ing.note || "",


### PR DESCRIPTION
## What this PR does / why we need it:

When a user adds section titles to recipe ingredients using the **Toggle Section**
feature, and then runs the **Parse** function to match ingredients against the
food database, all section titles are silently lost.

**Root cause:** The ingredient parser API receives ingredient text strings and
returns fresh `RecipeIngredient` objects without the `title` field (which holds
the section title). After parsing, these fresh objects replace the originals —
taking the `title` field with them.

**Fix:** After receiving the API response, the section title (`title` field) is
restored from the corresponding original ingredient. The index order is
guaranteed to match since the parser returns results in the same order as the
input.

Changed file:
- `frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue`
  - Extract filtered ingredients into `filteredIngredients` variable (reused for title restoration)
  - After API response: restore `title` from original ingredient by index
  - Remove a redundant `parsedIngs.value = data` assignment that was immediately overwritten

## Which issue(s) this PR fixes:

Fixes https://github.com/mealie-recipes/mealie/issues/6303

## Special notes for your reviewer:

The fix is entirely frontend-side, which is the correct layer — the parser
correctly handles text parsing; preserving UI metadata like section titles is
the client's responsibility.

## Testing

Manually tested:
1. Open a recipe in edit mode
2. Add section titles to some ingredients via **Toggle Section**
3. Click **Parse**
4. Confirm: section titles are preserved after parsing and saving

Before this fix, step 4 would show all section titles gone.

## AI / LLM Assistance

This fix was developed with the assistance of **Claude Sonnet 4.6** (Claude Code CLI
by Anthropic). The LLM identified the root cause by tracing the data flow through
`parseIngredients()`, designed the fix, and wrote the code. The fix was manually
verified in a local Docker environment before submitting.