### PR TITLE
fix: use correct title and icon on Recipe Actions data page

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="text-center">
+    <BaseDialog
+      v-model="dialogDeleteImage"
+      :title="$t('recipe.delete-image')"
+      :icon="$globals.icons.alertCircle"
+      color="error"
+      can-delete
+      @delete="deleteImage"
+    >
+      <v-card-text>
+        {{ $t("recipe.delete-image-confirmation") }}
+      </v-card-text>
+    </BaseDialog>
     <v-menu
       v-model="menu"
       offset-y
@@ -37,18 +49,6 @@
               delete
               @click="dialogDeleteImage = true"
             />
-            <BaseDialog
-              v-model="dialogDeleteImage"
-              :title="$t('recipe.delete-image')"
-              :icon="$globals.icons.alertCircle"
-              color="error"
-              can-delete
-              @delete="deleteImage"
-            >
-              <v-card-text>
-                {{ $t("recipe.delete-image-confirmation") }}
-              </v-card-text>
-            </BaseDialog>
           </div>
         </v-card-title>
         <v-card-text class="mt-n5">

--- a/frontend/app/pages/group/data/recipe-actions.vue
+++ b/frontend/app/pages/group/data/recipe-actions.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <GroupDataPage
-      :icon="$globals.icons.linkVariantPlus"
-      :title="$t('data-pages.recipe-actions.new-recipe-action')"
+      :icon="$globals.icons.link"
+      :title="$t('data-pages.recipe-actions.recipe-actions-data')"
       :create-title="$t('data-pages.recipe-actions.new-recipe-action')"
       :edit-title="$t('data-pages.recipe-actions.edit-recipe-action')"
       :table-headers="tableHeaders"


### PR DESCRIPTION
## What this PR does / why we need it:

This PR contains two independent bug fixes:

### 1. Fix: prevent delete-image dialog from looping inside v-menu

The `BaseDialog` for delete confirmation in `RecipeImageUploadBtn.vue` was originally nested inside the `<v-menu>` component. This caused a loop: opening the dialog triggered the menu's outside-click handler, which closed and reopened the menu, interfering with the dialog. Moving the dialog outside the `<v-menu>` (as a sibling within the root `div`) fixes this behavior.

**Files changed:**
- `frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue` — moved `BaseDialog` outside of `<v-menu>`

### 2. Fix: use correct title and icon on Recipe Actions data page

The Recipe Actions data page (`/group/data/recipe-actions`, Settings > Data Management > Recipe Actions) was using the wrong translation key and icon.

- **Title:** The page was using `new-recipe-action` ("New Recipe Action") as the page title, which is semantically incorrect — that string belongs to the creation form button/dialog, not the page heading. The correct key is `recipe-actions-data` ("Recipe Actions Data").
- **Icon:** The `linkVariantPlus` icon (a link with a plus sign) was used, which implies creating a new item. Since the icon represents the page itself (not an action), the neutral `link` icon is more appropriate.

**Screenshot before/after**
<img width="200" height="361" alt="Screenshot_20260419_134125_Chrome" src="https://github.com/user-attachments/assets/ba72e1e5-95cf-4003-a8e1-8e68cc6cb1e9" /><img width="200" height="361" alt="Screenshot_20260419_134338_Chrome" src="https://github.com/user-attachments/assets/9fcb3357-5e13-406d-bd4d-5a9d07271058" />

**Files changed:**
- `frontend/app/pages/group/data/recipe-actions.vue` — corrected `:title` binding and `:icon` prop

No translation files need to be updated, as all keys already exist in all locales.

## Which issue(s) this PR fixes:

_(no related issue)_

## Testing:

Built a Docker image with both fixes applied and manually verified that:
- The delete image dialog opens and closes correctly without triggering a menu loop
- The Recipe Actions data page renders with the correct title ("Recipe Actions Data") and icon

## AI / LLM Assistance:

The fixes were identified and implemented with the assistance of Claude (LLM), specifically **Claude Sonnet 4.6**. The changes were reviewed and manually tested by the author, including building and running a Docker image with the fixes applied.