### PR TITLE
fix: redirect to new slug URL after recipe rename

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -358,10 +358,15 @@ async function saveRecipe() {
     setMode(PageMode.VIEW);
   }
   if (data?.slug) {
-    router.push(`/g/${groupSlug.value}/r/` + data.slug);
     recipe.value = data as NoUndefinedField<Recipe>;
-    // Update the snapshot after successful save
     originalRecipe.value = deepCopy(recipe.value);
+    if (data.slug !== route.params.slug) {
+      // Wait for the isEditMode watcher (which removes ?edit=true via router.replace)
+      // to run and complete before navigating, otherwise it would cancel our navigation.
+      await nextTick();
+      await nextTick();
+      router.replace(`/g/${groupSlug.value}/r/` + data.slug);
+    }
   }
 }
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -336,8 +336,16 @@ onMounted(() => {
   }
 });
 
+// When set, the isEditMode watcher skips its URL cleanup because saveRecipe
+// is navigating to a new slug that naturally omits ?edit=true.
+const isNavigatingAfterRename = ref(false);
+
 watch(isEditMode, (newVal) => {
   if (!newVal) {
+    if (isNavigatingAfterRename.value) {
+      isNavigatingAfterRename.value = false;
+      return;
+    }
     paramsEdit.value = undefined;
   }
 });
@@ -355,16 +363,15 @@ watch(isParsing, () => {
 async function saveRecipe() {
   const { data, error } = await api.recipes.updateOne(recipe.value.slug, recipe.value);
   if (!error) {
+    if (data?.slug && data.slug !== route.params.slug) {
+      isNavigatingAfterRename.value = true;
+    }
     setMode(PageMode.VIEW);
   }
   if (data?.slug) {
     recipe.value = data as NoUndefinedField<Recipe>;
     originalRecipe.value = deepCopy(recipe.value);
     if (data.slug !== route.params.slug) {
-      // Wait for the isEditMode watcher (which removes ?edit=true via router.replace)
-      // to run and complete before navigating, otherwise it would cancel our navigation.
-      await nextTick();
-      await nextTick();
       router.replace(`/g/${groupSlug.value}/r/` + data.slug);
     }
   }


### PR DESCRIPTION
## What this PR does / why we need it:

When a user renames a recipe and saves it, the backend generates a new URL slug from the new name. However, the browser URL remained on the old (now invalid) slug after saving. Refreshing the page (F5) would result in a 404 error.

**Root cause:** A race condition between two concurrent Vue Router navigations:
1. `setMode(VIEW)` triggers the `isEditMode` watcher, which calls `paramsEdit.value = undefined` to remove `?edit=true` from the URL. The `useRouteQuery` setter schedules this via `nextTick(() => router.replace(...))` using the **current (old) path**.
2. `router.push(newSlug)` starts navigation to the new slug.
3. The watcher's `router.replace(oldSlug)` fires after the push and Vue Router cancels the in-progress navigation to the new slug.

Result: the URL reverts to the old slug without `?edit=true`, which is no longer valid after the rename.

**Changes in `RecipePage.vue`:**
- Move `recipe.value` and `originalRecipe.value` updates **before** navigation (was after), so `hasUnsavedChanges()` correctly returns false if any guard fires.
- Use `await nextTick(); await nextTick()` to let the `isEditMode` watcher's `router.replace` complete before our navigation runs.
- Replace `router.push` with `router.replace` so the old (now invalid) slug is not added to browser history — prevents a 404 when pressing the Back button.
- Only navigate when the slug actually changed (`data.slug !== route.params.slug`).

## Which issue(s) this PR fixes:

_(no existing issue found — this bug was discovered during testing)_

## Testing

Tested manually in Chrome:

- Rename a recipe and save → URL updates to the new slug immediately
- F5 after rename → page loads correctly at the new slug
- Back button after rename → navigates to the page before the recipe (not the old invalid slug)
- Save without changing the name → URL stays the same, no unnecessary navigation
- Open recipe with `?edit=true` URL, rename and save → URL updates to new slug without `?edit=true`

## AI / LLM Assistance

This PR was developed with assistance from Claude Code (claude-sonnet-4-6). The root cause analysis (race condition between Vue Router navigations) and the fix were identified and implemented with AI assistance. The fix was manually verified by the author in Chrome.