### PR TITLE
fix: recipe search ranking for separator characters 

### DIFF
--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -373,6 +373,14 @@ class Recipe(RecipeSummary):
                 .scalars()
                 .all()
             )
+            
+            #FIX: strip separators from the recipe name to improve token search results
+            normalized_recipe_name = func.replace(
+                func.replace(RecipeModel.name_normalized, "-", " "),
+                "·",
+                " ",
+            )
+            name_normalized = normalized_recipe_name
 
             return query.filter(
                 or_(


### PR DESCRIPTION
## What this PR does / why we need it:

- Updates recipe search ranking so separator characters in recipe titles are handled consistently.
- In `mealie/schema/recipe/recipe.py`, normalizes hyphens (`-`) and middle dots (`·`) in `RecipeModel.name_normalized` at comparison time before applying the title-ranking boost.
- Keeps stored and displayed recipe titles unchanged.
- Avoids changing shared model normalization or adding a database migration.

This helps searches like `Gluten-Free Apple Cinnamon Scones` and `Gluten Free Apple Cinnamon Scones` rank the same recipe more consistently.

## Which issue(s) this PR fixes:

Fixes #6865
Fixes #6826

## Special notes for your reviewer:

Please focus review on whether comparison-time normalization is the right scope for this issue. I intentionally avoided changing stored recipe titles or shared normalization logic because the reported issue appears to be search ranking, not recipe storage.

## Testing

Tested locally by running Mealie and searching for recipe titles containing separator characters, including hyphens and middle dots. Verified that stored recipe titles remain unchanged while the search comparison treats separator and space-separated forms consistently.

## AI / LLM Assistance

I used an LLM to help reason through the code path, summarize the issue, and draft this PR description. I reviewed the code changes and final wording myself.