### PR TITLE
fix: prevent double-scaling of sub-recipe ingredients in shopping list

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
@@ -321,7 +321,7 @@ async function consolidateRecipesIntoSections(recipes: RecipeWithScale[]) {
         const householdsWithFood = subIng.food?.householdsWithIngredientFood || [];
         ownIngs.push({
           checked: !householdsWithFood.includes(currentHouseholdSlug.value),
-          ingredient: { ...subIng, quantity: (ing.quantity || 1) * (subIng.quantity || 1) },
+          ingredient: subIng,
         });
       }
     }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

When adding a recipe that references another recipe as an ingredient (sub-recipe) to a shopping list, the sub-recipe's ingredient quantities were being scaled twice:

1. Once manually in `addSubRecipeToMap` by pre-multiplying the quantity into the ingredient object (`quantity: (ing.quantity || 1) * (subIng.quantity || 1)`)
2. A second time automatically by the template via the `recipeScale` prop passed to `RecipeIngredientListItem`

**Fix:** Remove the manual pre-multiplication — the scale is already correctly applied via `recipeSection.recipeScale` in the template.

**Also fixed:** After saving a recipe whose slug changed, the router navigation was being cancelled by the `isEditMode` watcher running `router.replace` first. Fixed by awaiting two `nextTick()` calls to let the watcher complete before navigating.

Changed files:
- `frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue` — remove double-scale of sub-recipe ingredient quantity
- `frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue` — fix navigation after recipe save when slug changes
- `tests/integration_tests/user_household_tests/test_group_shopping_lists.py` — add regression test for the double-scaling bug

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #7518

## Testing

Regression test added: `test_shopping_lists_add_nested_recipe_ingredients_with_scale`

The test creates a sub-recipe with 1000g of an ingredient and a parent recipe that references it with quantity 0.5. It verifies that the resulting shopping list item has quantity 500 (1000 × 0.5), not 250 (double-scaled).

Manually tested in Docker with a real recipe containing a sub-recipe reference — quantities in the shopping list dialog now match the expected values.

## AI / LLM Assistance

_(REQUIRED)_

This fix was developed with the assistance of Claude Sonnet (claude-sonnet-4-6) via Claude Code CLI. The root cause analysis, code changes, and regression test were written with AI assistance. The fix was reviewed and manually tested by the author.