### PR TITLE
feat: show full recipe title in tooltip on recipe cards

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -36,9 +36,13 @@
             </div>
           </v-expand-transition>
         </RecipeCardImage>
-        <v-card-title class="mb-n3 px-4" style="font-size: 1.25rem;">
-          {{ name }}
-        </v-card-title>
+        <v-tooltip location="bottom" :text="name">
+          <template #activator="{ props: tooltipProps }">
+            <v-card-title v-bind="tooltipProps" class="mb-n3 px-4" style="font-size: 1.25rem;">
+              {{ name }}
+            </v-card-title>
+          </template>
+        </v-tooltip>
 
         <slot name="actions">
           <v-card-actions

--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -36,7 +36,7 @@
             </div>
           </v-expand-transition>
         </RecipeCardImage>
-        <v-tooltip location="bottom" open-delay="3000" :text="name">
+        <v-tooltip location="bottom" open-delay="700" :text="name">
           <template #activator="{ props: tooltipProps }">
             <v-card-title v-bind="tooltipProps" class="mb-n3 px-4" style="font-size: 1.25rem;">
               {{ name }}

--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -36,7 +36,7 @@
             </div>
           </v-expand-transition>
         </RecipeCardImage>
-        <v-tooltip location="bottom" :text="name">
+        <v-tooltip location="bottom" open-delay="3000" :text="name">
           <template #activator="{ props: tooltipProps }">
             <v-card-title v-bind="tooltipProps" class="mb-n3 px-4" style="font-size: 1.25rem;">
               {{ name }}

--- a/frontend/app/components/Domain/Recipe/RecipeCardMobile.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCardMobile.vue
@@ -52,7 +52,7 @@
             </slot>
           </template>
           <div class="pl-4 d-flex flex-column justify-space-between align-stretch pr-2">
-            <v-tooltip location="bottom" open-delay="3000" :text="name">
+            <v-tooltip location="bottom" open-delay="700" :text="name">
               <template #activator="{ props: tooltipProps }">
                 <v-list-item-title v-bind="tooltipProps" class="mt-3 mb-1 text-top text-truncate w-100">
                   {{ name }}

--- a/frontend/app/components/Domain/Recipe/RecipeCardMobile.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCardMobile.vue
@@ -52,9 +52,13 @@
             </slot>
           </template>
           <div class="pl-4 d-flex flex-column justify-space-between align-stretch pr-2">
-            <v-list-item-title class="mt-3 mb-1 text-top text-truncate w-100">
-              {{ name }}
-            </v-list-item-title>
+            <v-tooltip location="bottom" open-delay="3000" :text="name">
+              <template #activator="{ props: tooltipProps }">
+                <v-list-item-title v-bind="tooltipProps" class="mt-3 mb-1 text-top text-truncate w-100">
+                  {{ name }}
+                </v-list-item-title>
+              </template>
+            </v-tooltip>
             <v-list-item-subtitle class="ma-0 text-top">
               <SafeMarkdown v-if="description" :source="description" />
               <p v-else>


### PR DESCRIPTION
## What this PR does / why we need it:

Recipe card titles are often truncated (ending with `…`) because card width is limited. This is especially frustrating when multiple recipes share a common prefix and differ only in the part that gets hidden — making it impossible to distinguish them without clicking into each recipe.

This PR adds a `v-tooltip` to the recipe card title in both card view variants (large grid cards and compact list cards), so hovering over a truncated title reveals the full name after a short delay.

Changes:
- `frontend/app/components/Domain/Recipe/RecipeCard.vue` — wrapped `<v-card-title>` with Vuetify `v-tooltip` (large card variant)
- `frontend/app/components/Domain/Recipe/RecipeCardMobile.vue` — wrapped `<v-list-item-title>` with Vuetify `v-tooltip` (compact card variant)

Both tooltips use `open-delay="700"` to avoid the tooltip triggering while the user is simply moving the cursor across the list. The existing Vuetify `v-tooltip` component is used — no new dependencies introduced.

**Note for maintainers:** The `open-delay` is currently set per component. A cleaner long-term solution would be to add a global default in `nuxt.config.ts` under the `vuetify.vuetifyOptions.defaults` section — e.g. `VTooltip: { openDelay: 700 }` — so the delay is consistent across the whole app without repeating it at every usage site. We're happy to adjust this PR if that direction is preferred.

## Which issue(s) this PR fixes:

No existing issue. This is a small UX improvement.

## Result
<img width="330" height="147" alt="Snímek obrazovky 2026-05-01 154605" src="https://github.com/user-attachments/assets/afeddee1-01e6-433e-8e80-da26c3440a87" />
<img width="350" height="323" alt="Snímek obrazovky 2026-05-01 154630" src="https://github.com/user-attachments/assets/9335dfc1-a953-4960-8c04-7f23a6b3aacf" />



## Testing

Manually tested on the group recipe listing page (`/g/<group>/`) in both card view modes:
- Tooltip appears after ~700 ms of hovering over a recipe title
- Tooltip shows the full recipe name regardless of truncation
- No visual regressions observed in card layout or hover effects

## AI / LLM Assistance

This PR was developed with assistance from Claude (Sonnet 4.6) via Claude Code. The implementation approach, component selection, and code changes were reviewed and guided by the human author. The use of the existing Vuetify `v-tooltip` pattern was intentional — matching conventions already present in the codebase.