### PR TITLE
fix: Don't hit authenticated endpoints when logged out

### DIFF
--- a/frontend/app/components/Layout/DefaultLayout.vue
+++ b/frontend/app/components/Layout/DefaultLayout.vue
@@ -110,7 +110,7 @@ const route = useRoute();
 const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const cookbookPreferences = useCookbookPreferences();
-const ownCookbookStore = useCookbookStore(i18n);
+const ownCookbookStore = computed(() => isOwnGroup.value ? useCookbookStore(i18n) : null);
 const publicCookbookStoreCache = ref<Record<string, ReturnType<typeof usePublicCookbookStore>>>({});
 
 function getPublicCookbookStore(slug: string) {
@@ -121,8 +121,8 @@ function getPublicCookbookStore(slug: string) {
 }
 
 const cookbooks = computed(() => {
-  if (isOwnGroup.value) {
-    return ownCookbookStore.store.value;
+  if (ownCookbookStore.value) {
+    return ownCookbookStore.value.store.value;
   }
   else if (groupSlug.value) {
     const publicStore = getPublicCookbookStore(groupSlug.value);

--- a/frontend/app/composables/use-groups.ts
+++ b/frontend/app/composables/use-groups.ts
@@ -6,7 +6,12 @@ const loading = ref(false);
 
 export const useGroupSelf = function () {
   const api = useUserApi();
+  const auth = useMealieAuth();
   async function refreshGroupSelf() {
+    if (!auth.user.value) {
+      groupSelfRef.value = null;
+      return;
+    }
     loading.value = true;
     const { data } = await api.groups.getCurrentUserGroup();
     groupSelfRef.value = data;

--- a/frontend/app/composables/use-households.ts
+++ b/frontend/app/composables/use-households.ts
@@ -6,8 +6,13 @@ const loading = ref(false);
 
 export const useHouseholdSelf = function () {
   const api = useUserApi();
+  const auth = useMealieAuth();
 
   async function refreshHouseholdSelf() {
+    if (!auth.user.value) {
+      householdSelfRef.value = null;
+      return;
+    }
     loading.value = true;
     const { data } = await api.households.getCurrentUserHousehold();
     householdSelfRef.value = data;

--- a/frontend/app/composables/use-recipe-explorer-search.ts
+++ b/frontend/app/composables/use-recipe-explorer-search.ts
@@ -73,11 +73,11 @@ function createRecipeExplorerSearchState(groupSlug: ComputedRef<string>): Recipe
   });
 
   // Store references
-  const categories = isOwnGroup ? useCategoryStore() : usePublicCategoryStore(groupSlug.value);
-  const foods = isOwnGroup ? useFoodStore() : usePublicFoodStore(groupSlug.value);
-  const households = isOwnGroup ? useHouseholdStore() : usePublicHouseholdStore(groupSlug.value);
-  const tags = isOwnGroup ? useTagStore() : usePublicTagStore(groupSlug.value);
-  const tools = isOwnGroup ? useToolStore() : usePublicToolStore(groupSlug.value);
+  const categories = isOwnGroup.value ? useCategoryStore() : usePublicCategoryStore(groupSlug.value);
+  const foods = isOwnGroup.value ? useFoodStore() : usePublicFoodStore(groupSlug.value);
+  const households = isOwnGroup.value ? useHouseholdStore() : usePublicHouseholdStore(groupSlug.value);
+  const tags = isOwnGroup.value ? useTagStore() : usePublicTagStore(groupSlug.value);
+  const tools = isOwnGroup.value ? useToolStore() : usePublicToolStore(groupSlug.value);
 
   // Selected items
   const selectedCategories = ref<NoUndefinedField<RecipeCategory>[]>([]);


### PR DESCRIPTION


## What this PR does / why we need it:

Unauthenticated visits will cause HTTP 401 errors because the app attempts to hit APIs that require auth. This causes issues for users that run fail2ban and autoban on a certain number of 401s. 

```
401 Unauthorized "GET /api/households/self"
401 Unauthorized "GET /api/groups/self"
401 Unauthorized "GET /api/groups/households?..."
401 Unauthorized "GET /api/households/cookbooks?..."
401 Unauthorized "GET /api/organizers/categories?..."
401 Unauthorized "GET /api/foods?..."
401 Unauthorized "GET /api/organizers/tags?..."
401 Unauthorized "GET /api/organizers/tools?..."
```
### Changes
- `use-recipe-explorer-search.ts`: update ternaries to use missing `.value` because objects are always truthy
- `use-households.ts`: Check if user is logged in and return null if not
- `use-groups.ts`: Check if user is logged in and return null if not
- `DefaultLayout.vue`: Lazy load the cookbook store

## Which issue(s) this PR fixes:

Fixes #4173

## Special notes for your reviewer:

I've never worked with typescript or Vue before

## Testing

Ran the dev container and compared network requests in browser dev tools before and after.
task py:check passed.
task ui:check passed.

## AI / LLM Assistance

Copilot with opus 4.7 to understand the codebase and where to find the issues