### PR TITLE
fix: Adjust ingredient section spacing

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
@@ -19,11 +19,11 @@
       >
         <h3
           v-if="showTitleEditor[index]"
-          class="mt-2"
+          class="mt-4 mb-0"
         >
           {{ ingredient.title }}
         </h3>
-        <v-divider v-if="showTitleEditor[index]" />
+        <v-divider v-if="showTitleEditor[index]" class="my-2" />
         <v-list-item
           density="compact"
           class="pa-0"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Adjusts the ingredient section spacing. Previously it looks quite awkward (note the horizontal line):
<img width="483" height="344" alt="image" src="https://github.com/user-attachments/assets/375682ef-f23b-4bc2-9d88-02955f1ec850" />

Adjusted:
<img width="447" height="348" alt="image" src="https://github.com/user-attachments/assets/262e5b18-3f97-4094-8642-635bbdcabac4" />

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

None