### PR TITLE
feat: Improve new shopping list UI

### DIFF
--- a/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
@@ -11,18 +11,28 @@
   >
     <div class="d-flex flex-column ga-3">
       <v-card-actions class="pa-0">
-        <InputLabelType
-          v-model="listItem.food"
-          v-model:item-id="listItem.foodId!"
-          :items="foods"
-          :label="rail ? $t('shopping-list.add-item') : $t('shopping-list.food')"
-          :icon="$globals.icons.foods"
-          :style="rail ? 'margin-inline: 3px;' : undefined"
-          :search="rail"
-          create
-          @create="createAssignFood"
-          @focus="rail = false"
-        />
+        <div class="position-relative" style="flex: 1;">
+          <InputLabelType
+            ref="foodInputRef"
+            v-model="listItem.food"
+            v-model:item-id="listItem.foodId!"
+            :items="foods"
+            :label="rail ? $t('shopping-list.add-item') : $t('shopping-list.food')"
+            :icon="$globals.icons.foods"
+            :style="rail ? 'margin-inline: 3px;' : undefined"
+            :search="rail"
+            :menu-props="{ location: $vuetify.display.smAndDown ? 'top' : 'bottom' }"
+            create
+            @create="createAssignFood"
+          />
+          <!-- Intercept clicks when collapsed so the drawer expands before the autocomplete opens -->
+          <div
+            v-if="rail"
+            class="position-absolute"
+            style="inset: 0; cursor: text;"
+            @click="expandAndFocus"
+          />
+        </div>
         <BaseButtonGroup
           v-if="!rail"
           :buttons="[
@@ -84,6 +94,17 @@ defineEmits<{
 
 const { createAssignFood } = useShoppingListItemEditor(listItem);
 
+const foodInputRef = ref<{ focus: () => void } | null>(null);
+const rail = ref(true);
+
+async function expandAndFocus() {
+  rail.value = false;
+  await nextTick();
+  setTimeout(() => {
+    foodInputRef.value?.focus();
+  }, 200);
+}
+
 watch(
   () => listItem.value.quantity,
   (newQty) => {
@@ -100,6 +121,4 @@ watch(
     listItem.value.labelId = listItem.value.label?.id || null;
   },
 );
-
-const rail = ref(true);
 </script>

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
@@ -21,7 +21,7 @@
             :icon="$globals.icons.foods"
             :style="rail ? 'margin-inline: 3px;' : undefined"
             :search="rail"
-            :menu-props="{ location: $vuetify.display.smAndDown ? 'top' : 'bottom' }"
+            :menu-props="{ location: menuDirection }"
             create
             @create="createAssignFood"
           />
@@ -93,6 +93,9 @@ defineEmits<{
 }>();
 
 const { createAssignFood } = useShoppingListItemEditor(listItem);
+
+const { smAndDown } = useDisplay();
+const menuDirection = computed(() => smAndDown.value ? "top" : "bottom");
 
 const foodInputRef = ref<{ focus: () => void } | null>(null);
 const rail = ref(true);

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListItem.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListItem.vue
@@ -11,11 +11,13 @@
     >
       <v-row
         v-touch="{
-          move: ({ originalEvent: { touches: [{ screenX }] } }) => {
+          move: ({ originalEvent: { touches: [{ screenX, screenY }] } }) => {
             swipeInfo.touchendX = screenX;
+            swipeInfo.touchendY = screenY;
           },
-          start: ({ originalEvent: { touches: [{ screenX }] } }) => {
+          start: ({ originalEvent: { touches: [{ screenX, screenY }] } }) => {
             swipeInfo.touchstartX = screenX;
+            swipeInfo.touchstartY = screenY;
           },
           end: () => {
             if (swiping < SWIPE_THRESHOLD) {
@@ -212,6 +214,7 @@ const emit = defineEmits<{
 }>();
 
 const SWIPE_THRESHOLD = 50;
+const SCROLL_THRESHOLD = 50;
 
 const { isRtl } = useRtl();
 const i18n = useI18n();
@@ -264,14 +267,22 @@ function save() {
   edit.value = false;
 }
 
-const swipeInfo: Ref<{ touchstartX?: number; touchendX?: number }> = ref({ touchstartX: undefined, touchendX: undefined });
+const swipeInfo: Ref<{ touchstartX?: number; touchendX?: number; touchstartY?: number; touchendY?: number }> = ref({});
 const swiping = computed(() => {
-  const { touchstartX, touchendX } = swipeInfo.value ?? {};
+  const { touchstartX, touchendX, touchstartY, touchendY } = swipeInfo.value ?? {};
   if (touchstartX === undefined || touchendX === undefined) {
     return 0;
   }
-  const delta = isRtl.value ? touchstartX - touchendX : touchendX - touchstartX;
-  return Math.min(Math.max(0, delta), 100);
+  const deltaX = isRtl.value ? touchstartX - touchendX : touchendX - touchstartX;
+
+  // If there's significant vertical movement, treat as a scroll gesture and ignore
+  if (touchstartY !== undefined && touchendY !== undefined) {
+    const deltaY = Math.abs(touchendY - touchstartY);
+    if (deltaY > SCROLL_THRESHOLD) {
+      return 0;
+    }
+  }
+  return Math.min(Math.max(0, deltaX), 100);
 });
 
 const recipeList = computed<RecipeSummary[]>(() => {

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
@@ -16,6 +16,7 @@
       :items="units"
       :label="$t('recipe.unit')"
       :icon="$globals.icons.units"
+      :menu-props="{ location: menuDirection }"
       style="flex: 3"
       create
       @create="createAssignUnit"
@@ -35,6 +36,7 @@
       v-model:item-id="listItem.labelId!"
       :items="labels"
       :label="$t('shopping-list.label')"
+      :menu-props="{ location: menuDirection }"
       style="flex: 1 0 200px"
     />
     <BaseButton
@@ -74,6 +76,9 @@ defineProps({
 const emit = defineEmits<{ (e: "save"): void }>();
 
 const { assignLabelToFood, createAssignUnit } = useShoppingListItemEditor(listItem);
+
+const { smAndDown } = useDisplay();
+const menuDirection = computed(() => smAndDown.value ? "top" : "bottom");
 
 function handleNoteKeyPress(event: KeyboardEvent) {
   // Save on Enter

--- a/frontend/app/components/global/InputLabelType.vue
+++ b/frontend/app/components/global/InputLabelType.vue
@@ -93,4 +93,8 @@ function emitCreate() {
   emit("create", searchInput.value);
   autocompleteRef.value?.blur();
 }
+
+defineExpose({
+  focus: () => autocompleteRef.value?.focus(),
+});
 </script>

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -943,7 +943,7 @@
     "are-you-sure-you-want-to-uncheck-all-items": "Are you sure you want to uncheck all items?",
     "are-you-sure-you-want-to-delete-checked-items": "Are you sure you want to delete all checked items?",
     "no-shopping-lists-found": "No Shopping Lists Found",
-    "item-checked-off": "{item} was checked off"
+    "item-checked-off": "Checked off {item}"
   },
   "sidebar": {
     "all-recipes": "All Recipes",

--- a/frontend/app/pages/shopping-lists/[id].vue
+++ b/frontend/app/pages/shopping-lists/[id].vue
@@ -377,20 +377,22 @@ const { store: allUnits } = useUnitStore();
 const { store: allFoods } = useFoodStore();
 
 function itemCheckedToast(item: ShoppingListItemOut) {
-  alert.info(
-    i18n.t("shopping-list.item-checked-off", { item: item.food?.name || item.note || i18n.t("recipe.ingredient") }),
-    undefined,
-    {
-      timeout: 4000,
-      action: {
-        message: i18n.t("general.undo"),
-        onClick: () => {
-          item.checked = false;
-          shoppingListPage.saveListItem(item);
+  setTimeout(() => {
+    alert.info(
+      i18n.t("shopping-list.item-checked-off", { item: item.food?.name || item.note || i18n.t("recipe.ingredient") }),
+      undefined,
+      {
+        timeout: 4000,
+        action: {
+          message: i18n.t("general.undo"),
+          onClick: () => {
+            item.checked = false;
+            shoppingListPage.saveListItem(item);
+          },
         },
       },
-    },
-  );
+    );
+  }, 500);
 }
 
 const {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Makes a few tweaks to the new shopping list UI:
- Tweaked the toast verbiage and delay it slightly to match the animation
- Ignore swipe if we're scrolling (so we don't check off items while scrolling)
- Delay opening the autocomplete menu so it's in the right place
- Force the menu to open up on mobile (instead of down, which is weird)

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

Largely copilot, manually fixed a few things.
