### PR TITLE
feat: Remember screen lock preference

### DIFF
--- a/frontend/app/components/global/WakelockSwitch.vue
+++ b/frontend/app/components/global/WakelockSwitch.vue
@@ -14,17 +14,25 @@
 
 <script setup lang="ts">
 import { useWakeLock } from "@vueuse/core";
+import { useUserExperiencePreferences } from "~/composables/use-users/preferences";
 
 const { isSupported: wakeIsSupported, isActive, request, release } = useWakeLock();
+const userExperiencePreferences = useUserExperiencePreferences();
+
+function handleLock() {
+  if (userExperiencePreferences.value.lockScreen) {
+    lockScreen();
+  }
+  else {
+    unlockScreen();
+  }
+}
+
 const wakeLock = computed({
-  get: () => isActive.value,
+  get: () => userExperiencePreferences.value.lockScreen,
   set: () => {
-    if (isActive.value) {
-      unlockScreen();
-    }
-    else {
-      lockScreen();
-    }
+    userExperiencePreferences.value.lockScreen = !userExperiencePreferences.value.lockScreen;
+    handleLock();
   },
 });
 async function lockScreen() {
@@ -34,11 +42,11 @@ async function lockScreen() {
   }
 }
 async function unlockScreen() {
-  if (wakeIsSupported || isActive) {
+  if (wakeIsSupported || isActive.value) {
     console.debug("Wake Lock Released");
     await release();
   }
 }
-onMounted(() => lockScreen());
+onMounted(() => handleLock());
 onUnmounted(() => unlockScreen());
 </script>

--- a/frontend/app/composables/use-users/preferences.ts
+++ b/frontend/app/composables/use-users/preferences.ts
@@ -85,9 +85,7 @@ export function useUserMealPlanPreferences(): Ref<UserMealPlanPreferences> {
       numberOfDays: 7,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserMealPlanPreferences>;
+  );
 
   return fromStorage;
 }
@@ -96,15 +94,14 @@ export function useUserPrintPreferences(): Ref<UserPrintPreferences> {
   const fromStorage = useLocalStorage(
     "recipe-print-preferences",
     {
-      imagePosition: "left",
+      imagePosition: "left" as ImagePosition,
       showDescription: true,
       showNotes: true,
+      showNutrition: false,
       expandChildRecipes: false,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserPrintPreferences>;
+  );
 
   return fromStorage;
 }
@@ -122,9 +119,7 @@ export function useUserSortPreferences(): Ref<UserRecipePreferences> {
       useMobileCards: false,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserRecipePreferences>;
+  );
 
   return fromStorage;
 }
@@ -136,9 +131,7 @@ export function useUserActivityPreferences(): Ref<UserActivityPreferences> {
       defaultActivity: ActivityKey.RECIPES,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as Ref<UserActivityPreferences>;
+  );
 
   return fromStorage;
 }
@@ -150,9 +143,7 @@ export function useUserSearchQuerySession(): Ref<UserSearchQuery> {
       recipe: "",
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserSearchQuery>;
+  );
 
   return fromStorage;
 }
@@ -164,9 +155,7 @@ export function useShoppingListPreferences(): Ref<UserShoppingListPreferences> {
       viewAllLists: false,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserShoppingListPreferences>;
+  );
 
   return fromStorage;
 }
@@ -179,9 +168,7 @@ export function useTimelinePreferences(): Ref<UserTimelinePreferences> {
       types: ["info", "system", "comment"] as TimelineEventType[],
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserTimelinePreferences>;
+  );
 
   return fromStorage;
 }
@@ -190,12 +177,10 @@ export function useParsingPreferences(): Ref<UserParsingPreferences> {
   const fromStorage = useLocalStorage(
     "parsing-preferences",
     {
-      parser: "nlp",
+      parser: "nlp" as RegisteredParser,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserParsingPreferences>;
+  );
 
   return fromStorage;
 }
@@ -207,9 +192,7 @@ export function useCookbookPreferences(): Ref<UserCookbooksPreferences> {
       hideOtherHouseholds: false,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserCookbooksPreferences>;
+  );
 
   return fromStorage;
 }
@@ -228,9 +211,7 @@ export function useRecipeFinderPreferences(): Ref<UserRecipeFinderPreferences> {
       includeToolsOnHand: true,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserRecipeFinderPreferences>;
+  );
 
   return fromStorage;
 }

--- a/frontend/app/composables/use-users/preferences.ts
+++ b/frontend/app/composables/use-users/preferences.ts
@@ -231,9 +231,9 @@ export function useRecipeCreatePreferences(): Ref<UserRecipeCreatePreferences> {
   return fromStorage;
 }
 
-export function useUseExperiencePreferences(): Ref<UserExperiencePreferences> {
+export function useUserExperiencePreferences(): Ref<UserExperiencePreferences> {
   const fromStorage = useLocalStorage(
-    "recipe-create-preferences",
+    "user-experience-preferences",
     {
       lockScreen: true,
     },

--- a/frontend/app/composables/use-users/preferences.ts
+++ b/frontend/app/composables/use-users/preferences.ts
@@ -73,6 +73,10 @@ export interface UserActivityPreferences {
   defaultActivity: ActivityKey;
 }
 
+export interface UserExperiencePreferences {
+  lockScreen: boolean;
+}
+
 export function useUserMealPlanPreferences(): Ref<UserMealPlanPreferences> {
   const fromStorage = useLocalStorage(
     "meal-planner-preferences",
@@ -241,9 +245,19 @@ export function useRecipeCreatePreferences(): Ref<UserRecipeCreatePreferences> {
       parseRecipe: true,
     },
     { mergeDefaults: true },
-    // we cast to a Ref because by default it will return an optional type ref
-    // but since we pass defaults we know all properties are set.
-  ) as unknown as Ref<UserRecipeCreatePreferences>;
+  );
+
+  return fromStorage;
+}
+
+export function useUseExperiencePreferences(): Ref<UserExperiencePreferences> {
+  const fromStorage = useLocalStorage(
+    "recipe-create-preferences",
+    {
+      lockScreen: true,
+    },
+    { mergeDefaults: true },
+  );
 
   return fromStorage;
 }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Adds a cookie to remember if a user wants the screen to stay locked or not. As suggested in https://github.com/mealie-recipes/mealie/discussions/7607.

This is global since we only have one shared entry, we could always add some differentiator down the line if we want to, but for now I don't see a need.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, discussed in https://github.com/mealie-recipes/mealie/discussions/7607

## Testing

_(fill-in or delete this section)_

Manually

## AI / LLM Assistance

_(REQUIRED)_

Copilot helped debug some weird logic I implemented.