### PR TITLE
feat: add Force OpenAI Scraper option to URL and bulk import

### DIFF
--- a/frontend/app/composables/use-new-recipe-options.ts
+++ b/frontend/app/composables/use-new-recipe-options.ts
@@ -5,6 +5,7 @@ export interface UseNewRecipeOptionsProps {
   enableImportCategories?: boolean;
   enableStayInEditMode?: boolean;
   enableParseRecipe?: boolean;
+  enableForceOpenAI?: boolean;
 }
 
 export function useNewRecipeOptions(props: UseNewRecipeOptionsProps = {}) {
@@ -13,6 +14,7 @@ export function useNewRecipeOptions(props: UseNewRecipeOptionsProps = {}) {
     enableImportCategories = true,
     enableStayInEditMode = true,
     enableParseRecipe = true,
+    enableForceOpenAI = true,
   } = props;
 
   const router = useRouter();
@@ -62,6 +64,17 @@ export function useNewRecipeOptions(props: UseNewRecipeOptionsProps = {}) {
     },
   });
 
+  const forceOpenAI = computed({
+    get() {
+      if (!enableForceOpenAI) return false;
+      return recipeCreatePreferences.value.forceOpenAI;
+    },
+    set(v: boolean) {
+      if (!enableForceOpenAI) return;
+      recipeCreatePreferences.value.forceOpenAI = v;
+    },
+  });
+
   function navigateToRecipe(recipeSlug: string, groupSlug: string, createPagePath: string) {
     const editParam = enableStayInEditMode ? stayInEditMode.value : false;
     const parseParam = enableParseRecipe ? parseRecipe.value : false;
@@ -87,6 +100,7 @@ export function useNewRecipeOptions(props: UseNewRecipeOptionsProps = {}) {
     importCategories,
     stayInEditMode,
     parseRecipe,
+    forceOpenAI,
 
     // Helper functions
     navigateToRecipe,
@@ -96,5 +110,6 @@ export function useNewRecipeOptions(props: UseNewRecipeOptionsProps = {}) {
     enableImportCategories,
     enableStayInEditMode,
     enableParseRecipe,
+    enableForceOpenAI,
   };
 }

--- a/frontend/app/composables/use-users/preferences.ts
+++ b/frontend/app/composables/use-users/preferences.ts
@@ -67,6 +67,7 @@ export interface UserRecipeCreatePreferences {
   importCategories: boolean;
   stayInEditMode: boolean;
   parseRecipe: boolean;
+  forceOpenAI: boolean;
 }
 
 export interface UserActivityPreferences {
@@ -224,6 +225,7 @@ export function useRecipeCreatePreferences(): Ref<UserRecipeCreatePreferences> {
       importCategories: false,
       stayInEditMode: false,
       parseRecipe: true,
+      forceOpenAI: false,
     },
     { mergeDefaults: true },
   );

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -652,6 +652,8 @@
     "import-original-categories": "Import original categories",
     "stay-in-edit-mode": "Stay in Edit mode",
     "parse-recipe-ingredients-after-import": "Parse recipe ingredients after import",
+    "force-openai-scraper": "Force OpenAI Scraper",
+    "force-openai-scraper-description": "Skip the default HTML scraper and use OpenAI directly.",
     "import-from-zip": "Import from Zip",
     "import-from-zip-description": "Import a single recipe that was exported from another Mealie instance.",
     "import-from-html-or-json": "Import from HTML or JSON",

--- a/frontend/app/lib/api/types/recipe.ts
+++ b/frontend/app/lib/api/types/recipe.ts
@@ -113,6 +113,7 @@ export interface RecipeTag {
 }
 export interface CreateRecipeByUrlBulk {
   imports: CreateRecipeBulk[];
+  useOpenAI?: boolean;
 }
 export interface DeleteRecipes {
   recipes: string[];

--- a/frontend/app/lib/api/user/recipes/recipe.ts
+++ b/frontend/app/lib/api/user/recipes/recipe.ts
@@ -206,9 +206,10 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
     url: string,
     includeTags: boolean,
     includeCategories: boolean,
+    useOpenAI: boolean = false,
     onProgress?: (message: string) => void,
   ): Promise<RequestResponse<string>> {
-    return this.streamRecipeCreate(routes.recipesCreateUrl, { url, includeTags, includeCategories }, onProgress);
+    return this.streamRecipeCreate(routes.recipesCreateUrl, { url, includeTags, includeCategories, useOpenAI }, onProgress);
   }
 
   async createManyByUrl(payload: CreateRecipeByUrlBulk) {

--- a/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
@@ -122,6 +122,12 @@
           </v-card-actions>
           <div class="px-0">
             <v-checkbox
+              v-if="$appInfo.enableOpenai"
+              v-model="state.forceOpenAI"
+              hide-details
+              :label="$t('recipe.force-openai-scraper')"
+            />
+            <v-checkbox
               v-model="state.showCatTags"
               hide-details
               :label="$t('recipe.set-categories-and-tags')"
@@ -165,6 +171,7 @@ import RecipeDialogBulkAdd from "~/components/Domain/Recipe/RecipeDialogBulkAdd.
 const state = reactive({
   showCatTags: false,
   bulkDialog: false,
+  forceOpenAI: false,
 });
 
 whenever(
@@ -185,7 +192,7 @@ async function bulkCreate() {
     return;
   }
 
-  const { response } = await api.recipes.createManyByUrl({ imports: bulkUrls.value });
+  const { response } = await api.recipes.createManyByUrl({ imports: bulkUrls.value, useOpenAI: state.forceOpenAI });
 
   if (response?.status === 202) {
     alert.success(i18n.t("recipe.bulk-import-process-has-started"));

--- a/frontend/app/pages/g/[groupSlug]/r/create/url.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/create/url.vue
@@ -41,6 +41,13 @@
           />
         </v-card-text>
         <v-checkbox
+          v-if="$appInfo.enableOpenai"
+          v-model="forceOpenAI"
+          color="primary"
+          hide-details
+          :label="$t('recipe.force-openai-scraper')"
+        />
+        <v-checkbox
           v-model="importKeywordsAsTags"
           color="primary"
           hide-details
@@ -171,6 +178,7 @@ const {
   importCategories,
   stayInEditMode,
   parseRecipe,
+  forceOpenAI,
   navigateToRecipe,
 } = useNewRecipeOptions();
 
@@ -273,6 +281,7 @@ async function createByUrl(url: string | null, importKeywordsAsTags: boolean, im
     url,
     importKeywordsAsTags,
     importCategories,
+    forceOpenAI.value,
     (message: string) => createStatus.value = message,
   );
   createStatus.value = null;

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -220,9 +220,11 @@ class RecipeController(BaseRecipeController):
                 )
             )
 
+        use_openai = req.use_openai if isinstance(req, ScrapeRecipe) else False
+
         async def run() -> None:
             try:
-                recipe, extras = await create_from_html(url, self.translator, html, on_progress=on_progress)
+                recipe, extras = await create_from_html(url, self.translator, html, on_progress=on_progress, use_openai=use_openai)
                 slug = self._finish_recipe_from_web(req, recipe, extras)
                 await queue.put(
                     ServerSentEvent(

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -107,6 +107,8 @@ class CreateRecipeBulk(BaseModel):
 
 class CreateRecipeByUrlBulk(BaseModel):
     imports: list[CreateRecipeBulk]
+    use_openai: bool = Field(False, alias="useOpenAI")
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class CreateRecipe(MealieModel):

--- a/mealie/schema/recipe/recipe_scraper.py
+++ b/mealie/schema/recipe/recipe_scraper.py
@@ -15,12 +15,14 @@ class ScrapeRecipeBase(MealieModel):
 
 class ScrapeRecipe(ScrapeRecipeBase):
     url: str
+    use_openai: bool = Field(False, alias="useOpenAI")
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "url": "https://myfavoriterecipes.com/recipes",
                 "includeTags": True,
                 "includeCategories": True,
+                "useOpenAI": False,
             },
         }
     )

--- a/mealie/services/openai/prompts/recipes/scrape-recipe.txt
+++ b/mealie/services/openai/prompts/recipes/scrape-recipe.txt
@@ -1,5 +1,7 @@
 Extract recipe data from webpage contents (HTML, text, etc.) and return it in schema.org Recipe format. Reference: https://schema.org/Recipe
 
+The response MUST include "@context": "https://schema.org" and "@type": "Recipe" fields.
+
 Do not create or make up any information. If insufficient data is found, return an empty object.
 
 You will receive the webpage contents, including (but not necessarily limited to) text extracted from the HTML.

--- a/mealie/services/scraper/recipe_bulk_scraper.py
+++ b/mealie/services/scraper/recipe_bulk_scraper.py
@@ -85,7 +85,7 @@ class RecipeBulkScraperService(BaseService):
         async def _do(url: str) -> Recipe | None:
             async with sem:
                 try:
-                    recipe, _ = await create_from_html(url, self.translator)
+                    recipe, _ = await create_from_html(url, self.translator, use_openai=urls.use_openai)
                     return recipe
                 except Exception as e:
                     self.service.logger.error(f"failed to scrape url during bulk url import {url}")

--- a/mealie/services/scraper/scraper.py
+++ b/mealie/services/scraper/scraper.py
@@ -14,6 +14,7 @@ from mealie.services.recipe.recipe_data_service import RecipeDataService
 from mealie.services.scraper.scraped_extras import ScrapedExtras
 
 from .recipe_scraper import RecipeScraper
+from .scraper_strategies import RecipeScraperOpenAI, RecipeScraperOpenAITranscription
 
 
 class ParserErrors(StrEnum):
@@ -27,6 +28,7 @@ async def create_from_html(
     translator: Translator,
     html: str | None = None,
     on_progress: Callable[[str], Awaitable[None]] | None = None,
+    use_openai: bool = False,
 ) -> tuple[Recipe, ScrapedExtras | None]:
     """Main entry point for generating a recipe from a URL. Pass in a URL and
     a Recipe object will be returned if successful. Optionally pass in the HTML to skip fetching it.
@@ -35,11 +37,13 @@ async def create_from_html(
         url (str): a valid string representing a URL
         html (str | None): optional HTML string to skip network request. Defaults to None.
         on_progress: optional async callable invoked with a status message at each stage.
+        use_openai (bool): skip the default HTML scraper and route directly to OpenAI strategies.
 
     Returns:
         Recipe: Recipe Object
     """
-    scraper = RecipeScraper(translator)
+    scrapers = [RecipeScraperOpenAITranscription, RecipeScraperOpenAI] if use_openai else None
+    scraper = RecipeScraper(translator, scrapers=scrapers)
 
     if not html:
         extracted_url = regex_search(r"(https?://|www\.)[^\s]+", url)

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import json
 import re
 import time
 from abc import ABC, abstractmethod
@@ -420,7 +421,15 @@ class RecipeScraperOpenAI(RecipeScraperPackage):
             if not (response and response.text):
                 raise Exception("OpenAI did not return any data")
 
-            return self.ld_json_to_html(response.text)
+            # Ensure @context and @type are present — some models omit them,
+            # which causes recipe_scrapers to silently skip the JSON-LD block.
+            try:
+                data = json.loads(response.text)
+            except json.JSONDecodeError:
+                data = {}
+            data.setdefault("@context", "https://schema.org")
+            data.setdefault("@type", "Recipe")
+            return self.ld_json_to_html(json.dumps(data))
         except Exception:
             self.logger.exception(f"OpenAI was unable to extract a recipe from {url}")
             return ""

--- a/tests/integration_tests/user_recipe_tests/test_recipe_create_from_openai.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_create_from_openai.py
@@ -165,45 +165,63 @@ def test_create_by_url_openai_returns_none(
     assert response.status_code == 400
 
 
-def test_create_by_url_with_force_openai_flag(
-    api_client: TestClient,
-    unique_user: TestUser,
-    monkeypatch: pytest.MonkeyPatch,
-    recipe_ld_json: str,
-    recipe_url: str,
-    recipe_name: str,
-):
-    """useOpenAI=True routes directly to OpenAI strategies, bypassing DEFAULT_SCRAPER_STRATEGIES.
+class TestForceOpenAIFlag:
+    """Tests that useOpenAI=True in the request body routes directly to OpenAI.
 
-    The defaults are replaced with an empty list so that without the flag the
-    endpoint would return 400.  With useOpenAI=True the scraper is initialised
-    with [RecipeScraperOpenAITranscription, RecipeScraperOpenAI] regardless of
-    the (empty) defaults, and the recipe is created successfully.
+    The module-level openai_scraper_setup fixture is shadowed here so that
+    DEFAULT_SCRAPER_STRATEGIES is left at its real value.  This lets the test
+    verify that the flag itself — not a monkeypatched default list — causes the
+    OpenAI strategy to be selected.
     """
-    # Override defaults to empty — without the flag this request would return 400
-    monkeypatch.setattr(recipe_scraper_module, "DEFAULT_SCRAPER_STRATEGIES", [])
 
-    # Provide a complete settings stub so RecipeScraperOpenAITranscription.can_scrape()
-    # can evaluate OPENAI_ENABLE_TRANSCRIPTION_SERVICES (False → falls through to
-    # RecipeScraperOpenAI which only needs OPENAI_ENABLED=True).
-    settings_stub = type("_Settings", (), {"OPENAI_ENABLED": True, "OPENAI_ENABLE_TRANSCRIPTION_SERVICES": False})()
-    monkeypatch.setattr(scraper_strategies_module, "get_app_settings", lambda: settings_stub)
+    @pytest.fixture(autouse=True)
+    def openai_scraper_setup(self, monkeypatch: pytest.MonkeyPatch, bare_html: str):
+        """Shadow the module-level autouse fixture.
 
-    async def mock_get_response(self, prompt, message, *args, **kwargs) -> OpenAIText | None:
-        return OpenAIText(text=recipe_ld_json)
+        Provides the same HTTP / image-download stubs but does NOT replace
+        DEFAULT_SCRAPER_STRATEGIES, keeping the real strategy chain intact.
+        OPENAI_ENABLE_TRANSCRIPTION_SERVICES is set to False so the
+        transcription strategy is skipped for plain URLs.
+        """
+        settings_stub = type(
+            "_Settings",
+            (),
+            {"OPENAI_ENABLED": True, "OPENAI_ENABLE_TRANSCRIPTION_SERVICES": False},
+        )()
+        monkeypatch.setattr(scraper_strategies_module, "get_app_settings", lambda: settings_stub)
 
-    monkeypatch.setattr(OpenAIService, "get_response", mock_get_response)
+        async def mock_safe_scrape_html(url: str) -> str:
+            return bare_html
 
-    response = api_client.post(
-        api_routes.recipes_create_url,
-        json={"url": recipe_url, "include_tags": False, "useOpenAI": True},
-        headers=unique_user.token,
-    )
+        monkeypatch.setattr(recipe_scraper_module, "safe_scrape_html", mock_safe_scrape_html)
+        monkeypatch.setattr(RecipeDataService, "scrape_image", lambda *_: "TEST_IMAGE")
 
-    assert response.status_code == 201
-    slug = json.loads(response.text)
-    recipe = api_client.get(api_routes.recipes_slug(slug), headers=unique_user.token).json()
-    assert recipe["name"] == recipe_name
+    def test_create_by_url_with_force_openai_flag(
+        self,
+        api_client: TestClient,
+        unique_user: TestUser,
+        monkeypatch: pytest.MonkeyPatch,
+        recipe_ld_json: str,
+        recipe_url: str,
+        recipe_name: str,
+    ):
+        """useOpenAI=True in the request body routes directly to RecipeScraperOpenAI."""
+
+        async def mock_get_response(self, prompt, message, *args, **kwargs) -> OpenAIText | None:
+            return OpenAIText(text=recipe_ld_json)
+
+        monkeypatch.setattr(OpenAIService, "get_response", mock_get_response)
+
+        response = api_client.post(
+            api_routes.recipes_create_url,
+            json={"url": recipe_url, "include_tags": False, "useOpenAI": True},
+            headers=unique_user.token,
+        )
+
+        assert response.status_code == 201
+        slug = json.loads(response.text)
+        recipe = api_client.get(api_routes.recipes_slug(slug), headers=unique_user.token).json()
+        assert recipe["name"] == recipe_name
 
 
 def test_create_by_url_openai_disabled(

--- a/tests/integration_tests/user_recipe_tests/test_recipe_create_from_openai.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_create_from_openai.py
@@ -165,6 +165,47 @@ def test_create_by_url_openai_returns_none(
     assert response.status_code == 400
 
 
+def test_create_by_url_with_force_openai_flag(
+    api_client: TestClient,
+    unique_user: TestUser,
+    monkeypatch: pytest.MonkeyPatch,
+    recipe_ld_json: str,
+    recipe_url: str,
+    recipe_name: str,
+):
+    """useOpenAI=True routes directly to OpenAI strategies, bypassing DEFAULT_SCRAPER_STRATEGIES.
+
+    The defaults are replaced with an empty list so that without the flag the
+    endpoint would return 400.  With useOpenAI=True the scraper is initialised
+    with [RecipeScraperOpenAITranscription, RecipeScraperOpenAI] regardless of
+    the (empty) defaults, and the recipe is created successfully.
+    """
+    # Override defaults to empty — without the flag this request would return 400
+    monkeypatch.setattr(recipe_scraper_module, "DEFAULT_SCRAPER_STRATEGIES", [])
+
+    # Provide a complete settings stub so RecipeScraperOpenAITranscription.can_scrape()
+    # can evaluate OPENAI_ENABLE_TRANSCRIPTION_SERVICES (False → falls through to
+    # RecipeScraperOpenAI which only needs OPENAI_ENABLED=True).
+    settings_stub = type("_Settings", (), {"OPENAI_ENABLED": True, "OPENAI_ENABLE_TRANSCRIPTION_SERVICES": False})()
+    monkeypatch.setattr(scraper_strategies_module, "get_app_settings", lambda: settings_stub)
+
+    async def mock_get_response(self, prompt, message, *args, **kwargs) -> OpenAIText | None:
+        return OpenAIText(text=recipe_ld_json)
+
+    monkeypatch.setattr(OpenAIService, "get_response", mock_get_response)
+
+    response = api_client.post(
+        api_routes.recipes_create_url,
+        json={"url": recipe_url, "include_tags": False, "useOpenAI": True},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 201
+    slug = json.loads(response.text)
+    recipe = api_client.get(api_routes.recipes_slug(slug), headers=unique_user.token).json()
+    assert recipe["name"] == recipe_name
+
+
 def test_create_by_url_openai_disabled(
     api_client: TestClient,
     unique_user: TestUser,


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a **"Force OpenAI Scraper"** checkbox to the URL import page (`/g/{household}/r/create/url`) and the bulk import page (`/g/{household}/r/create/bulk`).

When checked, the request bypasses the default HTML scraper (`RecipeScraperPackage`) and routes directly to the OpenAI LLM scraper (`RecipeScraperOpenAI`). This is useful when the standard scraper fails on sites that use JavaScript rendering or non-standard markup, but the page content is still parseable by an LLM.

The checkbox is only shown when OpenAI is configured on the server (`$appInfo.enableOpenai`).

**File-by-file summary:**

- `mealie/schema/recipe/recipe_scraper.py` — added `use_openai: bool = Field(False, alias="useOpenAI")` to `ScrapeRecipe`
- `mealie/schema/recipe/recipe.py` — added same field to `CreateRecipeByUrlBulk` with `populate_by_name=True`
- `mealie/services/scraper/scraper.py` — added `use_openai` parameter to `create_from_html()`; when `True`, initialises `RecipeScraper` with `[RecipeScraperOpenAITranscription, RecipeScraperOpenAI]` instead of the default strategy list
- `mealie/services/scraper/recipe_bulk_scraper.py` — passes `use_openai` to each `create_from_html()` call
- `mealie/routes/recipe/recipe_crud_routes.py` — extracts `use_openai` from the request (via `isinstance` check) and passes it to `create_from_html()`
- `mealie/services/openai/prompts/recipes/scrape-recipe.txt` — prompt now explicitly requires `@context` and `@type` fields; fixes a systematic issue where some models omit them, causing `recipe_scrapers` to raise `NoSchemaFoundInWildMode`
- `mealie/services/scraper/scraper_strategies.py` — added `setdefault` fallback for `@context`/`@type` in `RecipeScraperOpenAI.get_html()` as a safety net
- `frontend/app/lang/messages/en-US.json` — added `force-openai-scraper` and `force-openai-scraper-description` i18n keys
- `frontend/app/composables/use-users/preferences.ts` — added `forceOpenAI: boolean` to `UserRecipeCreatePreferences` (persisted in localStorage)
- `frontend/app/composables/use-new-recipe-options.ts` — added `enableForceOpenAI` prop and `forceOpenAI` computed
- `frontend/app/lib/api/types/recipe.ts` — added `useOpenAI?: boolean` to `CreateRecipeByUrlBulk`
- `frontend/app/lib/api/user/recipes/recipe.ts` — added `useOpenAI` parameter to `createOneByUrl()`
- `frontend/app/pages/g/[groupSlug]/r/create/url.vue` — checkbox with `v-if="$appInfo.enableOpenai"`; preference persisted via composable
- `frontend/app/pages/g/[groupSlug]/r/create/bulk.vue` — checkbox with local reactive state (consistent with `showCatTags`)

**Design decisions:**

- YouTube/video URLs work correctly: `RecipeScraperOpenAITranscription` is included first so video transcription still takes priority when the URL matches.
- `ScrapeRecipeData` (raw HTML import) intentionally does not expose the flag — it inherits from `ScrapeRecipeBase`, not `ScrapeRecipe`.
- The per-URL preference is stored in localStorage (same pattern as `importKeywordsAsTags`, `stayInEditMode`, etc.). The bulk page uses local reactive state only, consistent with how `showCatTags` works there.
- A future improvement could be a per-user/household persistent setting (discussed in #7527).

## Which issue(s) this PR fixes:

Relates to https://github.com/mealie-recipes/mealie/discussions/5307
Relates to https://github.com/mealie-recipes/mealie/discussions/7527

## Special notes for your reviewer:

The prompt fix (`scrape-recipe.txt` + `setdefault` in `get_html()`) is a self-contained bug fix that is independent of the checkbox feature — it prevents `NoSchemaFoundInWildMode` when a model returns recipe JSON without the `@context`/`@type` boilerplate fields.

**Screenshots:**
<img width="600" height="445" alt="Snímek obrazovky 2026-05-13 132949" src="https://github.com/user-attachments/assets/52f85a92-6068-419c-8286-d3daedc7837d" />


## Testing

- **Automated:** integration tests added in `tests/integration_tests/user_recipe_tests/test_recipe_create_from_openai.py`. The new test uses a class that shadows the module-level `openai_scraper_setup` autouse fixture so that `DEFAULT_SCRAPER_STRATEGIES` is left at its real value — verifying that the `useOpenAI` flag (not a patched default list) causes `RecipeScraperOpenAI` to be selected.
- **Manual:** tested on Debian Linux in Docker.

## AI / LLM Assistance

This PR was developed with substantial assistance from Claude (Anthropic). The implementation plan, all code changes, and the integration test were produced with AI assistance and reviewed and tested manually by the author.