### PR TITLE
fix: downgrade OIDC missing-claims log from ERROR to DEBUG (#6801)

### DIFF
--- a/mealie/core/security/providers/openid_provider.py
+++ b/mealie/core/security/providers/openid_provider.py
@@ -35,7 +35,7 @@ class OpenIDProvider(AuthProvider[UserInfo]):
             self._logger.debug("[OIDC]   %s: %s", key, value)
 
         if not self.required_claims.issubset(claims.keys()):
-            self._logger.error(
+            self._logger.debug(
                 "[OIDC] Required claims not present. Expected: %s Actual: %s",
                 self.required_claims,
                 claims.keys(),
@@ -45,7 +45,7 @@ class OpenIDProvider(AuthProvider[UserInfo]):
         # Check for empty required claims
         for claim in self.required_claims:
             if not claims.get(claim):
-                self._logger.error("[OIDC] Required claim '%s' is empty", claim)
+                self._logger.debug("[OIDC] Required claim '%s' is empty", claim)
                 raise MissingClaimException()
 
         repos = get_repositories(self.session, group_id=None, household_id=None)

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -134,6 +134,7 @@ async def oauth_callback(request: Request, session: Session = Depends(generate_s
             auth_provider = OpenIDProvider(session, userinfo, use_default_groups=True)
             auth = auth_provider.authenticate()
         except MissingClaimException:
+            logger.error("[OIDC] Required claims not present in ID token or userinfo endpoint")
             auth = None
 
     if not auth:


### PR DESCRIPTION
## What this PR does / why we need it:

When OIDC login is configured and the `id_token` does not contain required claims (name, email, groups), the code immediately falls back to the userinfo endpoint and completes login normally. Despite this being an expected intermediate state, the missing-claims check was logging at `ERROR` level, producing misleading noise in logs for users whose IdP omits claims from the id_token.

Changes:
- `mealie/core/security/providers/openid_provider.py`: Downgrade "Required claims not present" and "Required claim is empty" log messages from `ERROR` to `DEBUG`. Both raise `MissingClaimException`, which the caller catches to attempt the userinfo fallback — they are not final failures.
- `mealie/routes/auth/auth.py`: Add an `ERROR` log in the inner `except MissingClaimException` block so that an error is still surfaced when both the id_token *and* userinfo endpoint fail to provide required claims.

## Which issue(s) this PR fixes:

Fixes #6801

## AI / LLM Assistance

This PR was created with Claude Code assistance (Anthropic). The fix and implementation were AI-generated based on the issue description and codebase analysis.