### PR TITLE
fix: block scriptable asset extensions and force Content-Disposition: attachment (GHSA-gfwc-pjx4-mg9p)

### DIFF
--- a/mealie/routes/media/media_recipe.py
+++ b/mealie/routes/media/media_recipe.py
@@ -58,6 +58,6 @@ async def get_recipe_asset(recipe_id: UUID4, file_name: str):
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
 
     if file.exists():
-        return FileResponse(file)
+        return FileResponse(file, filename=file.name, content_disposition_type="attachment")
     else:
         raise HTTPException(status.HTTP_404_NOT_FOUND)

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -80,6 +80,8 @@ from mealie.services.scraper.scraper_strategies import (
 
 from ._base import BaseRecipeController, JSONBytes
 
+ASSET_ALLOWED_EXTENSIONS = {"pdf", "jpg", "jpeg", "png", "gif", "webp", "bmp", "avif", "txt", "md", "csv", "json"}
+
 router = UserAPIRouter(prefix="/recipes", route_class=MealieCrudRoute)
 
 
@@ -659,6 +661,10 @@ class RecipeController(BaseRecipeController):
         """Upload a file to store as a recipe asset"""
         if "." in extension:
             extension = extension.split(".")[-1]
+
+        extension = extension.lower()
+        if extension not in ASSET_ALLOWED_EXTENSIONS:
+            raise HTTPException(status_code=400, detail="Unsupported file extension")
 
         file_slug = slugify(name)
         if not extension or not file_slug:

--- a/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
@@ -87,6 +87,23 @@ def test_recipe_asset_exploit(api_client: TestClient, unique_user: TestUser, rec
     assert not (recipe.asset_dir / "test.txt").exists()
 
 
+def test_recipe_asset_dangerous_extension_blocked(
+    api_client: TestClient, unique_user: TestUser, recipe_ingredient_only: Recipe
+):
+    """Ensure scriptable extensions are rejected to prevent stored XSS (GHSA-gfwc-pjx4-mg9p)."""
+    recipe = recipe_ingredient_only
+    for ext in ("html", "svg", "js", "htm", "xhtml"):
+        payload = {"name": random_string(10), "icon": "mdi-file", "extension": ext}
+        file_payload = {"file": b"<script>alert(1)</script>"}
+        response = api_client.post(
+            f"/api/recipes/{recipe.slug}/assets",
+            data=payload,
+            files=file_payload,
+            headers=unique_user.token,
+        )
+        assert response.status_code == 400, f"expected 400 for extension={ext}, got {response.status_code}"
+
+
 def test_recipe_image_upload(api_client: TestClient, unique_user: TestUser, recipe_ingredient_only: Recipe):
     data_payload = {"extension": "jpg"}
     file_payload = {"image": data.images_test_image_1.read_bytes()}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a stored XSS vulnerability (GHSA-gfwc-pjx4-mg9p) in the recipe asset upload and serve pipeline.

**Attack path:**
1. Any authenticated household member uploads a `.html` or `.svg` file via `POST /api/recipes/{slug}/assets` — the `extension` field was not validated, so any extension passed through.
2. The unauthenticated `GET /api/media/recipes/{id}/assets/{file_name}` endpoint returned `FileResponse(file)` without a `filename` kwarg, so Starlette omitted `Content-Disposition` and inferred `Content-Type: text/html` (or `image/svg+xml`) from the extension. The browser rendered the file inline in the Mealie origin.
3. The auth cookie (`mealie.access_token`) has no `httpOnly` flag, so `document.cookie` exposes it to the injected script. An attacker who captures the token can fully impersonate the victim, including chaining to admin privilege escalation.

**Changes:**
- `mealie/routes/recipe/recipe_crud_routes.py`: Added `ASSET_ALLOWED_EXTENSIONS` allowlist (`pdf`, `jpg`, `jpeg`, `png`, `gif`, `webp`, `bmp`, `avif`, `txt`, `md`, `csv`, `json`). The upload endpoint now normalises the extension to lowercase and rejects anything outside the allowlist with HTTP 400.
- `mealie/routes/media/media_recipe.py`: Changed `FileResponse(file)` to `FileResponse(file, filename=file.name, content_disposition_type="attachment")`. This forces `Content-Disposition: attachment` on every asset response, so assets download rather than render inline — defense in depth if the allowlist is ever loosened.
- `tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py`: Added `test_recipe_asset_dangerous_extension_blocked` which asserts HTTP 400 for `html`, `svg`, `js`, `htm`, and `xhtml` extensions.

Either fix alone closes the vulnerability; both together prevent regression if the allowlist is later expanded.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes GHSA-gfwc-pjx4-mg9p

## Special notes for your reviewer:

The `Content-Disposition: attachment` change means clicking "View" on an asset in edit mode now triggers a download instead of an inline browser preview. This is intentional and acceptable given the security tradeoff. Image thumbnails in the asset list are unaffected — browsers ignore `Content-Disposition` for `<img>` subresource loads.

The `httpOnly` cookie and `Content-Security-Policy` improvements mentioned in the advisory are valuable further hardening but involve larger frontend auth flow changes and are out of scope for this patch.

## Testing

- Ran `task py:test -- tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py`: 4 passed (3 existing + 1 new regression test).
- Ran `task py:lint` and `task py:format`: no issues.

## AI / LLM Assistance

This PR was authored with AI assistance (Claude Code). The vulnerability analysis, fix implementation, and test were all AI-generated and reviewed by the submitter.