### PR TITLE
fix: Inconsistent "from an image" vs "from images" translation

### DIFF
--- a/frontend/app/components/Layout/DefaultLayout.vue
+++ b/frontend/app/components/Layout/DefaultLayout.vue
@@ -205,7 +205,7 @@ const createLinks = computed(() => [
     insertDivider: false,
     icon: $globals.icons.fileImage,
     title: i18n.t("recipe.create-from-images"),
-    subtitle: i18n.t("recipe.create-recipe-from-an-image"),
+    subtitle: i18n.t("recipe.create-recipe-from-images"),
     to: `/g/${groupSlug.value}/r/create/image`,
     restricted: true,
     hide: !showImageImport.value,

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -628,7 +628,7 @@
     "create-recipe-description": "Create a new recipe from scratch.",
     "create-recipes": "Create Recipes",
     "import-with-zip": "Import with .zip",
-    "create-recipe-from-an-image": "Create Recipe from Images",
+    "create-recipe-from-images": "Create Recipe from Images",
     "create-recipe-from-an-image-description": "Create a recipe by uploading images of the recipe text. Mealie will attempt to extract the text from the images using AI and create a new recipe from it.",
     "crop-and-rotate-the-image": "Crop and rotate the image so that only the text is visible, and it's in the correct orientation.",
     "create-from-images": "Create from Images",

--- a/frontend/app/pages/g/[groupSlug]/r/create/image.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/create/image.vue
@@ -3,7 +3,7 @@
     <v-form ref="domUrlForm" @submit.prevent="createRecipe">
       <div>
         <v-card-title class="headline">
-          {{ $t("recipe.create-recipe-from-an-image") }}
+          {{ $t("recipe.create-recipe-from-images") }}
         </v-card-title>
         <v-card-text>
           <p>{{ $t("recipe.create-recipe-from-an-image-description") }}</p>


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

When we moved from creating a recipe from a single image vs multiple images, we changed the translation VALUE, but not the KEY, leading to some languages respecting the change and some not.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, reported in Discord

## Special notes for your reviewer:

_(fill-in or delete this section)_

Ideally we keep existing translations and just add a new key/value, but since we're in an awkward in-between state we don't know which translations are right and which are wrong, so I opted to just reset it with a new key.

## AI / LLM Assistance

_(REQUIRED)_

None