### PR TITLE
fix: locale-aware (accent-folded) recipe name sorting

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -26,7 +26,7 @@ from mealie.schema.recipe.recipe import RecipePagination, RecipeSummary, create_
 from mealie.schema.recipe.recipe_ingredient import IngredientFood
 from mealie.schema.recipe.recipe_suggestion import RecipeSuggestionQuery, RecipeSuggestionResponseItem
 from mealie.schema.recipe.recipe_tool import RecipeToolOut
-from mealie.schema.response.pagination import PaginationQuery
+from mealie.schema.response.pagination import OrderByNullPosition, OrderDirection, PaginationQuery
 from mealie.services.query_filter.builder import QueryFilterBuilder
 
 from ..db.models._model_base import SqlAlchemyBase
@@ -91,6 +91,20 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
             ),
         )
         return sa.cast(effective_rating, sa.Float)
+
+    def add_order_attr_to_query(
+        self,
+        query: sa.Select,
+        order_attr: orm.InstrumentedAttribute,
+        order_dir: OrderDirection,
+        order_by_null: OrderByNullPosition | None,
+    ) -> sa.Select:
+        # Sort recipe names by their normalized (accent-folded, lowercased) form so that
+        # accented and umlaut characters sort next to their base letter (e.g. "Über" near
+        # "U") instead of after "Z" by raw code point. See GH #6853.
+        if order_attr is RecipeModel.name:
+            order_attr = RecipeModel.name_normalized
+        return super().add_order_attr_to_query(query, order_attr, order_dir, order_by_null)
 
     def create(self, document: Recipe) -> Recipe:  # type: ignore
         max_retries = 10

--- a/tests/unit_tests/repository_tests/test_recipe_repository.py
+++ b/tests/unit_tests/repository_tests/test_recipe_repository.py
@@ -647,6 +647,40 @@ def test_order_by_last_made(unique_user: TestUser, h2_user: TestUser):
     assert [item.id for item in h2_query.items] == [recipe_2.id, recipe_1.id]
 
 
+def test_order_by_name_is_accent_folded(unique_user: TestUser):
+    # Names chosen so that raw code-point sorting (the previous behavior) would place the
+    # umlaut/accented entries after "Zebra". Accent-folded sorting must instead place them
+    # next to their base letter: "ärtsoppa" near "a", "Über" near "u". See GH #6853.
+    names = ["Zebra", "ärtsoppa", "Apple", "Über"]
+    recipes = [
+        unique_user.repos.recipes.create(Recipe(user_id=unique_user.user_id, group_id=unique_user.group_id, name=name))
+        for name in names
+    ]
+    recipe_ids = ", ".join(str(recipe.id) for recipe in recipes)
+
+    ascending = unique_user.repos.recipes.page_all(
+        PaginationQuery(
+            page=1,
+            per_page=-1,
+            order_by="name",
+            order_direction=OrderDirection.asc,
+            query_filter=f"id IN [{recipe_ids}]",
+        )
+    )
+    assert [item.name for item in ascending.items] == ["Apple", "ärtsoppa", "Über", "Zebra"]
+
+    descending = unique_user.repos.recipes.page_all(
+        PaginationQuery(
+            page=1,
+            per_page=-1,
+            order_by="name",
+            order_direction=OrderDirection.desc,
+            query_filter=f"id IN [{recipe_ids}]",
+        )
+    )
+    assert [item.name for item in descending.items] == ["Zebra", "Über", "ärtsoppa", "Apple"]
+
+
 def test_coalesce_last_made(unique_user: TestUser):
     dt = datetime.now(UTC)
 


### PR DESCRIPTION
## What this PR does / why we need it:

Alphabetical recipe sorting was not locale-aware: accented and umlaut characters sorted after `Z` by raw Unicode code point. With recipes `AAA`, `ÜÜÜ`, `XXX`, alphabetical sort produced `AAA, XXX, ÜÜÜ` instead of the expected `AAA, ÜÜÜ, XXX`.

Recipe sorting is server-side. `add_order_attr_to_query` (`mealie/repos/repository_generic.py`) applies `func.lower()` to the raw `name` column, so ordering falls back to raw code-point comparison — lowercase `ü` (U+00FC) is greater than every ASCII letter, so umlaut/accented names sort after `Z`.

Changes:
- `mealie/repos/repository_recipes.py`: override `add_order_attr_to_query` so that ordering by `name` sorts on the existing `name_normalized` column (indexed, `unidecode`-folded, lowercased; `Über` → `uber`, `ärtsoppa` → `artsoppa`). Accented characters then sort next to their base letter.
- `tests/unit_tests/repository_tests/test_recipe_repository.py`: add a regression test.

Decisions:
- Reuses the existing `name_normalized` column (the approach @michael-genson suggested in the issue) — small and dependency-free.
- The override is scoped to ordering only. `name_normalized` is intentionally **not** added to `column_aliases`, because that map is also consumed by the query-filter builder (`QueryFilterBuilder.filter_query`) and would change `name` filter semantics, not just sort order.
- Works identically on SQLite and Postgres because the sort key is a pre-computed ASCII column rather than a database collation — no per-dialect `COLLATE`/ICU handling required.

Caveat: this is accent-folding, not full per-locale collation. It fixes the reported German umlaut case and folds accents next to their base letter, but it is locale-independent (e.g. Swedish `å`/`ä`/`ö` will not sort *after* `z`). True per-locale ordering would require ICU (Postgres ICU collations + a PyICU-backed SQLite collation) and threading the request locale into the repository layer; that was kept out of scope in favor of a minimal, consistent fix.

## Which issue(s) this PR fixes:

Fixes #6853

## Special notes for your reviewer:

```
['Zebra', 'ärtsoppa', 'Apple', 'Über']  →  Apple, ärtsoppa, Über, Zebra
```

On "could this be more general rather than just `name`?": the existing `column_aliases` override mechanism (used by ratings/last_made) is shared between ordering **and** query filtering, so reusing it for `name` would also rewrite `name` filters to hit `name_normalized`. If a general approach is preferred, the clean path would be an ordering-only alias map (e.g. `order_by_column_aliases`) applied solely in `add_order_attr_to_query`, separate from the filter aliases. Happy to refactor in that direction if you'd like.

## Testing

- Added `test_order_by_name_is_accent_folded`, seeding `['Zebra', 'ärtsoppa', 'Apple', 'Über']` and asserting both ascending (`Apple, ärtsoppa, Über, Zebra`) and descending order.
- Ran the new test against both SQLite (CI default) and a local Postgres 15 instance.
- `task py:check` (format, lint, mypy, and the full test suite — 2382 passed) is green.

## AI / LLM Assistance

This PR was created with substantial assistance from an LLM (Claude Code): codebase research, the implementation, the regression test, and this description. All output was reviewed and validated by running the formatters, linter, type checker, and full test suite, and by manually verifying sort behavior on both SQLite and Postgres.