### PR TITLE
dev: Disable approvals for lockfile maintenance PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,13 @@
       "dependencyDashboardApproval": true
     },
     {
+      "description": "Always create lockfile maintenance PRs without dashboard approval",
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
       "matchManagers": [
         "pep621"
       ],


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Lockfile maintenance PRs aren't getting created because they need manual approval. This PR disables the need for approval (PRs still need approval to merge).

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

Copilot helped with diagnosing the problem.
