### PR TITLE
chore: add 5-day dependency cooling period for supply-chain hardening

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --only-group docs --no-install-project
+        run: uv sync --frozen --only-group docs --no-install-project
 
       - name: Build docs
         run: uv run --no-project mkdocs build -d site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Install from the committed lockfile; never re-resolve (see pyproject
+      # [tool.uv] exclude-newer cooling window).
+      UV_FROZEN: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -27,7 +31,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --frozen --only-group docs --no-install-project
+        run: uv sync --only-group docs --no-install-project
 
       - name: Build docs
         run: uv run --no-project mkdocs build -d site

--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-          uv sync --group dev
+          uv sync --frozen --group dev
         if: steps.cached-python-dependencies.outputs.cache-hit != 'true'
 
       - name: Run locale generation

--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   sync-locales:
     runs-on: ubuntu-latest
+    env:
+      # Install from the committed lockfile; never re-resolve (see pyproject
+      # [tool.uv] exclude-newer cooling window).
+      UV_FROZEN: "1"
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -54,7 +58,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-          uv sync --frozen --group dev
+          uv sync --group dev
         if: steps.cached-python-dependencies.outputs.cache-hit != 'true'
 
       - name: Run locale generation

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-          uv sync --group dev --extra pgsql
+          uv sync --frozen --group dev --extra pgsql
         if: steps.cached-python-dependencies.outputs.cache-hit != 'true' || steps.cache-validate.outputs.cache-hit-success != 'true'
 
       - name: Formatting (Ruff)

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -13,6 +13,10 @@ jobs:
 
     env:
       PRODUCTION: false
+      # Install from the committed lockfile; never re-resolve. The rolling
+      # `exclude-newer` cooling window (pyproject [tool.uv]) would otherwise make
+      # every uv command re-resolve and fail on in-window pins.
+      UV_FROZEN: "1"
 
     strategy:
       fail-fast: true
@@ -77,7 +81,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-          uv sync --frozen --group dev --extra pgsql
+          uv sync --group dev --extra pgsql
         if: steps.cached-python-dependencies.outputs.cache-hit != 'true' || steps.cache-validate.outputs.cache-hit-success != 'true'
 
       - name: Formatting (Ruff)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,10 @@ env:
   DEFAULT_GROUP: Home
   DEFAULT_HOUSEHOLD: Family
   PRODUCTION: false
+  # Install from the committed lockfile; never re-resolve. Required because the
+  # rolling `exclude-newer` cooling window (pyproject [tool.uv]) would otherwise
+  # make every `uv run`/`uv sync` re-resolve and fail on in-window pins.
+  UV_FROZEN: "1"
   API_PORT: 9000
   API_DOCS: True
   TOKEN_TIME: 256 # hours
@@ -45,7 +49,7 @@ tasks:
     desc: setup python dependencies
     run: once
     cmds:
-      - uv sync --frozen --extra pgsql --group dev
+      - uv sync --extra pgsql --group dev
       - uv run pre-commit install
     sources:
       - uv.lock

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
     desc: setup python dependencies
     run: once
     cmds:
-      - uv sync --extra pgsql --group dev
+      - uv sync --frozen --extra pgsql --group dev
       - uv run pre-commit install
     sources:
       - uv.lock

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,11 @@ RUN apt-get update \
 
 RUN pip install uv
 
+# Install from the committed lockfile; never re-resolve. The rolling
+# `exclude-newer` cooling window (pyproject [tool.uv]) would otherwise make
+# `uv export` below re-resolve and fail on in-window pins.
+ENV UV_FROZEN=1
+
 WORKDIR /mealie
 
 # copy project files here to ensure they will be cached.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,3 +178,7 @@ max-complexity = 24  # Default is 10.
 
 [tool.uv]
 add-bounds = "exact"
+# Cooling period: ignore package releases newer than 5 days to mitigate
+# supply-chain attacks (compromised releases are usually caught and yanked
+# within days). Evaluated at resolve time as a rolling window.
+exclude-newer = "5 days"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,8 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
   "addLabels": [
     "dependencies"
   ],
@@ -51,8 +53,7 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "minimumReleaseAge": "5 days"
+      "automergeStrategy": "squash"
     },
     {
       "description": "Auto-merge Docker digest and patch updates",
@@ -66,8 +67,7 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "minimumReleaseAge": "5 days"
+      "automergeStrategy": "squash"
     }
   ]
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Enforces a 5-day minimum release age before any dependency update is adopted, mitigating supply-chain attacks (compromised releases are usually caught and yanked within days).

- **Renovate** (`renovate.json`): top-level `minimumReleaseAge: "5 days"` covering all managers + `internalChecksFilter: "strict"`. Removes the now-redundant per-rule entries.
- **uv** (`pyproject.toml`): `exclude-newer = "5 days"` as defense-in-depth for manual `uv add`/`uv lock`.
- **CI / Taskfile / Dockerfile**: `UV_FROZEN=1` everywhere uv runs, so it installs from the lockfile instead of re-resolving (a rolling `exclude-newer` otherwise makes every uv command re-resolve and fail on in-window pins).

## Which issue(s) this PR fixes:

N/A — proactive supply-chain hardening.

## Special notes for your reviewer:

The frontend uses Yarn Classic (no `minimum-release-age`); its npm deps are gated via Renovate's npm manager. Already-locked deps are unaffected — the window only governs adopting new versions.

## Testing

- Full PR CI is green (backend tests, package build, Trivy, docs) — these initially failed on the `exclude-newer` re-resolve and now pass with `UV_FROZEN`.
- Verified locally that a manual `uv lock` correctly refuses an in-window release.

## AI / LLM Assistance

Created with substantial assistance from Claude Code (Anthropic) — investigation, config, CI-failure diagnosis, and this description — all reviewed and directed by the author.