### PR TITLE
fix: default ingredient_references on RecipeInstruction init

### DIFF
--- a/mealie/db/models/recipe/instruction.py
+++ b/mealie/db/models/recipe/instruction.py
@@ -38,5 +38,7 @@ class RecipeInstruction(SqlAlchemyBase):
     )
 
     @auto_init()
-    def __init__(self, ingredient_references, session, **_) -> None:
-        self.ingredient_references = [RecipeIngredientRefLink(**ref, session=session) for ref in ingredient_references]
+    def __init__(self, session, ingredient_references=None, **_) -> None:
+        self.ingredient_references = [
+            RecipeIngredientRefLink(**ref, session=session) for ref in (ingredient_references or [])
+        ]

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -1389,6 +1389,29 @@ def test_patch_recipe_after_name_changes_without_slug_update(api_client: TestCli
     assert patched_recipe["description"] == "Translated without changing the stored slug"
 
 
+def test_patch_recipe_instructions_without_ingredient_references(api_client: TestClient, unique_user: TestUser):
+    response = api_client.post(
+        api_routes.recipes,
+        json={"name": "Patch instructions without refs"},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 201
+    slug = response.json()
+
+    response = api_client.patch(
+        api_routes.recipes_slug(slug),
+        json={"recipeInstructions": [{"text": "Step one."}, {"text": "Step two."}]},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 200
+
+    response = api_client.get(api_routes.recipes_slug(slug), headers=unique_user.token)
+    assert response.status_code == 200
+    recipe = response.json()
+    assert [step["text"] for step in recipe["recipeInstructions"]] == ["Step one.", "Step two."]
+    assert all(step["ingredientReferences"] == [] for step in recipe["recipeInstructions"])
+
+
 def test_put_recipe_name_change_updates_slug(api_client: TestClient, unique_user: TestUser):
     original_name = "Original Recipe Name"
     renamed_name = "Renamed Recipe Name"


### PR DESCRIPTION
## What this PR does / why we need it:

`PATCH /api/recipes/{slug}` returns HTTP 500 whenever the request body contains `recipeInstructions` with step dicts that omit `ingredientReferences`:

```json
{"detail":{"message":"Unknown Error","error":true,"exception":"TypeError"}}
```

Failing example:

```http
PATCH /api/recipes/my-recipe
Content-Type: application/json

{"recipeInstructions": [{"text": "Step one."}]}
```

`RecipeService.patch_one` dumps the incoming body with `model_dump(exclude_unset=True)`, so optional nested fields the caller did not send are stripped from the dict. Each step then reaches `RecipeInstruction(**step, session=session)` without the `ingredient_references` key, and the ORM `__init__` raises:

```
TypeError: __init__() missing 1 required positional argument: 'ingredient_references'
```

`PUT /api/recipes/{slug}` is unaffected because `RepositoryRecipes.update` dumps without `exclude_unset`, so the Pydantic schema default (`ingredient_references: list[IngredientReferences] = []`) materialises before the ORM is called.

**Changes:**

- `mealie/db/models/recipe/instruction.py` — default `ingredient_references` to `None` on `RecipeInstruction.__init__` and coalesce with `[]` when building the link list. `session` moves to the first positional parameter because Python requires defaulted arguments after non-defaulted ones; the resulting signature `(self, session, ingredient_references=None, **_)` matches `RecipeModel.__init__`, which already handles its sibling list fields the same way.
- `tests/integration_tests/user_recipe_tests/test_recipe_crud.py` — regression test that PATCHes a recipe with `recipeInstructions` omitting `ingredientReferences`, asserts 200, and verifies the steps persist with empty refs.

## Which issue(s) this PR fixes:

No related issue — discovered while exercising the PATCH endpoint.

## Special notes for your reviewer:

Considered fixing this at the service-layer dump instead, but changing `exclude_unset` would alter PATCH semantics for every nested model on Recipe and could mask other partial-update bugs. Defaulting the ORM constructor is the narrower fix and matches the existing sibling pattern in `RecipeModel.__init__`.

## Testing

- New integration test `test_patch_recipe_instructions_without_ingredient_references` fails on `mealie-next` with the exact `TypeError` above and passes with the patch.
- Affected recipe test suite (1418 tests in `tests/integration_tests/user_recipe_tests/`) passes locally with the patch.
- `ruff format`, `ruff check mealie`, and `mypy mealie` are clean.

## AI / LLM Assistance

This PR was developed with Claude (Claude Code). The LLM identified the root cause, drafted the patch, and drafted the regression test. The fix was reviewed and verified locally by the author against both un-patched and patched code.
