### PR TITLE
fix: Upgrade pytest-asyncio

### DIFF
--- a/tests/unit_tests/services_tests/ingredient_parser/test_brute_parser.py
+++ b/tests/unit_tests/services_tests/ingredient_parser/test_brute_parser.py
@@ -101,9 +101,8 @@ def test_brute_parser(
     comment: str,
 ):
     with session_context() as session:
-        loop = asyncio.get_event_loop()
         parser = get_parser(RegisteredParser.brute, unique_local_group_id, session, get_locale_provider())
-        parsed = loop.run_until_complete(parser.parse_one(input))
+        parsed = asyncio.run(parser.parse_one(input))
         ing = parsed.ingredient
 
         if ing.quantity:
@@ -145,15 +144,8 @@ def test_brute_parser_confidence(
     input_str = f"1 {unit} {food}"
 
     with session_context() as session:
-        original_loop = asyncio.get_event_loop()
-        try:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            parser = get_parser(RegisteredParser.brute, unique_local_group_id, session, get_locale_provider())
-            parsed = loop.run_until_complete(parser.parse_one(input_str))
-        finally:
-            loop.close()
-            asyncio.set_event_loop(original_loop)
+        parser = get_parser(RegisteredParser.brute, unique_local_group_id, session, get_locale_provider())
+        parsed = asyncio.run(parser.parse_one(input_str))
 
         conf = parsed.confidence
 

--- a/tests/unit_tests/services_tests/ingredient_parser/test_nlp_parser.py
+++ b/tests/unit_tests/services_tests/ingredient_parser/test_nlp_parser.py
@@ -50,9 +50,8 @@ def normalize(val: str) -> str:
 )
 def test_nlp_parser(unique_local_group_id: UUID4, test_ingredient: TestIngredient):
     with session_context() as session:
-        loop = asyncio.get_event_loop()
         parser = get_parser(RegisteredParser.nlp, unique_local_group_id, session, get_locale_provider())
-        parsed = loop.run_until_complete(parser.parse_one(test_ingredient.input))
+        parsed = asyncio.run(parser.parse_one(test_ingredient.input))
         ing = parsed.ingredient
 
         assert ing.quantity == pytest.approx(test_ingredient.quantity)

--- a/tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
+++ b/tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
@@ -56,11 +56,10 @@ def test_openai_parser(
     monkeypatch.setattr(OpenAIService, "__init__", mock_openai_init)
 
     with session_context() as session:
-        loop = asyncio.get_event_loop()
         parser = get_parser(RegisteredParser.openai, unique_local_group_id, session, get_locale_provider())
 
         inputs = [random_string() for _ in range(ingredient_count)]
-        parsed = loop.run_until_complete(parser.parse(inputs))
+        parsed = asyncio.run(parser.parse(inputs))
 
         # since OpenAI is mocked, we don't need to validate the data, we just need to make sure parsing works
         # and that it preserves order
@@ -109,10 +108,10 @@ def test_openai_parser_sanitize_output(
     monkeypatch.setattr(OpenAIService, "__init__", mock_openai_init)
 
     with session_context() as session:
-        loop = asyncio.get_event_loop()
         parser = get_parser(RegisteredParser.openai, unique_local_group_id, session, get_locale_provider())
 
-        parsed = loop.run_until_complete(parser.parse([""]))
+        parsed = asyncio.run(parser.parse([""]))
+
         assert len(parsed) == 1
         parsed_ing = cast(ParsedIngredient, parsed[0])
         assert parsed_ing.ingredient.food

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[options]
+exclude-newer = "2026-06-04T20:28:42.393928614Z"
+exclude-newer-span = "P5D"
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -1012,7 +1016,7 @@ dev = [
     { name = "pydantic-to-typescript2", specifier = "==1.0.6" },
     { name = "pylint", specifier = "==4.0.5" },
     { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-asyncio", specifier = "==1.3.0" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "rich", specifier = "==15.0.0" },
     { name = "ruff", specifier = "==0.15.14" },
     { name = "types-python-dateutil", specifier = "==2.9.0.20260518" },
@@ -1579,15 +1583,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Our unit tests are failing due to usage of deprecated `asyncio` logic. This PR upgrades `pytest-asyncio` and fixes the deprecated logic.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

This is currently blocking our dependency upgrades.

## Testing

_(fill-in or delete this section)_

Reproduced with the upgrade, confirmed it's fixed now.

## AI / LLM Assistance

_(REQUIRED)_

Copilot helped identify the root cause/solution.
