### PR TITLE
fix: surface 502 on image URL fetch failure (#7578)

### DIFF
--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -65,6 +65,7 @@ from mealie.services.event_bus_service.event_types import (
     EventTypes,
 )
 from mealie.services.recipe.recipe_data_service import (
+    ImageFetchError,
     InvalidDomainError,
     NotAnImageError,
     RecipeDataService,
@@ -627,6 +628,19 @@ class RecipeController(BaseRecipeController):
             raise HTTPException(
                 status_code=400,
                 detail=ErrorResponse.respond("Url is not from an allowed domain"),
+            ) from e
+        except ImageFetchError as e:
+            # Upstream image fetch failed (transport error, non-2xx, WAF block, ...).
+            # Surface 502 Bad Gateway with the upstream status (or 0 for transport
+            # errors) so the caller can distinguish "image not saved" from a real
+            # 200 success. Previously this path silently returned 200 OK.
+            # See https://github.com/mealie-recipes/mealie/issues/7578
+            data_service.logger.error(f"Image fetch failed for recipe {slug}: {e!s}")
+            raise HTTPException(
+                status_code=502,
+                detail=ErrorResponse.respond(
+                    f"Could not fetch image from URL (upstream status: {e.status_code})"
+                ),
             ) from e
 
         recipe.image = cache.cache_key.new_key()

--- a/mealie/services/migrations/utils/migration_helpers.py
+++ b/mealie/services/migrations/utils/migration_helpers.py
@@ -9,7 +9,10 @@ from PIL import UnidentifiedImageError
 from pydantic import UUID4
 
 from mealie.core import root_logger
-from mealie.services.recipe.recipe_data_service import RecipeDataService
+from mealie.services.recipe.recipe_data_service import (
+    ImageFetchError,
+    RecipeDataService,
+)
 
 
 class MigrationReaders:
@@ -161,6 +164,15 @@ async def scrape_image(image_url: str, recipe_id: UUID4):
     try:
         await data_service.scrape_image(image_url)
     except UnidentifiedImageError:
+        return
+    except ImageFetchError as e:
+        # Migrations intentionally skip individual image failures (broken
+        # source URL, WAF block, rate limit, etc.) rather than aborting the
+        # whole import. The recipe is preserved; only the image is missing.
+        # See https://github.com/mealie-recipes/mealie/issues/7578
+        root_logger.get_logger(__name__).warning(
+            f"Migration image fetch failed for {image_url}: {e!s}"
+        )
         return
 
 

--- a/mealie/services/recipe/recipe_data_service.py
+++ b/mealie/services/recipe/recipe_data_service.py
@@ -54,6 +54,21 @@ class InvalidDomainError(Exception):
     pass
 
 
+class ImageFetchError(Exception):
+    """
+    Raised when an upstream image URL fetch fails. Carries the upstream
+    HTTP status code (or 0 for transport-level failures) so callers can
+    surface a meaningful error to API clients instead of silently
+    returning a 200 OK with no image written.
+
+    See https://github.com/mealie-recipes/mealie/issues/7578
+    """
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
 class RecipeDataService(BaseService):
     minifier: img.ABCMinifier
 
@@ -149,14 +164,20 @@ class RecipeDataService(BaseService):
         async with AsyncClient(transport=safehttp.AsyncSafeTransport(impersonate="chrome")) as client:
             try:
                 r = await client.get(image_url_str)
-            except Exception:
+            except Exception as e:
+                # Transport-level failure (DNS, TLS, timeout, connection reset, ...).
+                # Surface as ImageFetchError so the route can return a real error
+                # to the caller instead of silently 200-OKing with no image written.
+                # See https://github.com/mealie-recipes/mealie/issues/7578
                 self.logger.exception("Fatal Image Request Exception")
-                return None
+                raise ImageFetchError(0, f"Image fetch failed: {e!s}") from e
 
             if r.status_code != 200:
-                # TODO: Probably should throw an exception in this case as well, but before these changes
-                # we were returning None if it failed anyways.
-                return None
+                # Upstream returned a non-success status (e.g. 460 from a WAF-fronted
+                # CDN). Surface the real status to the API client rather than the old
+                # silent-200 behavior. Migration/scraper callers already wrap this
+                # in a broad try/except.
+                raise ImageFetchError(r.status_code, f"Image fetch returned HTTP {r.status_code}")
 
             content_type = r.headers.get("content-type", "")
 

--- a/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
@@ -1,8 +1,11 @@
 import filecmp
 
+import pytest
 from fastapi.testclient import TestClient
+from httpx import Response
 from slugify import slugify
 
+from mealie.pkgs.safehttp.transport import AsyncSafeTransport
 from mealie.schema.recipe.recipe import Recipe
 from tests import data
 from tests.utils.factories import random_string
@@ -150,3 +153,111 @@ def test_recipe_image_upload(api_client: TestClient, unique_user: TestUser, reci
     response = api_client.get(f"/api/recipes/{recipe_ingredient_only.slug}", headers=unique_user.token)
     recipe_respons = response.json()
     assert recipe_respons["image"] == image_version
+
+
+# Regression tests for https://github.com/mealie-recipes/mealie/issues/7578
+# `POST /api/recipes/{slug}/image` (the URL scrape path) used to silently
+# return 200 OK when the upstream image fetch failed, leaving the recipe
+# with no image and the caller none the wiser. It must now surface 502
+# Bad Gateway with the upstream status code in the body.
+
+
+@pytest.mark.parametrize("upstream_status", [403, 404, 460, 500, 502, 503])
+def test_scrape_image_url_returns_502_on_upstream_non_2xx(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+    upstream_status: int,
+):
+    """Upstream returning a non-2xx (e.g. 460 from a WAF-fronted CDN) must
+    surface as 502 Bad Gateway with the upstream status in the body, not
+    as the old silently-correct 200 OK."""
+
+    async def return_non_2xx(*args, **kwargs):
+        return Response(upstream_status, content=b"")
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", return_non_2xx)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/waf-blocked.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 502
+    body = response.json()
+    # The upstream status code should be surfaced in the error detail so
+    # callers can distinguish a 460 WAF block from a 500 server error.
+    assert str(upstream_status) in str(body)
+
+
+def test_scrape_image_url_returns_502_on_transport_error(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Network-level failures (DNS, TLS, timeout) must also surface as
+    502 Bad Gateway rather than the old silent 200 OK."""
+
+    async def raise_connection_error(*args, **kwargs):
+        raise ConnectionError("simulated network failure")
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", raise_connection_error)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/timeout.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 502
+
+
+def test_scrape_image_service_raises_on_non_2xx():
+    """Direct unit test on RecipeDataService.scrape_image — the data
+    service must raise ImageFetchError rather than swallowing the failure
+    and returning None as it did before #7578."""
+
+    import asyncio
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    from mealie.services.recipe.recipe_data_service import (
+        ImageFetchError,
+        RecipeDataService,
+    )
+
+    # Use a plain MagicMock for the logger so calls to .info / .exception
+    # are no-ops (the service code calls both, including the exception path).
+    service = RecipeDataService(recipe_id=uuid4(), logger=MagicMock())
+
+    async def run():
+        # Build a fake httpx AsyncClient context manager
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, *args, **kwargs):
+                return Response(460, content=b"")
+
+        # Patch AsyncClient via the module under test so the data service
+        # uses our fake client instead of opening a real network connection.
+        import mealie.services.recipe.recipe_data_service as mod
+
+        original_async_client = mod.AsyncClient
+        mod.AsyncClient = lambda *a, **kw: FakeClient()
+        try:
+            await service.scrape_image("https://example.com/waf.jpg")
+        except ImageFetchError as e:
+            assert e.status_code == 460
+            return "raised"
+        finally:
+            mod.AsyncClient = original_async_client
+        return "no-raise"
+
+    assert asyncio.run(run()) == "raised"


### PR DESCRIPTION
## Problem

`POST /api/recipes/{slug}/image` (the URL scrape path) silently returns `200 OK` when the upstream image fetch fails — transport error, non-2xx status, or a WAF block (e.g. CloudFront's 460 for `python-httpx/*` UAs). The recipe ends up with no image, the API trace looks clean, and the caller has no way to tell that the save didn't happen. Any client (curl, Python SDK, browser UI, MCP, agent) sees a confidently-wrong success.

## Fix

- `RecipeDataService.scrape_image` now raises a new `ImageFetchError` (carrying the upstream status, or `0` for transport-level failures) instead of swallowing the failure and returning `None`.
- `POST /api/recipes/{slug}/image` translates `ImageFetchError` into a `502 Bad Gateway` with the upstream status code in the body. The caller can now distinguish a 460 WAF block from a 500 server error, and a transport error from a clean 200.
- Migration / scraper callers, which already wrap the call in a broad try/except, now log a warning and continue without aborting the import — a single broken image URL no longer kills a bulk migration.

## Bug 1 of #7578 (User-Agent spoofing)

Already fixed at the code level: `RecipeDataService.scrape_image` uses `safehttp.AsyncSafeTransport(impersonate='chrome')`, which spoofs a Chrome UA on the wire. The `python-httpx/*` UA never reaches the CDN. This PR addresses bug 2 only; the two changes are independent.

## Tests

- 6 parameterized cases for upstream non-2xx (`403`, `404`, `460`, `500`, `502`, `503`) → `502`
- Transport-level `ConnectionError` → `502`
- Direct unit test on `RecipeDataService.scrape_image` (no API): asserts `ImageFetchError` is raised with the right `status_code`
- All 8 fail on the old code, all 8 pass on the new code (verified by reverting just the source change and re-running the test file)
- `test_recipe_image_assets.py`: 13/13
- `test_recipe_crud.py`: 50/50
- `test_services/`: 223/223

Fixes #7578