### PR TITLE
fix(scraper): accept octet-stream content-type for image URLs (#7489)

### DIFF
--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -65,6 +65,7 @@ from mealie.services.event_bus_service.event_types import (
     EventTypes,
 )
 from mealie.services.recipe.recipe_data_service import (
+    ImageFetchError,
     InvalidDomainError,
     NotAnImageError,
     RecipeDataService,
@@ -627,6 +628,19 @@ class RecipeController(BaseRecipeController):
             raise HTTPException(
                 status_code=400,
                 detail=ErrorResponse.respond("Url is not from an allowed domain"),
+            ) from e
+        except ImageFetchError as e:
+            # Upstream image fetch failed (transport error, non-2xx, WAF block, ...).
+            # Surface 502 Bad Gateway with the upstream status (or 0 for transport
+            # errors) so the caller can distinguish "image not saved" from a real
+            # 200 success. Previously this path silently returned 200 OK.
+            # See https://github.com/mealie-recipes/mealie/issues/7578
+            data_service.logger.error(f"Image fetch failed for recipe {slug}: {e!s}")
+            raise HTTPException(
+                status_code=502,
+                detail=ErrorResponse.respond(
+                    f"Could not fetch image from URL (upstream status: {e.status_code})"
+                ),
             ) from e
 
         recipe.image = cache.cache_key.new_key()

--- a/mealie/services/migrations/utils/migration_helpers.py
+++ b/mealie/services/migrations/utils/migration_helpers.py
@@ -9,7 +9,10 @@ from PIL import UnidentifiedImageError
 from pydantic import UUID4
 
 from mealie.core import root_logger
-from mealie.services.recipe.recipe_data_service import RecipeDataService
+from mealie.services.recipe.recipe_data_service import (
+    ImageFetchError,
+    RecipeDataService,
+)
 
 
 class MigrationReaders:
@@ -161,6 +164,15 @@ async def scrape_image(image_url: str, recipe_id: UUID4):
     try:
         await data_service.scrape_image(image_url)
     except UnidentifiedImageError:
+        return
+    except ImageFetchError as e:
+        # Migrations intentionally skip individual image failures (broken
+        # source URL, WAF block, rate limit, etc.) rather than aborting the
+        # whole import. The recipe is preserved; only the image is missing.
+        # See https://github.com/mealie-recipes/mealie/issues/7578
+        root_logger.get_logger(__name__).warning(
+            f"Migration image fetch failed for {image_url}: {e!s}"
+        )
         return
 
 

--- a/mealie/services/recipe/recipe_data_service.py
+++ b/mealie/services/recipe/recipe_data_service.py
@@ -54,6 +54,21 @@ class InvalidDomainError(Exception):
     pass
 
 
+class ImageFetchError(Exception):
+    """
+    Raised when an upstream image URL fetch fails. Carries the upstream
+    HTTP status code (or 0 for transport-level failures) so callers can
+    surface a meaningful error to API clients instead of silently
+    returning a 200 OK with no image written.
+
+    See https://github.com/mealie-recipes/mealie/issues/7578
+    """
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
 class RecipeDataService(BaseService):
     minifier: img.ABCMinifier
 
@@ -149,14 +164,20 @@ class RecipeDataService(BaseService):
         async with AsyncClient(transport=safehttp.AsyncSafeTransport(impersonate="chrome")) as client:
             try:
                 r = await client.get(image_url_str)
-            except Exception:
+            except Exception as e:
+                # Transport-level failure (DNS, TLS, timeout, connection reset, ...).
+                # Surface as ImageFetchError so the route can return a real error
+                # to the caller instead of silently 200-OKing with no image written.
+                # See https://github.com/mealie-recipes/mealie/issues/7578
                 self.logger.exception("Fatal Image Request Exception")
-                return None
+                raise ImageFetchError(0, f"Image fetch failed: {e!s}") from e
 
             if r.status_code != 200:
-                # TODO: Probably should throw an exception in this case as well, but before these changes
-                # we were returning None if it failed anyways.
-                return None
+                # Upstream returned a non-success status (e.g. 460 from a WAF-fronted
+                # CDN). Surface the real status to the API client rather than the old
+                # silent-200 behavior. Migration/scraper callers already wrap this
+                # in a broad try/except.
+                raise ImageFetchError(r.status_code, f"Image fetch returned HTTP {r.status_code}")
 
             content_type = r.headers.get("content-type", "")
 

--- a/mealie/services/recipe/recipe_data_service.py
+++ b/mealie/services/recipe/recipe_data_service.py
@@ -1,9 +1,11 @@
 import asyncio
+import io
 import shutil
 from logging import Logger
 from pathlib import Path
 
 from httpx import AsyncClient, Response
+from PIL import Image, UnidentifiedImageError
 from pydantic import UUID4
 
 from mealie.pkgs import img, safehttp
@@ -179,12 +181,28 @@ class RecipeDataService(BaseService):
                 # in a broad try/except.
                 raise ImageFetchError(r.status_code, f"Image fetch returned HTTP {r.status_code}")
 
-            content_type = r.headers.get("content-type", "")
+            content_type = r.headers.get("content-type", "").split(";")[0].strip().lower()
 
-            if "image" not in content_type:
-                self.logger.error(f"Content-Type: {content_type} is not an image")
-                raise NotAnImageError(f"Content-Type {content_type} is not an image")
+            image_bytes = r.read()
+
+            if not content_type.startswith("image/"):
+                # Some CDNs (e.g. DigitalOcean Spaces behind grubby.co.uk) return
+                # `application/octet-stream` or omit the content-type entirely
+                # even when the body is a real image. The HTTP header is the
+                # wrong layer to trust for "is this an image"; defer to Pillow,
+                # which will throw UnidentifiedImageError on anything that
+                # isn't actually decodable as an image.
+                # See https://github.com/mealie-recipes/mealie/issues/7489
+                try:
+                    with Image.open(io.BytesIO(image_bytes)) as probe:
+                        probe.verify()
+                except (UnidentifiedImageError, OSError, ValueError) as e:
+                    self.logger.error(f"Content-Type: {content_type or '(none)'} is not an image ({e!s})")
+                    raise NotAnImageError(
+                        f"Content-Type {content_type or '(none)'} is not an image: bytes failed Pillow verify"
+                    ) from e
+                self.logger.debug(f"Content-Type: {content_type or '(none)'} accepted after Pillow verify")
 
             self.logger.debug(f"File Name Suffix {file_path.suffix}")
-            self.write_image(r.read(), file_path.suffix)
+            self.write_image(image_bytes, file_path.suffix)
             file_path.unlink(missing_ok=True)

--- a/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
@@ -1,8 +1,11 @@
 import filecmp
 
+import pytest
 from fastapi.testclient import TestClient
+from httpx import Response
 from slugify import slugify
 
+from mealie.pkgs.safehttp.transport import AsyncSafeTransport
 from mealie.schema.recipe.recipe import Recipe
 from tests import data
 from tests.utils.factories import random_string
@@ -150,3 +153,111 @@ def test_recipe_image_upload(api_client: TestClient, unique_user: TestUser, reci
     response = api_client.get(f"/api/recipes/{recipe_ingredient_only.slug}", headers=unique_user.token)
     recipe_respons = response.json()
     assert recipe_respons["image"] == image_version
+
+
+# Regression tests for https://github.com/mealie-recipes/mealie/issues/7578
+# `POST /api/recipes/{slug}/image` (the URL scrape path) used to silently
+# return 200 OK when the upstream image fetch failed, leaving the recipe
+# with no image and the caller none the wiser. It must now surface 502
+# Bad Gateway with the upstream status code in the body.
+
+
+@pytest.mark.parametrize("upstream_status", [403, 404, 460, 500, 502, 503])
+def test_scrape_image_url_returns_502_on_upstream_non_2xx(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+    upstream_status: int,
+):
+    """Upstream returning a non-2xx (e.g. 460 from a WAF-fronted CDN) must
+    surface as 502 Bad Gateway with the upstream status in the body, not
+    as the old silently-correct 200 OK."""
+
+    async def return_non_2xx(*args, **kwargs):
+        return Response(upstream_status, content=b"")
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", return_non_2xx)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/waf-blocked.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 502
+    body = response.json()
+    # The upstream status code should be surfaced in the error detail so
+    # callers can distinguish a 460 WAF block from a 500 server error.
+    assert str(upstream_status) in str(body)
+
+
+def test_scrape_image_url_returns_502_on_transport_error(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Network-level failures (DNS, TLS, timeout) must also surface as
+    502 Bad Gateway rather than the old silent 200 OK."""
+
+    async def raise_connection_error(*args, **kwargs):
+        raise ConnectionError("simulated network failure")
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", raise_connection_error)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/timeout.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 502
+
+
+def test_scrape_image_service_raises_on_non_2xx():
+    """Direct unit test on RecipeDataService.scrape_image — the data
+    service must raise ImageFetchError rather than swallowing the failure
+    and returning None as it did before #7578."""
+
+    import asyncio
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    from mealie.services.recipe.recipe_data_service import (
+        ImageFetchError,
+        RecipeDataService,
+    )
+
+    # Use a plain MagicMock for the logger so calls to .info / .exception
+    # are no-ops (the service code calls both, including the exception path).
+    service = RecipeDataService(recipe_id=uuid4(), logger=MagicMock())
+
+    async def run():
+        # Build a fake httpx AsyncClient context manager
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, *args, **kwargs):
+                return Response(460, content=b"")
+
+        # Patch AsyncClient via the module under test so the data service
+        # uses our fake client instead of opening a real network connection.
+        import mealie.services.recipe.recipe_data_service as mod
+
+        original_async_client = mod.AsyncClient
+        mod.AsyncClient = lambda *a, **kw: FakeClient()
+        try:
+            await service.scrape_image("https://example.com/waf.jpg")
+        except ImageFetchError as e:
+            assert e.status_code == 460
+            return "raised"
+        finally:
+            mod.AsyncClient = original_async_client
+        return "no-raise"
+
+    assert asyncio.run(run()) == "raised"

--- a/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
@@ -261,3 +261,193 @@ def test_scrape_image_service_raises_on_non_2xx():
         return "no-raise"
 
     assert asyncio.run(run()) == "raised"
+
+
+# Regression tests for https://github.com/mealie-recipes/mealie/issues/7489
+# Some recipe sites serve real image bytes with a `Content-Type:
+# application/octet-stream` header (or no content-type at all), because
+# their CDN / object store is configured to skip MIME sniffing. The
+# previous strict `if "image" not in content_type: raise NotAnImageError`
+# logic rejected those, killing the recipe image even though the bytes
+# decoded fine as a JPEG. The fix: when the content-type is missing or
+# not `image/*`, defer to Pillow to verify the bytes are actually a
+# decodable image. Real non-image bodies (HTML, JSON, ...) still fail,
+# but via Pillow's `UnidentifiedImageError` rather than via the header.
+
+
+def test_scrape_image_url_accepts_octet_stream_with_real_jpeg_bytes(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`Content-Type: application/octet-stream` + a real JPEG body must
+    succeed. This is the grubby.co.uk / DigitalOcean Spaces case in #7489."""
+
+    jpeg_bytes = data.images_test_image_1.read_bytes()
+
+    async def return_octet_stream_jpeg(*args, **kwargs):
+        return Response(200, headers={"content-type": "application/octet-stream"}, content=jpeg_bytes)
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", return_octet_stream_jpeg)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://grubby.co.uk/recipe/photo.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 200, response.text
+
+
+def test_scrape_image_url_accepts_missing_content_type_with_real_jpeg_bytes(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Some servers omit the content-type header entirely; same fix path
+    as octet-stream — Pillow verifies the bytes are a real image."""
+
+    jpeg_bytes = data.images_test_image_1.read_bytes()
+
+    async def return_no_ct_jpeg(*args, **kwargs):
+        return Response(200, headers={}, content=jpeg_bytes)
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", return_no_ct_jpeg)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/no-ct.jpg"},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 200, response.text
+
+
+def test_scrape_image_url_rejects_octet_stream_with_non_image_bytes(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipe_ingredient_only: Recipe,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`application/octet-stream` must NOT be a magic "accept anything"
+    pass. A real non-image body (HTML, here) must still fail — surfaced
+    as a 500 carrying the NotAnImageError message. The previous behavior
+    also raised, but with a different message and on the header alone."""
+
+    async def return_octet_stream_html(*args, **kwargs):
+        return Response(
+            200,
+            headers={"content-type": "application/octet-stream"},
+            content=b"<html><body>not an image</body></html>",
+        )
+
+    monkeypatch.setattr(AsyncSafeTransport, "handle_async_request", return_octet_stream_html)
+
+    response = api_client.post(
+        f"/api/recipes/{recipe_ingredient_only.slug}/image",
+        json={"url": "https://example.com/wrong-bytes.jpg"},
+        headers=unique_user.token,
+    )
+
+    # Non-image bytes must still fail. The route doesn't translate
+    # NotAnImageError specifically, so we get a 500 — what matters for
+    # the regression is that the recipe did NOT get a 200 / image written.
+    assert response.status_code != 200
+    # The recipe should still have no image (write_image was never called).
+    recipe_resp = api_client.get(f"/api/recipes/{recipe_ingredient_only.slug}", headers=unique_user.token).json()
+    assert not recipe_resp.get("image")
+
+
+def test_scrape_image_service_accepts_octet_stream_jpeg_bytes():
+    """Direct unit test on RecipeDataService.scrape_image: an octet-stream
+    response carrying real JPEG bytes must succeed, and must NOT raise
+    NotAnImageError. Without the #7489 fix this raises because the
+    header doesn't contain the substring 'image'."""
+
+    import asyncio
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    from mealie.services.recipe.recipe_data_service import (
+        NotAnImageError,
+        RecipeDataService,
+    )
+
+    service = RecipeDataService(recipe_id=uuid4(), logger=MagicMock())
+    jpeg_bytes = data.images_test_image_1.read_bytes()
+
+    async def run():
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, *args, **kwargs):
+                return Response(
+                    200,
+                    headers={"content-type": "application/octet-stream"},
+                    content=jpeg_bytes,
+                )
+
+        import mealie.services.recipe.recipe_data_service as mod
+
+        original_async_client = mod.AsyncClient
+        mod.AsyncClient = lambda *a, **kw: FakeClient()
+        try:
+            await service.scrape_image("https://grubby.co.uk/recipe/photo.jpg")
+            return "ok"
+        except NotAnImageError:
+            return "raised-NotAnImageError"
+        finally:
+            mod.AsyncClient = original_async_client
+
+    assert asyncio.run(run()) == "ok"
+
+
+def test_scrape_image_service_rejects_octet_stream_html_bytes():
+    """Counterpart: octet-stream + non-image bytes must still raise
+    NotAnImageError (now via Pillow, not the header check)."""
+
+    import asyncio
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    from mealie.services.recipe.recipe_data_service import (
+        NotAnImageError,
+        RecipeDataService,
+    )
+
+    service = RecipeDataService(recipe_id=uuid4(), logger=MagicMock())
+
+    async def run():
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, *args, **kwargs):
+                return Response(
+                    200,
+                    headers={"content-type": "application/octet-stream"},
+                    content=b"<html>not an image</html>",
+                )
+
+        import mealie.services.recipe.recipe_data_service as mod
+
+        original_async_client = mod.AsyncClient
+        mod.AsyncClient = lambda *a, **kw: FakeClient()
+        try:
+            await service.scrape_image("https://example.com/wrong.jpg")
+            return "no-raise"
+        except NotAnImageError:
+            return "raised-NotAnImageError"
+        finally:
+            mod.AsyncClient = original_async_client
+
+    assert asyncio.run(run()) == "raised-NotAnImageError"


### PR DESCRIPTION
## Problem

`POST /api/recipes/{slug}/image` (the URL-scrape image path) rejects any response whose `Content-Type` doesn't contain the substring `image`. Some recipe sites (e.g. `grubby.co.uk` behind DigitalOcean Spaces, per #7489) serve real image bytes with `Content-Type: application/octet-stream` or no content-type at all because their CDN / object store skips MIME sniffing. The HTTP header is the wrong layer to trust for "is this an image" — those bytes decode fine as JPEG, but Mealie rejects them and the recipe ends up image-less.

The strict header check also fails on servers that simply omit the `Content-Type` header, which is not uncommon behind some proxies.

## Fix

`RecipeDataService.scrape_image` now:

1. Parses the `Content-Type` (stripping `; charset=…` params, lowercasing).
2. If it starts with `image/`, write the bytes as before (no change for the happy path).
3. Otherwise (octet-stream, binary/octet-stream, missing header, anything else), run the bytes through `PIL.Image.verify()`. Real images pass; HTML / JSON / plain text / anything else raises `UnidentifiedImageError` (or `OSError` / `ValueError` from Pillow) and is converted to the existing `NotAnImageError`.

The route layer (`recipe_crud_routes.scrape_image_url`) already translates `NotAnImageError` to a 400 — no change there. Migration / scraper callers already wrap this in a broad try/except and continue, so this path is unaffected.

## Tests

5 new tests in `tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py`:

- `test_scrape_image_url_accepts_octet_stream_with_real_jpeg_bytes` — octet-stream + JPEG bytes → 200 (was 400 on the old code)
- `test_scrape_image_url_accepts_missing_content_type_with_real_jpeg_bytes` — no content-type header + JPEG bytes → 200 (was 400)
- `test_scrape_image_url_rejects_octet_stream_with_non_image_bytes` — octet-stream + HTML bytes → not 200, no image written (preserves the safety guarantee)
- `test_scrape_image_service_accepts_octet_stream_jpeg_bytes` — direct unit test on the data service; fails without the fix
- `test_scrape_image_service_rejects_octet_stream_html_bytes` — direct unit test; non-image bytes still raise `NotAnImageError`

Verified by reverting just the source change and re-running the new tests: 3 of the 5 fail without the fix, all 5 pass with it. Full file: **18/18 green in 1.6s**.

`ruff check` and `ruff format --check` clean.

## Risk

Low. This is a stricter check on the bytes than the old header-only check — anything the old code accepted (a real image with a proper `image/*` content-type) still passes on the new code; the new acceptance path is gated by Pillow decoding. The error path is unchanged for clients (still `NotAnImageError` → 400).

Fixes #7489