### PR TITLE
fix: send default_headers with curl_cffi impersonation (fixes 403 on WAF sites)

### DIFF
--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -78,6 +78,7 @@ async def safe_scrape_html(url: str) -> str:
 
         transport = safehttp.AsyncSafeTransport(
             impersonate=impersonation,
+            default_headers=True,
             verify=False,  # disable SSL verification since we can handle untrusted data and some sites don't have certs
         )
         async with AsyncClient(transport=transport) as client:


### PR DESCRIPTION
## What this PR does / why we need it:

When scraping recipe URLs, `AsyncSafeTransport` is configured with `curl_cffi` browser impersonation (`impersonate=impersonation`). However, without `default_headers=True`, curl_cffi only spoofs the TLS/JA3 fingerprint — it does **not** send the full set of browser-default HTTP headers (Accept, Accept-Language, Sec-Ch-Ua, etc.) that match the impersonated browser.

WAF/anti-bot services (Cloudflare and similar) fingerprint on the *combination* of TLS handshake and HTTP headers. A request with a Chrome TLS fingerprint but missing Chrome's default headers is an obvious mismatch and gets blocked with a `403`.

- `mealie/services/scraper/scraper_strategies.py`: pass `default_headers=True` to `AsyncSafeTransport` so curl_cffi sends the browser-default header set that matches the active impersonation profile.

This is a one-line change with no behavioral effect on sites that already worked; it only adds the headers curl_cffi already knows how to emit for each impersonation target.

## Which issue(s) this PR fixes:

No tracked issue — surfaced while debugging recurring `403` responses from WAF-protected recipe sites during import.

## Testing

- `ruff format --check` and `ruff check` pass on the changed file.
- Full PR CI (`Backend Server Tests` on both SQLite and Postgres, plus the `End-to-End` Playwright suite) was run and passed on a fork before opening this PR.
- **Built and ran the production Docker image locally** (`docker compose ... --target production`) from this branch and exercised the live scraper via `POST /api/recipes/test-scrape-url`:
  - `https://www.campbells.com/recipes/green-bean-casserole/` (Cloudflare/WAF-fronted — previously returned `403`) → **HTTP 200**, parsed *"Green Bean Casserole"* (5 ingredients, 3 steps). Container logs show `Trying browser impersonation: "chrome"` → `HTTP/2 200 OK`.
  - `https://www.bonappetit.com/recipe/bas-best-chocolate-chip-cookies` (WAF-fronted) → **HTTP 200**, fully parsed.
  - `https://www.allrecipes.com/recipe/20144/banana-banana-bread/` (regression check, non-WAF) → **HTTP 200**, fully parsed.
  - No `403`/forbidden responses observed in any test.

## AI / LLM Assistance

The code change, commit message, and this PR description were drafted with assistance from Claude (Anthropic) via Claude Code. The change is a single-line, well-understood addition to an existing call site; the author reviewed and verified it before opening the PR.
