### PR TITLE
docs: fix broken link to backend configuration in AI providers page

### DIFF
--- a/docs/docs/documentation/getting-started/installation/ai-providers.md
+++ b/docs/docs/documentation/getting-started/installation/ai-providers.md
@@ -20,7 +20,7 @@ If you have another provider you'd like to use, such as Azure, you can configure
 
 Note that some models are capable of handling multiple features (e.g. `gpt-5` can handle both normal chat requests and image recognition requests). You may configure one provider for multiple provider features.
 
-While Mealie has prompts for each AI task, you can override these with your own prompts if you'd like. For more information, check out the [backend configuration](./installation/ai-providers.md).
+While Mealie has prompts for each AI task, you can override these with your own prompts if you'd like. For more information, check out the [backend configuration](./installation/backend-config.md).
 
 ## AI Features
 - The OpenAI Ingredient Parser can be used as an alternative to the NLP and Brute Force parsers. Simply choose the OpenAI parser while parsing ingredients (:octicons-tag-24: v1.7.0)

--- a/docs/docs/documentation/getting-started/installation/ai-providers.md
+++ b/docs/docs/documentation/getting-started/installation/ai-providers.md
@@ -20,7 +20,7 @@ If you have another provider you'd like to use, such as Azure, you can configure
 
 Note that some models are capable of handling multiple features (e.g. `gpt-5` can handle both normal chat requests and image recognition requests). You may configure one provider for multiple provider features.
 
-While Mealie has prompts for each AI task, you can override these with your own prompts if you'd like. For more information, check out the [backend configuration](./installation/backend-config.md).
+While Mealie has prompts for each AI task, you can override these with your own prompts if you'd like. For more information, check out the [backend configuration](../installation/backend-config.md).
 
 ## AI Features
 - The OpenAI Ingredient Parser can be used as an alternative to the NLP and Brute Force parsers. Simply choose the OpenAI parser while parsing ingredients (:octicons-tag-24: v1.7.0)


### PR DESCRIPTION
## What this PR does / why we need it:

backend configuration link on the [AI providers](https://docs.mealie.io/documentation/getting-started/installation/ai-providers/) page lead to [404](https://docs.mealie.io/documentation/getting-started/installation/ai-providers/installation/ai-providers.md) and ai providers page itself instead of [backend configuration page](https://docs.mealie.io/documentation/getting-started/installation/backend-config/)

## Which issue(s) this PR fixes:

no related issue

## AI / LLM Assistance

Used Claude to create conventional commit msg