### PR TITLE
fix: wrap long words in timeline to prevent horizontal scroll

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
@@ -25,7 +25,7 @@
               {{ $d(new Date(event.timestamp || "")) }}
             </v-chip>
           </v-col>
-          <v-col v-else cols="9" style="margin: auto; text-align: center">
+          <v-col v-else cols="9" class="break-word" style="margin: auto; text-align: center">
             {{ event.subject }}
           </v-col>
           <v-col :cols="useMobileFormat ? 'auto' : '1'" class="px-0 pt-0">
@@ -68,7 +68,7 @@
       <v-card-text class="background">
         <v-row>
           <v-col>
-            <strong v-if="useMobileFormat">{{ event.subject }}</strong>
+            <strong v-if="useMobileFormat" class="break-word">{{ event.subject }}</strong>
             <v-img
               v-if="eventImageUrl"
               :src="eventImageUrl"
@@ -79,7 +79,7 @@
               :class="attrs.image.class"
               @error="hideImage = true"
             />
-            <div v-if="event.eventMessage" :class="useMobileFormat ? 'text-caption' : ''">
+            <div v-if="event.eventMessage" class="break-word" :class="useMobileFormat ? 'text-caption' : ''">
               <SafeMarkdown :source="event.eventMessage" />
             </div>
           </v-col>
@@ -178,5 +178,9 @@ const eventImageUrl = computed<string>(() => {
 <style>
 .v-card::after {
   display: none;
+}
+
+.break-word {
+  overflow-wrap: anywhere;
 }
 </style>


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes horizontal scroll in the recipe timeline when an entry contains a very long unbroken word or URL.

**Cause:** `event.subject` and `event.eventMessage` (rendered via `SafeMarkdown`) had no break points, so a long string forced the timeline card/popup to overflow horizontally and clip the start of the text.

**Fix (CSS only):**
- `frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue` — added a `break-word` class applying `overflow-wrap: anywhere` to the subject (desktop + mobile) and the message container.

`anywhere` is used rather than `word-break: break-word` because it also reduces the flex item's min-content size, letting the `v-col` actually shrink and wrap.

## Which issue(s) this PR fixes:

Fixes #7760

## Testing

Create a timeline entry with a long word or link without spaces, e.g.

```
https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

The text now wraps to a new line instead of adding horizontal scroll. Verified on both desktop and mobile layouts.

## AI / LLM Assistance

An LLM was used to help locate the overflow source and draft the CSS fix. All changes were reviewed and tested manually before submitting.

