### PR TITLE
fix: prevent empty bulk add from clearing import URLs

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDialogBulkAdd.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDialogBulkAdd.vue
@@ -9,6 +9,7 @@
       :title="$t('new-recipe.bulk-add')"
       :icon="$globals.icons.createAlt"
       :submit-text="$t('general.add')"
+      :submit-disabled="!canSave"
       :disable-submit-on-enter="true"
       can-submit
       @submit="save"
@@ -74,8 +75,10 @@ const dialog = ref(false);
 const inputText = ref(props.inputTextProp);
 
 function splitText() {
-  return inputText.value.split("\n").filter(line => !(line === "\n" || !line));
+  return inputText.value.split("\n").filter(line => line.trim().length > 0);
 }
+
+const canSave = computed(() => splitText().length > 0);
 
 function removeFirstCharacter() {
   inputText.value = splitText()
@@ -106,6 +109,10 @@ function trimAllLines() {
 }
 
 function save() {
+  if (!canSave.value) {
+    return;
+  }
+
   emit("bulk-data", splitText());
   dialog.value = false;
 }

--- a/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
@@ -223,6 +223,10 @@ async function deleteReport(id: string) {
 fetchReports();
 
 function assignUrls(urls: string[]) {
+  if (urls.length === 0) {
+    return;
+  }
+
   bulkUrls.value = urls.map(url => ({ url, categories: [], tags: [] }));
 }
 </script>


### PR DESCRIPTION
## What this PR does / why we need it:

- Updates `RecipeDialogBulkAdd.vue` so the shared Bulk Add dialog does not emit a save event when the textarea is empty or only whitespace.
- Updates `bulk.vue` so empty Bulk Add results are ignored instead of replacing the existing `bulkUrls` list.
- This prevents accidentally clearing manually entered import URLs by clicking Save in an empty Bulk Add dialog.
- There is no visual UI change, so before/after screenshots are not included.

## Which issue(s) this PR fixes:

Fixes #6947

## Special notes for your reviewer:

The guard is intentionally applied in both places:

- The dialog avoids emitting invalid empty submissions.
- The page still protects its existing URL list if it receives an empty result from another caller or future change.

## Testing

- `./node_modules/.bin/eslint app/components/Domain/Recipe/RecipeDialogBulkAdd.vue 'app/pages/g/[groupSlug]/r/create/bulk.vue'`
- `git diff HEAD~1..HEAD --check`

## AI / LLM Assistance

This PR was prepared with Codex assistance. Codex helped identify the issue, make the code changes, and run the local checks listed above.
