### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Docker Pulls][docker-pull]][docker-url]
 [![GHCR Pulls][ghcr-pulls]][ghcr-url]
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/mealie)
+
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Mealie to our marketplace, so this PR adds a small "Deploy with Zenith" link in the header links row (next to View Demo), linking to https://zenith.hosting/host/mealie.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

- README.md: added one link, "Deploy with Zenith", to the centered header links row alongside the existing View Demo / Report Bug links. additions-only, one file, no new section.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

N/A (documentation-only change; no code or tests affected)

## AI / LLM Assistance

_(REQUIRED)_

No LLM was used.