### PR TITLE
chore(deps): remove unused aiofiles dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "Pillow==12.3.0",
     "PyYAML==6.0.3",
     "SQLAlchemy==2.0.51",
-    "aiofiles==25.1.0",
     "alembic==1.18.5",
     "apprise==1.12.0",
     "bcrypt==5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,17 +3,8 @@ revision = 3
 requires-python = "==3.12.*"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-07T18:40:59.877317248Z"
 exclude-newer-span = "P5D"
-
-[[package]]
-name = "aiofiles"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
-]
 
 [[package]]
 name = "alembic"
@@ -885,7 +876,6 @@ name = "mealie"
 version = "3.20.1"
 source = { editable = "." }
 dependencies = [
-    { name = "aiofiles" },
     { name = "alembic" },
     { name = "apprise" },
     { name = "authlib" },
@@ -959,7 +949,6 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = "==25.1.0" },
     { name = "alembic", specifier = "==1.18.5" },
     { name = "apprise", specifier = "==1.12.0" },
     { name = "authlib", specifier = "==1.7.2" },


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.

  If there is a UI component to the change, please include before/after images.
-->

`aiofiles` has been declared since the first commit in Dec 2020, when `starlette` required it for `FileResponse`. Starlette moved to `anyio` in 0.15 (2021) and dropped that requirement, and `mealie` itself never imported aiofiles, so Renovate has spent five years dutifully version-bumping a package nothing uses.

Discovered with pyproject-udeps [[1]].

[1]: https://github.com/lukehsiao/pyproject-udeps