### PR TITLE
fix: preserve deep link when redirecting to login

### DIFF
--- a/frontend/app/composables/recipes/use-recipes.ts
+++ b/frontend/app/composables/recipes/use-recipes.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { useAsyncKey } from "../use-utils";
 import { usePublicExploreApi } from "~/composables/api/api-client";
 import { useUserApi } from "~/composables/api";
+import { isSafeRedirectTarget } from "~/lib/validators/redirect";
 import type { OrderByNullPosition, Recipe } from "~/lib/api/types/recipe";
 import type { RecipeSearchQuery } from "~/lib/api/user/recipes/recipe";
 
@@ -43,6 +44,7 @@ function getParams(
 
 export const useLazyRecipes = function (publicGroupSlug: string | null = null) {
   const router = useRouter();
+  const route = useRoute();
 
   // passing the group slug switches to using the public API
   const api = publicGroupSlug ? usePublicExploreApi(publicGroupSlug).explore : useUserApi();
@@ -65,7 +67,8 @@ export const useLazyRecipes = function (publicGroupSlug: string | null = null) {
     );
 
     if (error?.response?.status === 404) {
-      router.push("/login");
+      const redirect = typeof route.query.redirect === "string" ? route.query.redirect : undefined;
+      router.push(isSafeRedirectTarget(redirect) ? { path: "/login", query: { redirect } } : "/login");
     }
 
     return data ? data.items : [];

--- a/frontend/app/lib/validators/redirect.test.ts
+++ b/frontend/app/lib/validators/redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { isSafeRedirectTarget } from "./redirect";
+
+describe("isSafeRedirectTarget", () => {
+  test("accepts an internal path", () => {
+    expect(isSafeRedirectTarget("/g/home/r/some-recipe")).toBe(true);
+  });
+
+  test("rejects protocol-relative URLs", () => {
+    expect(isSafeRedirectTarget("//evil.com")).toBe(false);
+  });
+
+  test("rejects backslash variants used to bypass same-origin checks", () => {
+    expect(isSafeRedirectTarget("/\\evil.com")).toBe(false);
+    expect(isSafeRedirectTarget("\\\\evil.com")).toBe(false);
+  });
+
+  test("rejects absolute URLs", () => {
+    expect(isSafeRedirectTarget("https://evil.com")).toBe(false);
+  });
+
+  test("rejects empty or missing values", () => {
+    expect(isSafeRedirectTarget("")).toBe(false);
+    expect(isSafeRedirectTarget(null)).toBe(false);
+    expect(isSafeRedirectTarget(undefined)).toBe(false);
+  });
+});

--- a/frontend/app/lib/validators/redirect.ts
+++ b/frontend/app/lib/validators/redirect.ts
@@ -1,0 +1,4 @@
+// rejects protocol-relative payloads (`//evil.com`, `/\evil.com`) that a bare startsWith("/") check would miss
+export function isSafeRedirectTarget(target: string | null | undefined): target is string {
+  return !!target && target.startsWith("/") && !/^[/\\]{2}/.test(target);
+}

--- a/frontend/app/pages/g/[groupSlug]/r/[slug]/index.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/[slug]/index.vue
@@ -40,7 +40,7 @@ async function loadPublicRecipe() {
     const { data, error } = await api.explore.recipes.getOne(slug);
     if (error) {
       console.error("error loading recipe -> ", error);
-      router.push(`/g/${groupSlug.value}`);
+      router.push({ path: `/g/${groupSlug.value}`, query: { redirect: route.fullPath } });
     }
 
     return data;

--- a/frontend/app/pages/login.vue
+++ b/frontend/app/pages/login.vue
@@ -216,6 +216,7 @@ import { useLoggedInState } from "~/composables/use-logged-in-state";
 import { usePasswordField } from "~/composables/use-passwords";
 import { alert } from "~/composables/use-toast";
 import { useAsyncKey } from "~/composables/use-utils";
+import { isSafeRedirectTarget } from "~/lib/validators/redirect";
 import type { AppStartupInfo } from "~/lib/api/types/admin";
 import { useUserActivityPreferences } from "~/composables/use-users/preferences";
 
@@ -275,7 +276,7 @@ whenever(
     // the query string).
     const redirectFromQuery = route.query.redirect as string | undefined;
     const redirectTarget = redirectFromQuery ?? pendingShareRedirect.value;
-    if (redirectTarget && redirectTarget.startsWith("/")) {
+    if (isSafeRedirectTarget(redirectTarget)) {
       pendingShareRedirect.value = null;
       router.push(redirectTarget);
       return;
@@ -339,7 +340,7 @@ async function oidcAuthenticate(callback = false) {
     // The OIDC callback reloads the page, which clears the query string, so we
     // persist the target in sessionStorage and restore it after login.
     const redirectTarget = route.query.redirect as string | undefined;
-    if (redirectTarget && redirectTarget.startsWith("/")) {
+    if (isSafeRedirectTarget(redirectTarget)) {
       pendingShareRedirect.value = redirectTarget;
     }
     navigateTo("/api/auth/oauth", { external: true }); // start the redirect process

--- a/frontend/app/plugins/axios.ts
+++ b/frontend/app/plugins/axios.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { alert } from "~/composables/use-toast";
 import { getTokenCookieOptions } from "~/composables/use-token-cookie";
+import { isSafeRedirectTarget } from "~/lib/validators/redirect";
 
 declare module "axios" {
   interface AxiosRequestConfig {
@@ -49,7 +50,10 @@ export default defineNuxtPlugin(() => {
 
           // Disable beforeunload warnings to prevent "Are you sure you want to leave?" popups
           window.onbeforeunload = null;
-          window.location.href = "/login";
+
+          const target = window.location.pathname + window.location.search;
+          const redirect = isSafeRedirectTarget(target) && target !== "/login" ? `?redirect=${encodeURIComponent(target)}` : "";
+          window.location.href = `/login${redirect}`;
         }
       }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Experience: My wife dropped me a recipe link to cook tonight, i opened it and got redirected to login, and then after login I wasn't taken straight to the recipe page.

More:

Visiting a private recipe/group URL while logged out drops you on a bare `/login` with no way back to the page you wanted.

A logged-out deep link (e.g. `/g/home/r/some-recipe`) goes through two client-side hops before landing on `/login`:
- The recipe page's public-explore fetch 404s (private group) and bounces to the group home page.
- The group home page's recipe list fetch 404s too, and *that's* what pushes to `/login` - two navigations removed from the original URL, so it's already lost by then.

There's already a `?redirect=` mechanism on the login page (built for PWA share-target), it just wasn't wired into this path. This threads the original path through both hops via the query string, and reuses the same mechanism for the axios 401 handler (expired-session-with-token case), which had the same bug.

Also tightened the existing `redirectTarget.startsWith("/")` open-redirect check, which let `//evil.com` and `/\evil.com` through - extracted into a small `isSafeRedirectTarget` helper with a unit test.

## Which issue(s) this PR fixes:

None filed - I ran into this myself and couldn't find an existing tracked issue for it.

## Testing

Reproduced the original bug against a private group/recipe, confirmed the fix end-to-end in a browser (deep link -> `/login?redirect=...` -> back to the recipe after signing in), and confirmed a crafted `redirect` payload pointing off-site is ignored. Added a unit test for `isSafeRedirectTarget`.

## AI / LLM Assistance

Built with Claude Code. It traced the redirect chain through the source to find where the deep link actually gets dropped (two hops before the `/login` push, not the first 401 handler I assumed), implemented the fix and the open-redirect hardening, wrote the unit test, and drove a real browser session against a local instance to verify the fix end-to-end. I reviewed the diff and the verification results before opening this PR.