### PR TITLE
fix: fall back to servings for recipe yield display

### DIFF
--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -163,7 +163,11 @@ class RecipeSummary(MealieModel):
 
     @property
     def recipe_yield_display(self) -> str:
-        return f"{self.recipe_yield_quantity} {self.recipe_yield}".strip()
+        # Fall back to recipe_servings when no explicit yield quantity is set, otherwise
+        # a servings-only recipe emits a bare "0.0" (or "0.0 None") into schema.org.
+        quantity = self.recipe_yield_quantity or self.recipe_servings
+        number = f"{quantity:g}" if quantity else ""
+        return f"{number} {self.recipe_yield or ''}".strip()
 
     @classmethod
     def loader_options(cls) -> list[LoaderOption]:

--- a/tests/unit_tests/schema_tests/test_recipe.py
+++ b/tests/unit_tests/schema_tests/test_recipe.py
@@ -63,6 +63,43 @@ def test_recipe_string_sanitation(field: str, val: Any, expected: Any):
     assert getattr(recipe, field) == expected
 
 
+@pytest.mark.parametrize(
+    ["recipe_yield_quantity", "recipe_yield", "recipe_servings", "expected"],
+    [
+        # Explicit yield quantity + text
+        (8, "slices", 0, "8 slices"),
+        # Whole-number quantities render without a trailing ".0"
+        (8, "servings", 0, "8 servings"),
+        # Fractional quantities are preserved
+        (2.25, "loaves", 0, "2.25 loaves"),
+        # Yield text only, no quantity
+        (0, "a dozen cookies", 0, "a dozen cookies"),
+        # Servings-only recipe: falls back to recipe_servings instead of "0.0"
+        (0, None, 4, "4"),
+        (0, "", 4, "4"),
+        # Nothing set at all
+        (0, None, 0, ""),
+    ],
+)
+def test_recipe_yield_display(
+    recipe_yield_quantity: float,
+    recipe_yield: str | None,
+    recipe_servings: float,
+    expected: str,
+):
+    recipe = RecipeSummary(
+        id=uuid4(),
+        user_id=uuid4(),
+        household_id=uuid4(),
+        group_id=uuid4(),
+        recipe_yield_quantity=recipe_yield_quantity,
+        recipe_yield=recipe_yield,
+        recipe_servings=recipe_servings,
+    )
+
+    assert recipe.recipe_yield_display == expected
+
+
 def test_recipe_preserves_existing_slug():
     recipe = RecipeSummary(
         id=uuid4(),


### PR DESCRIPTION
### What this does

`RecipeSummary.recipe_yield_display` builds its string only from `recipe_yield_quantity`
and `recipe_yield`. The `clean_numbers` validator coerces an unset quantity to `0`, so a
recipe that has `recipe_servings` set but no explicit yield renders a bare `"0.0"` (or
`"0.0 None"`).

That value is written straight into the schema.org JSON-LD in the SPA route:

```python
# mealie/routes/spa/__init__.py
"recipeYield": escape(recipe.recipe_yield_display),
```

so any consumer of the public recipe page (Google, recipe scrapers, nutrition trackers)
sees `recipeYield: "0.0"` for servings-only recipes, which poisons per-serving math.

### The fix

- Fall back to `recipe_servings` when no yield quantity is set.
- Format the number with `:g` so whole numbers no longer carry a trailing `.0`
  (e.g. `"8.0 slices"` → `"8 slices"`), and a bare `"0.0"` can no longer be produced.

```python
@property
def recipe_yield_display(self) -> str:
    quantity = self.recipe_yield_quantity or self.recipe_servings
    number = f"{quantity:g}" if quantity else ""
    return f"{number} {self.recipe_yield or ''}".strip()
```

### Tests

Adds parametrized coverage for `recipe_yield_display` in
`tests/unit_tests/schema_tests/test_recipe.py`, including the servings-only fallback and
the whole-number formatting.

| quantity | yield | servings | before | after |
|----------|-------|----------|--------|-------|
| 8 | "slices" | 0 | `8.0 slices` | `8 slices` |
| 0 | none | 4 | `0.0` | `4` |
| 0 | none | 0 | `0.0` | `` (empty) |
