### PR TITLE
chore(l10n): add [ci skip] to Crowdin commit messages

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,6 +3,8 @@ pull_request_title: "chore(l10n): New Crowdin updates"
 pull_request_labels: [
   "l10n"
 ]
+commit_message: "New translations %original_file_name% (%language%) [ci skip]"
+append_commit_message: false
 files:
   - source: /frontend/app/lang/messages/en-US.json
     translation: /frontend/app/lang/messages/%locale%.json


### PR DESCRIPTION
## What this PR does / why we need it:

Configures Crowdin to add a `[ci skip]` tag to the commit messages it makes on
localization branches.

- `crowdin.yml`: sets `commit_message` to `New translations %original_file_name% (%language%) [ci skip]` and `append_commit_message: false` so the message is used verbatim.

Translation-only commits from Crowdin don't need the full PR CI suite (backend/frontend/e2e/CodeQL/Trivy) to run. Because there is no custom skip logic in our workflows, CI-skipping relies on GitHub's built-in commit-message tokens, so the tag must be one GitHub actually recognizes — `[ci skip]` (space), not `[ci-skip]`. Setting `append_commit_message: false` is required because a custom message otherwise drops the default `[ci skip]` that Crowdin would append.

Docs reference: https://support.crowdin.com/developer/configuration-file/#commit-message

## Which issue(s) this PR fixes:

N/A — no associated issue.

## AI / LLM Assistance

_(REQUIRED)_

This PR was created with assistance from Claude Code. The agent located the Crowdin config and CI workflows, confirmed the correct GitHub CI-skip token, made the single `crowdin.yml` change, and validated that the YAML still parses. The change was reviewed by the author before opening.
