### PR TITLE
fix: re-enable automatic merges with crowding CI

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -14,3 +14,7 @@ files:
     translation: /mealie/repos/seed/resources/units/locales/%locale%.json
   - source: /mealie/repos/seed/resources/labels/locales/en-US.json
     translation: /mealie/repos/seed/resources/labels/locales/%locale%.json
+
+# New commit messages use [skip ci] causing our ci not to run on automatic PRs
+commit_message: "New translations %original_file_name% (%language%)"
+append_commit_message: false


### PR DESCRIPTION
## What this PR does / why we need it:

Removes the [skip ci] from commit messages

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

## AI / LLM Assistance

_(REQUIRED)_

<!--
  Describe to which degree an LLM was used in creating this pull request. Failure to accurately disclose LLM usage may result in
  review delays or closure of your PR.
-->

Claude did I bad job so I did this with my own two hands.
