### PR TITLE
fix: stamp timeline events at request time, not process start

### DIFF
--- a/mealie/schema/recipe/recipe_timeline_events.py
+++ b/mealie/schema/recipe/recipe_timeline_events.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Annotated
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.interfaces import LoaderOption
 
 from mealie.core.config import get_app_dirs
+from mealie.db.models._model_utils.datetime import get_utc_now
 from mealie.db.models.recipe.recipe_timeline import RecipeTimelineEvent
 from mealie.db.models.users.users import User
 from mealie.schema._mealie import MealieModel
@@ -40,7 +41,7 @@ class RecipeTimelineEventIn(MealieModel):
     message: str | None = Field(None, alias="eventMessage")
     image: Annotated[TimelineEventImage | None, Field(validate_default=True)] = TimelineEventImage.does_not_have_image
 
-    timestamp: datetime = datetime.now(UTC)
+    timestamp: datetime = Field(default_factory=get_utc_now)
     model_config = ConfigDict(use_enum_values=True)
 
 

--- a/tests/integration_tests/user_recipe_tests/test_recipe_timeline_events.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_timeline_events.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -69,6 +70,35 @@ def test_create_timeline_event(
     event = RecipeTimelineEventOut.model_validate(event_response.json())
     assert event.recipe_id == recipe.id
     assert str(event.user_id) == str(user.user_id)
+
+
+def test_create_timeline_event_defaults_timestamp_to_request_time(
+    api_client: TestClient,
+    unique_user: TestUser,
+    recipes: list[Recipe],
+):
+    recipe = recipes[0]
+    new_event = {
+        "recipe_id": str(recipe.id),
+        "user_id": str(unique_user.user_id),
+        "subject": random_string(),
+        "event_type": "info",
+    }
+
+    before = datetime.now(UTC) - timedelta(seconds=5)
+    event_response = api_client.post(
+        api_routes.recipes_timeline_events,
+        json=new_event,
+        headers=unique_user.token,
+    )
+    after = datetime.now(UTC) + timedelta(seconds=5)
+    assert event_response.status_code == 201
+
+    event = RecipeTimelineEventOut.model_validate(event_response.json())
+    timestamp = event.timestamp
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    assert before <= timestamp <= after
 
 
 @pytest.mark.parametrize("use_other_household_user", [True, False])

--- a/tests/unit_tests/schema_tests/test_recipe_timeline_event_timestamp.py
+++ b/tests/unit_tests/schema_tests/test_recipe_timeline_event_timestamp.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from freezegun import freeze_time
+
+from mealie.schema.recipe.recipe_timeline_events import RecipeTimelineEventIn, TimelineEventType
+
+
+@freeze_time("2020-01-01 12:00:00")
+def test_omitted_timestamp_is_stamped_at_instance_creation():
+    """An omitted timestamp is stamped when the event is created, not at import time.
+
+    A bare ``datetime.now(UTC)`` default is evaluated once when the class is
+    defined, so every timestamp-less event in a process run shares the same
+    stale value. A ``default_factory`` recomputes it for each instance.
+    """
+    event = RecipeTimelineEventIn(
+        recipe_id=uuid4(),
+        subject="made this",
+        event_type=TimelineEventType.info,
+    )
+
+    assert event.timestamp == datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+
+
+def test_explicit_timestamp_is_respected():
+    """A supplied timestamp is used verbatim and the default factory is not consulted."""
+    supplied = datetime(2021, 6, 15, 8, 30, tzinfo=UTC)
+    event = RecipeTimelineEventIn(
+        recipe_id=uuid4(),
+        subject="made this",
+        event_type=TimelineEventType.info,
+        timestamp=supplied,
+    )
+
+    assert event.timestamp == supplied


### PR DESCRIPTION
## What this PR does / why we need it:

`RecipeTimelineEventIn.timestamp` used a default evaluated once at class
definition (`datetime.now(UTC)`), so every timeline event created without an
explicit timestamp was stamped with the time the server process started, not
the time of the request. All timestamp-less events in a given server run shared
the same stale value.

- `mealie/schema/recipe/recipe_timeline_events.py`: switch the `timestamp`
  default to `Field(default_factory=get_utc_now)` so it is computed per
  request. This reuses the existing `get_utc_now` helper and removes the frozen
  datetime literal from the generated OpenAPI schema.

## Which issue(s) this PR fixes:

(none filed; reproduction below)

## Special notes for your reviewer:

`get_utc_now` is the pattern already used for this in the codebase
(`reports.py`), so this change makes the timeline schema consistent with it.

The `RecipeTimelineEvent` model has its own `timestamp or datetime.now(UTC)`
fallback in `__init__`, but it only fires on a falsy timestamp. The frozen
schema default was always a truthy datetime, so the fallback never engaged for
API creates and the stale value was persisted.

Every internal caller (`recipe_service.py`, the scheduler task) already passes
an explicit timestamp, so only API clients that rely on the documented optional
default were affected. The web UI's "I made this" dialog always sends a
timestamp.

### Reproduction (before this PR)

1. Start the server and leave it running.
2. Later, `POST /api/recipes/timeline/events` without a `timestamp`.
3. Read the event back: its `timestamp` equals the server start time while
   `createdAt` is the true current time. Sorting a recipe timeline by
   `timestamp` then misorders the event.

## Testing

- New unit test `tests/unit_tests/schema_tests/test_recipe_timeline_event_timestamp.py`
  uses `freeze_time` to assert an omitted timestamp is stamped at instance
  creation, and that an explicit timestamp is respected. The first test fails
  on the old frozen default and passes with the factory.
- Extended `tests/integration_tests/user_recipe_tests/test_recipe_timeline_events.py`
  to assert a timestamp-less create lands at request time.
- `task py:check` equivalents on the changed surface: `ruff format --check`,
  `ruff check`, `mypy mealie`, and the timeline test files all pass.

## AI / LLM Assistance

This change was researched, written, and verified with the assistance of an
LLM-based coding agent (Claude Code), including the root-cause analysis, the
fix, and the tests. All changes were reviewed by the author.
