### PR TITLE
fix: restrict user ratings and favorites reads to the requesting user

### DIFF
--- a/mealie/routes/users/ratings.py
+++ b/mealie/routes/users/ratings.py
@@ -44,11 +44,13 @@ class UserRatingsController(BaseUserController):
     @router.get("/{id}/ratings", response_model=UserRatings[UserRatingOut])
     async def get_ratings(self, id: UUID4):
         """Get user's rated recipes"""
+        assert_user_change_allowed(id, self.user, self.user)
         return UserRatings(ratings=self.repos.user_ratings.get_by_user(id))
 
     @router.get("/{id}/favorites", response_model=UserRatings[UserRatingOut])
     async def get_favorites(self, id: UUID4):
         """Get user's favorited recipes"""
+        assert_user_change_allowed(id, self.user, self.user)
         return UserRatings(ratings=self.repos.user_ratings.get_by_user(id, favorites_only=True))
 
     @router.post("/{id}/ratings/{slug}")

--- a/tests/integration_tests/user_recipe_tests/test_recipe_ratings.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_ratings.py
@@ -412,3 +412,33 @@ def test_average_recipe_rating_includes_all_households(
     assert response.status_code == 200
     data = response.json()
     assert data["rating"] == 3.5
+
+
+def test_cannot_read_other_users_ratings_or_favorites_cross_group(
+    api_client: TestClient, unique_user: TestUser, g2_user: TestUser
+):
+    # g2_user is in a different group entirely
+    response = api_client.get(api_routes.users_id_ratings(unique_user.user_id), headers=g2_user.token)
+    assert response.status_code == 403
+
+    response = api_client.get(api_routes.users_id_favorites(unique_user.user_id), headers=g2_user.token)
+    assert response.status_code == 403
+
+
+def test_cannot_read_other_users_ratings_or_favorites_same_group(
+    api_client: TestClient, unique_user: TestUser, h2_user: TestUser
+):
+    # h2_user is in the same group but a different household
+    response = api_client.get(api_routes.users_id_ratings(unique_user.user_id), headers=h2_user.token)
+    assert response.status_code == 403
+
+    response = api_client.get(api_routes.users_id_favorites(unique_user.user_id), headers=h2_user.token)
+    assert response.status_code == 403
+
+
+def test_can_read_own_ratings_and_favorites_via_id_route(api_client: TestClient, unique_user: TestUser):
+    response = api_client.get(api_routes.users_id_ratings(unique_user.user_id), headers=unique_user.token)
+    assert response.status_code == 200
+
+    response = api_client.get(api_routes.users_id_favorites(unique_user.user_id), headers=unique_user.token)
+    assert response.status_code == 200


### PR DESCRIPTION
## What this PR does / why we need it:

The `GET /users/{id}/ratings` and `/favorites` routes returned any user's data with no ownership check, so an authenticated user could read another user's ratings and favorites across groups/households. This scopes both reads to the requesting user, matching the guard the sibling write route already uses. The frontend reads through the `/users/self/...` routes, so client behavior is unchanged.

## Which issue(s) this PR fixes:

_No linked issue._

## Testing

Added regression tests for cross-group and same-group access (now 403), and that reading your own still works.

## AI / LLM Assistance

Prepared with the assistance of an LLM (Claude), reviewed by a human before submission.
