### PR TITLE
fix: Repair shopping lists and recipes when a food is deleted. 

### DIFF
--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -876,7 +876,7 @@
   },
   "data-pages": {
     "foods": {
-      "delete-affects-recipes": "Warning: this food is used in {count} recipe(s). Deleting it will leave an empty ingredient in the recipe(s).",
+      "delete-affects-recipes": "Warning: this food is used in {count} recipe(s). Deleting it will cause the food field to be moved to the note.",
       "delete-affects-recipes-more": "View all {count} recipes",
       "merge-dialog-text": "Combining the selected foods will merge the source food and target food into a single food. The source food will be deleted and all of the references to the source food will be updated to point to the target food.",
       "merge-food-example": "Merging {food1} into {food2}",

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -1149,7 +1149,7 @@
   },
   "data-pages": {
     "foods": {
-      "delete-affects-recipes": "Warning: this food is used in {count} recipe(s). Deleting it will leave an empty ingredient in the recipe(s).",
+      "delete-affects-recipes": "Warning: this food is used in {count} recipe(s). Deleting it will cause the food field to be moved to the note.",
       "delete-affects-recipes-more": "View all {count} recipes",
       "merge-dialog-text": "Combining the selected foods will merge the source food and target food into a single food. The source food will be deleted and all of the references to the source food will be updated to point to the target food.",
       "merge-food-example": "Merging {food1} into {food2}",

--- a/mealie/routes/unit_and_foods/foods.py
+++ b/mealie/routes/unit_and_foods/foods.py
@@ -1,8 +1,12 @@
 from functools import cached_property
 
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import UUID4
 
+from mealie.db.models.household.shopping_list import ShoppingList, ShoppingListItem
+from mealie.db.models.recipe.ingredient import RecipeIngredientModel
+from mealie.db.models.recipe.recipe import RecipeModel
 from mealie.routes._base.base_controllers import BaseUserController
 from mealie.routes._base.controller import controller
 from mealie.routes._base.mixins import HttpRepo
@@ -17,6 +21,8 @@ from mealie.schema.recipe.recipe_ingredient import (
 )
 from mealie.schema.response.pagination import PaginationQuery
 from mealie.schema.response.responses import SuccessResponse
+from mealie.services.household_services.shopping_lists import ShoppingListService
+from mealie.services.recipe.recipe_service import RecipeService
 
 router = APIRouter(prefix="/foods", tags=["Recipes: Foods"], route_class=MealieCrudRoute)
 
@@ -75,4 +81,35 @@ class IngredientFoodsController(BaseUserController):
     @router.delete("/{item_id}", response_model=IngredientFood)
     def delete_one(self, item_id: UUID4):
         self.checks.can_organize()
+        self._repair_recipes(item_id)
+        self._repair_shopping_lists(item_id)
+
         return self.mixins.delete_one(item_id)
+
+    def _repair_recipes(self, item_id: UUID4):
+        recipe_service = RecipeService(self.repos, self.user, self.household, translator=self.translator)
+        fltr = RecipeModel.recipe_ingredient.any(RecipeIngredientModel.food_id == item_id)
+        query = sa.select(RecipeModel).filter(RecipeModel.household_id.is_not(None)).filter(fltr)
+        recipes = self.session.execute(query).scalars().unique().all()
+        for recipe_model in recipes:
+            recipe = recipe_service.get_one(recipe_model.id)
+            for ingredient in recipe.recipe_ingredient:
+                if ingredient.food is None or not ingredient.food.id == item_id:
+                    continue
+                ingredient.note = f"{ingredient.food.name} {ingredient.note}"
+            recipe_service.update_one(recipe_model.id, recipe)
+
+    def _repair_shopping_lists(self, item_id: UUID4):
+        service = ShoppingListService(self.repos)
+        fltr = ShoppingList.list_items.any(ShoppingListItem.food_id == item_id)
+        query = sa.select(ShoppingList).filter(ShoppingList.household_id.is_not(None)).filter(fltr)
+        lists = self.session.execute(query).scalars().unique().all()
+        for list_model in lists:
+            for item_model in list_model.list_items:
+                if item_model.food is None or not item_model.food.id == item_id:
+                    continue
+                item = service.list_items.get_one(item_model.id, "id")
+                if item is None or item.food is None:
+                    continue
+                item.note = f"{item.food.name} {item.note}"
+                service.list_items.update(item_model.id, item)


### PR DESCRIPTION
## What this PR does / why we need it:
When a food is deleted via data management, we will now search each recipe and each shopping list for items containing that food.
If any are found, we will prepend the deleted food to that items note. 

## Which issue(s) this PR fixes:
Fixes: #7711

## Testing
Tested in docker dev container. 

## AI / LLM Assistance
No AI used. 