### PR TITLE
fix: Merge ingredients linked ingredients when merging instructions

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -405,6 +405,8 @@ interface MergerHistory {
   source: number;
   targetText: string;
   sourceText: string;
+  targetIngredientReferences: IngredientReferences[];
+  sourceIngredientReferences: IngredientReferences[];
 }
 
 const instructionList = defineModel<RecipeStep[]>("modelValue", { required: true, default: () => [] });
@@ -657,14 +659,29 @@ function mergeAbove(target: number, source: number) {
     return;
   }
 
+  const targetInstruction = instructionList.value[target];
+  const sourceInstruction = instructionList.value[source];
+
+  if (!targetInstruction || !sourceInstruction) {
+    return;
+  }
+
+  const targetIngredients = targetInstruction.ingredientReferences || [];
+  const sourceIngredients = sourceInstruction.ingredientReferences || [];
+
   mergeHistory.value.push({
     target,
     source,
-    targetText: instructionList.value[target].text,
-    sourceText: instructionList.value[source].text,
+    targetText: targetInstruction.text,
+    sourceText: sourceInstruction.text,
+    targetIngredientReferences: targetIngredients,
+    sourceIngredientReferences: sourceIngredients,
   });
 
+  const newReferences = sourceIngredients?.filter(ref => !targetIngredients.find(val => val.referenceId === ref.referenceId));
+
   instructionList.value[target].text += " " + instructionList.value[source].text;
+  instructionList.value[target].ingredientReferences = [...targetIngredients, ...newReferences];
   instructionList.value.splice(source, 1);
 }
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -396,6 +396,8 @@ interface MergerHistory {
   source: number;
   targetText: string;
   sourceText: string;
+  targetIngredientReferences: IngredientReferences[];
+  sourceIngredientReferences: IngredientReferences[];
 }
 
 const instructionList = defineModel<RecipeStep[]>("modelValue", { required: true, default: () => [] });
@@ -648,14 +650,29 @@ function mergeAbove(target: number, source: number) {
     return;
   }
 
+  const targetInstruction = instructionList.value[target];
+  const sourceInstruction = instructionList.value[source];
+
+  if (!targetInstruction || !sourceInstruction) {
+    return;
+  }
+
+  const targetIngredients = targetInstruction.ingredientReferences || [];
+  const sourceIngredients = sourceInstruction.ingredientReferences || [];
+
   mergeHistory.value.push({
     target,
     source,
-    targetText: instructionList.value[target].text,
-    sourceText: instructionList.value[source].text,
+    targetText: targetInstruction.text,
+    sourceText: sourceInstruction.text,
+    targetIngredientReferences: targetIngredients,
+    sourceIngredientReferences: sourceIngredients,
   });
 
+  const newReferences = sourceIngredients?.filter(ref => !targetIngredients.find(val => val.referenceId === ref.referenceId));
+
   instructionList.value[target].text += " " + instructionList.value[source].text;
+  instructionList.value[target].ingredientReferences = [...targetIngredients, ...newReferences];
   instructionList.value.splice(source, 1);
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:
Previously, when merging two recipe instructions with linked ingredients, the linked ingredients of the lower instruction would be unlinked.

Now, the ingredient references will be merged. 

## Which issue(s) this PR fixes:
Fixes #5909

## Testing
Tested in firefox

## AI / LLM Assistance
No AI used. 