### PR TITLE
fix: Keep instruction sticky in ingredient linker

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -9,55 +9,65 @@
       max-width="600px"
       max-height="40%"
     >
-      <v-card-text class="pt-4">
-        <p>
-          {{ activeText }}
-        </p>
-        <v-divider class="my-4" />
-        <template v-if="Object.keys(groupedUnusedIngredients).length > 0">
-          <h4 class="ml-1">
-            {{ $t("recipe.unlinked") }}
-          </h4>
-          <template v-for="(ingredients, title) in groupedUnusedIngredients" :key="title">
-            <h4 v-if="title" class="py-3 ml-1 pl-4">
-              {{ title }}
-            </h4>
-            <v-checkbox-btn
-              v-for="ing in ingredients"
-              :key="ing.referenceId"
-              v-model="activeRefs"
-              :value="ing.referenceId"
-              class="ml-4"
-            >
-              <template #label>
-                <RecipeIngredientHtml :ingredient="ing" :scale="scale" />
+      <div class="grid">
+        <div class="sticky">
+          <v-card flat style="max-height: 40dvh; overflow-y: auto;">
+            <v-card-text>
+              <p>
+                {{ activeText }}
+              </p>
+            </v-card-text>
+          </v-card>
+          <v-divider />
+        </div>
+        <v-card flat>
+          <v-card-text>
+            <template v-if="Object.keys(groupedUnusedIngredients).length > 0">
+              <h4 class="ml-1">
+                {{ $t("recipe.unlinked") }}
+              </h4>
+              <template v-for="(ingredients, title) in groupedUnusedIngredients" :key="title">
+                <h4 v-if="title" class="py-3 ml-1 pl-4">
+                  {{ title }}
+                </h4>
+                <v-checkbox-btn
+                  v-for="ing in ingredients"
+                  :key="ing.referenceId"
+                  v-model="activeRefs"
+                  :value="ing.referenceId"
+                  class="ml-4"
+                >
+                  <template #label>
+                    <RecipeIngredientHtml :ingredient="ing" :scale="scale" />
+                  </template>
+                </v-checkbox-btn>
               </template>
-            </v-checkbox-btn>
-          </template>
-        </template>
+            </template>
 
-        <template v-if="Object.keys(groupedUsedIngredients).length > 0">
-          <h4 class="py-3 ml-1">
-            {{ $t("recipe.linked-to-other-step") }}
-          </h4>
-          <template v-for="(ingredients, title) in groupedUsedIngredients" :key="title">
-            <h4 v-if="title" class="py-3 ml-1 pl-4">
-              {{ title }}
-            </h4>
-            <v-checkbox-btn
-              v-for="ing in ingredients"
-              :key="ing.referenceId"
-              v-model="activeRefs"
-              :value="ing.referenceId"
-              class="ml-4"
-            >
-              <template #label>
-                <RecipeIngredientHtml :ingredient="ing" :scale="scale" />
+            <template v-if="Object.keys(groupedUsedIngredients).length > 0">
+              <h4 class="py-3 ml-1">
+                {{ $t("recipe.linked-to-other-step") }}
+              </h4>
+              <template v-for="(ingredients, title) in groupedUsedIngredients" :key="title">
+                <h4 v-if="title" class="py-3 ml-1 pl-4">
+                  {{ title }}
+                </h4>
+                <v-checkbox-btn
+                  v-for="ing in ingredients"
+                  :key="ing.referenceId"
+                  v-model="activeRefs"
+                  :value="ing.referenceId"
+                  class="ml-4"
+                >
+                  <template #label>
+                    <RecipeIngredientHtml :ingredient="ing" :scale="scale" />
+                  </template>
+                </v-checkbox-btn>
               </template>
-            </v-checkbox-btn>
-          </template>
-        </template>
-      </v-card-text>
+            </template>
+          </v-card-text>
+        </v-card>
+      </div>
 
       <v-divider />
 
@@ -779,6 +789,23 @@ function openImageUpload(index: number) {
 </script>
 
 <style lang="css" scoped>
+.grid {
+  display: grid;
+  gap: 0.5rem;
+  height: 100%;
+  box-sizing: border-box;
+
+  > * {
+    overflow-y: auto;
+  }
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
 .v-card--link:before {
   background: none;
 }

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -9,11 +9,11 @@
       max-width="600px"
       max-height="40%"
     >
-      <v-card-text class="pt-4">
-        <p>
-          {{ activeText }}
-        </p>
+      <div class="sticky bg-surface pt-4 px-4">
+        {{ activeText }}
         <v-divider class="my-4" />
+      </div>
+      <v-card-text class="pt-4">
         <template v-if="Object.keys(groupedUnusedIngredients).length > 0">
           <h4 class="ml-1">
             {{ $t("recipe.unlinked") }}
@@ -779,6 +779,14 @@ function openImageUpload(index: number) {
 </script>
 
 <style lang="css" scoped>
+.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  max-height: 40dvh;
+  overflow: scroll;
+}
+
 .v-card--link:before {
   background: none;
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Previously, if a recipe had a long list of ingredients, you may have to scroll far enough through the recipe linker that the recipe instruction was completely gone. 
<img width="605" height="925" alt="image" src="https://github.com/user-attachments/assets/b91b0750-ba08-41c9-839c-df2f71ad271d" />

Now, the recipe instruction is sticky. 
<img width="608" height="926" alt="image" src="https://github.com/user-attachments/assets/444d9b73-7fa6-4ba4-937e-0dc08ee5044e" />

Additionally, if the instruction itself is too long, it will be constrained to a separate scrollable area. 

## Which issue(s) this PR fixes:
Fixes #6207

## Testing
Tested on desktop (Firefox) and Mobile (Android Firefox)

## AI / LLM Assistance
No AI used.
