### PR TITLE
fix: New Asset dialog Type dropdown broken by Vuetify 4.1.2 item slot…

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeAssets.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeAssets.vue
@@ -125,7 +125,7 @@
                   <template #prepend>
                     <v-avatar>
                       <v-icon>
-                        {{ item.raw.icon }}
+                        {{ item.icon }}
                       </v-icon>
                     </v-avatar>
                   </template>


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the New Asset dialog's Type dropdown, which was completely non-functional on `mealie-next`: clicking it threw an uncaught exception and never opened, and as a side effect the dialog's Cancel button also stopped responding to clicks.

**Root cause:** #7811 (fix: Invisible quantities) bumped `vuetify` 4.0.5 → 4.1.2 and `vuetify-nuxt-module` to 1.0.0-rc.1. In 4.1.2, VSelect's `#item` slot now passes the raw item directly as `item`, rather than a wrapped object with a `.raw` accessor. `RecipeAssets.vue`'s Type dropdown template still referenced `item.raw.icon`, which is `undefined` on the new API shape — throwing `TypeError: Cannot read properties of undefined (reading 'icon')` at render time. That uncaught exception left an invisible overlay stacked over the dialog, which also swallowed the Cancel button's click events.

**Fix:** `item.raw.icon` → `item.icon` in the dropdown's item template, matching the item shape Vuetify 4.1.2 now provides. One line changed, no other files touched.

## Which issue(s) this PR fixes:

N/A — this is a regression discovered during development of an unrelated upcoming PR, not tied to an existing issue.

## Special notes for reviewer:

This is a pure regression fix with no behavior changes beyond restoring the dropdown/Cancel button to working order. No new tests were added since this is a one-line template binding fix with no new logic branches to cover; existing test suite confirms no regressions.

## Testing:

- `DB_ENGINE=sqlite uv run pytest` — 2466 passed, 16 skipped, 1 unrelated pre-existing failure (`test_config.py::test_pg_connection_args` — fails identically with this change stashed out; caused by local Postgres env vars not matching the test's hardcoded connection string, unrelated to this Vue-only fix)
- Manually verified in UI: New Asset dialog Type dropdown opens and selects correctly; Cancel button responds as expected

## AI / LLM Assistance

Claude Code was used to investigate the regression (bisecting the change against v3.20.0, tracing the console error through the Vuetify render chain) and apply the one-line fix. The fix was reviewed, tested manually, and verified against the codebase conventions before submission.
