### PR TITLE
fix: Don't crash when adding recipe to shopping list

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
@@ -194,6 +194,7 @@ import RecipeIngredientListItem from "./RecipeIngredientListItem.vue";
 import { useUserApi } from "~/composables/api";
 import { alert } from "~/composables/use-toast";
 import { useShoppingListPreferences } from "~/composables/use-users/preferences";
+import { ref } from "vue";
 import type { RecipeIngredient, ShoppingListAddRecipeParamsBulk, ShoppingListSummary } from "~/lib/api/types/household";
 import type { Recipe } from "~/lib/api/types/recipe";
 


### PR DESCRIPTION
## What this PR does / why we need it:
Don't crash when adding recipe to a shopping list

## Which issue(s) this PR fixes:
fixes: #7934

## Special notes for your reviewer:
This is a very naive fix, I think something may be going wrong on a deeper level with how global imports work, but I wanted to get something quick on the table since I think this bug is going to be pretty disruptive. 

## Testing
Tested in firefox desktop

## AI / LLM Assistance
No AI used.