### PR TITLE
fix: Replace shadowed `ref` var name when adding recipe to shopping list

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue
@@ -308,12 +308,12 @@ async function consolidateRecipesIntoSections(recipes: RecipeWithScale[]) {
   const recipeSectionMap = new Map<string, ShoppingListRecipeIngredientSection>();
 
   function addSubRecipeToMap(ing: RecipeIngredient, parentQuantity: number, parentScale: number, parentRecipe: Recipe) {
-    const ref = ing.referencedRecipe!;
-    const key = ref.id || ref.slug || "";
+    const subRecipe = ing.referencedRecipe!;
+    const key = subRecipe.id || subRecipe.slug || "";
     const ownIngs: ShoppingListIngredient[] = [];
     const subRefIngs: RecipeIngredient[] = [];
 
-    for (const subIng of ref.recipeIngredient ?? []) {
+    for (const subIng of subRecipe.recipeIngredient ?? []) {
       if (subIng.referencedRecipe) {
         subRefIngs.push(subIng);
       }
@@ -327,14 +327,14 @@ async function consolidateRecipesIntoSections(recipes: RecipeWithScale[]) {
     }
 
     recipeSectionMap.set(key, {
-      recipeId: ref.id || "",
-      recipeName: ref.name || "",
+      recipeId: subRecipe.id || "",
+      recipeName: subRecipe.name || "",
       recipeScale: parentQuantity * parentScale,
       ingredientSections: buildIngredientSections(ownIngs),
       parentRecipe,
     });
 
-    subRefIngs.forEach(subIng => addSubRecipeToMap(subIng, (ing.quantity || 1) * (subIng.quantity || 1), parentScale, ref));
+    subRefIngs.forEach(subIng => addSubRecipeToMap(subIng, (ing.quantity || 1) * (subIng.quantity || 1), parentScale, subRecipe));
   }
 
   for (const recipe of recipes) {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

We use the local var `ref` which conflicts with Vue's `ref` functionality, causing the typical autoimport to fail. This PR renames the var to `subRecipe`.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/7934

## AI / LLM Assistance

_(REQUIRED)_

N/A
