### PR TITLE
feat: skip expiring share link for fully-public groups/households

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -111,6 +111,7 @@ import { useGroupSelf } from "~/composables/use-groups";
 import { useHouseholdSelf } from "~/composables/use-households";
 import { alert } from "~/composables/use-toast";
 import { usePlanTypeOptions } from "~/composables/use-group-mealplan";
+import { isRecipeFullyPublic } from "~/lib/recipe/recipe-visibility";
 import type { Recipe } from "~/lib/api/types/recipe";
 import type { GroupRecipeActionOut, ShoppingListSummary } from "~/lib/api/types/household";
 import type { PlanEntryType } from "~/lib/api/types/meal-plan";
@@ -215,11 +216,6 @@ const groupSlug = computed(() => route.params.groupSlug as string || auth.user.v
 const firstDayOfWeek = computed(() => {
   return household.value?.preferences?.firstDayOfWeek || 0;
 });
-
-const isFullyPublic = computed(() =>
-  group.value?.preferences?.privateGroup === false
-  && household.value?.preferences?.privateHousehold === false,
-);
 
 const { share, isSupported: shareIsSupported } = useShare();
 const { copy, copied, isSupported: clipboardIsSupported } = useClipboard();
@@ -326,6 +322,9 @@ const shoppingLists = ref<ShoppingListSummary[]>();
 const recipeRef = ref<Recipe | undefined>(props.recipe);
 const recipeRefWithScale = computed(() =>
   recipeRef.value ? { scale: props.recipeScale, ...recipeRef.value } : undefined,
+);
+const isFullyPublic = computed(() =>
+  isRecipeFullyPublic(recipeRef.value, group.value, household.value),
 );
 const isAdminAndNotOwner = computed(() => {
   return (

--- a/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -100,12 +100,14 @@
 </template>
 
 <script setup lang="ts">
+import { useClipboard, useShare } from "@vueuse/core";
 import RecipeDialogAddToShoppingList from "~/components/Domain/Recipe/RecipeDialogAddToShoppingList.vue";
 import RecipeDialogPrintPreferences from "~/components/Domain/Recipe/RecipeDialogPrintPreferences.vue";
 import RecipeDialogShare from "~/components/Domain/Recipe/RecipeDialogShare.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import { useUserApi } from "~/composables/api";
 import { useGroupRecipeActions } from "~/composables/use-group-recipe-actions";
+import { useGroupSelf } from "~/composables/use-groups";
 import { useHouseholdSelf } from "~/composables/use-households";
 import { alert } from "~/composables/use-toast";
 import { usePlanTypeOptions } from "~/composables/use-group-mealplan";
@@ -204,14 +206,46 @@ const i18n = useI18n();
 const auth = useMealieAuth();
 const { $globals } = useNuxtApp();
 const { household } = useHouseholdSelf();
+const { group } = useGroupSelf();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
-const groupSlug = computed(() => route.params.groupSlug || auth.user.value?.groupSlug || "");
+const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
 
 const firstDayOfWeek = computed(() => {
   return household.value?.preferences?.firstDayOfWeek || 0;
 });
+
+const isFullyPublic = computed(() =>
+  group.value?.preferences?.privateGroup === false
+  && household.value?.preferences?.privateHousehold === false,
+);
+
+const { share, isSupported: shareIsSupported } = useShare();
+const { copy, copied, isSupported: clipboardIsSupported } = useClipboard();
+
+function getPlainRecipeLink() {
+  return `${window.location.origin}/g/${groupSlug.value}/r/${props.slug}`;
+}
+
+async function sharePlainLink() {
+  if (shareIsSupported.value) {
+    await share({
+      title: props.name,
+      url: getPlainRecipeLink(),
+      text: i18n.t("recipe.share-recipe-message", [props.name]) as string,
+    });
+    return;
+  }
+  if (!clipboardIsSupported.value) {
+    alert.error(i18n.t("general.clipboard-not-supported") as string);
+    return;
+  }
+  await copy(getPlainRecipeLink());
+  alert[copied.value ? "success" : "error"](
+    i18n.t(copied.value ? "recipe-share.recipe-link-copied-message" : "general.clipboard-copy-failure") as string,
+  );
+}
 
 // ===========================================================================
 // Context Menu Setup
@@ -425,7 +459,12 @@ const eventHandlers: { [key: string]: () => void | Promise<any> } = {
     });
   },
   share: () => {
-    shareDialog.value = true;
+    if (isFullyPublic.value) {
+      sharePlainLink();
+    }
+    else {
+      shareDialog.value = true;
+    }
   },
 };
 

--- a/frontend/app/components/Domain/Recipe/RecipeDialogShare.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDialogShare.vue
@@ -186,7 +186,7 @@ async function copyTokenLink(token: string) {
 }
 
 async function shareRecipe(token: string) {
-  if (shareIsSupported) {
+  if (shareIsSupported.value) {
     share({
       title: props.name,
       url: getTokenLink(token),

--- a/frontend/app/lib/recipe/recipe-visibility.test.ts
+++ b/frontend/app/lib/recipe/recipe-visibility.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { isRecipeFullyPublic } from "./recipe-visibility";
+import type { Recipe } from "~/lib/api/types/recipe";
+import type { HouseholdInDB } from "~/lib/api/types/household";
+import type { GroupSummary } from "~/lib/api/types/user";
+
+const groupId = "group-1";
+const householdId = "household-1";
+
+function fakeRecipe(overrides: Partial<Recipe> = {}): Recipe {
+  return {
+    groupId,
+    householdId,
+    settings: { public: true },
+    ...overrides,
+  } as Recipe;
+}
+
+function fakeGroup(overrides: Partial<GroupSummary> = {}): GroupSummary {
+  return {
+    id: groupId,
+    preferences: { privateGroup: false },
+    ...overrides,
+  } as GroupSummary;
+}
+
+function fakeHousehold(overrides: Partial<HouseholdInDB> = {}): HouseholdInDB {
+  return {
+    id: householdId,
+    preferences: { privateHousehold: false },
+    ...overrides,
+  } as HouseholdInDB;
+}
+
+describe("isRecipeFullyPublic", () => {
+  test("matching ids, fully public group and household", () => {
+    expect(isRecipeFullyPublic(fakeRecipe(), fakeGroup(), fakeHousehold())).toBe(true);
+  });
+
+  test("rejects a mismatched householdId", () => {
+    const recipe = fakeRecipe({ householdId: "other-household" });
+    expect(isRecipeFullyPublic(recipe, fakeGroup(), fakeHousehold())).toBe(false);
+  });
+
+  test("rejects a mismatched groupId", () => {
+    const recipe = fakeRecipe({ groupId: "other-group" });
+    expect(isRecipeFullyPublic(recipe, fakeGroup(), fakeHousehold())).toBe(false);
+  });
+
+  test("rejects when the recipe itself is not marked public", () => {
+    const recipe = fakeRecipe({ settings: { public: false } });
+    expect(isRecipeFullyPublic(recipe, fakeGroup(), fakeHousehold())).toBe(false);
+  });
+
+  test("rejects when the group is private", () => {
+    const group = fakeGroup({ preferences: { privateGroup: true } });
+    expect(isRecipeFullyPublic(fakeRecipe(), group, fakeHousehold())).toBe(false);
+  });
+
+  test("rejects when the household is private", () => {
+    const household = fakeHousehold({ preferences: { privateHousehold: true } });
+    expect(isRecipeFullyPublic(fakeRecipe(), fakeGroup(), household)).toBe(false);
+  });
+
+  test("defaults safe when group or household haven't loaded yet", () => {
+    expect(isRecipeFullyPublic(fakeRecipe(), undefined, fakeHousehold())).toBe(false);
+    expect(isRecipeFullyPublic(fakeRecipe(), fakeGroup(), undefined)).toBe(false);
+  });
+
+  test("rejects when the recipe is undefined", () => {
+    expect(isRecipeFullyPublic(undefined, fakeGroup(), fakeHousehold())).toBe(false);
+  });
+});

--- a/frontend/app/lib/recipe/recipe-visibility.ts
+++ b/frontend/app/lib/recipe/recipe-visibility.ts
@@ -1,0 +1,17 @@
+import type { Recipe } from "~/lib/api/types/recipe";
+import type { HouseholdInDB } from "~/lib/api/types/household";
+import type { GroupSummary } from "~/lib/api/types/user";
+
+export function isRecipeFullyPublic(
+  recipe: Recipe | null | undefined,
+  group: GroupSummary | null | undefined,
+  household: HouseholdInDB | null | undefined,
+): boolean {
+  return (
+    recipe?.groupId === group?.id
+    && recipe?.householdId === household?.id
+    && recipe?.settings?.public === true
+    && group?.preferences?.privateGroup === false
+    && household?.preferences?.privateHousehold === false
+  );
+}


### PR DESCRIPTION
## What this PR does / why we need it:

- Adds a check on the recipe Share button: when the recipe's group **and** household are
  both fully public (`private_group === false && private_household === false`), Share now
  triggers an instant native share (mobile) or clipboard copy (desktop) of the plain recipe
  URL, instead of opening the expiring-link dialog.
- For every other combination of group/household privacy, the existing expiring-token
  share dialog is untouched and behaves exactly as before.
- Rationale: when an instance (or a specific group/household within it) is already
  configured to be publicly viewable without login, the plain recipe URL is already fully
  functional and permanent — generating a time-limited token for it is redundant friction
  for the user. The existing token flow remains necessary for non-public groups/households,
  where it's the only way to grant temporary outside access.
- Change is entirely in `frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue`:
  added `useGroupSelf`, an `isFullyPublic` computed property, and a `sharePlainLink()`
  function (using `useShare`/`useClipboard` from `@vueuse/core`, mirroring the existing
  pattern in `RecipeDialogShare.vue`). The share menu item's click handler now branches on
  `isFullyPublic` before deciding whether to open the dialog.
- `RecipeDialogShare.vue` is unchanged — no new share tokens are created or stored for the
  new public-link path, by design.
- No backend changes. No new endpoints, no schema changes.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

- The public/private determination deliberately uses `=== false` rather than `!value`,
  since `useGroupSelf()`/`useHouseholdSelf()` load asynchronously and may be `undefined`
  on first render. This ensures an unloaded/unknown privacy state safely falls through to
  the existing (safe) dialog behavior rather than being mistakenly treated as public.
- This mirrors the server-side gating exactly: `get_public_group` (in
  `mealie/core/dependencies/dependencies.py`) 404s the entire explore namespace for a
  private group before any household-level check runs, and `controller_public_recipes.py`
  separately checks `household.preferences.private_household` per recipe. The frontend's
  `&&` of both flags matches this two-gate backend behavior, so the button's decision
  never diverges from what's actually reachable anonymously.
- `navigator.share` / `navigator.clipboard` both require a secure context (HTTPS or
  `localhost`) per browser spec — this was initially mistaken for a bug while testing over
  plain HTTP on a LAN IP (`Clipboard not supported` fired on both mobile and desktop
  identically), until testing was moved to an HTTPS-exposed dev subdomain, which resolved
  it. No code change was needed; noting it here in case a future reviewer testing over
  plain HTTP hits the same false negative.

## Testing

Manually tested against 4 seeded accounts covering all group/household privacy
combinations, over HTTPS (to get real `navigator.share`/`navigator.clipboard` behavior
rather than a secure-context false negative):

| Account  | Group   | Household | Result |
|----------|---------|-----------|--------|
| pubpub   | Public  | Public    | ✅ Instant share — native share sheet (mobile) / clipboard + toast (desktop), no dialog |
| pubpriv  | Public  | Private   | ✅ Existing expiring-link dialog, unchanged |
| privpub  | Private | Public    | ✅ Existing expiring-link dialog, unchanged |
| privpriv | Private | Private   | ✅ Existing expiring-link dialog, unchanged |

Confirmed via direct API calls that each seeded account's actual `privateGroup`/
`privateHousehold` values matched the intended matrix before running the UI pass, so the
above results reflect the real decision logic rather than a data-seeding mismatch.

`pubpub` on desktop (Windows share flyout via `navigator.share`):

<img width="801" height="724" alt="Desktop" src="https://github.com/user-attachments/assets/5eae397f-1bbc-4941-a556-d86d9ca889b0" />

`pubpub` on mobile (Android native share sheet via `navigator.share`):

<img width="431" height="934" alt="Mobile" src="https://github.com/user-attachments/assets/ff02f905-27dd-4fbb-bc7d-a1fccd3d12a7" />

Both confirm the plain recipe URL (`https://mealietest.schroth.ca/g/public/r/leek-and-mushroom-soup`)
is populated with no token or expiration query params.

ESLint clean. `DB_ENGINE=sqlite uv run pytest` run as a sanity check (no backend code
changed by this PR, so no new backend tests were needed). One pre-existing failure
(`test_pg_connection_args`) observed, unrelated to this change — caused by local
`.env` using custom Postgres credentials/DB name rather than the test's hardcoded
`mealie`/`mealie`/`mealie` defaults; confirmed not present in this PR's diff and expected
to be absent in CI, which sets its own clean env vars.

## AI / LLM Assistance

Claude Code was used to generate the initial implementation following the existing image
import pattern. All generated code was reviewed, tested manually, and verified against the
codebase conventions before submission.