### PR TITLE
fix: keep recipe cook times in sync

### DIFF
--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import datetime
 from numbers import Number
 from pathlib import Path
-from typing import Annotated, Any, ClassVar
+from typing import Annotated, Any, ClassVar, Self
 from uuid import uuid4
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
+from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from slugify import slugify
 from sqlalchemy import Select, desc, func, or_, select, text
@@ -160,6 +160,16 @@ class RecipeSummary(MealieModel):
             return str(val)
 
         return val
+
+    @model_validator(mode="after")
+    def sync_cook_time(self) -> Self:
+        """Keep the schema.org cook time and Mealie's legacy field consistent."""
+        if self.perform_time is not None:
+            self.cook_time = self.perform_time
+        elif self.cook_time is not None:
+            self.perform_time = self.cook_time
+
+        return self
 
     @property
     def recipe_yield_display(self) -> str:

--- a/tests/unit_tests/schema_tests/test_recipe.py
+++ b/tests/unit_tests/schema_tests/test_recipe.py
@@ -74,3 +74,29 @@ def test_recipe_preserves_existing_slug():
     )
 
     assert recipe.slug == "nourish-bowls-zuppa-copycat"
+
+
+@pytest.mark.parametrize(
+    ("cook_time", "perform_time", "expected"),
+    [
+        (None, "20 minutes", "20 minutes"),
+        ("20 minutes", None, "20 minutes"),
+        ("stale value", "20 minutes", "20 minutes"),
+        (None, None, None),
+    ],
+)
+def test_recipe_keeps_cook_and_perform_time_in_sync(
+    cook_time: str | None, perform_time: str | None, expected: str | None
+):
+    recipe = RecipeSummary(
+        id=uuid4(),
+        user_id=uuid4(),
+        household_id=uuid4(),
+        group_id=uuid4(),
+        cook_time=cook_time,
+        perform_time=perform_time,
+    )
+
+    assert recipe.cook_time == expected
+    assert recipe.perform_time == expected
+    assert recipe.model_dump(by_alias=True)["cookTime"] == expected


### PR DESCRIPTION
## What type of PR is this?

Bug fix

## What this PR does / why we need it

Mealie labels and edits `performTime` as Cook Time for legacy compatibility, but raw JSON exports also expose the schema.org `cookTime` field. Recipes edited in the UI therefore exported a null `cookTime` even though the visible Cook Time had a value.

This keeps the two aliases synchronized in `RecipeSummary`:

- legacy `performTime` remains authoritative when present
- input containing only standard `cookTime` also hydrates `performTime`
- old database rows are corrected when they are serialized, so no data migration is required

Fixes #7938

## Testing

- `uv run pytest tests/unit_tests/schema_tests -q` (81 passed)
- `uv run mypy mealie/schema/recipe/recipe.py`
- `uv run ruff check mealie/schema/recipe/recipe.py tests/unit_tests/schema_tests/test_recipe.py`
- `uv run ruff format --check mealie/schema/recipe/recipe.py tests/unit_tests/schema_tests/test_recipe.py`
- `git diff --check`

## AI assistance

This change was developed with AI assistance. I reviewed the historical field contract, implementation, and tests.