### PR TITLE
Fix translated ingredient food seeding

### DIFF
--- a/mealie/repos/seed/seeders.py
+++ b/mealie/repos/seed/seeders.py
@@ -108,14 +108,15 @@ class IngredientFoodsSeeder(AbstractSeeder):
         for label, values in self.load_file(file).items():
             label_out = self.get_label(label)
 
-            for food_name, attributes in values["foods"].items():
-                if food_name in seen_foods_names:
+            for attributes in values["foods"].values():
+                translated_name = attributes["name"]
+                if translated_name in seen_foods_names:
                     continue
 
-                seen_foods_names.add(food_name)
+                seen_foods_names.add(translated_name)
                 yield SaveIngredientFood(
                     group_id=self.repos.group_id,
-                    name=attributes["name"],
+                    name=translated_name,
                     plural_name=attributes.get("plural_name"),
                     description="",  # description expected to be empty string by UnitFoodBase class
                     label_id=label_out.id if label_out and label_out.id else None,

--- a/tests/unit_tests/repository_tests/test_seeders.py
+++ b/tests/unit_tests/repository_tests/test_seeders.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from mealie.repos.seed.seeders import IngredientFoodsSeeder
+
+
+def test_food_seeder_deduplicates_by_translated_name(monkeypatch: pytest.MonkeyPatch):
+    repos = MagicMock()
+    repos.group_id = uuid4()
+    seeder = IngredientFoodsSeeder(repos)
+    monkeypatch.setattr(seeder, "get_file", lambda _: Path("da-DK.json"))
+    monkeypatch.setattr(
+        seeder,
+        "load_file",
+        lambda _: {
+            "Sweeteners": {
+                "foods": {
+                    "sugar": {
+                        "name": "sukker",
+                        "plural_name": "sukker",
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(seeder, "get_all_foods", lambda: [SimpleNamespace(name="sugar")])
+    monkeypatch.setattr(seeder, "get_label", lambda _: None)
+
+    foods = list(seeder.load_data("da-DK"))
+
+    assert [food.name for food in foods] == ["sukker"]


### PR DESCRIPTION
Fixes #7409.

IngredientFoodsSeeder now deduplicates against the localized name that it actually saves instead of the English source key. This allows a translated locale such as da-DK to add sukker even when the existing database already contains sugar, while still preventing duplicate localized names.

Tests:
- uv run pytest tests/unit_tests/repository_tests/test_seeders.py -q
- uv run pytest tests/unit_tests/repository_tests -q (155 passed)
- uv run mypy mealie/repos/seed/seeders.py
- uv run ruff check mealie/repos/seed/seeders.py tests/unit_tests/repository_tests/test_seeders.py
- uv run ruff format --check mealie/repos/seed/seeders.py tests/unit_tests/repository_tests/test_seeders.py

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the final diff and test results.