### PR TITLE
fix: make organizer search case- and accent-insensitive

### DIFF
--- a/mealie/schema/_mealie/mealie_model.py
+++ b/mealie/schema/_mealie/mealie_model.py
@@ -164,10 +164,10 @@ class MealieModel(BaseModel):
         else:
             filters = []
             for prop in model_properties:
-                filters.extend([prop.like(f"%{s}%") for s in search_list])
+                filters.extend([prop.ilike(f"%{s}%") for s in search_list])
 
             # order by how close the result is to the first searchable property
-            return query.filter(or_(*filters)).order_by(desc(model_properties[0].like(f"%{search}%")))
+            return query.filter(or_(*filters)).order_by(desc(model_properties[0].ilike(f"%{search}%")))
 
 
 class HasUUID(Protocol):

--- a/mealie/schema/recipe/recipe.py
+++ b/mealie/schema/recipe/recipe.py
@@ -64,7 +64,7 @@ class RecipeTag(MealieModel):
     name: str
     slug: str
 
-    _searchable_properties: ClassVar[list[str]] = ["name"]
+    _searchable_properties: ClassVar[list[str]] = ["name", "slug"]
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/mealie/schema/recipe/recipe_category.py
+++ b/mealie/schema/recipe/recipe_category.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from pydantic import UUID4, ConfigDict
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.interfaces import LoaderOption
@@ -24,6 +26,8 @@ class CategoryBase(CategoryIn):
 class CategoryOut(CategoryBase):
     slug: str
     group_id: UUID4
+
+    _searchable_properties: ClassVar[list[str]] = ["name", "slug"]
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -47,6 +51,8 @@ class TagBase(CategoryBase):
 class TagOut(TagSave):
     id: UUID4
     slug: str
+
+    _searchable_properties: ClassVar[list[str]] = ["name", "slug"]
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/mealie/schema/recipe/recipe_tool.py
+++ b/mealie/schema/recipe/recipe_tool.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from pydantic import UUID4, ConfigDict, field_validator
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.interfaces import LoaderOption
@@ -20,6 +22,7 @@ class RecipeToolOut(RecipeToolCreate):
     group_id: UUID4
     slug: str
 
+    _searchable_properties: ClassVar[list[str]] = ["name", "slug"]
     model_config = ConfigDict(from_attributes=True)
 
     @field_validator("households_with_tool", mode="before")

--- a/tests/unit_tests/repository_tests/test_search.py
+++ b/tests/unit_tests/repository_tests/test_search.py
@@ -77,6 +77,7 @@ def search_tags(unique_db: AllRepositories, unique_local_group_id: str) -> list[
         [
             TagSave(group_id=unique_local_group_id, name="Weeknight Dinner"),
             TagSave(group_id=unique_local_group_id, name="Party Food"),
+            TagSave(group_id=unique_local_group_id, name="Frühstück"),
         ]
     )
 
@@ -144,6 +145,18 @@ def test_search_is_case_insensitive(
     results = repo.page_all(pagination, override=RecipeTag, search='"weeknight dinner"').items
 
     assert [tag.name for tag in results] == ["Weeknight Dinner"]
+
+
+def test_search_matches_slug(
+    unique_db: AllRepositories,
+    search_tags: list[TagOut],  # required so database is populated
+):
+    # the name column keeps its accents, the slug does not, so searching both makes them optional
+    repo = unique_db.tags
+    pagination = PaginationQuery(page=1, per_page=-1, order_by="created_at", order_direction=OrderDirection.asc)
+    results = repo.page_all(pagination, override=RecipeTag, search="fruhstuck").items
+
+    assert [tag.name for tag in results] == ["Frühstück"]
 
 
 def test_random_order_search(

--- a/tests/unit_tests/repository_tests/test_search.py
+++ b/tests/unit_tests/repository_tests/test_search.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Session
 from mealie.db.models._model_base import SqlAlchemyBase
 from mealie.repos.all_repositories import get_repositories
 from mealie.repos.repository_factory import AllRepositories
+from mealie.schema.recipe.recipe import RecipeTag
+from mealie.schema.recipe.recipe_category import TagOut, TagSave
 from mealie.schema.recipe.recipe_ingredient import IngredientUnit, SaveIngredientUnit
 from mealie.schema.response.pagination import OrderDirection, PaginationQuery
 from mealie.schema.response.query_search import SearchFilter
@@ -69,6 +71,16 @@ def search_units(unique_db: AllRepositories, unique_local_group_id: str) -> list
     return unique_db.ingredient_units.create_many(units)
 
 
+@pytest.fixture()
+def search_tags(unique_db: AllRepositories, unique_local_group_id: str) -> list[TagOut]:
+    return unique_db.tags.create_many(
+        [
+            TagSave(group_id=unique_local_group_id, name="Weeknight Dinner"),
+            TagSave(group_id=unique_local_group_id, name="Party Food"),
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     "search, expected_names",
     [
@@ -120,6 +132,18 @@ def test_fuzzy_search(
     results = repo.page_all(pagination, search="tabel spoone").items
 
     assert results and results[0].name == "Table Spoon"
+
+
+def test_search_is_case_insensitive(
+    unique_db: AllRepositories,
+    search_tags: list[TagOut],  # required so database is populated
+):
+    # tags, categories and tools search their raw name column, where LIKE is case sensitive on postgres
+    repo = unique_db.tags
+    pagination = PaginationQuery(page=1, per_page=-1, order_by="created_at", order_direction=OrderDirection.asc)
+    results = repo.page_all(pagination, override=RecipeTag, search='"weeknight dinner"').items
+
+    assert [tag.name for tag in results] == ["Weeknight Dinner"]
 
 
 def test_random_order_search(

--- a/tests/unit_tests/repository_tests/test_search.py
+++ b/tests/unit_tests/repository_tests/test_search.py
@@ -7,8 +7,9 @@ from mealie.db.models._model_base import SqlAlchemyBase
 from mealie.repos.all_repositories import get_repositories
 from mealie.repos.repository_factory import AllRepositories
 from mealie.schema.recipe.recipe import RecipeTag
-from mealie.schema.recipe.recipe_category import TagOut, TagSave
+from mealie.schema.recipe.recipe_category import CategorySave, TagOut, TagSave
 from mealie.schema.recipe.recipe_ingredient import IngredientUnit, SaveIngredientUnit
+from mealie.schema.recipe.recipe_tool import RecipeToolSave
 from mealie.schema.response.pagination import OrderDirection, PaginationQuery
 from mealie.schema.response.query_search import SearchFilter
 from mealie.schema.user.user import GroupBase
@@ -157,6 +158,28 @@ def test_search_matches_slug(
     results = repo.page_all(pagination, override=RecipeTag, search="fruhstuck").items
 
     assert [tag.name for tag in results] == ["Frühstück"]
+
+
+@pytest.mark.parametrize(
+    "repo_name, save_schema",
+    [("tags", TagSave), ("categories", CategorySave), ("tools", RecipeToolSave)],
+    ids=["tags", "categories", "tools"],
+)
+def test_search_without_an_override_schema(
+    repo_name: str,
+    save_schema: type,
+    unique_db: AllRepositories,
+    unique_local_group_id: str,
+):
+    # the routes always search with an override schema; without one the repository falls back
+    # to the schema it was built with, which has to be searchable as well
+    repo = getattr(unique_db, repo_name)
+    repo.create(save_schema(group_id=unique_local_group_id, name="Party Food"))
+
+    pagination = PaginationQuery(page=1, per_page=-1, order_by="created_at", order_direction=OrderDirection.asc)
+    results = repo.page_all(pagination, search="party").items
+
+    assert [item.name for item in results] == ["Party Food"]
 
 
 def test_random_order_search(


### PR DESCRIPTION
## What this PR does / why we need it:

Tags, categories and tools are searched differently from everything else, and the difference is not deliberate.

Foods, units and recipes keep a normalized, lower-cased copy of their name (`name_normalized`) and search that. Tags, categories and tools have no such column, so they search the raw `name`. Two things fall out of that:

- **`LIKE` is case sensitive on postgres.** Any search that takes the substring path missed anything whose casing did not match exactly. The unquoted case only worked by accident, because it takes the trigram path instead and pg_trgm lower-cases its input.
- **Accents are mandatory.** `Café Favourites` could only be found by typing the accent, while `Café Latte` as a *food* has always been findable as `cafe latte`.

Both are fixed without a migration. The first by using `ILIKE`, the second by also searching the existing `slug` column, which is `slugify(name)` and therefore exactly the normalized form that was missing.

The third commit fixes a smaller thing found on the way: the schemas the organizer repositories are actually built with never declared `_searchable_properties` at all.

### Commits

1. **`fix: search organizer names case-insensitively`** — `LIKE` → `ILIKE` in `MealieModel.filter_search_query`. For the normalized columns this is a no-op, since their contents are already lower-case, and the existing `gin_trgm_ops` indexes support `ILIKE` as well as `LIKE`.
2. **`fix: find tags, categories and tools by their slug`** — `RecipeTag._searchable_properties` becomes `["name", "slug"]`. `RecipeCategory` and `RecipeTool` inherit from `RecipeTag`, so all three are covered. `name` stays first, so ordering is unchanged.
3. **`fix: declare searchable properties on the organizer schemas`** — `CategoryOut`, `TagOut` and `RecipeToolOut` get `_searchable_properties`. Searching those repositories previously raised `AttributeError: Not Implemented`. Not reachable over the API, since the routes pass an override schema, but a trap for anything using the repositories directly.

### Before / after

Tags named `Weeknight Dinner, Weekend Baking, Party Food, Café Favourites, Jalapeño Poppers, Slow Cooker, Grill`, number of results:

| search | pg before | pg after | sqlite before | sqlite after |
| --- | --- | --- | --- | --- |
| `"party"` | **0** | 1 | 1 | 1 |
| `"Party"` | 1 | 1 | 1 | 1 |
| `party` | 1 | 1 | 1 | 1 |
| `"weeknight dinner"` | **0** | 1 | 1 | 1 |
| `jalapeno` | 1 | 1 | **0** | 1 |
| `"jalapeno"` | **0** | 1 | 1 | 1 |
| `cafe` | 1 | 1 | **0** | 1 |
| `grill` | 1 | 1 | 1 | 1 |

The two failure modes are visible per backend: postgres lost every quoted search, sqlite lost every accented name. `jalapeno` unquoted already worked on postgres because the trigram operator is accent-tolerant enough here; quoting it, which is the documented way to be precise, dropped it to zero.

## Which issue(s) this PR fixes:

None that I could find an issue for.

## Special notes for your reviewer:

**Result counts can grow slightly**, because a token now also matches against the slug. Since the slug is derived from the name, this only adds rows whose name differs from the search by accents or punctuation — `Mac & Cheese` has the slug `mac-cheese` and is now also found as `mac cheese`. Ordering still uses `name` as the first searchable property, so ranking is untouched.

**Labels are deliberately left out of commit 2.** `multi_purpose_labels` has no slug column and no index on `name`, so making them accent-insensitive would need a migration. They do benefit from the `ILIKE` fix in commit 1.

## Testing

- New tests in `tests/unit_tests/repository_tests/test_search.py`, one per commit, the last one parametrized over the three repositories. Each was verified to fail on its parent commit: the case-insensitivity test fails on postgres, the slug test on both backends, the override test on both with `AttributeError`.
- `tests/unit_tests` passes on sqlite and postgres, as do the organizer-related `tests/integration_tests` (68 tests) on both. `ruff check`, `ruff format` and `mypy` are clean.
- The table above was produced by running the same queries against both backends, with and without the patch.

## AI / LLM Assistance

Substantial. The analysis, the code, the tests and this description were produced with
Claude Code (Opus), which is why the commits carry a `Co-Authored-By` trailer.

I directed the work and made the design calls: reusing the existing `slug` instead of
adding a normalized column, so that no migration is needed; leaving labels out because
they would need one; and keeping `name` as the first searchable property so that ordering
does not change. I reviewed every commit individually and sent several back for changes,
and the before/after numbers were measured against a local dev environment running both
sqlite and postgres.
