### PR TITLE
fix: recipe image lost after using "Get" (fetch by URL) then saving

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
@@ -85,11 +85,12 @@ import { useUserApi } from "~/composables/api";
 
 const UPLOAD_EVENT = "upload";
 const DELETE_EVENT = "delete";
+const REFRESH_EVENT = "refresh";
 
 const props = defineProps<{ slug: string }>();
 
 const emit = defineEmits<{
-  refresh: [];
+  refresh: [image: string];
   upload: [fileObject: File];
   delete: [];
 }>();
@@ -125,8 +126,9 @@ async function deleteImage() {
 
 async function getImageFromURL() {
   loading.value = true;
-  if (await api.recipes.updateImagebyURL(props.slug, url.value)) {
-    emit(DELETE_EVENT);
+  const { data } = await api.recipes.updateImagebyURL(props.slug, url.value);
+  if (data?.image) {
+    emit(REFRESH_EVENT, data.image);
   }
   loading.value = false;
   menu.value = false;

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
@@ -4,7 +4,7 @@
       class="my-2"
       :slug="recipe.slug"
       @upload="uploadImage"
-      @refresh="imageKey++"
+      @refresh="refreshImage"
       @delete="deleteImage"
     />
     <RecipeSettingsMenu
@@ -76,6 +76,13 @@ async function uploadImage(fileObject: File) {
   const newVersion = await api.recipes.updateImage(recipe.value.slug, fileObject);
   if (newVersion?.data?.image) {
     recipe.value.image = newVersion.data.image;
+  }
+  imageKey.value++;
+}
+
+function refreshImage(image: string) {
+  if (image) {
+    recipe.value.image = image;
   }
   imageKey.value++;
 }

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -629,7 +629,7 @@ class RecipeController(BaseRecipeController):
     # ==================================================================================================================
     # Image and Assets
 
-    @router.post("/{slug}/image", tags=["Recipe: Images and Assets"])
+    @router.post("/{slug}/image", response_model=UpdateImageResponse, tags=["Recipe: Images and Assets"])
     async def scrape_image_url(self, slug: str, url: ScrapeRecipe):
         recipe = self.mixins.get_one(slug)
         data_service = RecipeDataService(recipe.id)
@@ -649,6 +649,7 @@ class RecipeController(BaseRecipeController):
 
         recipe.image = cache.cache_key.new_key()
         self.service.update_one(recipe.slug, recipe)
+        return UpdateImageResponse(image=recipe.image)
 
     @router.put("/{slug}/image", response_model=UpdateImageResponse, tags=["Recipe: Images and Assets"])
     def update_recipe_image(self, slug: str, image: bytes = File(...), extension: str = Form(...)):


### PR DESCRIPTION
## What this PR does / why we need it:
- Fixes a bug where using **Edit → Image → Get** (fetch recipe image by URL) causes the recipe to lose its image after saving, even though the image is correctly downloaded and processed.
- **Root cause:** `RecipeImageUploadBtn.vue`'s `getImageFromURL()` emitted the same event as the delete-image button on success instead of a refresh event, wiping `recipe.image` in the frontend's local state immediately. If the user then saved, that empty value was persisted, overwriting the correct value the backend had already written.
- `mealie/routes/recipe/recipe_crud_routes.py`: `scrape_image_url` (`POST /{slug}/image`) now returns `UpdateImageResponse(image=recipe.image)`, matching the existing pattern used by the upload endpoint (`PUT /{slug}/image`).
- `RecipeImageUploadBtn.vue`: `getImageFromURL()` now reads the new image version from the response and emits a `refresh` event with that value, instead of wrongly emitting `delete`.
- `RecipePageEditorToolbar.vue`: added a `refreshImage(image)` handler that applies the new image value to `recipe.value.image` before bumping `imageKey`, replacing the previous no-op `imageKey++`.
- The existing `deleteImage()` flow (actual image deletion) was left untouched.

## Which issue(s) this PR fixes:
Fixes #8007

## Special notes for your reviewer:
Root cause and reproduction details are documented in my comment on #8007. Reproduced on both v3.22.0 (prod) and `mealie-next` (dev) before diagnosing.

## Testing
- `DB_ENGINE=sqlite uv run pytest` — full suite passes
- `ruff format . --check` and `ruff check` — clean, no new issues
- Manually reproduced the bug before the fix (confirmed via API: `recipe.image` field wiped to `""` after Get + Save, despite the correct image file being written to disk)
- Manually verified the fix: `recipe.image` now updates to a valid value immediately after Get, persists correctly through Save, and the image displays as expected
- Regression-tested Upload and Delete flows on other recipes — both still work correctly

## AI / LLM Assistance
Claude Code was used to generate the initial implementation following the existing image import pattern. All generated code was reviewed, tested manually, and verified against the codebase conventions before submission.
