### PR TITLE
fix: revalidate stale group/household preferences cache and settings forms

### DIFF
--- a/frontend/app/components/Domain/Group/GroupPreferencesEditor.vue
+++ b/frontend/app/components/Domain/Group/GroupPreferencesEditor.vue
@@ -42,4 +42,5 @@ import type { ReadGroupPreferences } from "~/lib/api/types/user";
 const preferences = defineModel<ReadGroupPreferences>({ required: true });
 const local = reactive({ ...preferences.value });
 watch(local, (newVal) => { preferences.value = { ...newVal }; });
+watch(preferences, (newVal) => { if (newVal) Object.assign(local, newVal); });
 </script>

--- a/frontend/app/components/Domain/Household/HouseholdPreferencesEditor.vue
+++ b/frontend/app/components/Domain/Household/HouseholdPreferencesEditor.vue
@@ -63,6 +63,7 @@ import type { ReadHouseholdPreferences } from "~/lib/api/types/household";
 const preferences = defineModel<ReadHouseholdPreferences>({ required: true });
 const local = reactive({ ...preferences.value });
 watch(local, (newVal) => { preferences.value = { ...newVal }; });
+watch(preferences, (newVal) => { if (newVal) Object.assign(local, newVal); });
 
 const i18n = useI18n();
 

--- a/frontend/app/composables/use-households.ts
+++ b/frontend/app/composables/use-households.ts
@@ -48,6 +48,9 @@ export const useHouseholdSelf = function () {
 
       return data || undefined;
     },
+    async refresh() {
+      await refreshHouseholdSelf();
+    },
   };
 
   const household = actions.get();

--- a/frontend/app/pages/group/index.vue
+++ b/frontend/app/pages/group/index.vue
@@ -76,6 +76,14 @@ useSeoMeta({
   title: i18n.t("group.group"),
 });
 
+// useGroupSelf() caches data in a module-level singleton for the lifetime of the tab,
+// so revisiting this page via client-side navigation can otherwise show stale
+// preferences/AI settings if they were changed elsewhere (e.g. Admin Groups panel)
+// in the same session. Force a revalidation whenever this page is entered.
+onMounted(() => {
+  groupActions.refresh();
+});
+
 const refGroupPrefsEditForm = ref<VForm | null>(null);
 const refGroupAISettingsForm = ref<VForm | null>(null);
 

--- a/frontend/app/pages/household/index.vue
+++ b/frontend/app/pages/household/index.vue
@@ -49,6 +49,14 @@ useSeoMeta({
   title: i18n.t("household.household"),
 });
 
+// useHouseholdSelf() caches data in a module-level singleton for the lifetime of the tab,
+// so revisiting this page via client-side navigation can otherwise show stale
+// preferences if they were changed elsewhere (e.g. Admin Households panel) in the
+// same session. Force a revalidation whenever this page is entered.
+onMounted(() => {
+  householdActions.refresh();
+});
+
 const refHouseholdEditForm = ref<VForm | null>(null);
 
 async function handleSubmit() {

--- a/frontend/app/pages/household/mealplan/planner.vue
+++ b/frontend/app/pages/household/mealplan/planner.vue
@@ -116,10 +116,18 @@ const route = useRoute();
 const router = useRouter();
 const i18n = useI18n();
 const api = useUserApi();
-const { household } = useHouseholdSelf();
+const { household, actions: householdActions } = useHouseholdSelf();
 
 useSeoMeta({
   title: i18n.t("meal-plan.dinner-this-week"),
+});
+
+// useHouseholdSelf() caches data in a module-level singleton for the lifetime of the tab,
+// so revisiting this page via client-side navigation can otherwise use a stale
+// firstDayOfWeek value if household preferences were changed elsewhere (e.g. Admin
+// Households panel) in the same session. Force a revalidation whenever this page is entered.
+onMounted(() => {
+  householdActions.refresh();
 });
 
 const mealPlanPreferences = useUserMealPlanPreferences();


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes two related bugs behind #7888, where changing group/household preferences via the Admin panel wasn't reflected on the User Profile Group/Household Settings pages (or the Meal Planner's week-start setting) without a hard browser refresh.

**Root cause 1 — stale singleton cache:**
`useGroupSelf()` and `useHouseholdSelf()` (`frontend/app/composables/use-groups.ts` / `use-households.ts`) cache their data in a module-level singleton ref that's only fetched once per tab session. Revisiting a page via client-side navigation reused the cached value instead of refetching, so changes made elsewhere (e.g. Admin panel) in the same tab went unnoticed.

- `frontend/app/pages/group/index.vue` — revalidate `useGroupSelf()` data on page entry (`onMounted`)
- `frontend/app/pages/household/index.vue` — revalidate `useHouseholdSelf()` data on page entry
- `frontend/app/pages/household/mealplan/planner.vue` — same, since this page reads `household.preferences.firstDayOfWeek` for the date-range picker
- `frontend/app/composables/use-households.ts` — added a `refresh()` action to the composable's action set, mirroring the one `use-groups.ts` already had (needed for the above pages to call it)

**Root cause 2 — one-way local state binding:**
`GroupPreferencesEditor.vue` and `HouseholdPreferencesEditor.vue` snapshot their `v-model` prop into a local `reactive()` copy once at component creation, with a watcher that only pushes local edits *up* to the parent. There was no watcher syncing new prop values *down* into local state, so even after the cache fix above, an already-mounted form wouldn't pick up externally-changed data.

- `frontend/app/components/Domain/Group/GroupPreferencesEditor.vue`
- `frontend/app/components/Domain/Household/HouseholdPreferencesEditor.vue`

Both now add `watch(preferences, (newVal) => { if (newVal) Object.assign(local, newVal); });`, matching the pattern already used correctly in `GroupAIProviderSettingsEditor.vue`.

## Which issue(s) this PR fixes:

Fixes #7888

## Special notes for your reviewer:

`useGroupSelf()`/`useHouseholdSelf()` are also consumed by several other components (`RecipeContextMenuContent.vue`, `RecipeLastMade.vue`, `RecipeDialogShare.vue`, `QueryFilterBuilder.vue`, `DefaultLayout.vue`, `use-announcements.ts`, the cookbooks index page, recipe-creation pages). I deliberately did **not** add the same on-mount revalidation to those — several are per-recipe-card components that can render dozens of times on a single list page, and forcing a refetch on every mount there would add unnecessary API load for low-stakes data (e.g. household name, privacy flags used for a share dialog). The settings pages and meal planner are the only surfaces where the staleness was actually the reported, user-visible bug.

## Testing

- `DB_ENGINE=sqlite uv run pytest`: 2546 passed, 16 skipped (no regressions; this is a frontend-only change)
- `yarn lint`: clean
- `yarn vitest run`: 151 passed, 18 files
- Manual verification: reproduced the original bug with two tabs (User Profile in one, Admin Groups/Households panel in the other), confirmed stale data before the fix, then confirmed both `showAnnouncements` and `firstDayOfWeek` correctly update on the **first** revisit (no hard refresh needed) after applying both parts of the fix.

## AI / LLM Assistance

Claude Code was used to generate the initial implementation, following the existing reactive sync pattern already used correctly in `GroupAIProviderSettingsEditor.vue`. All generated code was reviewed, tested manually, and verified against the codebase conventions before submission.