### PR TITLE
fix: prevent recipe tags from hiding card actions

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -176,7 +176,7 @@ const cursor = computed(() => showRecipeContent.value ? "pointer" : "auto");
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  height: 84px;
+  min-height: 84px;
 }
 .recipe-card-footer--no-tags {
   justify-content: center;
@@ -190,12 +190,7 @@ const cursor = computed(() => showRecipeContent.value ? "pointer" : "auto");
 }
 .recipe-card-tags .v-chip {
   flex: 0 1 auto;
-  min-width: 0;
-  max-width: calc(50% - 2px);
   margin: 0 !important;
-}
-.recipe-card-tags .v-chip:only-child {
-  max-width: 100%;
 }
 .recipe-card-tags .v-chip__content {
   display: block;
@@ -205,6 +200,5 @@ const cursor = computed(() => showRecipeContent.value ? "pointer" : "auto");
 }
 .recipe-card-actions {
   width: 100%;
-  min-height: 40px;
 }
 </style>

--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -40,55 +40,62 @@
           {{ name }}
         </v-card-title>
 
-        <slot name="actions">
-          <v-card-actions
-            v-if="showRecipeContent"
-            class="px-1"
-          >
-            <RecipeFavoriteBadge
-              v-if="isOwnGroup"
-              :recipe-id="recipeId"
-              show-always
-            />
-            <div v-else class="px-1" /> <!-- Empty div to keep the layout consistent -->
+        <div
+          class="recipe-card-footer"
+          :class="{ 'recipe-card-footer--no-tags': tags.length === 0 }"
+        >
+          <RecipeChips
+            v-if="tags.length > 0"
+            class="recipe-card-tags px-4"
+            :truncate="false"
+            :items="tags"
+            :title="false"
+            :limit="2"
+            small
+            url-prefix="tags"
+            v-bind="$attrs"
+          />
 
-            <RecipeCardRating
-              :model-value="rating"
-              :recipe-id="recipeId"
-            />
-            <v-spacer />
-            <RecipeChips
-              :truncate="true"
-              :items="tags"
-              :title="false"
-              :limit="2"
-              small
-              url-prefix="tags"
-              v-bind="$attrs"
-            />
+          <slot name="actions">
+            <v-card-actions
+              v-if="showRecipeContent"
+              class="recipe-card-actions px-1 py-0"
+            >
+              <RecipeFavoriteBadge
+                v-if="isOwnGroup"
+                :recipe-id="recipeId"
+                show-always
+              />
+              <div v-else class="px-1" /> <!-- Empty div to keep the layout consistent -->
 
-            <!-- If we're not logged-in, no items display, so we hide this menu -->
-            <RecipeContextMenu
-              v-if="isOwnGroup && showRecipeContent"
-              color="grey-darken-2"
-              :slug="slug"
-              :menu-icon="$globals.icons.dotsVertical"
-              :name="name"
-              :recipe-id="recipeId"
-              :use-items="{
-                delete: false,
-                edit: false,
-                download: true,
-                mealplanner: true,
-                shoppingList: true,
-                print: false,
-                printPreferences: false,
-                share: true,
-              }"
-              @deleted="$emit('delete', slug)"
-            />
-          </v-card-actions>
-        </slot>
+              <RecipeCardRating
+                :model-value="rating"
+                :recipe-id="recipeId"
+              />
+              <v-spacer />
+              <!-- If we're not logged-in, no items display, so we hide this menu -->
+              <RecipeContextMenu
+                v-if="isOwnGroup && showRecipeContent"
+                color="grey-darken-2"
+                :slug="slug"
+                :menu-icon="$globals.icons.dotsVertical"
+                :name="name"
+                :recipe-id="recipeId"
+                :use-items="{
+                  delete: false,
+                  edit: false,
+                  download: true,
+                  mealplanner: true,
+                  shoppingList: true,
+                  print: false,
+                  printPreferences: false,
+                  share: true,
+                }"
+                @deleted="$emit('delete', slug)"
+              />
+            </v-card-actions>
+          </slot>
+        </div>
         <slot />
       </v-card>
     </v-hover>
@@ -164,5 +171,40 @@ const cursor = computed(() => showRecipeContent.value ? "pointer" : "auto");
   -webkit-line-clamp: 8;
   line-clamp: 8;
   overflow: hidden;
+}
+.recipe-card-footer {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 84px;
+}
+.recipe-card-footer--no-tags {
+  justify-content: center;
+}
+.recipe-card-tags {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+.recipe-card-tags .v-chip {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: calc(50% - 2px);
+  margin: 0 !important;
+}
+.recipe-card-tags .v-chip:only-child {
+  max-width: 100%;
+}
+.recipe-card-tags .v-chip__content {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.recipe-card-actions {
+  width: 100%;
+  min-height: 40px;
 }
 </style>


### PR DESCRIPTION
## What this PR does / why we need it:

Long recipe tags can push the action menu outside desktop recipe cards. Cards with tags can also have an inconsistent layout compared with cards without tags.

This PR:

- Uses the existing tag layout in `RecipeCardMobile.vue` as a reference.
- Moves recipe tags to a separate row above the card actions.
- Continues to display a maximum of two tags.
- Truncates long tag names with an ellipsis.
- Keeps the recipe card footer height consistent.
- Vertically centres the action buttons when no tags are present.
- Removes the vertical padding from the action row.

### Before

<img width="1026" height="509" alt="Recipe card layout before the fix" src="https://github.com/user-attachments/assets/3721257e-1d17-41c6-a7d1-90e5e27e1fc9" />

### After

<img width="1038" height="395" alt="Recipe card layout after the fix" src="https://github.com/user-attachments/assets/af4cc394-dc4f-47d0-ac1e-aaed4698aac6" />

## Which issue(s) this PR fixes:

- Fixes #8027
- Also addresses #8052

## Testing

- `task ui:check`
  - Frontend lint passed
  - 18 test files passed
  - 151 tests passed
- Manually tested with:
  - No tags
  - One tag
  - Two tags
  - More than two tags
  - Long English and Chinese tag names
  - Two-column and three-column desktop layouts
  - Favorite, rating and action-menu controls

## AI / LLM Assistance

I used ChatGPT to discuss the UI approach and help draft parts of the implementation. I reviewed and understood the final changes, tested the affected layouts manually, and made the final implementation decisions.