### PR TITLE
dev: bind-mount dev postgres data to dev/data/postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dev/data/migration/*
 dev/data/templates/*
 dev/data/users/*
 dev/data/groups/*
+dev/data/postgres/*
 
 .DS_Store
 node_modules

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
     cmds:
       - rm -r ./dev/data/recipes/
       - rm -r ./dev/data/users/
+      - rm -rf ./dev/data/postgres/
       - rm -f ./dev/data/mealie*.db
       - rm -f ./dev/data/mealie*.db-shm
       - rm -f ./dev/data/mealie*.db-wal

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -18,3 +18,5 @@ services:
     environment:
       POSTGRES_PASSWORD: mealie
       POSTGRES_USER: mealie
+    volumes:
+      - ../dev/data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
## What this PR does / why we need it:

The dev Postgres container (docker-compose.dev.yml) relied on an anonymous Docker volume for its data directory. This makes the data hard to locate/inspect/back up, and is fragile across container recreation compared to an explicit, named location — unlike the SQLite dev database, which already lives in a visible spot under `dev/data/`.

- `docker/docker-compose.dev.yml`: bind-mount `../dev/data/postgres:/var/lib/postgresql/data` so Postgres data lives alongside the SQLite dev data in `dev/data/`.
- `.gitignore`: ignore the contents of `dev/data/postgres/`.
- `Taskfile.yml`: add `dev/data/postgres/` to `task dev:clean` so it's wiped along with the other dev data directories.

Only affects local dev tooling — the production `docker-compose.yml` doesn't bundle a Postgres service, so it's untouched.

## Which issue(s) this PR fixes:

_(none — small dev-tooling improvement, not tied to an issue)_

## Special notes for your reviewer:

Verified locally: recreated the dev postgres container and confirmed `docker inspect` shows a bind mount (not an anonymous volume) resolving to `dev/data/postgres`, and the directory is populated with Postgres's data files after startup. Also verified that a fresh `task dev:clean` + `task dev:services` + `task py:postgres` cycle still auto-migrates the schema correctly against the bind-mounted database.

## Testing

Ran `task dev:clean` to reset, `task dev:services` to bring up Postgres, and `task py:postgres` to start the backend against it — confirmed the schema is created automatically, `dev/data/postgres/` is populated on disk, and the data survives a container restart (`docker compose restart postgres`).

## AI / LLM Assistance

Used an AI coding assistant (Claude Code) to investigate how the dev Postgres container stored its data and to implement/verify the bind mount change.
