### PR TITLE
fix: improve IntegrityError message for unique constraint violations

### DIFF
--- a/mealie/routes/_base/mixins.py
+++ b/mealie/routes/_base/mixins.py
@@ -1,12 +1,30 @@
+import sqlite3
 from collections.abc import Callable
 from logging import Logger
 
+import psycopg2
 import sqlalchemy.exc
 from fastapi import HTTPException, status
 from pydantic import UUID4, BaseModel
 
+from mealie.core.config import get_app_settings
 from mealie.repos.repository_generic import RepositoryGeneric
 from mealie.schema.response import ErrorResponse
+
+
+def is_postgres() -> bool:
+    return get_app_settings().DB_ENGINE == "postgres"
+
+
+def is_unique_violation(ex: sqlalchemy.exc.IntegrityError) -> bool:
+
+    if is_postgres() and isinstance(ex.orig, psycopg2.Error):
+        return getattr(ex.orig, "pgcode", None) == "23505"
+
+    if isinstance(ex.orig, sqlite3.Error):
+        return getattr(ex.orig, "sqlite_errorcode", None) == sqlite3.SQLITE_CONSTRAINT_UNIQUE
+
+    return False
 
 
 class HttpRepo[C: BaseModel, R: BaseModel, U: BaseModel]:
@@ -59,6 +77,8 @@ class HttpRepo[C: BaseModel, R: BaseModel, U: BaseModel]:
                 detail=ErrorResponse.respond(message=msg, exception=str(ex)),
             )
         elif isinstance(ex, sqlalchemy.exc.IntegrityError):
+            if is_unique_violation(ex):
+                msg = "This item already exists."
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 detail=ErrorResponse.respond(message=msg, exception=str(ex)),

--- a/tests/utils/routes/test_mixins.py
+++ b/tests/utils/routes/test_mixins.py
@@ -1,0 +1,53 @@
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import psycopg2
+import pytest
+import sqlalchemy.exc
+
+from mealie.routes._base.mixins import is_unique_violation
+
+
+def make_postgres_integrity_error(pgcode: str) -> sqlalchemy.exc.IntegrityError:
+    orig = Mock(spec=psycopg2.Error)
+    orig.pgcode = pgcode
+    return sqlalchemy.exc.IntegrityError(None, None, orig)
+
+
+@patch("mealie.routes._base.mixins.get_app_settings")
+@pytest.mark.parametrize(
+    ("pgcode", "expected"),
+    [
+        ("23505", True),  # unique_violation
+        ("23503", False),  # foreign_key_violation
+    ],
+)
+def test_is_unique_violation_postgres(mock_settings, pgcode, expected):
+    mock_settings.return_value = SimpleNamespace(DB_ENGINE="postgres")
+
+    ex = make_postgres_integrity_error(pgcode)
+
+    assert is_unique_violation(ex) is expected
+
+
+def make_sqlite_integrity_error(sqlite_errorcode: int) -> sqlalchemy.exc.IntegrityError:
+    orig = sqlite3.IntegrityError()
+    orig.sqlite_errorcode = sqlite_errorcode
+    return sqlalchemy.exc.IntegrityError(None, None, orig)
+
+
+@patch("mealie.routes._base.mixins.get_app_settings")
+@pytest.mark.parametrize(
+    ("sqlite_errorcode", "expected"),
+    [
+        (sqlite3.SQLITE_CONSTRAINT_UNIQUE, True),
+        (sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY, False),
+    ],
+)
+def test_is_unique_violation_sqlite(mock_settings, sqlite_errorcode, expected):
+    mock_settings.return_value = SimpleNamespace(DB_ENGINE="sqlite")
+
+    ex = make_sqlite_integrity_error(sqlite_errorcode)
+
+    assert is_unique_violation(ex) is expected


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, and is not marked as "required", then delete that section.

  PLEASE READ:
  -------------------------
  Mealie uses a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

This PR improves the user-facing error message returned for unique constraint violations.
Previously, attempting to create or rename an item to an existing value returned the generic message:

> An unexpected error occurred.

This change recognizes the unique constraint violation messages returned by both SQLite and PostgreSQL and instead returns:

> This item already exists.

The existing HTTP 409 response and exception details are preserved.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Fixes #7988

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39

Be sure to include the word "fixes" otherwise the associated issue will not be closed.
-->

## Special notes for your reviewer:

Only unique constraint violations receive the updated user-facing message. Other `IntegrityError` responses continue to use the existing behavior.


<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

- Reproduced the issue by renaming an ingredient to an existing ingredient name.
- Verified that duplicate tag creation also returns the updated user-facing message.
- Verified that the API now returns **"This item already exists."** instead of **"An unexpected error occurred."**.
- Verified the change with SQLite.

<!--
  Describe how you tested this change.
-->

## AI / LLM Assistance

_(REQUIRED)_

<!--
  Describe to which degree an LLM was used in creating this pull request. Failure to accurately disclose LLM usage may result in
  review delays or closure of your PR.
-->
