### PR TITLE
fix: Allow psycopg2-binary to be optional again

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.Database }}-${{ hashFiles('**/uv.lock') }}
 
       - name: Check venv cache
         id: cache-validate
@@ -81,7 +81,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-          uv sync --group dev --extra pgsql
+          if [ "${{ matrix.Database }}" = "postgres" ]; then
+            uv sync --group dev --extra pgsql
+          else
+            uv sync --group dev
+          fi
         if: steps.cached-python-dependencies.outputs.cache-hit != 'true' || steps.cache-validate.outputs.cache-hit-success != 'true'
 
       - name: Formatting (Ruff)

--- a/mealie/routes/_base/mixins.py
+++ b/mealie/routes/_base/mixins.py
@@ -2,7 +2,6 @@ import sqlite3
 from collections.abc import Callable
 from logging import Logger
 
-import psycopg2
 import sqlalchemy.exc
 from fastapi import HTTPException, status
 from pydantic import UUID4, BaseModel
@@ -18,8 +17,14 @@ def is_postgres() -> bool:
 
 def is_unique_violation(ex: sqlalchemy.exc.IntegrityError) -> bool:
 
-    if is_postgres() and isinstance(ex.orig, psycopg2.Error):
-        return getattr(ex.orig, "pgcode", None) == "23505"
+    try:
+        import psycopg2  # noqa: I001
+
+        if is_postgres() and isinstance(ex.orig, psycopg2.Error):
+            return getattr(ex.orig, "pgcode", None) == "23505"
+
+    except ImportError:
+        pass
 
     if isinstance(ex.orig, sqlite3.Error):
         return getattr(ex.orig, "sqlite_errorcode", None) == sqlite3.SQLITE_CONSTRAINT_UNIQUE

--- a/tests/utils/routes/test_mixins.py
+++ b/tests/utils/routes/test_mixins.py
@@ -2,7 +2,6 @@ import sqlite3
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-import psycopg2
 import pytest
 import sqlalchemy.exc
 
@@ -10,6 +9,8 @@ from mealie.routes._base.mixins import is_unique_violation
 
 
 def make_postgres_integrity_error(pgcode: str) -> sqlalchemy.exc.IntegrityError:
+    psycopg2 = pytest.importorskip("psycopg2", reason="psycopg2 is only installed with the pgsql extra")
+
     orig = Mock(spec=psycopg2.Error)
     orig.pgcode = pgcode
     return sqlalchemy.exc.IntegrityError(None, None, orig)


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

`psycopg2-binary` should only be required if using Postgres, but we are importing `psycopg2` for an error check. This fixes the logic to make it optional again and skip the import if not needed.

I updated our backend test CI to catch this in the future.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Local dev, since it broke.

## AI / LLM Assistance

_(REQUIRED)_

None