### PR TITLE
Trusted Header Authentication (reverse proxy single sign-on)

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -73,7 +73,10 @@ change_user
 init
 load_secrets
 
-# Start API
-HOST_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
+# Backward-compatible default: only derive from gateway if neither trust variable is set.
+if [ -z "${TRUSTED_PROXY}" ] && [ -z "${HOST_IP}" ]; then
+    export TRUSTED_PROXY=`/sbin/ip route|awk '/default/ { print $3 }'`
+fi
 
+# Start API
 exec mealie

--- a/docs/docs/documentation/getting-started/authentication/proxy-auth.md
+++ b/docs/docs/documentation/getting-started/authentication/proxy-auth.md
@@ -1,0 +1,95 @@
+# Trusted Proxy Header Authentication (SSO)
+
+:octicons-tag-24: (not yet released)
+
+Trusted proxy header authentication lets Mealie authenticate a user using a header supplied by a trusted reverse proxy.
+
+When enabled, Mealie will automatically login an existing user from a configured request header (for example, `Remote-User`).
+
+## Security Model
+
+This feature assumes your reverse proxy is the trust boundary.
+
+- Clients should not be able to reach Mealie directly.
+- Your proxy **must** strip client-supplied identity headers and set its own trusted headers.
+- `TRUSTED_PROXY` must be configured correctly.
+
+If your proxy is misconfigured, identity header spoofing may be possible.
+
+## Required Settings
+
+Configure these variables in backend configuration:
+
+- `PROXY_AUTH_ENABLED=true`
+- `PROXY_AUTH_HEADER=Remote-User` (or your chosen header name)
+- `TRUSTED_PROXY=<single IP>`
+
+Notes:
+
+- `TRUSTED_PROXY` must be a single IP address
+- CIDRs, comma-separated lists and `*` are not supported when trusted proxy header authentication is enabled
+
+Any value other than a single IP address will disable trusted proxy header auth for safety reasons.
+
+## Request Flow and Auth Precedence
+
+For authenticated API routes:
+
+1. Mealie first checks for a valid Mealie session token (bearer or cookie).
+2. If no valid token is present, Mealie will attempt to match the user supplied in `PROXY_AUTH_HEADER`.
+3. If neither path authenticates, Mealie returns `401`.
+
+Notes:
+
+- If an invalid token is supplied, Mealie returns `401` and does not fall back to proxy header auth.
+- Mealie will not automatically create a user that does not exist. The header value must match an existing user.
+
+## User Matching
+
+When proxy-header auth is attempted:
+
+1. Mealie reads the configured header (`PROXY_AUTH_HEADER`).
+2. Mealie matches the header value to an existing user:
+   - first by `username` (case-insensitive)
+   - then by `email` (case-insensitive)
+
+If no user matches, authentication fails.
+
+## Header Behavior
+
+- `PROXY_AUTH_HEADER` is used as configured (no whitespace trimming).
+- HTTP header names are case-insensitive in request lookup.
+
+## Authelia Example
+
+Example deployment with Authelia in front of Mealie, with the proxy forwarding identity to Mealie as `Remote-User`.
+
+High-level setup:
+
+1. User authenticates with Authelia
+2. Proxy (e.g. haproxy) at 10.0.0.5 forwards request to Mealie and sets `Remote-User`
+3. Uvicorn trusts forwarded headers only from `TRUSTED_PROXY`
+4. Mealie maps `Remote-User` to an existing Mealie user
+
+Example Mealie env:
+
+```env
+PROXY_AUTH_ENABLED=true
+PROXY_AUTH_HEADER=Remote-User
+TRUSTED_PROXY=10.0.0.5
+```
+
+For exact Authelia/proxy configuration syntax, follow your proxy and Authelia docs.
+
+## Troubleshooting
+
+- Proxy auth never activates:
+  - Confirm `PROXY_AUTH_ENABLED=true`
+  - Confirm `TRUSTED_PROXY` is a single IP and not `*`
+  - Confirm Mealie receives traffic through your trusted reverse proxy
+- Always getting `401`:
+  - Confirm proxy sets `PROXY_AUTH_HEADER`
+  - Confirm mapped user already exists in Mealie
+  - Confirm invalid/stale bearer token is not being sent
+- Header mismatch:
+  - Verify `PROXY_AUTH_HEADER` name and whitespace in config

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -120,6 +120,22 @@ For usage, see [Usage - OpenID Connect](../authentication/oidc-v2.md)
 | OIDC_TLS_CACERTFILE                                                                 |  None   | File path to Certificate Authority used to verify server certificate (e.g. `/path/to/ca.crt`)                                                                                                                                                                                                          |
 | OIDC_CLIENT_TIMEOUT                                                                 | default | Configures the timeout value of the httpx client used for OIDC communications. If set to the string `default`, does not configure the value (uses the library's default of 5.0s). If set to the string `None`, disables the timeout entirely. If set to a numeric value, uses that as the timeout.     |
 
+
+### Trusted Proxy Header Authentication (SSO)
+
+:octicons-tag-24: (not yet released)
+
+When enabled, Mealie will authenticate the user supplied in `PROXY_AUTH_HEADER` from `TRUSTED_PROXY`, when no valid session token is present (bearer or cookie).
+Users are matched by username first, then email.  Users are not auto-created.
+
+
+`TRUSTED_PROXY` must be set, and must be a single IP (CIDR and lists not supported).  Any other value will disable trusted proxy header auth for safety reasons
+
+| Variables                     |   Default   | Description                                                                                                                                                                                                                                                                                            |
+| ----------------------------- | :---------: | -------------------------------------------------------------------------------------- |
+| PROXY_AUTH_ENABLED            |    false    | Enables trusted proxy header authentication.                                           |
+| PROXY_AUTH_HEADER             | Remote-User | HTTP header used for authentication (for example `Remote-User` or `X-Forwarded-User`). |
+
 ### OpenAI
 
 :octicons-tag-24: v1.7.0

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -125,11 +125,15 @@ For usage, see [Usage - OpenID Connect](../authentication/oidc-v2.md)
 
 :octicons-tag-24: (not yet released)
 
+For usage, see [Usage - Trusted Proxy Header Authentication](../authentication/proxy-auth.md)
+
 When enabled, Mealie will authenticate the user supplied in `PROXY_AUTH_HEADER` from `TRUSTED_PROXY`, when no valid session token is present (bearer or cookie).
 Users are matched by username first, then email.  Users are not auto-created.
 
 
 `TRUSTED_PROXY` must be set, and must be a single IP (CIDR and lists not supported).  Any other value will disable trusted proxy header auth for safety reasons
+
+For trusted proxy header auth, `TRUSTED_PROXY` is a safety/readiness requirement. Request source trust is enforced by Uvicorn's trusted forwarded-header handling and your proxy/network configuration.
 
 | Variables                     |   Default   | Description                                                                                                                                                                                                                                                                                            |
 | ----------------------------- | :---------: | -------------------------------------------------------------------------------------- |

--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -14,6 +14,8 @@
 | TOKEN_TIME                    |          48           | The time in hours that a login/auth token is valid. Must be <= 9600 (400 days, in hours).                                                               |
 | API_PORT                      |         9000          | The port exposed by backend API. **Do not change this if you're running in Docker**                                                                     |
 | API_DOCS                      |         True          | Turns on/off access to the API documentation locally                                                                                                    |
+| TRUSTED_PROXY                 |          *            | Passed to Uvicorn as `forwarded_allow_ips` (trusted sources for `X-Forwarded-*`; supports `*`, comma-separated IPs, and CIDRs).                         |
+| HOST_IP (deprecated)          |          *            | Backward-compatible alias for `TRUSTED_PROXY`. Use `TRUSTED_PROXY`.  Ignored if `TRUSTED_PROXY` is set.                                                 |
 | TZ                            |          UTC          | Must be set to get correct date/time on the server                                                                                                      |
 | ALLOW_SIGNUP<super>\*</super> |         false         | Allow user sign-up without token                                                                                                                        |
 | ALLOW_PASSWORD_LOGIN          |         true          | Whether or not to display the username+password input fields. Keep set to true unless you use OIDC authentication                                       |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Authentication:
           - LDAP: "documentation/getting-started/authentication/ldap.md"
           - OpenID Connect: "documentation/getting-started/authentication/oidc-v2.md"
+          - Trusted Proxy Header Auth: "documentation/getting-started/authentication/proxy-auth.md"
 
       - Community Guides:
           - Bring API without internet exposure: "documentation/community-guide/bring-api.md"

--- a/frontend/app/composables/use-auth-backend.ts
+++ b/frontend/app/composables/use-auth-backend.ts
@@ -19,7 +19,7 @@ interface AuthState {
   signIn: (credentials: FormData, options?: { redirect?: boolean }) => Promise<void>;
   signOut: (callbackUrl?: string) => Promise<void>;
   refresh: () => Promise<void>;
-  getSession: () => Promise<void>;
+  getSession: (options?: { allowProxyAuthProbe?: boolean }) => Promise<void>;
   setToken: (token: string | null) => void;
 }
 
@@ -54,7 +54,14 @@ export const useAuthBackend = function (): AuthState {
     }
   }
 
-  async function getSession(): Promise<void> {
+  async function getSession(options?: { allowProxyAuthProbe?: boolean }): Promise<void> {
+    const allowProxyAuthProbe = options?.allowProxyAuthProbe ?? false;
+    if (!tokenCookie.value && !allowProxyAuthProbe) {
+      authUser.value = null;
+      authStatus.value = "unauthenticated";
+      return;
+    }
+
     authStatus.value = "loading";
     try {
       const { data } = await $axios.get<UserOut>("/api/users/self");
@@ -62,7 +69,12 @@ export const useAuthBackend = function (): AuthState {
       authStatus.value = "authenticated";
     }
     catch (error: any) {
-      console.error("Failed to fetch user session:", error);
+      if (error?.response?.status === 401) {
+        console.warn("Unauthenticated user session:", error);
+      }
+      else {
+        console.error("Failed to fetch user session:", error);
+      }
       handleAuthError(error);
       authStatus.value = "unauthenticated";
     }

--- a/frontend/app/composables/use-auth-backend.ts
+++ b/frontend/app/composables/use-auth-backend.ts
@@ -55,12 +55,6 @@ export const useAuthBackend = function (): AuthState {
   }
 
   async function getSession(): Promise<void> {
-    if (!tokenCookie.value) {
-      authUser.value = null;
-      authStatus.value = "unauthenticated";
-      return;
-    }
-
     authStatus.value = "loading";
     try {
       const { data } = await $axios.get<UserOut>("/api/users/self");

--- a/frontend/app/lib/api/types/admin.ts
+++ b/frontend/app/lib/api/types/admin.ts
@@ -92,6 +92,7 @@ export interface CheckAppConfig {
   emailReady: boolean;
   ldapReady: boolean;
   oidcReady: boolean;
+  proxyAuthReady: boolean;
   baseUrlSet: boolean;
   isUpToDate: boolean;
 }

--- a/frontend/app/lib/api/types/admin.ts
+++ b/frontend/app/lib/api/types/admin.ts
@@ -14,6 +14,7 @@ export interface AdminAboutInfo {
   defaultGroupSlug?: string | null;
   defaultHouseholdSlug?: string | null;
   enableOidc: boolean;
+  enableProxyAuth: boolean;
   oidcRedirect: boolean;
   oidcProviderName: string;
   tokenTime: number;
@@ -45,6 +46,7 @@ export interface AppInfo {
   defaultGroupSlug?: string | null;
   defaultHouseholdSlug?: string | null;
   enableOidc: boolean;
+  enableProxyAuth: boolean;
   oidcRedirect: boolean;
   oidcProviderName: string;
   tokenTime: number;

--- a/frontend/app/pages/admin/site-settings.vue
+++ b/frontend/app/pages/admin/site-settings.vue
@@ -311,6 +311,7 @@ const appConfig = ref<CheckApp>({
   isUpToDate: false,
   ldapReady: false,
   oidcReady: false,
+  proxyAuthReady: false,
 });
 const adminStats = ref<AppStatistics>({
   totalRecipes: 0,

--- a/frontend/app/plugins/init-auth.client.ts
+++ b/frontend/app/plugins/init-auth.client.ts
@@ -1,9 +1,10 @@
 export default defineNuxtPlugin({
   async setup() {
     const auth = useAuthBackend();
+    const { $appInfo } = useNuxtApp();
 
     console.debug("Initializing auth plugin");
-    await auth.getSession();
+    await auth.getSession({ allowProxyAuthProbe: Boolean($appInfo.enableProxyAuth) });
     console.debug("Auth plugin initialized");
   },
 });

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -174,7 +174,7 @@ def main():
         use_colors=True,
         log_config=None,
         workers=1,
-        forwarded_allow_ips="*",
+        forwarded_allow_ips=settings.TRUSTED_PROXY,
         ws="websockets-sansio",
     )
 

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -88,6 +88,8 @@ async def lifespan_fn(_: FastAPI) -> AsyncGenerator[None, None]:
     logger.info(settings.LDAP_FEATURE)
     logger.info("--------==OIDC==--------")
     logger.info(settings.OIDC_FEATURE)
+    logger.info("-----==PROXY AUTH==-----")
+    logger.info(settings.PROXY_AUTH_FEATURE)
     logger.info("------------------------")
 
     yield

--- a/mealie/core/dependencies/dependencies.py
+++ b/mealie/core/dependencies/dependencies.py
@@ -19,11 +19,9 @@ from mealie.repos.all_repositories import get_repositories
 from mealie.schema.user import PrivateUser, TokenData
 from mealie.schema.user.user import DEFAULT_INTEGRATION_ID, GroupInDB
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
 oauth2_scheme_soft_fail = OAuth2PasswordBearer(tokenUrl="/api/auth/token", auto_error=False)
 ALGORITHM = "HS256"
 app_dirs = get_app_dirs()
-settings = get_app_settings()
 logger = root_logger.get_logger("dependencies")
 
 credentials_exception = HTTPException(
@@ -31,6 +29,45 @@ credentials_exception = HTTPException(
     detail="Could not validate credentials",
     headers={"WWW-Authenticate": "Bearer"},
 )
+
+
+def _get_proxy_auth_username(request: Request) -> str | None:
+    settings = get_app_settings()
+    header_name = settings.PROXY_AUTH_HEADER
+    header_value = request.headers.get(header_name)
+    if header_value is None:
+        logger.debug("[ProxyAuth] missing configured header '%s'", header_name)
+        return None
+
+    username = header_value.strip()
+    if not username:
+        logger.debug("[ProxyAuth] configured header '%s' was empty after trimming", header_name)
+        return None
+
+    return username
+
+
+def _try_proxy_auth_user(request: Request, session: Session) -> PrivateUser | None:
+    settings = get_app_settings()
+    if not settings.PROXY_AUTH_READY:
+        return None
+
+    username = _get_proxy_auth_username(request)
+    if not username:
+        return None
+
+    repos = get_repositories(session, group_id=None, household_id=None)
+    user = repos.users.get_one(username, "username", any_case=True)
+    if user is None:
+        user = repos.users.get_one(username, "email", any_case=True)
+
+    if user is None:
+        logger.debug("[ProxyAuth] no existing user found for header value '%s'", username)
+        return None
+
+    logger.debug("[ProxyAuth] successfully authenticated existing user '%s' via proxy header", user.username)
+    session.commit()
+    return user
 
 
 async def is_logged_in(token: str = Depends(oauth2_scheme_soft_fail), session=Depends(generate_session)) -> bool:
@@ -47,6 +84,7 @@ async def is_logged_in(token: str = Depends(oauth2_scheme_soft_fail), session=De
         bool: True = Valid User / False = Not User
     """
     try:
+        settings = get_app_settings()
         payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         user_id: str = payload.get("sub")
         long_token: str = payload.get("long_token")
@@ -90,41 +128,52 @@ async def get_current_user(
     token: str | None = Depends(oauth2_scheme_soft_fail),
     session=Depends(generate_session),
 ) -> PrivateUser:
-    if token is None and "mealie.access_token" in request.cookies:
+    settings = get_app_settings()
+    provided_token = token
+    if provided_token is None and "mealie.access_token" in request.cookies:
         # Try extract from cookie
-        token = request.cookies.get("mealie.access_token", "")
-    else:
-        token = token or ""
+        provided_token = request.cookies.get("mealie.access_token", "")
 
-    try:
-        payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
-        user_id: str | None = payload.get("sub")
-        long_token: str | None = payload.get("long_token")
+    token_value = (provided_token or "").strip()
+    if token_value:
+        try:
+            payload = jwt.decode(token_value, settings.SECRET, algorithms=[ALGORITHM])
+            user_id: str | None = payload.get("sub")
+            long_token: str | None = payload.get("long_token")
 
-        if long_token is not None:
-            return validate_long_live_token(session, token, payload.get("id"))
+            if long_token is not None:
+                return validate_long_live_token(session, token_value, payload.get("id"))
 
-        if user_id is None:
+            if user_id is None:
+                raise credentials_exception
+
+            token_data = TokenData(user_id=user_id)
+        except PyJWTError as e:
+            raise credentials_exception from e
+
+        repos = get_repositories(session, group_id=None, household_id=None)
+
+        user = repos.users.get_one(token_data.user_id, "id", any_case=False)
+
+        # If we don't commit here, lazy-loads from user relationships will leave some table lock in postgres
+        # which can cause quite a bit of pain further down the line
+        session.commit()
+        if user is None:
             raise credentials_exception
+        return user
 
-        token_data = TokenData(user_id=user_id)
-    except PyJWTError as e:
-        raise credentials_exception from e
+    if proxy_user := _try_proxy_auth_user(request, session):
+        return proxy_user
 
-    repos = get_repositories(session, group_id=None, household_id=None)
-
-    user = repos.users.get_one(token_data.user_id, "id", any_case=False)
-
-    # If we don't commit here, lazy-loads from user relationships will leave some table lock in postgres
-    # which can cause quite a bit of pain further down the line
-    session.commit()
-    if user is None:
-        raise credentials_exception
-    return user
+    raise credentials_exception
 
 
-async def get_integration_id(token: str = Depends(oauth2_scheme)) -> str:
+async def get_integration_id(token: str | None = Depends(oauth2_scheme_soft_fail)) -> str:
+    if not token:
+        return DEFAULT_INTEGRATION_ID
+
     try:
+        settings = get_app_settings()
         decoded_token = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         return decoded_token.get("integration_id", DEFAULT_INTEGRATION_ID)
 
@@ -162,6 +211,7 @@ def validate_file_token(token: str | None = None) -> Path:
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
 
     try:
+        settings = get_app_settings()
         payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         file_path = Path(payload.get("file"))
     except PyJWTError as e:

--- a/mealie/core/dependencies/dependencies.py
+++ b/mealie/core/dependencies/dependencies.py
@@ -22,6 +22,7 @@ from mealie.schema.user.user import DEFAULT_INTEGRATION_ID, GroupInDB
 oauth2_scheme_soft_fail = OAuth2PasswordBearer(tokenUrl="/api/auth/token", auto_error=False)
 ALGORITHM = "HS256"
 app_dirs = get_app_dirs()
+settings = get_app_settings()
 logger = root_logger.get_logger("dependencies")
 
 credentials_exception = HTTPException(
@@ -32,7 +33,6 @@ credentials_exception = HTTPException(
 
 
 def _get_proxy_auth_username(request: Request) -> str | None:
-    settings = get_app_settings()
     header_name = settings.PROXY_AUTH_HEADER
     header_value = request.headers.get(header_name)
     if header_value is None:
@@ -48,7 +48,6 @@ def _get_proxy_auth_username(request: Request) -> str | None:
 
 
 def _try_proxy_auth_user(request: Request, session: Session) -> PrivateUser | None:
-    settings = get_app_settings()
     if not settings.PROXY_AUTH_READY:
         return None
 
@@ -84,7 +83,6 @@ async def is_logged_in(token: str = Depends(oauth2_scheme_soft_fail), session=De
         bool: True = Valid User / False = Not User
     """
     try:
-        settings = get_app_settings()
         payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         user_id: str = payload.get("sub")
         long_token: str = payload.get("long_token")
@@ -128,44 +126,41 @@ async def get_current_user(
     token: str | None = Depends(oauth2_scheme_soft_fail),
     session=Depends(generate_session),
 ) -> PrivateUser:
-    settings = get_app_settings()
-    provided_token = token
-    if provided_token is None and "mealie.access_token" in request.cookies:
+    if token is None and "mealie.access_token" in request.cookies:
         # Try extract from cookie
-        provided_token = request.cookies.get("mealie.access_token", "")
+        token = request.cookies.get("mealie.access_token", "")
+    else:
+        token = token or ""
+    if not token:
+        if proxy_user := _try_proxy_auth_user(request, session):
+            return proxy_user
+        raise credentials_exception
 
-    token_value = (provided_token or "").strip()
-    if token_value:
-        try:
-            payload = jwt.decode(token_value, settings.SECRET, algorithms=[ALGORITHM])
-            user_id: str | None = payload.get("sub")
-            long_token: str | None = payload.get("long_token")
+    try:
+        payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
+        user_id: str | None = payload.get("sub")
+        long_token: str | None = payload.get("long_token")
 
-            if long_token is not None:
-                return validate_long_live_token(session, token_value, payload.get("id"))
+        if long_token is not None:
+            return validate_long_live_token(session, token, payload.get("id"))
 
-            if user_id is None:
-                raise credentials_exception
-
-            token_data = TokenData(user_id=user_id)
-        except PyJWTError as e:
-            raise credentials_exception from e
-
-        repos = get_repositories(session, group_id=None, household_id=None)
-
-        user = repos.users.get_one(token_data.user_id, "id", any_case=False)
-
-        # If we don't commit here, lazy-loads from user relationships will leave some table lock in postgres
-        # which can cause quite a bit of pain further down the line
-        session.commit()
-        if user is None:
+        if user_id is None:
             raise credentials_exception
-        return user
 
-    if proxy_user := _try_proxy_auth_user(request, session):
-        return proxy_user
+        token_data = TokenData(user_id=user_id)
+    except PyJWTError as e:
+        raise credentials_exception from e
 
-    raise credentials_exception
+    repos = get_repositories(session, group_id=None, household_id=None)
+
+    user = repos.users.get_one(token_data.user_id, "id", any_case=False)
+
+    # If we don't commit here, lazy-loads from user relationships will leave some table lock in postgres
+    # which can cause quite a bit of pain further down the line
+    session.commit()
+    if user is None:
+        raise credentials_exception
+    return user
 
 
 async def get_integration_id(token: str | None = Depends(oauth2_scheme_soft_fail)) -> str:
@@ -173,7 +168,6 @@ async def get_integration_id(token: str | None = Depends(oauth2_scheme_soft_fail
         return DEFAULT_INTEGRATION_ID
 
     try:
-        settings = get_app_settings()
         decoded_token = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         return decoded_token.get("integration_id", DEFAULT_INTEGRATION_ID)
 
@@ -211,7 +205,6 @@ def validate_file_token(token: str | None = None) -> Path:
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
 
     try:
-        settings = get_app_settings()
         payload = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         file_path = Path(payload.get("file"))
     except PyJWTError as e:

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -8,7 +8,7 @@ from typing import Annotated, Literal, NamedTuple
 from urllib.parse import urlparse
 
 from dateutil.tz import tzlocal
-from pydantic import PlainSerializer, field_validator
+from pydantic import AliasChoices, Field, PlainSerializer, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from mealie.core.settings.themes import Theme
@@ -152,7 +152,7 @@ class AppSettings(AppLoggingSettings):
 
     IS_DEMO: bool = False
 
-    HOST_IP: str = "*"
+    TRUSTED_PROXY: str = Field(default="*", validation_alias=AliasChoices("TRUSTED_PROXY", "HOST_IP"))
 
     API_HOST: str = "0.0.0.0"
     API_PORT: int = 9000

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -3,6 +3,7 @@ import os
 import secrets
 from datetime import UTC, datetime
 from enum import StrEnum
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Annotated, Literal, NamedTuple
 from urllib.parse import urlparse
@@ -430,6 +431,51 @@ class AppSettings(AppLoggingSettings):
     def OIDC_READY(self) -> bool:
         """Validates OIDC settings are all set"""
         return self.OIDC_FEATURE.enabled
+
+    # ===============================================
+    # Proxy Header Authentication Configuration
+
+    PROXY_AUTH_ENABLED: bool = False
+    PROXY_AUTH_HEADER: str = "Remote-User"
+
+    @property
+    def PROXY_AUTH_FEATURE(self) -> FeatureDetails:
+        description = None if self.PROXY_AUTH_ENABLED else "PROXY_AUTH_ENABLED is false"
+
+        header = self.PROXY_AUTH_HEADER if self.PROXY_AUTH_HEADER else ""
+        trusted_proxy = self.TRUSTED_PROXY.strip() if self.TRUSTED_PROXY else ""
+        required = {
+            "PROXY_AUTH_HEADER": header,
+            "TRUSTED_PROXY": trusted_proxy,
+        }
+        not_none = "" not in required.values() and None not in required.values()
+        valid_trusted_proxy = True
+
+        if trusted_proxy == "*":
+            valid_trusted_proxy = False
+            if not description:
+                description = "TRUSTED_PROXY cannot be '*' when PROXY_AUTH_ENABLED is true"
+        elif trusted_proxy and not (self.TESTING and trusted_proxy == "testclient"):
+            try:
+                ip_address(trusted_proxy)
+            except ValueError:
+                valid_trusted_proxy = False
+                if not description:
+                    description = "TRUSTED_PROXY must be a single IP address when PROXY_AUTH_ENABLED is true"
+
+        if not not_none and not description:
+            missing_values = [key for (key, value) in required.items() if value is None or value == ""]
+            description = f"Missing required values for {missing_values}"
+
+        return FeatureDetails(
+            enabled=self.PROXY_AUTH_ENABLED and not_none and valid_trusted_proxy,
+            description=description,
+        )
+
+    @property
+    def PROXY_AUTH_READY(self) -> bool:
+        """Validates proxy auth settings are all set."""
+        return self.PROXY_AUTH_FEATURE.enabled
 
     # ===============================================
     # OpenAI Configuration

--- a/mealie/main.py
+++ b/mealie/main.py
@@ -12,7 +12,7 @@ def main():
         log_level=settings.LOG_LEVEL.lower(),
         log_config=log_config(),
         workers=settings.WORKERS,
-        forwarded_allow_ips=settings.HOST_IP,
+        forwarded_allow_ips=settings.TRUSTED_PROXY,
         ssl_keyfile=settings.TLS_PRIVATE_KEY_PATH,
         ssl_certfile=settings.TLS_CERTIFICATE_PATH,
         ws="websockets-sansio",

--- a/mealie/routes/admin/admin_about.py
+++ b/mealie/routes/admin/admin_about.py
@@ -34,6 +34,7 @@ class AdminAboutController(BaseAdminController):
             build_id=settings.GIT_COMMIT_HASH,
             recipe_scraper_version=recipe_scraper_version.__version__,
             enable_oidc=settings.OIDC_AUTH_ENABLED,
+            enable_proxy_auth=settings.PROXY_AUTH_READY,
             oidc_redirect=settings.OIDC_AUTO_REDIRECT,
             oidc_provider_name=settings.OIDC_PROVIDER_NAME,
         )

--- a/mealie/routes/admin/admin_about.py
+++ b/mealie/routes/admin/admin_about.py
@@ -57,6 +57,7 @@ class AdminAboutController(BaseAdminController):
         return CheckAppConfig(
             email_ready=settings.SMTP_ENABLE,
             ldap_ready=settings.LDAP_ENABLED,
+            proxy_auth_ready=settings.PROXY_AUTH_READY,
             base_url_set=settings.BASE_URL != "http://localhost:8080",
             is_up_to_date=APP_VERSION == "develop" or APP_VERSION == "nightly" or get_latest_version() == APP_VERSION,
             oidc_ready=settings.OIDC_READY,

--- a/mealie/routes/app/app_about.py
+++ b/mealie/routes/app/app_about.py
@@ -39,6 +39,7 @@ def get_app_info(session: Session = Depends(generate_session)):
         default_group_slug=default_group_slug,
         default_household_slug=default_household_slug,
         enable_oidc=settings.OIDC_READY,
+        enable_proxy_auth=settings.PROXY_AUTH_READY,
         oidc_redirect=settings.OIDC_AUTO_REDIRECT,
         oidc_provider_name=settings.OIDC_PROVIDER_NAME,
         allow_password_login=settings.ALLOW_PASSWORD_LOGIN,

--- a/mealie/schema/admin/about.py
+++ b/mealie/schema/admin/about.py
@@ -19,6 +19,7 @@ class AppInfo(MealieModel):
     default_group_slug: str | None = None
     default_household_slug: str | None = None
     enable_oidc: bool
+    enable_proxy_auth: bool
     oidc_redirect: bool
     oidc_provider_name: str
     token_time: int

--- a/mealie/schema/admin/about.py
+++ b/mealie/schema/admin/about.py
@@ -71,5 +71,6 @@ class CheckAppConfig(MealieModel):
     email_ready: bool
     ldap_ready: bool
     oidc_ready: bool
+    proxy_auth_ready: bool
     base_url_set: bool
     is_up_to_date: bool

--- a/tests/integration_tests/admin_tests/test_admin_about.py
+++ b/tests/integration_tests/admin_tests/test_admin_about.py
@@ -26,6 +26,7 @@ def test_public_about_get_app_info(
     assert as_dict["version"] == APP_VERSION
     assert as_dict["demoStatus"] == settings.IS_DEMO
     assert as_dict["allowSignup"] == settings.ALLOW_SIGNUP
+    assert as_dict["enableProxyAuth"] == settings.PROXY_AUTH_READY
 
     if is_private_group:
         assert as_dict["defaultGroupSlug"] is None
@@ -45,6 +46,7 @@ def test_admin_about_get_app_info(api_client: TestClient, admin_user: TestUser):
     assert as_dict["apiPort"] == settings.API_PORT
     assert as_dict["apiDocs"] == settings.API_DOCS
     assert as_dict["dbType"] == settings.DB_ENGINE
+    assert as_dict["enableProxyAuth"] == settings.PROXY_AUTH_READY
     # assert as_dict["dbUrl"] == settings.DB_URL_PUBLIC
     assert as_dict["defaultGroup"] == settings.DEFAULT_GROUP
 

--- a/tests/integration_tests/admin_tests/test_admin_about.py
+++ b/tests/integration_tests/admin_tests/test_admin_about.py
@@ -72,5 +72,6 @@ def test_admin_about_check_app_config(api_client: TestClient, admin_user: TestUs
     # Smoke Test - Test the endpoint returns something that's a the expected shape
     assert as_dict["emailReady"] in [True, False]
     assert as_dict["ldapReady"] in [True, False]
+    assert as_dict["proxyAuthReady"] in [True, False]
     assert as_dict["baseUrlSet"] in [True, False]
     assert as_dict["isUpToDate"] in [True, False]

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -3,11 +3,17 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
+from mealie.core.dependencies import dependencies
 from mealie.core.config import get_app_settings
 from mealie.services.user_services.user_service import UserService
 from tests.utils import api_routes
 from tests.utils.factories import random_string
 from tests.utils.fixture_schemas import TestUser
+
+
+def _refresh_dependency_settings() -> None:
+    get_app_settings.cache_clear()
+    dependencies.settings = get_app_settings()
 
 
 def test_failed_login(api_client: TestClient):
@@ -43,25 +49,25 @@ def test_proxy_header_auth_existing_user(
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
     assert response.status_code == 200
     assert response.json()["username"] == unique_user.username
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_proxy_header_auth_user_not_found(api_client: TestClient, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(api_routes.users_self, headers={"Remote-User": random_string()})
     assert response.status_code == 401
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_proxy_header_auth_disabled_does_not_authenticate(
@@ -70,12 +76,12 @@ def test_proxy_header_auth_disabled_does_not_authenticate(
     monkeypatch.delenv("PROXY_AUTH_ENABLED", raising=False)
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
     assert response.status_code == 401
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_proxy_header_auth_rejects_wildcard_trusted_proxy(
@@ -85,12 +91,12 @@ def test_proxy_header_auth_rejects_wildcard_trusted_proxy(
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     # Unsafe wildcard should disable proxy auth readiness and fail closed.
     monkeypatch.setenv("TRUSTED_PROXY", "*")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
     assert response.status_code == 401
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_invalid_token_does_not_fall_back_to_proxy_auth(
@@ -99,7 +105,7 @@ def test_invalid_token_does_not_fall_back_to_proxy_auth(
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(
         api_routes.users_self,
@@ -110,7 +116,7 @@ def test_invalid_token_does_not_fall_back_to_proxy_auth(
     )
     assert response.status_code == 401
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_valid_token_takes_precedence_over_proxy_header(
@@ -119,7 +125,7 @@ def test_valid_token_takes_precedence_over_proxy_header(
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
     monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(
         api_routes.users_self,
@@ -131,7 +137,7 @@ def test_valid_token_takes_precedence_over_proxy_header(
     assert response.status_code == 200
     assert response.json()["username"] == admin_user.username
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 def test_proxy_header_auth_custom_header_existing_user(
@@ -140,13 +146,13 @@ def test_proxy_header_auth_custom_header_existing_user(
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
     monkeypatch.setenv("PROXY_AUTH_HEADER", "X-Forwarded-User")
     monkeypatch.setenv("TRUSTED_PROXY", "testclient")
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
     response = api_client.get(api_routes.users_self, headers={"X-Forwarded-User": unique_user.username})
     assert response.status_code == 200
     assert response.json()["username"] == unique_user.username
 
-    get_app_settings.cache_clear()
+    _refresh_dependency_settings()
 
 
 @pytest.mark.parametrize("use_token", [True, False], ids=["with token", "without token"])

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -64,6 +64,20 @@ def test_proxy_header_auth_user_not_found(api_client: TestClient, monkeypatch: p
     get_app_settings.cache_clear()
 
 
+def test_proxy_header_auth_disabled_does_not_authenticate(
+    api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("PROXY_AUTH_ENABLED", raising=False)
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
+    assert response.status_code == 401
+
+    get_app_settings.cache_clear()
+
+
 def test_proxy_header_auth_rejects_wildcard_trusted_proxy(
     api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
 ):
@@ -95,6 +109,42 @@ def test_invalid_token_does_not_fall_back_to_proxy_auth(
         },
     )
     assert response.status_code == 401
+
+    get_app_settings.cache_clear()
+
+
+def test_valid_token_takes_precedence_over_proxy_header(
+    api_client: TestClient, unique_user: TestUser, admin_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(
+        api_routes.users_self,
+        headers={
+            **admin_user.token,
+            "Remote-User": unique_user.username,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["username"] == admin_user.username
+
+    get_app_settings.cache_clear()
+
+
+def test_proxy_header_auth_custom_header_existing_user(
+    api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "X-Forwarded-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(api_routes.users_self, headers={"X-Forwarded-User": unique_user.username})
+    assert response.status_code == 200
+    assert response.json()["username"] == unique_user.username
 
     get_app_settings.cache_clear()
 

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -37,6 +37,53 @@ def test_user_token_refresh(api_client: TestClient, admin_user: TestUser):
     assert response.status_code == 200
 
 
+def test_proxy_header_auth_existing_user(
+    api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
+    assert response.status_code == 200
+    assert response.json()["username"] == unique_user.username
+
+    get_app_settings.cache_clear()
+
+
+def test_proxy_header_auth_user_not_found(api_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(api_routes.users_self, headers={"Remote-User": random_string()})
+    assert response.status_code == 401
+
+    get_app_settings.cache_clear()
+
+
+def test_invalid_token_does_not_fall_back_to_proxy_auth(
+    api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    monkeypatch.setenv("TRUSTED_PROXY", "testclient")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(
+        api_routes.users_self,
+        headers={
+            "Authorization": f"Bearer {random_string()}",
+            "Remote-User": unique_user.username,
+        },
+    )
+    assert response.status_code == 401
+
+    get_app_settings.cache_clear()
+
+
 @pytest.mark.parametrize("use_token", [True, False], ids=["with token", "without token"])
 def test_get_logged_in_user_invalid_token(api_client: TestClient, use_token: bool):
     headers = {"Authorization": f"Bearer {random_string()}"} if use_token else {}

--- a/tests/integration_tests/user_tests/test_user_login.py
+++ b/tests/integration_tests/user_tests/test_user_login.py
@@ -64,6 +64,21 @@ def test_proxy_header_auth_user_not_found(api_client: TestClient, monkeypatch: p
     get_app_settings.cache_clear()
 
 
+def test_proxy_header_auth_rejects_wildcard_trusted_proxy(
+    api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PROXY_AUTH_HEADER", "Remote-User")
+    # Unsafe wildcard should disable proxy auth readiness and fail closed.
+    monkeypatch.setenv("TRUSTED_PROXY", "*")
+    get_app_settings.cache_clear()
+
+    response = api_client.get(api_routes.users_self, headers={"Remote-User": unique_user.username})
+    assert response.status_code == 401
+
+    get_app_settings.cache_clear()
+
+
 def test_invalid_token_does_not_fall_back_to_proxy_auth(
     api_client: TestClient, unique_user: TestUser, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -376,6 +376,74 @@ def test_oidc_settings_validation(data: OIDCValidationCase, monkeypatch: pytest.
     assert app_settings.OIDC_READY is data.is_valid
 
 
+class ProxyAuthValidationCase:
+    settings: list[EnvVar]
+    is_valid: bool
+
+    def __init__(
+        self,
+        enabled: bool,
+        header: str | None,
+        trusted_proxy: str | None,
+        is_valid: bool,
+        use_host_ip_alias: bool = False,
+    ):
+        trusted_proxy_var = "HOST_IP" if use_host_ip_alias else "TRUSTED_PROXY"
+        self.settings = [
+            EnvVar("PROXY_AUTH_ENABLED", enabled),
+            EnvVar("PROXY_AUTH_HEADER", header),
+            EnvVar(trusted_proxy_var, trusted_proxy),
+        ]
+        if use_host_ip_alias:
+            self.settings.append(EnvVar("TRUSTED_PROXY", None))
+        self.is_valid = is_valid
+
+
+proxy_auth_validation_cases = [
+    (
+        "not enabled",
+        ProxyAuthValidationCase(False, None, None, False),
+    ),
+    (
+        "missing header",
+        ProxyAuthValidationCase(True, "", "127.0.0.1", False),
+    ),
+    (
+        "missing trusted proxy ip",
+        ProxyAuthValidationCase(True, "Remote-User", None, False),
+    ),
+    (
+        "all good",
+        ProxyAuthValidationCase(True, "Remote-User", "127.0.0.1", True),
+    ),
+    (
+        "all good with HOST_IP alias",
+        ProxyAuthValidationCase(True, "Remote-User", "127.0.0.1", True, use_host_ip_alias=True),
+    ),
+    (
+        "wildcard trusted proxy rejected",
+        ProxyAuthValidationCase(True, "Remote-User", "*", False),
+    ),
+]
+
+proxy_auth_cases = [x[1] for x in proxy_auth_validation_cases]
+proxy_auth_cases_ids = [x[0] for x in proxy_auth_validation_cases]
+
+
+@pytest.mark.parametrize("data", proxy_auth_cases, ids=proxy_auth_cases_ids)
+def test_proxy_auth_settings_validation(data: ProxyAuthValidationCase, monkeypatch: pytest.MonkeyPatch):
+    for setting in data.settings:
+        if setting.value is not None:
+            monkeypatch.setenv(setting.name, setting.value)
+        else:
+            monkeypatch.delenv(setting.name, raising=False)
+
+    get_app_settings.cache_clear()
+    app_settings = get_app_settings()
+
+    assert app_settings.PROXY_AUTH_READY is data.is_valid
+
+
 def test_sensitive_settings_mask(monkeypatch: pytest.MonkeyPatch):
     sensitive_settings = [
         "LDAP_QUERY_PASSWORD",


### PR DESCRIPTION
## What this PR does / why we need it:
Adds single sign-on using a trusted header added by a reverse proxy (e.g. haproxy) and an auth gateway (e.g. Authelia).  For brevity, this will be referred to as "Proxy Authentication"/"proxy auth" in this PR.

Explicitly designed not to interfere with existing auth tokens, or other authentication methods.

### Key changes:
- `mealie/core/settings/settings.py` + `docker/entry.sh`: renames legacy `HOST_IP` to `TRUSTED_PROXY`, to clarify the intended use of this env var.
- `mealie/core/settings/settings.py`: adds `PROXY_AUTH_ENABLED` and `PROXY_AUTH_HEADER`; validates `TRUSTED_PROXY` is not "`*`"
- `mealie/core/dependencies/dependencies.py`: adds proxy auth in `get_current_user()` only when no token is present; token takes priority (valid token wins, invalid token stays 401); updates `get_integration_id` to support proxy auth.
- `mealie/routes/app/about.py`: exposes proxy auth readiness to the frontend, similar to OIDC
- `mealie/routes/admin/admin_about.py` + schema/frontend types: exposes proxy auth readiness for use on admin page
- frontend/app/plugins/init-auth.client.ts: checks whether proxy auth is enabled (from /api/app/about) before making the automatic /api/users/self request
- Documentation: adds backend config docs for proxy auth (`PROXY_AUTH_ENABLED`, `PROXY_AUTH_HEADER`, `TRUSTED_PROXY` behavior), clarifies auth precedence, and adds a dedicated proxy auth setup page with an Authelia example.

### Design choices:
- The existing OIDC auth was largely used as the "reference implementation" to guide design choices
- Zero-click SSO with minimal front-end changes (no login-page auto-submit or UI coupling).
- No change to existing bearer-token behavior.
- Trusted header authentication is disabled if `TRUSTED_PROXY` is "`*`"
- No auto-signup (unlike OIDC).  User must already exist in Mealie.

### Comparison to PR #6780
PR #6780 centered proxy auth around the /auth/token flow.  This PR differs by:
- enabling only when `TRUSTED_PROXY` (formerly `HOST_IP`) is not set to "`*`" for safety against accidental misconfiguration
- keeping login UI form unchanged - and checking whether trusted header auth is enabled
- authenticating per request (in `get_current_user()`) rather than at token issuance (i.e. not in `/api/auth/token`)

## Which issue(s) this PR fixes:
Fixes #2607
Fixes #801

## Special notes for your reviewer:
- Security-critical paths to focus on:
    - Verify blast radius of renaming `HOST_IP` to `TRUSTED_PROXY` is acceptable (though a fallback alias is supplied)
    - PROXY_AUTH_READY gated enablement by checking only for "`*`" is acceptable
    - get_current_user precedence is correct (token vs proxy header).
    - Failure logic is correct when proxy auth is enabled, but missing/empty header/unknown user is supplied

## Testing
Integration tests written for success, disabled state, missing/unknown user, header customization, wildcard in proxy, precedence behavior, and admin/app-about config exposure.

Unit/integration:
- tests/integration_tests/user_tests/test_user_login.py
- tests/integration_tests/admin_tests/test_admin_about.py

Manual validation (1 week in deployment):
- Reverse proxy injects configured header from trusted proxy
- Existing user is automatically authenticated
- Missing header / unknown user returns 401 (as expected)
- TRUSTED_PROXY="*" disables proxy auth (fail-closed)
- Token auth continues to work unchanged
- OIDC/LDAP-disabled environment remains stable

Container/runtime:
- Built and ran Docker image with proxy auth enabled and verified behaviour
- Tested in my Production instance for 1 week without issues

## AI / LLM Assistance
LLM assistance was used to become familiar with the codebase, assess the blast radius of renaming `HOST_IP` to `TRUSTED_PROXY`, draft code based on the OIDC integration, inspect the code for security issues, and to draft this PR.

All code, changes, and this PR were manually reviewed, and heavily edited by me before submission.