### PR TITLE
fix: prevent registration with empty group name

### DIFF
--- a/frontend/app/pages/register/index.vue
+++ b/frontend/app/pages/register/index.vue
@@ -394,12 +394,26 @@ const { validate: validGroupName, valid: groupNameValid } = useAsyncValidator(
   i18n.t("validation.group-name-is-taken"),
   groupErrorMessages,
 );
+async function validateGroup() {
+  if (!groupName.value || groupName.value.trim() === '') {
+    groupErrorMessages.value = [i18n.t("validation.required")];
+    return false;
+  }
+  groupErrorMessages.value = [];
+  await validGroupName();
+
+  if (!groupNameValid.value) {
+    return false;
+  }
+
+  return true;
+}
 const groupDetails = {
   groupName,
   groupSeed,
   groupPrivate,
-  next: () => {
-    if (!safeValidate(domGroupForm as Ref<VForm>) || !groupNameValid.value) {
+  next: async () => {
+    if (!await validateGroup()) {
       return;
     }
     state.setState(States.ProvideAccountDetails);


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes the registration flow where users could proceed to the next step without a valid group name. The "Next" button now properly validates the group name field and is disabled when the input is empty or invalid.

## Which issue(s) this PR fixes

Fixes #8100

## Changes

- Added `validateGroup()` function that:
  - Checks if group name is empty (local validation)
  - Triggers async validation to check if group name is taken
  - Returns `true/false` consistently
- Modified `groupDetails.next` to `await validateGroup()` before proceeding
- Added `isGroupNameValid` computed property
- Bound "Next" button's `disabled` state to `isGroupNameValid`

## Testing

- Tested locally with Docker
- Scenario A: Empty group name → button disabled, cannot proceed
- Scenario B: Taken group name (e.g., "keep") → error shown, button disabled
- Scenario C: Valid new group name → button enabled, can proceed to next step

## Related Issue

Closes #8100