### PR TITLE
fix: reset ingredient parser dialog state when reopening

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageParseDialog.vue
@@ -361,10 +361,26 @@ function nextIngredient() {
   state.allReviewed = true;
 }
 
+/** Clear everything left over from a previous run, so re-opening the dialog starts clean */
+function resetParserState() {
+  parsedIngs.value = [];
+  currentIng.value = null;
+  currentMissingUnit.value = "";
+  currentMissingFood.value = "";
+  currentIngShouldDelete.value = false;
+  state.currentParsedIndex = -1;
+  state.allReviewed = false;
+  state.loading.save = false;
+  createdUnits.clear();
+  createdFoods.clear();
+}
+
 async function parseIngredients() {
   if (state.loading.parser) {
     return;
   }
+
+  resetParserState();
 
   if (!props.ingredients || props.ingredients.length === 0) {
     state.loading.parser = false;
@@ -391,11 +407,6 @@ async function parseIngredients() {
       ingredient: ing,
     }));
     parsedIngs.value = [...parsed, ...recipeRefs];
-    state.currentParsedIndex = -1;
-    state.allReviewed = false;
-    createdUnits.clear();
-    createdFoods.clear();
-    currentIngShouldDelete.value = false;
     nextIngredient();
   }
   catch (error) {


### PR DESCRIPTION
## What this PR does / why we need it:

The ingredient parser dialog keeps its state between openings, which leaves it unusable after the first parse.

- `saveIngs()` sets `state.loading.save = true` and nothing sets it back. The dialog is visibility-controlled (`RecipePage.vue` binds `:model-value="isParsing"`) rather than destroyed, so the flag survives closing, and the Save button renders permanently in its loading state on every later parse — it spins and can't be clicked.
- `parseIngredients()` returned early when the ingredient list was empty, before the block that resets `parsedIngs`, `allReviewed`, `currentParsedIndex` and the food/unit caches. Re-opening with no ingredients therefore rendered the previous session's review list, and since `allReviewed` was still `true` it jumped straight to the review screen.

Extracted the reset into `resetParserState()` and call it unconditionally at the top of `parseIngredients()`, ahead of the early return. The per-run resets inside the `try` block became redundant and were removed.

## Which issue(s) this PR fixes:

Relates to #7645

Deliberately not "Fixes" — #7645 also carries two reports whose trigger I couldn't confirm, so it shouldn't auto-close on merge.

## Special notes for your reviewer:

No test added. There's no precedent in the repo for mounting a component this size — `app/tests/utils.ts` mounts a trivial wrapper for composables — and the bug lives entirely in component-local state. Happy to add one if you'd like to establish that pattern.

## Testing

Manual, on a local dev build and on demo.mealie.io:

1. Recipe in edit mode with a plain-text ingredient (`5g salt`), save
2. Parse → Next → Save — works
3. Without reloading, edit again and delete the ingredient
4. Parse again

Before: the dialog opened on the review screen listing the deleted ingredient, Save already spinning and inert, Cancel unresponsive, no request issued.
After: the dialog opens empty with a working Next; continuing through gives a normal, clickable Save.

`task ui:check` passes (lint + 255 tests).

## AI / LLM Assistance

The code change was written by an LLM (Claude). The reproduction, root-cause analysis and the manual verification above were done and checked by me against `mealie-next` @ dea741ec.
