### PR TITLE
fix: prevent duplicate iOS camera photos from overwriting recipe step assets

### DIFF
--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import AsyncIterable, Awaitable, Callable
 from shutil import copyfileobj
 from typing import Annotated
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import orjson
 import sqlalchemy
@@ -817,7 +817,6 @@ class RecipeController(BaseRecipeController):
             raise HTTPException(status_code=400, detail="Missing required fields")
 
         file_name = f"{file_slug}.{extension}"
-        asset_in = RecipeAsset(name=name, icon=icon, file_name=file_name)
 
         recipe = self.service.get_one(slug)
 
@@ -829,6 +828,14 @@ class RecipeController(BaseRecipeController):
                 status_code=400,
                 detail=f"File name {file_name} or extension {extension} not valid",
             )
+
+        # Client-supplied names aren't guaranteed to be unique (e.g. iOS camera captures are all
+        # named "image.jpg"), so avoid silently overwriting an existing asset with the same name.
+        if dest.is_file():
+            file_name = f"{file_slug}_{uuid4().hex[:8]}.{extension}"
+            dest = recipe.asset_dir / file_name
+
+        asset_in = RecipeAsset(name=name, icon=icon, file_name=file_name)
 
         with dest.open("wb") as buffer:
             copyfileobj(file.file, buffer)

--- a/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py
@@ -42,6 +42,49 @@ def test_recipe_assets_create(api_client: TestClient, unique_user: TestUser, rec
     assert recipe_respons["assets"][0]["name"] == payload["name"]
 
 
+def test_recipe_assets_create_duplicate_name(
+    api_client: TestClient, unique_user: TestUser, recipe_ingredient_only: Recipe
+):
+    """
+    Regression test for https://github.com/mealie-recipes/mealie/issues/5623
+
+    iOS Safari names every camera-captured photo "image.jpg", so uploading multiple assets in a
+    row with an identical client-supplied name must not silently overwrite the previous asset.
+    """
+    recipe = recipe_ingredient_only
+    payload = {
+        "name": "image",
+        "icon": random_string(10),
+        "extension": "jpg",
+    }
+
+    first_response = api_client.post(
+        f"/api/recipes/{recipe.slug}/assets",
+        data=payload,
+        files={"file": data.images_test_image_1.read_bytes()},
+        headers=unique_user.token,
+    )
+    assert first_response.status_code == 200
+    first_file_name = first_response.json()["fileName"]
+
+    second_response = api_client.post(
+        f"/api/recipes/{recipe.slug}/assets",
+        data=payload,
+        files={"file": data.images_test_image_1.read_bytes()},
+        headers=unique_user.token,
+    )
+    assert second_response.status_code == 200
+    second_file_name = second_response.json()["fileName"]
+
+    assert first_file_name != second_file_name
+    assert (recipe.asset_dir / first_file_name).exists()
+    assert (recipe.asset_dir / second_file_name).exists()
+
+    response = api_client.get(f"/api/recipes/{recipe.slug}", headers=unique_user.token)
+    assets = response.json()["assets"]
+    assert len(assets) == 2
+
+
 def test_recipe_asset_exploit(api_client: TestClient, unique_user: TestUser, recipe_ingredient_only: Recipe):
     """
     Test to ensure that users are unable to circumvent the destination directory when uploading a file


### PR DESCRIPTION
## What this PR does / why we need it:

When taking multiple photos with the in-app camera (e.g. on iOS) to insert into a recipe step,
only the first photo was ever kept — every subsequent photo's embedded image link pointed to the
same file as the first one.

Root cause: iOS Safari always names camera-captured files `image.jpg`, regardless of how many
photos are taken in a session (photos picked from the library instead keep a unique filename,
which is why that path worked fine). The `/api/recipes/{slug}/assets` upload endpoint derives the
on-disk filename deterministically from the client-supplied `name` via `slugify()`, with no
uniqueness check, and opens the destination file with `"wb"` — so a second upload with the same
name silently overwrote the first file on disk while also inserting a duplicate `RecipeAsset`
record pointing at the same URL.

- `mealie/routes/recipe/recipe_crud_routes.py`: in `upload_recipe_asset`, check whether the
  destination file already exists before writing; if so, append a short random suffix (uuid4 hex)
  to the filename so the new asset gets a unique path instead of overwriting the previous one.
- `tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py`: added
  `test_recipe_assets_create_duplicate_name`, a regression test that uploads two assets with the
  same `name` (mirroring the iOS `image.jpg` scenario) and asserts both files are kept, with
  distinct filenames, and both appear on the recipe.

This is a server-side fix, so it protects against filename collisions from any client, not just
the iOS camera capture flow.

## Which issue(s) this PR fixes:

Fixes #5623

## Special notes for your reviewer:

The fix only touches the collision-handling branch inside `upload_recipe_asset`; the happy path
(unique names) is unchanged, so the existing `test_recipe_assets_create` test still passes as-is.

## Testing

Added a new integration test (`test_recipe_assets_create_duplicate_name`) that uploads two assets
with an identical `name` and verifies:
- both HTTP requests succeed
- the two assets get different `fileName`s
- both files exist on disk
- the recipe ends up with 2 asset records (not 1 overwritten one)

Ran the full asset test file locally: `uv run pytest tests/integration_tests/user_recipe_tests/test_recipe_image_assets.py -v` — all 6 tests pass.

## AI / LLM Assistance

Claude Code (Anthropic) was used to investigate the root cause (tracing the upload flow from the
iOS camera capture in the frontend through to the backend asset-upload endpoint), implement the
fix, and write the regression test. The diagnosis and fix were reviewed and verified by me before
committing.
