### PR TITLE
fix: prevent meal planner recipe card menu from being clipped in narrow columns

### DIFF
--- a/frontend/app/pages/household/mealplan/planner/view.vue
+++ b/frontend/app/pages/household/mealplan/planner/view.vue
@@ -138,3 +138,15 @@ const isToday = (date: Date) => {
   return isSameDay(date, new Date());
 };
 </script>
+
+<style scoped>
+/*
+  RecipeCardMobile lays out a fixed-width thumbnail + a favorite/rating/menu action row
+  side-by-side. Below ~320px the action row no longer fits and the "..." menu button gets
+  clipped by the card's overflow:hidden. Enforcing a min-width here makes the day columns
+  wrap to fewer per row instead of shrinking past that point.
+*/
+.col-borders {
+  min-width: 340px;
+}
+</style>


### PR DESCRIPTION
## What this PR does / why we need it:

- The action row (favorite button / rating stars / `...` context menu) in `RecipeCardMobile.vue`
  needs ~171px of horizontal space to render without overlap.
- The Meal Planner's day columns can shrink below ~320px total card width at certain
  2-/3-column breakpoints, and since `v-card` has `overflow: hidden`, the part of the
  action row that no longer fits (usually the `...` menu button) gets silently clipped
  and becomes unclickable.
- Fix: enforce a `min-width: 340px` on the day columns (`.col-borders` in
  `planner/view.vue`) so they wrap to fewer columns per row instead of shrinking the
  card past the point where the action row overflows.
- This is a different root cause/component from #8027 (fixed by #8028), which was about
  tag chips wrapping vertically on the **recipes grid** (`RecipeCard.vue`). This issue is
  about **horizontal** overflow in the **Meal Planner**'s `RecipeCardMobile.vue`.

## Which issue(s) this PR fixes:

Fixes #8116

## Testing

Verified with browser resizing from 500px to 1920px window width — before the fix, the
`...` menu button overflowed the card by up to 23px and was clipped in 2-/3-column
layouts; after the fix, the button stays fully within the card bounds at every width
tested (columns wrap to fewer-per-row instead of shrinking below 340px).

## AI / LLM Assistance

Used Claude Code to help investigate the root cause (inspecting computed layout/overflow
in the browser), reproduce the bug across viewport widths, and write the CSS fix. I
reviewed and tested the change myself before submitting.