### PR TITLE
fix: await validation before creating admin user

### DIFF
--- a/frontend/app/pages/admin/manage/users/create.vue
+++ b/frontend/app/pages/admin/manage/users/create.vue
@@ -102,9 +102,15 @@ const newUserData = ref({
 });
 
 async function handleSubmit() {
-  if (!refNewUserForm.value?.validate()) return;
+  const { valid } = (await refNewUserForm.value?.validate()) ?? {
+    valid: false,
+  };
 
-  const { response } = await adminApi.users.createOne(newUserData.value as UserIn);
+  if (!valid) return;
+
+  const { response } = await adminApi.users.createOne(
+    newUserData.value as UserIn,
+  );
 
   if (response?.status === 201) {
     router.push("/admin/manage/users");


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes an issue in the Admin User Creation form where the form validation was not awaited before creating a user.

- Updated `frontend/app/pages/admin/manage/users/create.vue`.
- The result of `validate()` is now awaited before continuing with user creation.
- If the required User Group or User Household fields are empty, the form now stops the submission and displays the validation errors.
- A user is only created after the form passes validation.

Previously, the validation call returned a Promise and the request could continue even when the required fields were empty, resulting in a 400 response from the backend.

## Which issue(s) this PR fixes:

Fixes #6838

## Special notes for your reviewer:

The change is limited to the Admin User Creation form and does not modify the backend user creation logic.

## Testing

Tested locally using the Mealie development environment.

- Tried creating a user without selecting a User Group and User Household. The form now prevents submission and shows the required-field validation messages.
- Confirmed that an invalid request is no longer sent to the backend.
- Selected a valid User Group and User Household and confirmed that the user was created successfully.
- Ran `task ui:check` successfully.

## AI / LLM Assistance

AI assistance was used to help investigate the issue, understand the form validation behaviour, and discuss possible approaches to the fix. The proposed change was tested manually in the local Mealie development environment before submission.