### PR TITLE
fix: cascade delete a user's meal plans and shopping lists

### DIFF
--- a/mealie/db/models/users/users.py
+++ b/mealie/db/models/users/users.py
@@ -96,10 +96,10 @@ class User(SqlAlchemyBase, BaseMixins):
     owned_recipes: Mapped[Optional["RecipeModel"]] = orm.relationship(
         "RecipeModel", single_parent=True, foreign_keys=[owned_recipes_id]
     )
-    mealplans: Mapped[Optional["GroupMealPlan"]] = orm.relationship(
+    mealplans: Mapped[list["GroupMealPlan"]] = orm.relationship(
         "GroupMealPlan", order_by="GroupMealPlan.date", **sp_args
     )
-    shopping_lists: Mapped[Optional["ShoppingList"]] = orm.relationship("ShoppingList", **sp_args)
+    shopping_lists: Mapped[list["ShoppingList"]] = orm.relationship("ShoppingList", **sp_args)
     rated_recipes: Mapped[list["RecipeModel"]] = orm.relationship(
         "RecipeModel",
         secondary=UserToRecipe.__tablename__,

--- a/tests/integration_tests/admin_tests/test_admin_user_actions.py
+++ b/tests/integration_tests/admin_tests/test_admin_user_actions.py
@@ -1,7 +1,10 @@
+from datetime import UTC, datetime
+
 from fastapi.testclient import TestClient
 
 from mealie.core.config import get_app_settings
 from mealie.db.models.users.users import AuthMethod
+from mealie.schema.meal_plan.new_meal import CreatePlanEntry
 from tests import utils
 from tests.utils import api_routes
 from tests.utils.factories import random_email, random_string
@@ -137,4 +140,37 @@ def test_self_promote_admin(api_client: TestClient, unique_user: TestUser):
 
 def test_delete_user(api_client: TestClient, admin_token, unique_user: TestUser):
     response = api_client.delete(api_routes.admin_users_item_id(unique_user.user_id), headers=admin_token)
+    assert response.status_code == 200
+
+
+def test_delete_user_with_multiple_mealplans_and_shopping_lists(
+    api_client: TestClient, admin_token, unique_user_fn_scoped: TestUser
+):
+    """
+    Regression test for https://github.com/mealie-recipes/mealie/issues/7529
+
+    `User.mealplans` and `User.shopping_lists` were mapped as scalar relationships
+    (`Mapped[Optional[...]]`) instead of collections (`Mapped[list[...]]`), so
+    SQLAlchemy only ever cascade-deleted a single row on user delete. A user with
+    two or more meal plans or shopping lists would leave the rest behind and the
+    subsequent `DELETE FROM users` would fail with a foreign key violation.
+    """
+    for _ in range(3):
+        new_plan = CreatePlanEntry(
+            date=datetime.now(UTC).date(), entry_type="dinner", title=random_string(), text=random_string()
+        ).model_dump()
+        new_plan["date"] = datetime.now(UTC).date().strftime("%Y-%m-%d")
+
+        response = api_client.post(api_routes.households_mealplans, json=new_plan, headers=unique_user_fn_scoped.token)
+        assert response.status_code == 201
+
+    for _ in range(3):
+        response = api_client.post(
+            api_routes.households_shopping_lists,
+            json={"name": random_string()},
+            headers=unique_user_fn_scoped.token,
+        )
+        assert response.status_code == 201
+
+    response = api_client.delete(api_routes.admin_users_item_id(unique_user_fn_scoped.user_id), headers=admin_token)
     assert response.status_code == 200


### PR DESCRIPTION
## What this PR does / why we need it:

`User.mealplans` and `User.shopping_lists` were typed as scalar relationships (`Mapped[Optional[...]]`) instead of collections (`Mapped[list[...]]`), so SQLAlchemy's cascade delete only ever removed a single row. A user with more than one meal plan or shopping list would leave the rest behind, and deleting the user would fail with a foreign key violation.

## Which issue(s) this PR fixes:

Fixes #7529

## Testing

Added a regression test that creates 3 meal plans and 3 shopping lists for a user, then verifies the user can be deleted successfully. Confirmed it fails without the fix (reproduces the exact `SAWarning: Multiple rows returned with uselist=False` from the linked issue) and passes with it.

## AI / LLM Assistance

Used Claude Code to root-cause the issue (verified via SQLAlchemy's runtime relationship config, not just reading the code), implement the fix, and write/verify the regression test.
