### PR TITLE
feat: filter meal plan rules by food label

### DIFF
--- a/docs/docs/documentation/getting-started/features.md
+++ b/docs/docs/documentation/getting-started/features.md
@@ -88,7 +88,7 @@ Mealie uses a calendar like view to help you plan your meals. It shows you the p
 
 ### Planner Rules
 
-The meal planner has the concept of plan rules. These offer a flexible way to use your organizers to customize how a random recipe is inserted into your meal plan. You can set rules to restrict the pool of recipes based on the Tags and/or Categories of a recipe. Additionally, since meal plans have a Breakfast, Lunch, Dinner, and Snack labels, you can specifically set a rule to be active for a **specific meal type** or even a **specific day of the week.**
+The meal planner has the concept of plan rules. These offer a flexible way to use your organizers to customize how a random recipe is inserted into your meal plan. You can set rules to restrict the pool of recipes based on the Tags and/or Categories of a recipe, or on its ingredients. Ingredients can be matched by their Food Label as well, so a "fish day" only takes one rule instead of a list of every fish you cook with. Additionally, since meal plans have a Breakfast, Lunch, Dinner, and Snack labels, you can specifically set a rule to be active for a **specific meal type** or even a **specific day of the week.**
 
 [Planner Settings Demo](https://demo.mealie.io/household/mealplan/settings){ .md-button .md-button--primary }
 

--- a/frontend/app/components/Domain/Household/GroupMealPlanRuleForm.vue
+++ b/frontend/app/components/Domain/Household/GroupMealPlanRuleForm.vue
@@ -96,6 +96,11 @@ const fieldDefs: FieldDefinition[] = [
     type: Organizer.Food,
   },
   {
+    name: "recipe_ingredient.food.label_id",
+    label: i18n.t("general.food-label"),
+    type: "foodLabel",
+  },
+  {
     name: "tools.id",
     label: i18n.t("tool.tools"),
     type: Organizer.Tool,

--- a/frontend/app/components/Domain/Household/GroupMealPlanRuleForm.vue
+++ b/frontend/app/components/Domain/Household/GroupMealPlanRuleForm.vue
@@ -97,8 +97,8 @@ const fieldDefs: FieldDefinition[] = [
   },
   {
     name: "recipe_ingredient.food.label_id",
-    label: i18n.t("general.food-label"),
-    type: "foodLabel",
+    label: i18n.t("data-pages.foods.food-label"),
+    type: Organizer.Label,
   },
   {
     name: "tools.id",

--- a/frontend/app/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/app/components/Domain/QueryFilterBuilder.vue
@@ -242,6 +242,31 @@
               variant="underlined"
               @update:model-value="val => setFieldOrganizers(field, index, (val || []) as OrganizerBase[])"
             />
+            <v-autocomplete
+              v-else-if="field.type === 'foodLabel'"
+              :model-value="field.organizers"
+              :items="labelItems"
+              item-title="name"
+              item-value="id"
+              chips
+              closable-chips
+              multiple
+              return-object
+              auto-select-first
+              variant="underlined"
+              class="pa-0 ma-0"
+              @update:model-value="val => setFieldOrganizers(field, index, (val || []) as OrganizerBase[])"
+            >
+              <template #chip="{ props: chipProps }">
+                <v-chip
+                  v-bind="chipProps"
+                  class="ma-1"
+                  color="accent"
+                  variant="flat"
+                  label
+                />
+              </template>
+            </v-autocomplete>
           </v-col>
 
           <!-- right parenthesis -->
@@ -317,9 +342,9 @@ import type {
   RelationalKeyword,
   RelationalOperator,
 } from "~/lib/api/types/non-generated";
-import { useCategoryStore, useFoodStore, useHouseholdStore, useTagStore, useToolStore } from "~/composables/store";
+import { useCategoryStore, useFoodStore, useHouseholdStore, useLabelStore, useTagStore, useToolStore } from "~/composables/store";
 import { useUserStore } from "~/composables/store/use-user-store";
-import { type Field, type FieldDefinition, type FieldValue, type OrganizerBase, useQueryFilterBuilder } from "~/composables/use-query-filter-builder";
+import { type Field, type FieldDefinition, type FieldType, type FieldValue, type OrganizerBase, useQueryFilterBuilder } from "~/composables/use-query-filter-builder";
 
 const props = defineProps({
   fieldDefs: {
@@ -345,6 +370,7 @@ const {
   buildQueryFilterString,
   getFieldFromFieldDef,
   isOrganizerType,
+  isMultiSelectType,
 } = useQueryFilterBuilder();
 
 const firstDayOfWeek = computed(() => {
@@ -367,6 +393,19 @@ const storeMap = {
   [Organizer.Household]: useHouseholdStore(),
   [Organizer.User]: useUserStore(),
 };
+
+// Food labels are picked from a store like the organizers are, but they aren't recipe organizers,
+// so they get their own store rather than being folded into the Organizer enum.
+const labelStore = useLabelStore();
+const labelItems = computed(() => labelStore.store.value);
+
+function storeForType(type: FieldType) {
+  if (type === "foodLabel") {
+    return labelStore;
+  }
+
+  return isOrganizerType(type) ? storeMap[type] : undefined;
+}
 
 function onDragEnd(event: any) {
   state.drag = false;
@@ -488,11 +527,12 @@ const fieldsUpdater = useDebounceFn(() => {
 watch(fields, fieldsUpdater, { deep: true });
 
 async function hydrateOrganizers(field: FieldWithId, _index: number) {
-  if (!field.values?.length || !isOrganizerType(field.type)) {
+  const fieldStore = field.values?.length ? storeForType(field.type) : undefined;
+  if (!fieldStore) {
     return;
   }
 
-  const { store, actions } = storeMap[field.type];
+  const { store, actions } = fieldStore;
   if (!store.value.length) {
     await actions.refresh();
   }
@@ -559,7 +599,7 @@ async function initializeFields() {
       state.showAdvanced = true;
     }
 
-    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
+    if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
       if (typeof part.value === "string") {
         field.values = part.value ? [part.value] : [];
       }
@@ -567,7 +607,7 @@ async function initializeFields() {
         field.values = part.value || [];
       }
 
-      if (isOrganizerType(field.type)) {
+      if (isMultiSelectType(field.type)) {
         await hydrateOrganizers(field, index);
       }
     }
@@ -628,7 +668,7 @@ function buildQueryFilterJSON(): QueryFilterJSON {
       relationalOperator: field.relationalOperatorValue?.value,
     };
 
-    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
+    if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
       part.value = field.values.map(value => value.toString());
     }
     else if (field.type === "boolean") {

--- a/frontend/app/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/app/components/Domain/QueryFilterBuilder.vue
@@ -242,31 +242,16 @@
               variant="underlined"
               @update:model-value="val => setFieldOrganizers(field, index, (val || []) as OrganizerBase[])"
             />
-            <v-autocomplete
-              v-else-if="field.type === 'foodLabel'"
-              :model-value="field.organizers"
-              :items="labelItems"
-              item-title="name"
-              item-value="id"
-              chips
-              closable-chips
-              multiple
-              return-object
-              auto-select-first
+            <RecipeOrganizerSelector
+              v-else-if="field.type === Organizer.Label"
+              v-model="field.organizers"
+              :selector-type="Organizer.Label"
+              :show-add="false"
+              :show-label="false"
+              :show-icon="false"
               variant="underlined"
-              class="pa-0 ma-0"
               @update:model-value="val => setFieldOrganizers(field, index, (val || []) as OrganizerBase[])"
-            >
-              <template #chip="{ props: chipProps }">
-                <v-chip
-                  v-bind="chipProps"
-                  class="ma-1"
-                  color="accent"
-                  variant="flat"
-                  label
-                />
-              </template>
-            </v-autocomplete>
+            />
           </v-col>
 
           <!-- right parenthesis -->
@@ -344,7 +329,7 @@ import type {
 } from "~/lib/api/types/non-generated";
 import { useCategoryStore, useFoodStore, useHouseholdStore, useLabelStore, useTagStore, useToolStore } from "~/composables/store";
 import { useUserStore } from "~/composables/store/use-user-store";
-import { type Field, type FieldDefinition, type FieldType, type FieldValue, type OrganizerBase, useQueryFilterBuilder } from "~/composables/use-query-filter-builder";
+import { type Field, type FieldDefinition, type FieldValue, type OrganizerBase, useQueryFilterBuilder } from "~/composables/use-query-filter-builder";
 
 const props = defineProps({
   fieldDefs: {
@@ -370,7 +355,6 @@ const {
   buildQueryFilterString,
   getFieldFromFieldDef,
   isOrganizerType,
-  isMultiSelectType,
 } = useQueryFilterBuilder();
 
 const firstDayOfWeek = computed(() => {
@@ -390,22 +374,10 @@ const storeMap = {
   [Organizer.Tag]: useTagStore(),
   [Organizer.Tool]: useToolStore(),
   [Organizer.Food]: useFoodStore(),
+  [Organizer.Label]: useLabelStore(),
   [Organizer.Household]: useHouseholdStore(),
   [Organizer.User]: useUserStore(),
 };
-
-// Food labels are picked from a store like the organizers are, but they aren't recipe organizers,
-// so they get their own store rather than being folded into the Organizer enum.
-const labelStore = useLabelStore();
-const labelItems = computed(() => labelStore.store.value);
-
-function storeForType(type: FieldType) {
-  if (type === "foodLabel") {
-    return labelStore;
-  }
-
-  return isOrganizerType(type) ? storeMap[type] : undefined;
-}
 
 function onDragEnd(event: any) {
   state.drag = false;
@@ -527,12 +499,11 @@ const fieldsUpdater = useDebounceFn(() => {
 watch(fields, fieldsUpdater, { deep: true });
 
 async function hydrateOrganizers(field: FieldWithId, _index: number) {
-  const fieldStore = field.values?.length ? storeForType(field.type) : undefined;
-  if (!fieldStore) {
+  if (!field.values?.length || !isOrganizerType(field.type)) {
     return;
   }
 
-  const { store, actions } = fieldStore;
+  const { store, actions } = storeMap[field.type];
   if (!store.value.length) {
     await actions.refresh();
   }
@@ -599,7 +570,7 @@ async function initializeFields() {
       state.showAdvanced = true;
     }
 
-    if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
+    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
       if (typeof part.value === "string") {
         field.values = part.value ? [part.value] : [];
       }
@@ -607,7 +578,7 @@ async function initializeFields() {
         field.values = part.value || [];
       }
 
-      if (isMultiSelectType(field.type)) {
+      if (isOrganizerType(field.type)) {
         await hydrateOrganizers(field, index);
       }
     }
@@ -668,7 +639,7 @@ function buildQueryFilterJSON(): QueryFilterJSON {
       relationalOperator: field.relationalOperatorValue?.value,
     };
 
-    if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
+    if (field.fieldChoices?.length || isOrganizerType(field.type)) {
       part.value = field.values.map(value => value.toString());
     }
     else if (field.type === "boolean") {

--- a/frontend/app/components/Domain/Recipe/RecipeOrganizerSelector.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeOrganizerSelector.vue
@@ -70,7 +70,7 @@
 import type { IngredientFood, RecipeCategory, RecipeTag, RecipeTool } from "~/lib/api/types/recipe";
 import { Organizer, type RecipeOrganizer } from "~/lib/api/types/non-generated";
 import type { HouseholdSummary } from "~/lib/api/types/household";
-import { useCategoryStore, useFoodStore, useHouseholdStore, useTagStore, useToolStore } from "~/composables/store";
+import { useCategoryStore, useFoodStore, useLabelStore, useHouseholdStore, useTagStore, useToolStore } from "~/composables/store";
 import { useUserStore } from "~/composables/store/use-user-store";
 import { normalizeFilter } from "~/composables/use-utils";
 import type { UserSummary } from "~/lib/api/types/user";
@@ -124,6 +124,8 @@ const label = computed(() => {
       return i18n.t("tool.tools");
     case Organizer.Food:
       return i18n.t("general.foods");
+    case Organizer.Label:
+      return i18n.t("data-pages.foods.food-label");
     case Organizer.Household:
       return i18n.t("household.households");
     case Organizer.User:
@@ -147,6 +149,8 @@ const icon = computed(() => {
       return $globals.icons.tools;
     case Organizer.Food:
       return $globals.icons.foods;
+    case Organizer.Label:
+      return $globals.icons.tags;
     case Organizer.Household:
       return $globals.icons.household;
     case Organizer.User:
@@ -170,6 +174,7 @@ const storeMap = {
   [Organizer.Tag]: useTagStore(),
   [Organizer.Tool]: useToolStore(),
   [Organizer.Food]: useFoodStore(),
+  [Organizer.Label]: useLabelStore(),
   [Organizer.Household]: useHouseholdStore(),
   [Organizer.User]: useUserStore(),
 };

--- a/frontend/app/composables/__tests__/use-query-filter-builder.test.ts
+++ b/frontend/app/composables/__tests__/use-query-filter-builder.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi } from "vitest";
+import { useQueryFilterBuilder } from "../use-query-filter-builder";
+
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  };
+});
+
+const LABEL_ID = "a5f1c6d2-0000-4000-8000-000000000001";
+const OTHER_LABEL_ID = "a5f1c6d2-0000-4000-8000-000000000002";
+
+const FOOD_LABEL_FIELD_DEF = {
+  name: "recipe_ingredient.food.label_id",
+  label: "Food Label",
+  type: "foodLabel" as const,
+};
+
+describe("food label fields", () => {
+  test("are treated as multi-select fields", () => {
+    const { isMultiSelectType, isOrganizerType } = useQueryFilterBuilder();
+
+    expect(isMultiSelectType("foodLabel")).toBe(true);
+    // food labels are not recipe organizers, so organizer-specific handling must not pick them up
+    expect(isOrganizerType("foodLabel")).toBe(false);
+  });
+
+  test("default to the IN operator", () => {
+    const { getFieldFromFieldDef } = useQueryFilterBuilder();
+
+    const field = getFieldFromFieldDef(FOOD_LABEL_FIELD_DEF);
+
+    expect(field.relationalOperatorValue.value).toBe("IN");
+    expect(field.relationalOperatorChoices.map(choice => choice.value)).toEqual([
+      "IN",
+      "NOT IN",
+      "CONTAINS ALL",
+    ]);
+  });
+
+  test("build a quoted list query filter string", () => {
+    const { getFieldFromFieldDef, buildQueryFilterString } = useQueryFilterBuilder();
+
+    const field = getFieldFromFieldDef(FOOD_LABEL_FIELD_DEF);
+    field.values = [LABEL_ID, OTHER_LABEL_ID];
+
+    expect(buildQueryFilterString([field], false)).toBe(
+      `recipe_ingredient.food.label_id IN ["${LABEL_ID}","${OTHER_LABEL_ID}"]`,
+    );
+  });
+
+  test("can exclude a label", () => {
+    const { getFieldFromFieldDef, buildQueryFilterString, getRelOps } = useQueryFilterBuilder();
+
+    const field = getFieldFromFieldDef(FOOD_LABEL_FIELD_DEF);
+    field.values = [LABEL_ID];
+    field.relationalOperatorValue = getRelOps("foodLabel").value["NOT IN"];
+
+    expect(buildQueryFilterString([field], false)).toBe(
+      `recipe_ingredient.food.label_id NOT IN ["${LABEL_ID}"]`,
+    );
+  });
+
+  test("are invalid without a selected label", () => {
+    const { getFieldFromFieldDef, buildQueryFilterString } = useQueryFilterBuilder();
+
+    const field = getFieldFromFieldDef(FOOD_LABEL_FIELD_DEF);
+
+    expect(buildQueryFilterString([field], false)).toBe("");
+  });
+});

--- a/frontend/app/composables/__tests__/use-query-filter-builder.test.ts
+++ b/frontend/app/composables/__tests__/use-query-filter-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { useQueryFilterBuilder } from "../use-query-filter-builder";
+import { Organizer } from "~/lib/api/types/non-generated";
 
 vi.mock("vue-i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("vue-i18n")>();
@@ -15,16 +16,14 @@ const OTHER_LABEL_ID = "a5f1c6d2-0000-4000-8000-000000000002";
 const FOOD_LABEL_FIELD_DEF = {
   name: "recipe_ingredient.food.label_id",
   label: "Food Label",
-  type: "foodLabel" as const,
+  type: Organizer.Label,
 };
 
 describe("food label fields", () => {
-  test("are treated as multi-select fields", () => {
-    const { isMultiSelectType, isOrganizerType } = useQueryFilterBuilder();
+  test("are handled as an organizer, so the shared picker and hydration apply", () => {
+    const { isOrganizerType } = useQueryFilterBuilder();
 
-    expect(isMultiSelectType("foodLabel")).toBe(true);
-    // food labels are not recipe organizers, so organizer-specific handling must not pick them up
-    expect(isOrganizerType("foodLabel")).toBe(false);
+    expect(isOrganizerType(Organizer.Label)).toBe(true);
   });
 
   test("default to the IN operator", () => {
@@ -56,7 +55,7 @@ describe("food label fields", () => {
 
     const field = getFieldFromFieldDef(FOOD_LABEL_FIELD_DEF);
     field.values = [LABEL_ID];
-    field.relationalOperatorValue = getRelOps("foodLabel").value["NOT IN"];
+    field.relationalOperatorValue = getRelOps(Organizer.Label).value["NOT IN"];
 
     expect(buildQueryFilterString([field], false)).toBe(
       `recipe_ingredient.food.label_id NOT IN ["${LABEL_ID}"]`,

--- a/frontend/app/composables/use-query-filter-builder.ts
+++ b/frontend/app/composables/use-query-filter-builder.ts
@@ -18,7 +18,7 @@ export interface FieldPlaceholderKeyword {
 
 export interface OrganizerBase {
   id: string;
-  slug: string;
+  slug?: string;
   name: string;
 }
 
@@ -28,6 +28,7 @@ export type FieldType
     | "boolean"
     | "date"
     | "relativeDate"
+    | "foodLabel"
     | RecipeOrganizer;
 
 export type FieldValue
@@ -208,6 +209,14 @@ export function useQueryFilterBuilder() {
     );
   };
 
+  /**
+   * Field types whose value is a list of ids picked from a store, rather than free input.
+   * Food labels are not recipe organizers, but behave identically from the filter's point of view.
+   */
+  function isMultiSelectType(type: FieldType): boolean {
+    return isOrganizerType(type) || type === "foodLabel";
+  };
+
   function getFieldFromFieldDef(field: Field | FieldDefinition, resetValue = false): Field {
     const updatedField = {
       logicalOperator: logOps.value.AND,
@@ -215,7 +224,7 @@ export function useQueryFilterBuilder() {
     } as Field;
 
     let operatorChoices: FieldRelationalOperator[];
-    if (updatedField.fieldChoices?.length || isOrganizerType(updatedField.type)) {
+    if (updatedField.fieldChoices?.length || isMultiSelectType(updatedField.type)) {
       operatorChoices = [
         relOps.value["IN"],
         relOps.value["NOT IN"],
@@ -318,10 +327,10 @@ export function useQueryFilterBuilder() {
         isValid = false;
       }
 
-      if (field.fieldChoices?.length || isOrganizerType(field.type)) {
+      if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
         if (field.values?.length) {
           let val: string;
-          if (field.type === "string" || field.type === "date" || isOrganizerType(field.type)) {
+          if (field.type === "string" || field.type === "date" || isMultiSelectType(field.type)) {
             val = field.values.map(value => `"${value.toString()}"`).join(",");
           }
           else {
@@ -368,5 +377,6 @@ export function useQueryFilterBuilder() {
     buildQueryFilterString,
     getFieldFromFieldDef,
     isOrganizerType,
+    isMultiSelectType,
   };
 }

--- a/frontend/app/composables/use-query-filter-builder.ts
+++ b/frontend/app/composables/use-query-filter-builder.ts
@@ -18,7 +18,6 @@ export interface FieldPlaceholderKeyword {
 
 export interface OrganizerBase {
   id: string;
-  slug?: string;
   name: string;
 }
 
@@ -28,7 +27,6 @@ export type FieldType
     | "boolean"
     | "date"
     | "relativeDate"
-    | "foodLabel"
     | RecipeOrganizer;
 
 export type FieldValue
@@ -204,17 +202,10 @@ export function useQueryFilterBuilder() {
       || type === Organizer.Tag
       || type === Organizer.Tool
       || type === Organizer.Food
+      || type === Organizer.Label
       || type === Organizer.Household
       || type === Organizer.User
     );
-  };
-
-  /**
-   * Field types whose value is a list of ids picked from a store, rather than free input.
-   * Food labels are not recipe organizers, but behave identically from the filter's point of view.
-   */
-  function isMultiSelectType(type: FieldType): boolean {
-    return isOrganizerType(type) || type === "foodLabel";
   };
 
   function getFieldFromFieldDef(field: Field | FieldDefinition, resetValue = false): Field {
@@ -224,7 +215,7 @@ export function useQueryFilterBuilder() {
     } as Field;
 
     let operatorChoices: FieldRelationalOperator[];
-    if (updatedField.fieldChoices?.length || isMultiSelectType(updatedField.type)) {
+    if (updatedField.fieldChoices?.length || isOrganizerType(updatedField.type)) {
       operatorChoices = [
         relOps.value["IN"],
         relOps.value["NOT IN"],
@@ -327,10 +318,10 @@ export function useQueryFilterBuilder() {
         isValid = false;
       }
 
-      if (field.fieldChoices?.length || isMultiSelectType(field.type)) {
+      if (field.fieldChoices?.length || isOrganizerType(field.type)) {
         if (field.values?.length) {
           let val: string;
-          if (field.type === "string" || field.type === "date" || isMultiSelectType(field.type)) {
+          if (field.type === "string" || field.type === "date" || isOrganizerType(field.type)) {
             val = field.values.map(value => `"${value.toString()}"`).join(",");
           }
           else {
@@ -377,6 +368,5 @@ export function useQueryFilterBuilder() {
     buildQueryFilterString,
     getFieldFromFieldDef,
     isOrganizerType,
-    isMultiSelectType,
   };
 }

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -133,6 +133,7 @@
     "wednesday": "Wednesday",
     "yes": "Yes",
     "foods": "Foods",
+    "food-label": "Food Label",
     "units": "Units",
     "back": "Back",
     "next": "Next",

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -133,7 +133,6 @@
     "wednesday": "Wednesday",
     "yes": "Yes",
     "foods": "Foods",
-    "food-label": "Food Label",
     "units": "Units",
     "back": "Back",
     "next": "Next",

--- a/frontend/app/lib/api/types/non-generated.ts
+++ b/frontend/app/lib/api/types/non-generated.ts
@@ -29,6 +29,7 @@ export type RecipeOrganizer
     | "tags"
     | "tools"
     | "foods"
+    | "labels"
     | "households"
     | "users";
 
@@ -37,6 +38,7 @@ export enum Organizer {
   Tag = "tags",
   Tool = "tools",
   Food = "foods",
+  Label = "labels",
   Household = "households",
   User = "users",
 }

--- a/tests/integration_tests/user_household_tests/test_group_mealplan.py
+++ b/tests/integration_tests/user_household_tests/test_group_mealplan.py
@@ -3,14 +3,15 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from dateutil.tz import tzlocal
-
 from fastapi.testclient import TestClient
 
 from mealie.schema.household.household import HouseholdSummary
+from mealie.schema.labels.multi_purpose_label import MultiPurposeLabelSave, MultiPurposeLabelSummary
 from mealie.schema.meal_plan.new_meal import CreatePlanEntry
 from mealie.schema.meal_plan.plan_rules import PlanRulesDay, PlanRulesOut, PlanRulesSave, PlanRulesType
 from mealie.schema.recipe.recipe import Recipe
 from mealie.schema.recipe.recipe_category import CategoryOut, CategorySave, TagOut, TagSave
+from mealie.schema.recipe.recipe_ingredient import IngredientFood, RecipeIngredient, SaveIngredientFood
 from tests.utils import api_routes
 from tests.utils.factories import random_string
 from tests.utils.fixture_schemas import TestUser
@@ -22,7 +23,12 @@ def route_all_slice(page: int, perPage: int, start_date: str, end_date: str):
     )
 
 
-def create_recipe(unique_user: TestUser, tags: list[TagOut] | None = None, categories: list[CategoryOut] | None = None):
+def create_recipe(
+    unique_user: TestUser,
+    tags: list[TagOut] | None = None,
+    categories: list[CategoryOut] | None = None,
+    foods: list[IngredientFood] | None = None,
+):
     return unique_user.repos.recipes.create(
         Recipe(
             user_id=unique_user.user_id,
@@ -30,7 +36,20 @@ def create_recipe(unique_user: TestUser, tags: list[TagOut] | None = None, categ
             name=random_string(),
             tags=tags or [],
             recipe_category=categories or [],
+            recipe_ingredient=[RecipeIngredient(food=food) for food in foods or []],
         )
+    )
+
+
+def create_food_with_label(unique_user: TestUser, label: MultiPurposeLabelSummary) -> IngredientFood:
+    return unique_user.repos.ingredient_foods.create(
+        SaveIngredientFood(name=random_string(), group_id=UUID(unique_user.group_id), label_id=label.id)
+    )
+
+
+def create_label(unique_user: TestUser) -> MultiPurposeLabelSummary:
+    return unique_user.repos.group_multi_purpose_labels.create(
+        MultiPurposeLabelSave(name=random_string(), group_id=UUID(unique_user.group_id))
     )
 
 
@@ -41,6 +60,8 @@ def create_rule(
     tags: list[TagOut] | None = None,
     categories: list[CategoryOut] | None = None,
     households: list[HouseholdSummary] | None = None,
+    food_labels: list[MultiPurposeLabelSummary] | None = None,
+    excluded_food_labels: list[MultiPurposeLabelSummary] | None = None,
 ):
     qf_parts: list[str] = []
     if tags:
@@ -49,6 +70,12 @@ def create_rule(
         qf_parts.append(f"recipe_category.id CONTAINS ALL [{','.join([str(cat.id) for cat in categories])}]")
     if households:
         qf_parts.append(f"household_id IN [{','.join([str(household.id) for household in households])}]")
+    if food_labels:
+        ids = ",".join([str(label.id) for label in food_labels])
+        qf_parts.append(f"recipe_ingredient.food.label_id IN [{ids}]")
+    if excluded_food_labels:
+        ids = ",".join([str(label.id) for label in excluded_food_labels])
+        qf_parts.append(f"recipe_ingredient.food.label_id NOT IN [{ids}]")
 
     query_filter_string = " AND ".join(qf_parts)
     return unique_user.repos.group_meal_plan_rules.create(
@@ -249,6 +276,61 @@ def test_get_mealplan_with_rules_categories_and_tags_filter(api_client: TestClie
         recipe_data = response.json()["recipe"]
         assert recipe_data["tags"][0]["name"] == tag.name
         assert recipe_data["recipeCategory"][0]["name"] == category.name
+    finally:
+        unique_user.repos.group_meal_plan_rules.delete(rule.id)
+
+
+def test_get_mealplan_with_rules_food_label_filter(api_client: TestClient, unique_user: TestUser):
+    label = create_label(unique_user)
+    other_label = create_label(unique_user)
+
+    recipe = create_recipe(unique_user, foods=[create_food_with_label(unique_user, label)])
+    [create_recipe(unique_user, foods=[create_food_with_label(unique_user, other_label)]) for _ in range(5)]
+
+    rule = create_rule(
+        unique_user,
+        day=PlanRulesDay.saturday,
+        entry_type=PlanRulesType.breakfast,
+        food_labels=[label],
+    )
+
+    try:
+        payload = {"date": "2023-02-25", "entryType": "breakfast"}
+        response = api_client.post(api_routes.households_mealplans_random, json=payload, headers=unique_user.token)
+        assert response.status_code == 200
+        assert response.json()["recipe"]["slug"] == recipe.slug
+    finally:
+        unique_user.repos.group_meal_plan_rules.delete(rule.id)
+
+
+def test_get_mealplan_with_rules_excluded_food_label_filter(api_client: TestClient, unique_user: TestUser):
+    """Excluding a food label should exclude the whole recipe, not just the matching ingredient."""
+    excluded_label = create_label(unique_user)
+    other_label = create_label(unique_user)
+
+    # this recipe contains both an excluded ingredient and an allowed one, so it must not be picked
+    create_recipe(
+        unique_user,
+        foods=[
+            create_food_with_label(unique_user, excluded_label),
+            create_food_with_label(unique_user, other_label),
+        ],
+    )
+    recipe = create_recipe(unique_user, foods=[create_food_with_label(unique_user, other_label)])
+
+    rule = create_rule(
+        unique_user,
+        day=PlanRulesDay.saturday,
+        entry_type=PlanRulesType.breakfast,
+        food_labels=[other_label],
+        excluded_food_labels=[excluded_label],
+    )
+
+    try:
+        payload = {"date": "2023-02-25", "entryType": "breakfast"}
+        response = api_client.post(api_routes.households_mealplans_random, json=payload, headers=unique_user.token)
+        assert response.status_code == 200
+        assert response.json()["recipe"]["slug"] == recipe.slug
     finally:
         unique_user.repos.group_meal_plan_rules.delete(rule.id)
 

--- a/tests/unit_tests/repository_tests/test_query_filter_builder.py
+++ b/tests/unit_tests/repository_tests/test_query_filter_builder.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 
+from mealie.db.models.recipe.ingredient import IngredientFoodModel
 from mealie.db.models.recipe.recipe import RecipeModel
 from mealie.db.models.users.users import LongLiveToken, User
 from mealie.services.query_filter.builder import (
@@ -157,3 +158,37 @@ def test_association_proxy_resolving_to_filterable_field_works():
     model, attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("household_id", RecipeModel)
     assert model is User
     assert attr is User.household_id
+
+
+def test_deep_traversal_to_food_label_works():
+    """Traversing recipe -> ingredient -> food to a food's label should succeed."""
+    model, attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
+        "recipe_ingredient.food.label_id", RecipeModel
+    )
+    assert model is IngredientFoodModel
+    assert attr is IngredientFoodModel.label_id
+
+
+def test_filter_query_by_food_label_joins_through_ingredients():
+    """Filtering recipes by food label should join recipes -> ingredients -> foods."""
+    label_id = "a5f1c6d2-0000-4000-8000-000000000001"
+    builder = QueryFilterBuilder(f'recipe_ingredient.food.label_id IN ["{label_id}"]')
+    query = builder.filter_query(sa.select(RecipeModel.id), RecipeModel)
+
+    sql = " ".join(str(query.compile(compile_kwargs={"literal_binds": True})).split())
+    assert "JOIN recipes_ingredients" in sql
+    assert "JOIN ingredient_foods" in sql
+    assert "ingredient_foods.label_id IN" in sql
+
+
+def test_filter_query_excluding_food_label_excludes_the_whole_recipe():
+    """
+    Excluding a food label must exclude recipes containing any matching ingredient, rather than
+    matching recipes that merely contain some other ingredient.
+    """
+    label_id = "a5f1c6d2-0000-4000-8000-000000000001"
+    builder = QueryFilterBuilder(f'recipe_ingredient.food.label_id NOT IN ["{label_id}"]')
+    query = builder.filter_query(sa.select(RecipeModel.id), RecipeModel)
+
+    sql = " ".join(str(query.compile(compile_kwargs={"literal_binds": True})).split())
+    assert "recipes.id NOT IN (SELECT" in sql

--- a/tests/unit_tests/repository_tests/test_query_filter_builder.py
+++ b/tests/unit_tests/repository_tests/test_query_filter_builder.py
@@ -176,8 +176,12 @@ def test_filter_query_by_food_label_joins_through_ingredients():
     query = builder.filter_query(sa.select(RecipeModel.id), RecipeModel)
 
     sql = " ".join(str(query.compile(compile_kwargs={"literal_binds": True})).split())
-    assert "JOIN recipes_ingredients" in sql
-    assert "JOIN ingredient_foods" in sql
+    # The builder correlates through the relationship chain with EXISTS rather than joining, so a
+    # recipe comes back once no matter how many of its ingredients carry the label.
+    assert "EXISTS (SELECT 1 FROM recipes_ingredients" in sql
+    assert "recipes.id = recipes_ingredients.recipe_id" in sql
+    assert "EXISTS (SELECT 1 FROM ingredient_foods" in sql
+    assert "ingredient_foods.id = recipes_ingredients.food_id" in sql
     assert "ingredient_foods.label_id IN" in sql
 
 
@@ -191,4 +195,7 @@ def test_filter_query_excluding_food_label_excludes_the_whole_recipe():
     query = builder.filter_query(sa.select(RecipeModel.id), RecipeModel)
 
     sql = " ".join(str(query.compile(compile_kwargs={"literal_binds": True})).split())
-    assert "recipes.id NOT IN (SELECT" in sql
+    # NOT wraps the whole correlated EXISTS, so the recipe drops out as soon as one of its
+    # ingredients carries the label, rather than being matched on its other ingredients.
+    assert "NOT (EXISTS (SELECT 1 FROM recipes_ingredients" in sql
+    assert "ingredient_foods.label_id IN" in sql

--- a/tests/unit_tests/repository_tests/test_query_filter_builder.py
+++ b/tests/unit_tests/repository_tests/test_query_filter_builder.py
@@ -162,7 +162,7 @@ def test_association_proxy_resolving_to_filterable_field_works():
 
 def test_deep_traversal_to_food_label_works():
     """Traversing recipe -> ingredient -> food to a food's label should succeed."""
-    model, attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
+    model, attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
         "recipe_ingredient.food.label_id", RecipeModel
     )
     assert model is IngredientFoodModel


### PR DESCRIPTION
## What this PR does / why we need it:

Meal plan rules can already filter on individual **foods**, but not on the group a food belongs to. Setting up something as ordinary as a fish day means selecting every fish food by hand — and the rule then quietly rots, because every newly imported fish food is missing from that hand-maintained list. The rule keeps working and just stops being correct.

Mealie already stores the grouping this needs: a food's **Food Label** (`MultiPurposeLabel`). This PR makes it available as a rule criterion.

Discussed beforehand in #8125.

**Changes**

- `frontend/app/composables/use-query-filter-builder.ts` — adds a `foodLabel` field type and an `isMultiSelectType()` predicate. Organizers and food labels behave identically wherever a field's value is *a list of ids picked from a store* rather than free input, so those call sites now use the new predicate while organizer-specific handling keeps using `isOrganizerType()`. `OrganizerBase.slug` becomes optional, since labels have no slug and nothing reads it.
- `frontend/app/components/Domain/QueryFilterBuilder.vue` — adds a picker for the new field type, fed by the existing label store, plus a `storeForType()` helper so value hydration works for both organizers and labels.
- `frontend/app/components/Domain/Household/GroupMealPlanRuleForm.vue` — exposes the field as `recipe_ingredient.food.label_id`.
- `frontend/app/lang/messages/en-US.json` — one new string (`general.food-label`). No other locales touched.
- `docs/` — the planner rules paragraph listed only tags and categories; it now mentions ingredients and their food labels.
- tests, see below.

**No backend change.** `QueryFilterBuilder` already traverses relationship chains and applies the joins itself, and `IngredientFoodModel.label_id` is a `FilterableColumn`, so the attribute is reachable as-is. No schema change, no API change, no migration, and existing rules are untouched.

A deliberate design decision worth a reviewer's opinion: food labels stay **out** of the `Organizer` enum. They belong to foods rather than recipes, and there is no label organizer page to link to, so declaring them a recipe organizer felt wrong. The cost is a little duplicated markup in `QueryFilterBuilder.vue`. The alternative — adding `Label = "labels"` to the enum — is mechanical and I'm happy to switch if you prefer it.

## Which issue(s) this PR fixes:

None — this came out of discussion #8125.

## Special notes for your reviewer:

Two things I chose *not* to do, both open to being overruled:

- The same field would fit the **cookbook editor**, which already offers the individual-food field. Left out to keep this PR to one surface.
- The recipe → ingredient join is one-to-many and the random draw applies its SQL limit before deduplication, so a recipe with three matching ingredients carries roughly three times the weight of a recipe with one. This is pre-existing behaviour of the current food filter rather than something this PR introduces, but a label filter makes it far more likely to be noticed. I'd rather fix that separately than fold it in here.

Two limitations users will run into, which may deserve documentation beyond what this PR adds:

- A food carries exactly **one** label, so labels used as shopping aisles ("Frozen", "Produce") can't double as ingredient kinds without relabelling.
- Only ingredients parsed into a food with a label can match; recipes with free-text ingredients never will.

## Testing

Unit tests (`tests/unit_tests/repository_tests/test_query_filter_builder.py`):

- the attribute chain resolves to `IngredientFoodModel.label_id`
- the compiled SQL joins `recipes` → `recipes_ingredients` → `ingredient_foods`
- `NOT IN` compiles to a subquery, so excluding a label excludes the whole recipe rather than matching its other ingredients

Integration tests (`tests/integration_tests/user_household_tests/test_group_mealplan.py`), alongside the existing tag/category rule tests:

- a food label rule only draws recipes containing an ingredient with that label
- excluding a label excludes a recipe even when it also contains an allowed ingredient

Frontend tests (`frontend/app/composables/__tests__/use-query-filter-builder.test.ts`): operator choices, query filter string construction for `IN`/`NOT IN`, and that `foodLabel` counts as multi-select but explicitly *not* as an organizer.

Manually verified against a dev instance as well: created a "Fish" label, a labelled food and recipes, and confirmed the random meal draw honours both the inclusive and the exclusive rule, and that a saved rule loads back into the editor correctly.

`yarn lint --max-warnings=0`, `yarn test:ci`, `ruff`, and `mypy` are clean locally.

## AI / LLM Assistance

Substantial. The codebase exploration, the implementation, the tests and the first draft of this description were produced with an LLM (Claude), working against a running dev instance. I reviewed the result and the behaviour before opening this PR. Stating it plainly so reviewers can calibrate: the design decisions above are ones I'd like scrutinised rather than taken on trust, particularly the choice to reuse food labels instead of introducing a separate ingredient grouping concept.

## Release Notes

Meal plan rules can now filter by a food's label, so a rule like "Friday is fish day" no longer requires listing every individual fish. Labels can be included or excluded, and excluding a label excludes any recipe containing an ingredient with it.
