### PR TITLE
Fix #8019: remove default ingredient from new recipes

### DIFF
--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -176,11 +176,6 @@ class RecipeService(RecipeServiceBase):
             for i in range(len(additional_attrs.get("tags", []))):
                 additional_attrs["tags"][i]["group_id"] = self.user.group_id
 
-        if not additional_attrs.get("recipe_ingredient"):
-            additional_attrs["recipe_ingredient"] = [
-                RecipeIngredient(note=self.t("recipe.recipe-defaults.ingredient-note"))
-            ]
-
         if not additional_attrs.get("recipe_instructions"):
             additional_attrs["recipe_instructions"] = [RecipeStep(text=self.t("recipe.recipe-defaults.step-text"))]
 

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -1475,6 +1475,31 @@ def test_put_recipe_name_change_updates_slug(api_client: TestClient, unique_user
     assert renamed_recipe["name"] == renamed_name
 
 
+def test_create_recipe_without_ingredients(api_client: TestClient, unique_user: TestUser):
+    name = random_string(10)
+
+    response = api_client.post(
+        api_routes.recipes,
+        json={"name": name},
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 201
+
+    slug = response.json()
+
+    response = api_client.get(
+        api_routes.recipes_slug(slug),
+        headers=unique_user.token,
+    )
+
+    assert response.status_code == 200
+
+    recipe = response.json()
+
+    assert recipe["recipeIngredient"] == []
+
+
 def test_create_recipe_same_name(api_client: TestClient, unique_user: TestUser):
     slug = random_string(10)
 


### PR DESCRIPTION
## What this PR does / why we need it:

This PR removes the default "1 Cup Flour" ingredient that was automatically added when creating a new recipe without ingredients.

Removed the automatic RecipeIngredient creation from mealie/services/recipe/recipe_service.py.

<img width="1158" height="372" alt="image" src="https://github.com/user-attachments/assets/a598a7f2-4742-420c-a555-da2a7b33f0c8" />



New recipes are now created with an empty ingredient list when no ingredients are provided.

Added an integration test in tests/integration_tests/user_recipe_tests/test_recipe_crud.py to verify that a newly created recipe without ingredients has an empty recipeIngredient list.

No frontend/UI changes are required because this is a backend data/default-value change.

## Which issue(s) this PR fixes:

Fixes #8019 

## Special notes for your reviewer:

The change intentionally removes only the automatic default ingredient. The existing default recipe instruction behavior is unchanged.


## Testing

Added and ran the new integration test:

uv run pytest tests/integration_tests/user_recipe_tests/test_recipe_crud.py::test_create_recipe_without_ingredients -v

Result:  1 passed

## AI / LLM Assistance

An LLM was used to assist with understanding the existing code, identifying the source of the default "1 Cup Flour" ingredient.
