### PR TITLE
fix: prevent OpenAI ingredient parser from splitting plus quantities

### DIFF
--- a/mealie/services/openai/prompts/recipes/parse-recipe-ingredients.txt
+++ b/mealie/services/openai/prompts/recipes/parse-recipe-ingredients.txt
@@ -9,3 +9,4 @@ When parsing:
 - Recognize units: tablespoon, teaspoon, gram, tsp, tbsp, oz, sprig, can, bundle, bunch, unit, cube, package, pinch
 - For ranges (e.g., "3-5", "1 to 2"), use the lower number
 - All text must appear somewhere, or otherwise be accounted for; if converting "2 dozen" → "24", don't put "dozen" elsewhere. If you're unsure, put extra text in the notes
+- When a single input ingredient contains multiple quantities or phrases such as "plus", "and", or commas, do not split it into multiple ingredients. Return exactly one parsed ingredient for that input and keep the secondary quantity or preparation detail in the note field. For example, "1 tablespoon fresh lemon juice, plus 2 teaspoons zest" must be returned as one ingredient, not two.

--- a/tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
+++ b/tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
@@ -68,6 +68,44 @@ def test_openai_parser(
             assert output.input == input
 
 
+def test_openai_parser_rejects_extra(
+    unique_local_group_id: UUID4,
+    parsed_ingredient_data: tuple[list[IngredientFood], list[IngredientUnit]],  # required so database is populated
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def mock_get_response(self, prompt: str, message: str, *args, **kwargs) -> OpenAIIngredients:
+        return OpenAIIngredients(
+            ingredients=[
+                OpenAIIngredient(
+                    quantity=1,
+                    unit="tablespoon",
+                    food="fresh lemon juice",
+                    note="",
+                ),
+                OpenAIIngredient(
+                    quantity=2,
+                    unit="teaspoon",
+                    food="zest",
+                    note="",
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(OpenAIService, "get_response", mock_get_response)
+
+    def mock_openai_init(self, repos):
+        self.repos = repos
+        self.custom_prompt_dir = None
+
+    monkeypatch.setattr(OpenAIService, "__init__", mock_openai_init)
+
+    with session_context() as session:
+        parser = get_parser(RegisteredParser.openai, unique_local_group_id, session, get_locale_provider())
+
+        with pytest.raises(ValueError, match="Expected 1, got 2"):
+            asyncio.run(parser.parse(["1 tablespoon fresh lemon juice, plus 2 teaspoons zest"]))
+
+
 def test_openai_parser_sanitize_output(
     unique_local_group_id: UUID4,
     unique_user: TestUser,


### PR DESCRIPTION
## What this PR does / why we need it:

This fixes an issue where the OpenAI ingredient parser may split one input ingredient into multiple parsed ingredients when the input contains `plus`, `and`, commas, or multiple quantities.

For example:

```text
1 tablespoon fresh lemon juice, plus 2 teaspoons zest
```

The parser previously could return two ingredients for one input, causing:

```text
OpenAI returned an unexpected number of ingredients. Expected 1, got 2
```

Changes:

- Preserved the existing ingredient parsing prompt.
- Added an additional rule instructing the model to keep one input ingredient as one output ingredient.
- Instructed the model to keep secondary quantities and preparation details in the `note` field.
- Added a regression test using a mocked OpenAI response with an unexpected ingredient count.

## Which issue(s) this PR fixes:

Fixes #7420

## Special notes for your reviewer:

The original prompt instructions were preserved. This change only appends an additional parsing rule.

The original issue case was manually verified with a real OpenAI Provider:

```text
1 tablespoon fresh lemon juice, plus 2 teaspoons zest
```

The parser returned one ingredient and placed `plus 2 teaspoons zest` in the notes field.

## Testing

Automated tests:

```bash
.venv/bin/pytest -q \
  tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
```

Result:

```text
13 passed
```

```bash
.venv/bin/pytest -q \
  tests/unit_tests/services_tests/test_openai_service.py
```

Result:

```text
4 passed
```

Static checks:

```bash
.venv/bin/ruff check \
  tests/unit_tests/services_tests/ingredient_parser/test_openai_parser.py
```

Result:

```text
All checks passed!
```

Manual verification was also performed with a real OpenAI Provider using:

```text
1 tablespoon fresh lemon juice, plus 2 teaspoons zest
```

### Manual verification
The original issue case was manually verified with a real OpenAI Provider.
<img width="1541" height="481" alt="fixed issue7420" src="https://github.com/user-attachments/assets/f617eb54-6df3-4ebc-89ca-0c2ea1f8d552" />


## AI / LLM Assistance

An LLM was used during this contribution to investigate issue #7420, inspect the relevant code paths, propose the prompt change.

All changes were reviewed manually, and the automated tests, static checks, and manual OpenAI verification were completed before creating this pull request.