### PR TITLE
fix: wrap timeline event subjects

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
@@ -14,7 +14,7 @@
       class="elevation-12"
       @click="$emit('selected')"
     >
-      <v-card-title class="background">
+      <v-card-title class="background text-wrap">
         <v-row>
           <v-col align-self="center" :cols="useMobileFormat ? 'auto' : '2'" :class="attrs.avatar.class">
             <UserAvatar :user-id="event.userId" :size="attrs.avatar.size" />


### PR DESCRIPTION
## What this PR does / why we need it:

Timeline event subjects are rendered inside a Vuetify card title, whose default no-wrap behavior takes precedence over the existing word-wrapping rule. At intermediate viewport widths, longer subjects can therefore extend past the available title column and be clipped at the card boundary.

- Add Vuetify's existing `text-wrap` utility to the Timeline card title.
- Keep the current grid, responsive breakpoints, avatar, and context-menu layout unchanged.
- Allow long event subjects to wrap within their existing column instead of overflowing.

### Before

The event subject is clipped at the right edge of the card:

<img width="1186" height="831" alt="Timeline event subject overflowing its card" src="https://github.com/user-attachments/assets/7b73f6d5-392f-414d-ba56-4b239f2ff47e" />

### After

The event subjects remain fully contained within their card title areas. When less width is available, the title can wrap instead of overflowing. The surrounding Timeline layout and mobile behavior are unchanged.

<img width="1440" height="718" alt="Timeline event subjects contained within their cards" src="https://github.com/user-attachments/assets/fde83645-a2dc-4b8a-81f0-3ce5929429e7" />

## Which issue(s) this PR fixes:

Fixes #8142

## Testing

- Generated the production frontend successfully with `yarn generate` in the Docker frontend build stage.
- Ran `git diff --check`.
- Confirmed the change uses the existing Vuetify `text-wrap` utility already used by other Mealie card titles.

## Release notes

Fixed Timeline event subjects being clipped at intermediate viewport widths.

## AI / LLM Assistance

An LLM assisted with locating the relevant component and drafting the change. I reviewed the final diff and verified the production frontend build.
