### PR TITLE
fix: strip trailing footnote markers from parsed ingredient names

### DIFF
--- a/mealie/services/parser_services/brute/process.py
+++ b/mealie/services/parser_services/brute/process.py
@@ -3,7 +3,7 @@ import unicodedata
 
 from pydantic import BaseModel, ConfigDict
 
-from ..parser_utils import check_char, move_parens_to_end
+from ..parser_utils import check_char, move_parens_to_end, remove_footnote_markers
 
 
 class BruteParsedIngredient(BaseModel):
@@ -145,7 +145,7 @@ def parse(ing_str, parser) -> BruteParsedIngredient:
     if len(tokens) == 1:
         ingredient = tokens[0]
         # TODO Refactor to expect BFP to be returned instead of Tuple
-        return BruteParsedIngredient(food=ingredient, note=note, amount=amount, unit=unit)
+        return BruteParsedIngredient(food=remove_footnote_markers(ingredient), note=note, amount=amount, unit=unit)
 
     try:
         # try to parse first argument as amount
@@ -208,4 +208,4 @@ def parse(ing_str, parser) -> BruteParsedIngredient:
     if unit_note not in note:
         note += " " + unit_note
 
-    return BruteParsedIngredient(food=ingredient, note=note, amount=amount, unit=unit)
+    return BruteParsedIngredient(food=remove_footnote_markers(ingredient), note=note, amount=amount, unit=unit)

--- a/mealie/services/parser_services/parser_utils/string_utils.py
+++ b/mealie/services/parser_services/parser_utils/string_utils.py
@@ -3,6 +3,7 @@ from fractions import Fraction
 
 compiled_match = re.compile(r"(.){1,6}\s\((.[^\(\)])+\)\s")
 compiled_search = re.compile(r"\((.[^\(])+\)")
+compiled_footnote = re.compile(r"\s*\*+\s*$")
 
 
 def move_parens_to_end(ing_str) -> str:
@@ -17,6 +18,15 @@ def move_parens_to_end(ing_str) -> str:
             ing_str = ing_str[:start] + ing_str[end:] + " " + ing_str[start:end]
 
     return ing_str
+
+
+def remove_footnote_markers(ing_str: str) -> str:
+    """
+    Removes trailing asterisks from an ingredient name. Some sites use them to
+    reference a footnote elsewhere on the page, so they are not part of the
+    food's name. Asterisks anywhere else in the string are left alone.
+    """
+    return compiled_footnote.sub("", ing_str)
 
 
 def check_char(char, *eql) -> bool:

--- a/tests/unit_tests/services_tests/ingredient_parser/test_brute_parser.py
+++ b/tests/unit_tests/services_tests/ingredient_parser/test_brute_parser.py
@@ -89,6 +89,9 @@ def build_parsed_ing(food: str | None, unit: str | None) -> ParsedIngredient:
         pytest.param(
             "bell peppers, cut in pieces", 0, "", "bell peppers", "cut in pieces", id="bell peppers, cut in pieces"
         ),
+        pytest.param("2 Tbsp cooking oil*", 2, "Tbsp", "cooking oil", "", id="trailing footnote marker"),
+        pytest.param("2 Tbsp cooking oil* ($0.10)", 2, "Tbsp", "cooking oil", "$0.10", id="footnote marker with price"),
+        pytest.param("1 cup all-purpose flour**", 1, "Cups", "all-purpose flour", "", id="double footnote marker"),
     ],
 )
 def test_brute_parser(


### PR DESCRIPTION
## What this PR does / why we need it:

Some recipe sites append an asterisk to an ingredient to point at a footnote
elsewhere on the page (`2 Tbsp cooking oil*`). The brute parser keeps that
asterisk in the food name, because it joins the remaining tokens together with
no cleanup step. The NLP parser already handles it.

- `parser_utils/string_utils.py` — adds `remove_footnote_markers()`, which strips
  trailing asterisks. It is anchored to the end of the string, so asterisks
  elsewhere (`A*B`, `5* star anise`) are left alone.
- `brute/process.py` — applies it to the food name at both return points. The
  early return is the single-token case (`salt*`), which would otherwise be missed.

Before / after, same inputs through the brute parser:

| input | food before | food after |
| --- | --- | --- |
| `2 Tbsp cooking oil*` | `cooking oil*` | `cooking oil` |
| `2 Tbsp cooking oil* ($0.10)` | `cooking oil*` | `cooking oil` |
| `1 cup all-purpose flour**` | `all-purpose flour**` | `all-purpose flour` |
| `3 cloves garlic *` | `garlic *` | `garlic` |
| `1 lb chicken breast*, diced` | `chicken breast*` | `chicken breast` |
| `1 cup milk` | `milk` | `milk` |
| `1 tsp salt (optional)` | `salt` | `salt` |

Brute parser on the ingredient debug page, before and after:
<img width="2829" height="1529" alt="image" src="https://github.com/user-attachments/assets/6bd4ea98-a2d5-411d-86d9-f1cad6721934" />
<img width="2820" height="1520" alt="image" src="https://github.com/user-attachments/assets/ced656d7-c3c8-46e2-b361-ee7582d600e7" />


## Which issue(s) this PR fixes:

Fixes #5422

## Special notes for your reviewer:

The issue reports two problems. The price handling described in it no longer
reproduces — both parsers already put `($0.10)` into the note. Only the asterisk
was still outstanding, so that is all this PR changes. I posted the verification
for both halves on the issue.

On impact, in case it looks larger than it is: this does not cause duplicate
foods. `IngredientFoodModel.normalize()` strips the asterisk, so `cooking oil*`
and `cooking oil` normalise to the same string and match at 100. The problem is
that when the food does not exist yet, the new record is created from the
un-normalised name, leaving the user with a food permanently called
`cooking oil*`.

Only the brute parser is touched. The NLP parser handles these inputs correctly
already, so changing it would add risk for no benefit.

## Testing

Three cases added to the existing parametrised list in `test_brute_parser.py`
(trailing marker, marker alongside a price, and a double marker). They were added
first and confirmed failing against the old behaviour, then confirmed passing
after the change. The other 43 cases in that file are unaffected.

Also verified by hand in a local instance on the ingredient parser debug page,
with the NLP parser as a control.

## AI / LLM Assistance

I picked this issue, read through the existing discussion, and reproduced it in a
local instance before starting. Two earlier commenters had reported that they
could not reproduce it, so I tested both halves separately across both parsers
and posted the results and screenshots on #5422. Working out that the price half
was already fixed, that only the asterisk remained, and that it was specific to
the brute parser was my own conclusion, and it is what set the scope of this PR.

An LLM was then used to help trace the parser code path, to draft the change and
the test cases, and to work out the normalisation and fuzzy-matching behaviour
described above. I reviewed the diff, ran the tests locally, and confirmed the
before/after behaviour in the running instance myself.

