### PR TITLE
fix: repoint shopping list items when merging a food or unit

### DIFF
--- a/mealie/repos/repository_foods.py
+++ b/mealie/repos/repository_foods.py
@@ -1,6 +1,7 @@
 from pydantic import UUID4
-from sqlalchemy import select
+from sqlalchemy import select, update
 
+from mealie.db.models.household.shopping_list import ShoppingListItem
 from mealie.db.models.recipe.ingredient import IngredientFoodModel
 from mealie.schema.recipe.recipe_ingredient import IngredientFood
 
@@ -17,6 +18,13 @@ class RepositoryFood(GroupRepositoryGeneric[IngredientFood, IngredientFoodModel]
         to_model = self._get_food(to_food)
 
         to_model.ingredients += from_model.ingredients
+
+        # Shopping list items reference the food directly rather than through the ingredients
+        # relationship, so they have to be repointed explicitly. Without this the delete below
+        # either violates a foreign key constraint or leaves the item pointing at a missing food.
+        self.session.execute(
+            update(ShoppingListItem).where(ShoppingListItem.food_id == from_food).values(food_id=to_food)
+        )
 
         try:
             self.session.delete(from_model)

--- a/mealie/repos/repository_units.py
+++ b/mealie/repos/repository_units.py
@@ -1,8 +1,9 @@
 from collections.abc import Iterable
 
 from pydantic import UUID4, BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, update
 
+from mealie.db.models.household.shopping_list import ShoppingListItem
 from mealie.db.models.recipe.ingredient import IngredientUnitModel
 from mealie.lang.providers import get_locale_context
 from mealie.schema.recipe.recipe_ingredient import IngredientUnit, StandardizedUnitType
@@ -119,6 +120,13 @@ class RepositoryUnit(GroupRepositoryGeneric[IngredientUnit, IngredientUnitModel]
         to_model = self._get_unit(to_unit)
 
         to_model.ingredients += from_model.ingredients
+
+        # Shopping list items reference the unit directly rather than through the ingredients
+        # relationship, so they have to be repointed explicitly. Without this the delete below
+        # either violates a foreign key constraint or leaves the item pointing at a missing unit.
+        self.session.execute(
+            update(ShoppingListItem).where(ShoppingListItem.unit_id == from_unit).values(unit_id=to_unit)
+        )
 
         try:
             self.session.delete(from_model)

--- a/tests/unit_tests/repository_tests/test_food_repository.py
+++ b/tests/unit_tests/repository_tests/test_food_repository.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from mealie.schema.household.group_shopping_list import ShoppingListItemCreate, ShoppingListSave
 from mealie.schema.recipe.recipe import Recipe
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient, SaveIngredientFood
 from tests.utils.factories import random_string
@@ -50,3 +51,34 @@ def test_food_merger(unique_user: TestUser):
 
     for ingredient in recipe.recipe_ingredient:
         assert ingredient.food.id == food_1.id  # type: ignore
+
+
+def test_food_merger_with_shopping_list_reference(unique_user: TestUser):
+    """Merging a food that a shopping list item points at should move the reference, not fail."""
+    database = unique_user.repos
+
+    food_1 = database.ingredient_foods.create(SaveIngredientFood(name=random_string(10), group_id=unique_user.group_id))
+    food_2 = database.ingredient_foods.create(SaveIngredientFood(name=random_string(10), group_id=unique_user.group_id))
+
+    shopping_list = database.group_shopping_lists.create(
+        ShoppingListSave(
+            name=random_string(10),
+            group_id=unique_user.group_id,
+            user_id=unique_user.user_id,
+        )
+    )
+
+    item = database.group_shopping_list_item.create(
+        ShoppingListItemCreate(
+            shopping_list_id=shopping_list.id,
+            note=random_string(10),
+            quantity=1,
+            food_id=food_2.id,
+        )
+    )
+
+    database.ingredient_foods.merge(food_2.id, food_1.id)
+
+    updated_item = database.group_shopping_list_item.get_one(item.id)
+    assert updated_item
+    assert updated_item.food_id == food_1.id

--- a/tests/unit_tests/repository_tests/test_unit_repository.py
+++ b/tests/unit_tests/repository_tests/test_unit_repository.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from mealie.repos.all_repositories import AllRepositories, get_repositories
+from mealie.schema.household.group_shopping_list import ShoppingListItemCreate, ShoppingListSave
 from mealie.schema.recipe.recipe import Recipe
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient, SaveIngredientUnit
 from mealie.schema.user.user import GroupBase
@@ -142,3 +143,34 @@ def test_ignore_incomplete_standardization(unique_db: AllRepositories):
 
     assert unit_out.standard_quantity is None
     assert unit_out.standard_unit is None
+
+
+def test_unit_merger_with_shopping_list_reference(unique_user: TestUser):
+    """Merging a unit that a shopping list item points at should move the reference, not fail."""
+    database = unique_user.repos
+
+    unit_1 = database.ingredient_units.create(SaveIngredientUnit(name=random_string(10), group_id=unique_user.group_id))
+    unit_2 = database.ingredient_units.create(SaveIngredientUnit(name=random_string(10), group_id=unique_user.group_id))
+
+    shopping_list = database.group_shopping_lists.create(
+        ShoppingListSave(
+            name=random_string(10),
+            group_id=unique_user.group_id,
+            user_id=unique_user.user_id,
+        )
+    )
+
+    item = database.group_shopping_list_item.create(
+        ShoppingListItemCreate(
+            shopping_list_id=shopping_list.id,
+            note=random_string(10),
+            quantity=1,
+            unit_id=unit_2.id,
+        )
+    )
+
+    database.ingredient_units.merge(unit_2.id, unit_1.id)
+
+    updated_item = database.group_shopping_list_item.get_one(item.id)
+    assert updated_item
+    assert updated_item.unit_id == unit_1.id


### PR DESCRIPTION
## What this PR does / why we need it:

Merging a food that a shopping list item points at fails. `RepositoryFood.merge()`
moves the recipe ingredients from the old food to the new one and then deletes the
old food, but shopping list items reference the food through their own `food_id`
column rather than through that relationship, so nothing repoints them first.

The symptom depends on the database:

- **PostgreSQL** (as reported in the issue): the foreign key is enforced, the
  delete raises `shopping_list_items_food_id_fkey`, and the route returns HTTP 500
  with no feedback in the UI.
- **SQLite**: foreign keys are not enforced by default, so the delete succeeds and
  the shopping list item is left pointing at a food that no longer exists. The item
  silently shows no food, which is harder to notice than the 500.

Changes:

- `repos/repository_foods.py` — repoints shopping list items from the old food to
  the new one before the delete.
- `repos/repository_units.py` — the same fix for units. `RepositoryUnit.merge()`
  contains identical code and shopping list items also carry a `unit_id`, so this
  is the case reported in #4936, which was marked as a duplicate of this issue.

This is what the reporter asked for in the thread — repointing the reference rather
than blocking the merge.

## Which issue(s) this PR fixes:

Addresses #3624 (and #4936, marked as a duplicate of it).

I have deliberately not used a closing keyword, because the thread also covers
deleting a food, which this PR does not change. See the note below.

## Special notes for your reviewer:

**The deletion case is not covered here, and I would like your call on it before
adding it.** @ChrisLane raised deletion in the thread, and your reply was:

> Ideally when deleting foods, existing shopping list items are either deleted, or
> their food is converted to a note before deletion. Ingredients should probably do
> this too as long as we're adding custom food deletion logic.

I confirmed plain deletion has the same defect — on SQLite the shopping list item
survives with a `food_id` pointing at a row that no longer exists. But the two
options you listed lead to different user-visible behaviour, and picking one is a
product decision rather than a bug fix, so I did not want to guess. If you tell me
which you prefer I am happy to add it to this PR.

One implementation note: I used an explicit `UPDATE` rather than adding a
`shopping_list_items` relationship to the food and unit models, to keep the change
local to the merge methods.

## Testing

A regression test was added next to each existing merge test:
`test_food_merger_with_shopping_list_reference` and
`test_unit_merger_with_shopping_list_reference`. Both create a shopping list item
that references the food/unit being merged away, then assert the item points at the
surviving record. Both were confirmed failing against the old behaviour before the
fix was applied.

The existing `test_food_merger` and `test_unit_merger` only exercise recipe
ingredient references, which is why this went unnoticed.

Full `tests/unit_tests/repository_tests/` (156 tests) and the shopping list
integration suites (50 tests) pass.

## AI / LLM Assistance

I picked this issue and reproduced it locally before starting, including confirming
that the deletion path described in the comments has the same defect. An LLM was
used to help trace which tables reference `ingredient_foods`, to draft the fix and
the regression tests, and to check whether units were affected in the same way. I
reviewed the diff and ran the tests locally, including confirming both new tests
failed before the change and passed after it.