### PR TITLE
fix: export displayed recipe times as ISO durations

### DIFF
--- a/mealie/routes/spa/__init__.py
+++ b/mealie/routes/spa/__init__.py
@@ -1,7 +1,9 @@
 import html
 import json
 import pathlib
+import re
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 from bs4 import BeautifulSoup
@@ -17,8 +19,19 @@ from mealie.core.dependencies.dependencies import try_get_current_user
 from mealie.db.db_setup import generate_session
 from mealie.repos.repository_factory import AllRepositories
 from mealie.routes.spa.manifest import serve_manifest
+from mealie.schema._mealie.datetime_parse import parse_duration
 from mealie.schema.recipe.recipe import Recipe
 from mealie.schema.user.user import PrivateUser
+
+TIME_PART_RE = re.compile(
+    r"(?P<value>\d+(?:\.\d+)?)\s*"
+    r"(?P<unit>days?|hours?|hrs?|minutes?|mins?|seconds?|secs?)\b",
+    re.I,
+)
+TIME_SEPARATOR_RE = re.compile(
+    r"[\s,]*(?:and[\s,]*)?",
+    re.I,
+)
 
 
 @dataclass
@@ -113,6 +126,81 @@ def inject_recipe_json(contents: str, schema: dict) -> str:
     return contents.replace("</head>", schema_as_html_tag + "\n</head>", 1)
 
 
+def timedelta_to_iso8601_duration(
+    duration: timedelta,
+) -> str | None:
+    if duration < timedelta(0):
+        return None
+
+    total_seconds = int(duration.total_seconds())
+    if not total_seconds:
+        return "PT0S"
+
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    date_part = f"{days}D" if days else ""
+
+    time_parts = []
+    if hours:
+        time_parts.append(f"{hours}H")
+    if minutes:
+        time_parts.append(f"{minutes}M")
+    if seconds:
+        time_parts.append(f"{seconds}S")
+
+    time_part = f"T{''.join(time_parts)}" if time_parts else ""
+    return f"P{date_part}{time_part}"
+
+
+def schema_org_duration(value: str | None) -> str | None:
+    if not value:
+        return None
+
+    value = value.strip()
+    if not value:
+        return None
+
+    if value.isdecimal():
+        return timedelta_to_iso8601_duration(timedelta(minutes=int(value)))
+
+    try:
+        return timedelta_to_iso8601_duration(parse_duration(value))
+    except ValueError:
+        pass
+
+    duration = timedelta()
+    cursor = 0
+
+    for match in TIME_PART_RE.finditer(value):
+        separator = value[cursor : match.start()]
+        if TIME_SEPARATOR_RE.fullmatch(separator) is None:
+            return value
+
+        amount = float(match.group("value"))
+        unit = match.group("unit").lower()
+
+        if unit.startswith("day"):
+            duration += timedelta(days=amount)
+        elif unit.startswith(("hour", "hr")):
+            duration += timedelta(hours=amount)
+        elif unit.startswith(("minute", "min")):
+            duration += timedelta(minutes=amount)
+        elif unit.startswith(("second", "sec")):
+            duration += timedelta(seconds=amount)
+
+        cursor = match.end()
+
+    if TIME_SEPARATOR_RE.fullmatch(value[cursor:]) is None:
+        return value
+
+    if not duration:
+        return value
+
+    return timedelta_to_iso8601_duration(duration)
+
+
 def content_with_meta(group_slug: str, recipe: Recipe) -> str:
     # Inject meta tags
     recipe_url = f"{__app_settings.BASE_URL}/g/{group_slug}/r/{recipe.slug}"
@@ -147,9 +235,9 @@ def content_with_meta(group_slug: str, recipe: Recipe) -> str:
         "description": escape(recipe.description),
         "image": [image_url],
         "datePublished": recipe.created_at,
-        "prepTime": escape(recipe.prep_time),
-        "cookTime": escape(recipe.cook_time),
-        "totalTime": escape(recipe.total_time),
+        "prepTime": escape(schema_org_duration(recipe.prep_time)),
+        "cookTime": escape(schema_org_duration(recipe.perform_time or recipe.cook_time)),
+        "totalTime": escape(schema_org_duration(recipe.total_time)),
         "recipeYield": escape(recipe.recipe_yield_display),
         "recipeIngredient": ingredients,
         "recipeInstructions": [escape(i.text) for i in recipe.recipe_instructions]

--- a/tests/integration_tests/test_spa.py
+++ b/tests/integration_tests/test_spa.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from bs4 import BeautifulSoup
 
@@ -107,6 +109,37 @@ def test_spa_recipe_json_injection():
     assert "@context" in html
     assert "https://schema.org" in html
     assert recipe_name in html
+
+
+def test_spa_recipe_json_uses_iso8601_durations(
+    unique_user: TestUser,
+):
+    recipe = Recipe(
+        user_id=unique_user.user_id,
+        group_id=unique_user.group_id,
+        name=random_string(),
+        prep_time="10 minutes",
+        perform_time="30 minutes",
+        total_time="40 minutes",
+    )
+
+    html = spa.content_with_meta(
+        str(unique_user.group_id),
+        recipe,
+    )
+    soup = BeautifulSoup(html, "lxml")
+    script = soup.find(
+        "script",
+        type="application/ld+json",
+    )
+
+    assert script and script.string
+
+    schema = json.loads(script.string)
+
+    assert schema["prepTime"] == "PT10M"
+    assert schema["cookTime"] == "PT30M"
+    assert schema["totalTime"] == "PT40M"
 
 
 @pytest.mark.parametrize("use_public_user", [True, False])


### PR DESCRIPTION
## What this PR does / why we need it:

- Converts human-readable recipe times to ISO 8601 durations when generating
  Schema.org Recipe JSON-LD.
- Exports the recipe editor's `performTime` value as Schema.org `cookTime`.
- Falls back to `recipe.cook_time` when `recipe.perform_time` is unavailable.
- Keeps the stored values and recipe-page display unchanged.
- Leaves unrecognized time text unchanged instead of guessing.

Previously, values such as `10 minutes` and `40 minutes` were copied directly
into the JSON-LD. The displayed cooking time could also be exported as `null`
because the recipe editor uses `recipe.perform_time`, while the JSON-LD
generator previously read `recipe.cook_time`.

### Before

The page displays all three times, but the JSON-LD contains human-readable
durations and does not include the displayed cooking time.

<img width="1267" height="915" alt="8148before" src="https://github.com/user-attachments/assets/63bc111a-e834-4a92-a273-40087a8bdbab" />

### After

The displayed times are exported as ISO 8601 durations.

<img width="1259" height="929" alt="8148after" src="https://github.com/user-attachments/assets/555f3418-a6d5-4837-94d3-bc76ca2a57ae" />

## Which issue(s) this PR fixes:

Fixes #8148

## Difference from #8154

This PR overlaps with #8154, which also converts human-readable recipe times
to ISO 8601 durations.

The additional behavior covered here is the field used by the current recipe
editor. #8154 exports Schema.org `cookTime` from:

```python
recipe.cook_time

This prevents Schema.org `cookTime` from being `null` when the recipe page
displays a cooking time. The integration test uses
`perform_time="30 minutes"` to cover the behavior reproduced through the
current editor.

## Special notes for your reviewer:

Please review whether `perform_time` should be the preferred source for
Schema.org `cookTime`, with `cook_time` retained as a fallback for older
recipe data.

## Testing

- Built and ran the modified source using Docker.
- Verified a recipe with a 10-minute preparation time, a 30-minute cooking
  time, and a 40-minute total time.
- Verified that the recipe page still displays human-readable times.
- Verified that the JSON-LD exports `PT10M`, `PT30M`, and `PT40M`.
- Ran Ruff check on the modified files.
- Ran Ruff format check on the modified files.
- Ran `git diff --check`.

The focused pytest file could not be run locally because the available Python
environment was missing the application dependency `fastapi`. No pytest pass
is claimed.

## Release Notes

- Fixed Schema.org recipe time exports, including the cooking time displayed
  by the current recipe editor.

## AI / LLM Assistance

I used OpenAI Codex to help locate the JSON-LD generation path, compare the
implementation with #8154, prepare the duration conversion, troubleshoot the
local test environment, and plan the pull request. I reviewed the final diff
and manually verified the behavior using Docker before submitting.