### PR TITLE
fix: show progress on ingredient parser review buttons

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogParse.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogParse.vue
@@ -46,6 +46,7 @@
         :icon="$globals.icons.units"
         color="warning"
         size="small"
+        :loading="state.loading.unit"
         @click="createMissingUnit"
       >
         {{ $t("recipe.parser.missing-unit", { unit: currentMissingUnit }) }}
@@ -59,6 +60,7 @@
         :icon="$globals.icons.units"
         color="warning"
         size="small"
+        :loading="state.loading.unit"
         @click="addMissingUnitAsAlias"
       >
         {{ $t("recipe.parser.add-text-as-alias-for-item", { text: currentMissingUnit, item: currentIng.ingredient.unit.name }) }}
@@ -68,6 +70,7 @@
         :icon="$globals.icons.foods"
         color="warning"
         size="small"
+        :loading="state.loading.food"
         @click="createMissingFood"
       >
         {{ $t("recipe.parser.missing-food", { food: currentMissingFood }) }}
@@ -81,6 +84,7 @@
         :icon="$globals.icons.foods"
         color="warning"
         size="small"
+        :loading="state.loading.food"
         @click="addMissingFoodAsAlias"
       >
         {{ $t("recipe.parser.add-text-as-alias-for-item", { text: currentMissingFood, item: currentIng.ingredient.food.name }) }}
@@ -97,6 +101,7 @@ const props = defineProps<{
 }>();
 
 const {
+  state,
   currentIng,
   availableParsers,
   currentIngShouldDelete,

--- a/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
+++ b/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
@@ -69,6 +69,12 @@ export function useParseIngredientsDialog(
     saveLoading: false,
     step: ParseStep.LOADING,
     loadingCount: 0,
+    // Tracked separately from loadingCount, which covers the bulk parse: one ingredient can be
+    // missing both a unit and a food, and only the button that was pressed should react.
+    loading: {
+      unit: false,
+      food: false,
+    },
   });
   function nextStep() {
     state.step = getNextStep(state.step);
@@ -265,22 +271,28 @@ export function useParseIngredientsDialog(
     unitData.reset();
     unitData.data.name = currentMissingUnit.value;
 
-    let newUnit: IngredientUnit | null;
-    if (createdUnits.has(unitData.data.name)) {
-      newUnit = createdUnits.get(unitData.data.name)!;
-    }
-    else {
-      newUnit = await unitStore.actions.createOne(unitData.data);
-    }
+    state.loading.unit = true;
+    try {
+      let newUnit: IngredientUnit | null;
+      if (createdUnits.has(unitData.data.name)) {
+        newUnit = createdUnits.get(unitData.data.name)!;
+      }
+      else {
+        newUnit = await unitStore.actions.createOne(unitData.data);
+      }
 
-    if (!newUnit) {
-      alert.error(i18n.t("events.something-went-wrong"));
-      return;
-    }
+      if (!newUnit) {
+        alert.error(i18n.t("events.something-went-wrong"));
+        return;
+      }
 
-    currentIng.value!.ingredient.unit = newUnit;
-    createdUnits.set(newUnit.name.toLowerCase(), newUnit);
-    currentMissingUnit.value = "";
+      currentIng.value!.ingredient.unit = newUnit;
+      createdUnits.set(newUnit.name.toLowerCase(), newUnit);
+      currentMissingUnit.value = "";
+    }
+    finally {
+      state.loading.unit = false;
+    }
   }
 
   async function createMissingFood() {
@@ -291,22 +303,28 @@ export function useParseIngredientsDialog(
     foodData.reset();
     foodData.data.name = currentMissingFood.value;
 
-    let newFood: IngredientFood | null;
-    if (createdFoods.has(foodData.data.name)) {
-      newFood = createdFoods.get(foodData.data.name)!;
-    }
-    else {
-      newFood = await foodStore.actions.createOne(foodData.data);
-    }
+    state.loading.food = true;
+    try {
+      let newFood: IngredientFood | null;
+      if (createdFoods.has(foodData.data.name)) {
+        newFood = createdFoods.get(foodData.data.name)!;
+      }
+      else {
+        newFood = await foodStore.actions.createOne(foodData.data);
+      }
 
-    if (!newFood) {
-      alert.error(i18n.t("events.something-went-wrong"));
-      return;
-    }
+      if (!newFood) {
+        alert.error(i18n.t("events.something-went-wrong"));
+        return;
+      }
 
-    currentIng.value!.ingredient.food = newFood;
-    createdFoods.set(newFood.name.toLowerCase(), newFood);
-    currentMissingFood.value = "";
+      currentIng.value!.ingredient.food = newFood;
+      createdFoods.set(newFood.name.toLowerCase(), newFood);
+      currentMissingFood.value = "";
+    }
+    finally {
+      state.loading.food = false;
+    }
   }
 
   async function addMissingUnitAsAlias() {
@@ -321,14 +339,21 @@ export function useParseIngredientsDialog(
     }
 
     unit.aliases.push({ name: currentMissingUnit.value });
-    const updated = await unitStore.actions.updateOne(unit);
-    if (!updated) {
-      alert.error(i18n.t("events.something-went-wrong"));
-      return;
-    }
 
-    currentIng.value!.ingredient.unit = updated;
-    currentMissingUnit.value = "";
+    state.loading.unit = true;
+    try {
+      const updated = await unitStore.actions.updateOne(unit);
+      if (!updated) {
+        alert.error(i18n.t("events.something-went-wrong"));
+        return;
+      }
+
+      currentIng.value!.ingredient.unit = updated;
+      currentMissingUnit.value = "";
+    }
+    finally {
+      state.loading.unit = false;
+    }
   }
 
   async function addMissingFoodAsAlias() {
@@ -343,14 +368,21 @@ export function useParseIngredientsDialog(
     }
 
     food.aliases.push({ name: currentMissingFood.value });
-    const updated = await foodStore.actions.updateOne(food);
-    if (!updated) {
-      alert.error(i18n.t("events.something-went-wrong"));
-      return;
-    }
 
-    currentIng.value!.ingredient.food = updated;
-    currentMissingFood.value = "";
+    state.loading.food = true;
+    try {
+      const updated = await foodStore.actions.updateOne(food);
+      if (!updated) {
+        alert.error(i18n.t("events.something-went-wrong"));
+        return;
+      }
+
+      currentIng.value!.ingredient.food = updated;
+      currentMissingFood.value = "";
+    }
+    finally {
+      state.loading.food = false;
+    }
   }
 
   watch(parser, () => {


### PR DESCRIPTION
## What this PR does / why we need it:

The four buttons in the parser review step (create the missing unit or food, add the parsed text
as an alias) each do an API round trip with no feedback at all. On a slow connection nothing
appears to happen and you click again.

Uses the `state.loading` object the dialog already has. Unit and food are tracked separately,
since one ingredient can be missing both and only the button you pressed should react.

## Which issue(s) this PR fixes:

None that I could find. Noticed while using the parser on a German recipe library.

## AI / LLM Assistance

The change was written with Claude Code against a running dev instance. I reviewed it and checked
the button states before opening.

## Release Notes

The buttons for creating a missing unit or food, and for adding a parsed name as an alias, now
show a progress indicator while the change is saved.
