### PR TITLE
fix: don't default to the English-only parser in other languages

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogChangeParser.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogChangeParser.vue
@@ -14,6 +14,15 @@
       </BaseButton>
     </v-card-actions>
   </v-card>
+  <v-alert
+    v-if="showNlpLanguageHint"
+    type="info"
+    variant="tonal"
+    density="compact"
+    class="mt-3 text-body-2"
+  >
+    {{ $t("recipe.parser.natural-language-processor-english-only") }}
+  </v-alert>
   <BaseDialog
     v-model="open"
     bottom-sheet
@@ -41,7 +50,7 @@
 import type { MenuItem } from "~/components/global/BaseOverflowButton.vue";
 import type { Parser } from "~/lib/api/user/recipes/recipe";
 
-defineProps<{ availableParsers: MenuItem[] }>();
+defineProps<{ availableParsers: MenuItem[]; showNlpLanguageHint: boolean }>();
 const emit = defineEmits<{ parse: [] }>();
 const currentParser = defineModel<Parser>({ default: "nlp" });
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogParse.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogParse.vue
@@ -2,6 +2,7 @@
   <ParseDialogChangeParser
     v-model="parser"
     :available-parsers="availableParsers"
+    :show-nlp-language-hint="showNlpLanguageHint"
     @update:model-value="(newParser) => parser = newParser"
     @parse="parseIngredients"
   />
@@ -103,6 +104,7 @@ const props = defineProps<{
 const {
   state,
   currentIng,
+  showNlpLanguageHint,
   availableParsers,
   currentIngShouldDelete,
   parser,

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogReview.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/ParseDialogReview.vue
@@ -3,6 +3,7 @@
     <ParseDialogChangeParser
       v-model="state.parser"
       :available-parsers="availableParsers"
+      :show-nlp-language-hint="showNlpLanguageHint"
       @update:model-value="$emit('changeParser', $event)"
       @parse="$emit('parse')"
     />
@@ -64,6 +65,7 @@ defineEmits<{
 const props = defineProps<{
   availableParsers: MenuItem[];
   parser: Parser;
+  showNlpLanguageHint: boolean;
 }>();
 const parsedIngs = defineModel<ParsedIngredient[]>({ required: true });
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/RecipePageParseDialog.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipeParseDialog/RecipePageParseDialog.vue
@@ -26,6 +26,7 @@
             v-model="parsedIngs"
             :available-parsers="availableParsers"
             :parser="parser"
+            :show-nlp-language-hint="showNlpLanguageHint"
             @parse="parseIngredients"
             @change-parser="(newParser) => parser = newParser"
           />
@@ -83,6 +84,7 @@ const dialogState = useParseIngredientsDialog(props.ingredients, ings => emit("s
 const {
   availableParsers,
   parser,
+  showNlpLanguageHint,
   dontShowInfoPage,
   parsedIngs,
   currentIng,

--- a/frontend/app/composables/recipes/__tests__/use-parse-ingredients-dialog.test.ts
+++ b/frontend/app/composables/recipes/__tests__/use-parse-ingredients-dialog.test.ts
@@ -5,6 +5,7 @@ import type { ParsedIngredient, RecipeIngredient } from "~/lib/api/types/recipe"
 import { uuid4 } from "../../use-utils";
 import { ParseStep, useParseIngredientsDialog } from "../use-parse-ingredients-dialog";
 import type { Parser } from "~/lib/api/user/recipes/recipe";
+import { i18n } from "~/tests/setup";
 
 (global as any).uuid4 = uuid4;
 
@@ -33,8 +34,19 @@ const preferences = ref({
   parser: "nlp",
   dontShowInfoPage: true,
 });
+// `useLocalStorage(..., { mergeDefaults: true })` only falls back to the caller's default when
+// nothing has been stored yet. `parsingStorageEmpty` models that first-visit case; the existing
+// tests leave it false, so a stored preference keeps winning for them.
+let parsingStorageEmpty = false;
+let lastDefaultParser: Parser | undefined;
 vi.mock("../../use-users/preferences", () => ({
-  useParsingPreferences: () => preferences,
+  useParsingPreferences: (defaultParser: Parser = "nlp") => {
+    lastDefaultParser = defaultParser;
+    if (parsingStorageEmpty) {
+      preferences.value.parser = defaultParser;
+    }
+    return preferences;
+  },
 }));
 
 const createFood = vi.fn().mockResolvedValue({ id: "food_id", name: "fuwud" });
@@ -108,6 +120,9 @@ describe("useParseIngredientsDialog", () => {
       parser: "nlp",
       dontShowInfoPage: false,
     };
+    parsingStorageEmpty = false;
+    lastDefaultParser = undefined;
+    i18n.global.locale = "en-US";
     vi.clearAllMocks();
   });
 
@@ -659,5 +674,55 @@ describe("useParseIngredientsDialog", () => {
     const { parserPreferences: newPrefs } = wrapped.vm;
     expect(newPrefs.parser).toBe("openai");
     expect(newPrefs.dontShowInfoPage).toBe(true);
+  });
+
+  describe("locale-aware parser default", () => {
+    test("an English locale with nothing stored keeps the natural language processor", () => {
+      parsingStorageEmpty = true;
+      const { parser, showNlpLanguageHint } = wrapper().vm;
+      expect(lastDefaultParser).toBe("nlp");
+      expect(parser).toBe("nlp");
+      expect(showNlpLanguageHint).toBe(false);
+    });
+
+    test("another locale with nothing stored starts on the brute parser", () => {
+      i18n.global.locale = "de-DE";
+      parsingStorageEmpty = true;
+      const { parser, showNlpLanguageHint } = wrapper().vm;
+      expect(lastDefaultParser).toBe("brute");
+      expect(parser).toBe("brute");
+      // No hint: the parser it landed on is the one being recommended.
+      expect(showNlpLanguageHint).toBe(false);
+    });
+
+    test("a stored preference is never overridden", () => {
+      i18n.global.locale = "de-DE";
+      preferences.value.parser = "nlp";
+      const { parser } = wrapper().vm;
+      expect(parser).toBe("nlp");
+    });
+
+    test("the hint appears for a stored nlp preference outside English", () => {
+      i18n.global.locale = "de-DE";
+      preferences.value.parser = "nlp";
+      expect(wrapper().vm.showNlpLanguageHint).toBe(true);
+    });
+
+    test("the hint stays away on an English locale", () => {
+      preferences.value.parser = "nlp";
+      expect(wrapper().vm.showNlpLanguageHint).toBe(false);
+    });
+
+    test("the hint goes away once another parser is picked", async () => {
+      i18n.global.locale = "de-DE";
+      preferences.value.parser = "nlp";
+      const wrapped = wrapper();
+      expect(wrapped.vm.showNlpLanguageHint).toBe(true);
+
+      wrapped.vm.setParser("brute");
+      await wrapped.vm.$nextTick();
+
+      expect(wrapped.vm.showNlpLanguageHint).toBe(false);
+    });
   });
 });

--- a/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
+++ b/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
@@ -29,8 +29,12 @@ export function useParseIngredientsDialog(
   const foodStore = useFoodStore();
   const foodData = useFoodData();
 
-  const parserPreferences = useParsingPreferences();
+  // The natural language parser is trained on English recipes, so it isn't a sensible default for
+  // other languages: it recognises the quantity but leaves the unit in the food name.
+  const isEnglishLocale = computed(() => (i18n.locale.value || "").toLowerCase().startsWith("en"));
+  const parserPreferences = useParsingPreferences(isEnglishLocale.value ? "nlp" : "brute");
   const parser = ref<Parser>(parserPreferences.value.parser || "nlp");
+  const showNlpLanguageHint = computed(() => parser.value === "nlp" && !isEnglishLocale.value);
   const dontShowInfoPage = ref(parserPreferences.value.dontShowInfoPage);
   const availableParsers = computed(() => {
     return [
@@ -429,6 +433,7 @@ export function useParseIngredientsDialog(
     availableParsers,
     parserPreferences,
     parser,
+    showNlpLanguageHint,
     dontShowInfoPage,
     confidenceThreshold,
     parsedIngs,

--- a/frontend/app/composables/use-users/preferences.ts
+++ b/frontend/app/composables/use-users/preferences.ts
@@ -181,11 +181,16 @@ export function useTimelinePreferences(): Ref<UserTimelinePreferences> {
   return fromStorage;
 }
 
-export function useParsingPreferences(): Ref<UserParsingPreferences> {
+/**
+ * @param defaultParser used only when no preference has been stored yet. Callers that know the
+ * user's locale can pass a parser better suited to it, since the natural language parser is
+ * trained on English recipes.
+ */
+export function useParsingPreferences(defaultParser: RegisteredParser = "nlp" as RegisteredParser): Ref<UserParsingPreferences> {
   const fromStorage = useLocalStorage(
     "parsing-preferences",
     {
-      parser: "nlp" as RegisteredParser,
+      parser: defaultParser,
       dontShowInfoPage: false,
     },
     { mergeDefaults: true },

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -600,6 +600,7 @@
       "dont-show-again": "Don't show this again",
       "try-again-with-parser": "Try again with {parser}",
       "natural-language-processor": "Natural Language Processor",
+      "natural-language-processor-english-only": "The Natural Language Processor is trained on English recipes. For recipes in other languages it usually recognizes the amount but not the unit, so the Brute Parser or the OpenAI Parser tends to give better results.",
       "brute-parser": "Brute Parser",
       "openai-parser": "OpenAI Parser",
       "missing-unit": "Create missing unit: {unit}",


### PR DESCRIPTION
## What this PR does / why we need it:

The Natural Language Processor only has an English model (`SUPPORTED_LANGUAGES == ["en"]`). On a
recipe in another language it still gets the amount right, because digits are language
independent, but the unit never gets tagged and ends up inside the food name.

I ran 16 German ingredient lines from two recipes I had been experimenting with through
`/api/parser/ingredient`, with German units seeded:

| input | Natural Language Processor | Brute Parser |
| --- | --- | --- |
| `1/2 Dose gehackte Tomaten` | 0.5 · — · `Dosen gehackte Tomaten` | 0.5 · Dose · `gehackte Tomaten` |
| `2 EL Olivenöl` | 2 · — · `EL Olivenöl` | 2 · Esslöffel · `Olivenöl` |
| `1 TL Salz` | 1 · — · `TL Salz` | 1 · Teelöffel · `Salz` |
| `1 Päckchen Backpulver` | 1 · — · `Päckchen Backpulver` | 1 · Packung · `Backpulver` |
| `1 Bund Petersilie` | 1 · — · `Bund Petersilie` | 1 · Bund · `Petersilie` |

4 of 16 units recognised by the NLP parser (only g, ml, kg, which also occur in English recipes)
against 14 of 16 for the brute parser, which resolves abbreviations through the database.

Everyone still starts on the NLP parser, and its name makes it sound like the better of the two.

`useParsingPreferences()` now takes a default that only applies when nothing is stored, and the
dialog passes `brute` outside English locales. A stored preference is never overridden.

The dialog also shows a hint when the NLP parser is selected in a non-English locale. That part
is what reaches existing users: `mergeDefaults: true` persists the default on first use, so
anyone who has opened the dialog already has `{"parser":"nlp"}` stored and would never see a
changed default.

One new `en-US` string, no other locales touched.

## Which issue(s) this PR fixes:

None directly. Related: #7108, where a maintainer confirms the English-only limitation and
recommends the brute or OpenAI parser. This makes the product say that instead of relying on
users finding the issue.

## Special notes for your reviewer:

Locale detection is `locale.startsWith("en")`.

I left the backend default alone, since the server has no reliable notion of the caller's
language. Happy to move it if you'd rather decide this server-side.

## Testing

| locale | stored preference | preselected | hint |
| --- | --- | --- | --- |
| `de-DE` | none | Brute Parser | no |
| `en-US` | none | Natural Language Processor | no |
| `de-DE` | `nlp` | Natural Language Processor | yes |

`pnpm lint` and `pnpm vitest run` pass.

## AI / LLM Assistance

The measurements above, the change and the tests were produced with Claude Code against a running
dev instance. The parser table is reproducible via `/api/parser/ingredient`.

## Release Notes

Outside English, the ingredient parser no longer defaults to the Natural Language Processor,
which only understands English recipes. If it is selected anyway, the dialog explains why that
may not work.
