### PR TITLE
dev: relax pnpm pin

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -21,15 +21,9 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      # Work around pnpm/action-setup v6 resolving the wrong version from package.json
-      # https://github.com/pnpm/action-setup/issues/227
-      - name: Read pnpm version
-        id: pnpm-version
-        run: 'echo "version=$(jq --raw-output ''.packageManager | split("@")[1]'' package.json)" >> "$GITHUB_OUTPUT"'
-        working-directory: "frontend"
       - uses: pnpm/action-setup@v6
         with:
-          version: ${{ steps.pnpm-version.outputs.version }}
+          version: 11
 
       - name: Setup node env 🏗
         uses: actions/setup-node@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,14 +11,9 @@ jobs:
         working-directory: ./tests/e2e
     steps:
       - uses: actions/checkout@v6
-      # Work around pnpm/action-setup v6 resolving the wrong version from package.json
-      # https://github.com/pnpm/action-setup/issues/227
-      - name: Read pnpm version
-        id: pnpm-version
-        run: 'echo "version=$(jq --raw-output ''.packageManager | split("@")[1]'' package.json)" >> "$GITHUB_OUTPUT"'
       - uses: pnpm/action-setup@v6
         with:
-          version: ${{ steps.pnpm-version.outputs.version }}
+          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -17,15 +17,9 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      # Work around pnpm/action-setup v6 resolving the wrong version from package.json
-      # https://github.com/pnpm/action-setup/issues/227
-      - name: Read pnpm version
-        id: pnpm-version
-        run: 'echo "version=$(jq --raw-output ''.packageManager | split("@")[1]'' package.json)" >> "$GITHUB_OUTPUT"'
-        working-directory: "frontend"
       - uses: pnpm/action-setup@v6
         with:
-          version: ${{ steps.pnpm-version.outputs.version }}
+          version: 11
 
       - name: Setup node env 🏗
         uses: actions/setup-node@v6

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,7 @@
 FROM node:24@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 \
     AS frontend-builder
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN corepack enable
+RUN npm install --global pnpm@11
 
 WORKDIR /frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,13 @@
     "vite-plugin-commonjs": "^0.10.4",
     "vitest": "^4.0.0"
   },
-  "packageManager": "pnpm@11.18.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11",
+      "onFail": "warn"
+    }
+  },
   "resolutions": {
     "js-yaml": ">=4.1.1",
     "node-forge": ">=1.3.2"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -8,5 +8,11 @@
     "@types/node": "^24.12.4"
   },
   "scripts": {},
-  "packageManager": "pnpm@11.18.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11",
+      "onFail": "warn"
+    }
+  }
 }


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Relaxes the pnpm pin so we don't have to manage it so tightly. It's mostly a dev tool so tight version control is unnecessary. At build time we run e2e tests to make sure it works as expected anyway. This is more or less what we did with yarn.

## Which issue(s) this PR fixes:

_(REQUIRED)_

None

## Testing

_(fill-in or delete this section)_

Manually

## AI / LLM Assistance

_(REQUIRED)_

Claude go brrr
