### PR TITLE
fix: allow SMTP encryption without authentication

### DIFF
--- a/docs/docs/documentation/getting-started/installation/backend-config.md
+++ b/docs/docs/documentation/getting-started/installation/backend-config.md
@@ -53,8 +53,8 @@
 | SMTP_FROM_NAME                                  | Mealie  | Required For email                                |
 | SMTP_AUTH_STRATEGY                              |   TLS   | Required For email, Options: 'TLS', 'SSL', 'NONE' |
 | SMTP_FROM_EMAIL                                 |  None   | Required For email                                |
-| SMTP_USER<super>[&dagger;][secrets]</super>     |  None   | Required if SMTP_AUTH_STRATEGY is 'TLS' or 'SSL'  |
-| SMTP_PASSWORD<super>[&dagger;][secrets]</super> |  None   | Required if SMTP_AUTH_STRATEGY is 'TLS' or 'SSL'  |
+| SMTP_USER<super>[&dagger;][secrets]</super>     |  None   | Optional; must be set together with SMTP_PASSWORD |
+| SMTP_PASSWORD<super>[&dagger;][secrets]</super> |  None   | Optional; must be set together with SMTP_USER     |
 
 ### Webworker
 

--- a/mealie/core/settings/settings.py
+++ b/mealie/core/settings/settings.py
@@ -320,20 +320,15 @@ class AppSettings(AppLoggingSettings):
             "SMTP_FROM_EMAIL": from_email,
             "SMTP_AUTH_STRATEGY": strategy,
         }
-        missing_values = [key for (key, value) in required.items() if value is None]
+        if user or password:
+            required["SMTP_USER"] = user
+            required["SMTP_PASSWORD"] = password
+
+        missing_values = [key for (key, value) in required.items() if value is None or value == ""]
         if missing_values:
             description = f"Missing required values for {missing_values}"
 
-        if strategy and strategy.upper() in {"TLS", "SSL"}:
-            required["SMTP_USER"] = user
-            required["SMTP_PASSWORD"] = password
-            if not description:
-                missing_values = [key for (key, value) in required.items() if value is None]
-                description = f"Missing required values for {missing_values} because SMTP_AUTH_STRATEGY is not None"
-
-        not_none = "" not in required.values() and None not in required.values()
-
-        return FeatureDetails(enabled=not_none, description=description)
+        return FeatureDetails(enabled=not missing_values, description=description)
 
     # ===============================================
     # LDAP Configuration

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -189,8 +189,8 @@ class SMTPValidationCase:
     auth_strategy: str
     from_name: str
     from_email: str
-    user: str
-    password: str
+    user: str | None
+    password: str | None
     is_valid: bool
 
 
@@ -206,6 +206,24 @@ smtp_validation_cases = [
     (
         "no_auth",
         SMTPValidationCase("email.mealie.io", "25", "none", "Mealie", "mealie@mealie.io", "", "", True),
+    ),
+    (
+        "tls_without_credentials",
+        SMTPValidationCase("email.mealie.io", "587", "tls", "Mealie", "mealie@mealie.io", None, None, True),
+    ),
+    (
+        "ssl_without_credentials",
+        SMTPValidationCase("email.mealie.io", "465", "ssl", "Mealie", "mealie@mealie.io", "", "", True),
+    ),
+    (
+        "tls_with_username_only",
+        SMTPValidationCase(
+            "email.mealie.io", "587", "tls", "Mealie", "mealie@mealie.io", "mealie@mealie.io", "", False
+        ),
+    ),
+    (
+        "ssl_with_password_only",
+        SMTPValidationCase("email.mealie.io", "465", "ssl", "Mealie", "mealie@mealie.io", "", "mealie-password", False),
     ),
     (
         "good_data_tls",
@@ -225,7 +243,7 @@ smtp_validation_cases = [
         SMTPValidationCase(
             "email.mealie.io",
             "465",
-            "tls",
+            "ssl",
             "Mealie",
             "mealie@mealie.io",
             "mealie@mealie.io",


### PR DESCRIPTION
## What this PR does / why we need it:

### Problem

SMTP validation currently treats `TLS` and `SSL` as authentication modes and requires `SMTP_USER` and `SMTP_PASSWORD` for either. Transport encryption and SMTP authentication are independent, and the sender already skips `login()` when credentials are absent.

### Changes

- Allow TLS and SSL connections without SMTP credentials.
- Continue to reject configurations that provide only one of username or password.
- Add regression cases for authenticated, unauthenticated, and partially configured TLS/SSL settings.
- Document SMTP credentials as an optional pair.

### User impact

Mealie can send through trusted relays that provide encrypted SMTP without requiring users to create an unnecessary mailbox.

## Which issue(s) this PR fixes:

Fixes #6212

## Testing

- `pytest tests/unit_tests/test_config.py -k smtp`: 9 passed.
- Broader configuration suite excluding an existing Windows-only SQLite path assertion: 58 passed.
- Ruff check and format check: passed.
- Mypy on the changed settings and test modules: passed.
- MkDocs build: passed (with the repository's existing `demo_url` warning).

The locked Python environment was installed on Windows with `python-ldap` omitted because that package requires native OpenLDAP/MSVC build dependencies; the SMTP tests do not depend on LDAP.

## AI / LLM Assistance

LLM assistance was used to analyze the validation path, implement the focused change, and add regression tests. I reviewed the final diff and all reported verification results before submission.