### PR TITLE
fix: wrap timeline event subjects

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeTimelineItem.vue
@@ -25,7 +25,7 @@
               {{ $d(new Date(event.timestamp || "")) }}
             </v-chip>
           </v-col>
-          <v-col v-else cols="9" class="break-word" style="margin: auto; text-align: center">
+          <v-col v-else cols="9" class="text-wrap break-word" style="margin: auto; text-align: center">
             {{ event.subject }}
           </v-col>
           <v-col :cols="useMobileFormat ? 'auto' : '1'" class="px-0 pt-0">


### PR DESCRIPTION
## What this PR does / why we need it:

Timeline event subjects inherit Vuetify's no-wrap card-title behavior. At intermediate viewport widths, longer subjects can therefore overflow and be clipped.

- Add Vuetify's existing `text-wrap` utility to the subject column.
- Keep the current grid, responsive breakpoints, avatar, and context-menu layout unchanged.
- Retain the existing `break-word` behavior for long unbroken text.

This supersedes the previously closed #8143 with a fresh branch based on the current `mealie-next`.

### Before

The event subject is clipped at the right edge of the card:

<img width="1186" height="831" alt="Timeline event subject overflowing its card" src="https://github.com/user-attachments/assets/7b73f6d5-392f-414d-ba56-4b239f2ff47e" />

### After

The subject wraps inside the card while the context menu remains visible:

<img width="817" height="650" alt="Timeline event subjects contained within their cards after the fix" src="https://github.com/user-attachments/assets/c7ee0758-9aa2-4303-b082-4f8d98faa8de" />

## Which issue(s) this PR fixes:

Fixes #8142

## Testing

- Ran ESLint on `RecipeTimelineItem.vue`.
- Ran `git diff --check`.
- Built and ran the production Docker image.
- Imported two recipes and created long-subject Timeline events.
- Verified at 1100 x 800 that both subjects wrap to two lines, remain inside their cards, and leave the context menu visible.

## Release notes

Fixed Timeline event subjects being clipped at intermediate viewport widths.

## AI / LLM Assistance

OpenAI Codex assisted with the implementation. I reviewed and tested the final change.
