### PR TITLE
fix: labels get-by-id returns 404 instead of 500 for missing id

### DIFF
--- a/mealie/routes/groups/controller_labels.py
+++ b/mealie/routes/groups/controller_labels.py
@@ -70,7 +70,7 @@ class MultiPurposeLabelsController(BaseCrudController):
 
     @router.get("/{item_id}", response_model=MultiPurposeLabelOut)
     def get_one(self, item_id: UUID4):
-        return self.repo.get_one(item_id)
+        return self.mixins.get_one(item_id)
 
     @router.put("/{item_id}", response_model=MultiPurposeLabelOut)
     def update_one(self, item_id: UUID4, data: MultiPurposeLabelUpdate):

--- a/tests/integration_tests/user_household_tests/test_shopping_list_labels.py
+++ b/tests/integration_tests/user_household_tests/test_shopping_list_labels.py
@@ -1,4 +1,5 @@
 import random
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
@@ -33,6 +34,14 @@ def test_label_create_duplicate_name_returns_409(api_client: TestClient, unique_
 
     response = api_client.post(api_routes.groups_labels, json=payload, headers=unique_user_fn_scoped.token)
     assert response.status_code == 409
+
+
+def test_label_get_one_404(api_client: TestClient, unique_user: TestUser):
+    # Regression test for the get-by-id endpoint returning a 500 instead of a
+    # 404 when the label doesn't exist, matching the other organizer endpoints
+    # (tags, categories, tools, units, foods).
+    response = api_client.get(api_routes.groups_labels_item_id(uuid4()), headers=unique_user.token)
+    assert response.status_code == 404
 
 
 def test_new_list_creates_list_labels(api_client: TestClient, unique_user: TestUser):


### PR DESCRIPTION
## What this PR does / why we need it:
- Fixes GET /api/groups/labels/{id} returning 500 instead of 404 when the label doesn't exist
- `controller_labels.py`'s get-by-id endpoint called `self.repo.get_one()` directly instead of `self.mixins.get_one()`; `HttpRepo.get_one()` is what raises the 404 on a missing item, so bypassing it let `None` fall through to response_model serialization and throw a 500
- One-line fix: swap to `self.mixins.get_one(item_id)`, matching Tags/Categories/Foods/Tools/Units, all of which already use the mixin correctly
- Added `test_label_get_one_404` regression test

## Which issue(s) this PR fixes:
Fixes #8220

## Special notes for your reviewer:
Audited all six organizer get-by-id endpoints before fixing — Labels was the only one bypassing `self.mixins.get_one()`. No changes needed elsewhere.

## Testing
- Full suite: `DB_ENGINE=sqlite uv run pytest` — all passed
- `ruff check` and `ruff format --check` clean on both changed files
- New test `test_label_get_one_404` passes, confirmed alongside existing `test_label_create_duplicate`

## AI / LLM Assistance
Claude Code was used to generate the initial implementation following the existing image import pattern. All generated code was reviewed, tested manually, and verified against the codebase conventions before submission.