### PR TITLE
fix: preserve source language in AI recipe parsing

### DIFF
--- a/mealie/services/openai/prompts/recipes/build-recipe.txt
+++ b/mealie/services/openai/prompts/recipes/build-recipe.txt
@@ -3,6 +3,7 @@ You convert a transcribed recipe source document into structured recipe data.
 The user message contains the transcribed source. Everything you return must come from it. Do not create, infer, or make up any information, and do not calculate values the source does not provide. Leave a field empty rather than guessing at it.
 
 When converting:
+- Do not translate. Preserve the source's original language in every text field.
 - If the source has a section of text supplied by the user, that section is authoritative. Where it disagrees with the rest of the source, follow it: if it names the recipe, use their name; if it corrects or adds a detail, use theirs.
 - Keep ingredients and instructions in their original order.
 - Preserve section headings by setting the title on the first ingredient or instruction of each section, and leaving it blank on the rest.

--- a/mealie/services/openai/prompts/recipes/parse-recipe-ingredients.txt
+++ b/mealie/services/openai/prompts/recipes/parse-recipe-ingredients.txt
@@ -3,6 +3,7 @@ Parse ingredient strings into components. You will receive a list of one or more
 When parsing:
 - If uncertain about quantity, unit, or food, put the entire string in the note field
 - Respect grammar rules for multiple languages
+- Do not translate. Keep each unit, food, and note in the language in which that component appears in the input
 - Interpret singular/plural/grammatical variations
 - Text in parentheses = notes (e.g., "3 potatoes (roughly chopped)" → note: "roughly chopped")
 - Correct common typos (e.g., "potatos" → "potatoes")


### PR DESCRIPTION
## What this PR does / why we need it:

AI recipe parsing could translate source text into English even when translation was not requested.

- Preserve the source language during AI recipe imports.
- Preserve each component's input language in the OpenAI ingredient parser.
- Keep explicit recipe translation behavior unchanged.

## Which issue(s) this PR fixes:

No linked issue.

## Testing

- Manually tested a Japanese recipe through Import with AI and the OpenAI ingredient parser, confirming that the recipe and ingredients remained in Japanese.
- Ran the relevant tests: 45 passed.
- Rebuilt and verified the local Docker image.

## AI / LLM Assistance

Substantial. OpenAI Codex was used to investigate the issue, implement the prompt changes, and draft the PR description. I reviewed all generated changes.

## Release Notes

AI recipe parsing now preserves the source language unless translation is explicitly requested.
