### PR TITLE
dev: don't clobber devEngines.packageManager.version on release bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sed -i 's/^version = "[^"]*"/version = "${{ env.VERSION_NUM }}"/' pyproject.toml
           sed -i '/^name = "mealie"$/,/^version = / s/^version = "[^"]*"/version = "${{ env.VERSION_NUM }}"/' uv.lock
-          sed -i 's/\("version": "\)[^"]*"/\1${{ env.VERSION_NUM }}"/' frontend/package.json
+          sed -i '0,/"version": "/{s/\("version": "\)[^"]*"/\1${{ env.VERSION_NUM }}"/}' frontend/package.json
           sed -i 's/:v[0-9]*\.[0-9]*\.[0-9]*/:v${{ env.VERSION_NUM }}/' docs/docs/documentation/getting-started/installation/installation-checklist.md
           sed -i 's/:v[0-9]*\.[0-9]*\.[0-9]*/:v${{ env.VERSION_NUM }}/' docs/docs/documentation/getting-started/installation/sqlite.md
           sed -i 's/:v[0-9]*\.[0-9]*\.[0-9]*/:v${{ env.VERSION_NUM }}/' docs/docs/documentation/getting-started/installation/postgres.md


### PR DESCRIPTION
## What this PR does / why we need it:

The release automation's version-bump step (`.github/workflows/release.yml`) uses an unscoped `sed` command to update `frontend/package.json`'s top-level `version` field on every release. Because the pattern isn't anchored to a specific line, it also matches and overwrites `devEngines.packageManager.version` — a separate field meant to pin the pnpm version required to work on this project. This has already happened in practice: that field used to correctly say `"version": "11"`, and the `v3.24.0` release bump silently overwrote it to `"3.24.0"` — a pnpm version that was never published, which breaks `corepack`/anything reading that field. This PR scopes the `sed` command to only the first `"version": "` match in the file (using the `0,/pattern/{...}` range idiom), which is always the top-level app version field, leaving `devEngines.packageManager.version` untouched on future releases.

## Which issue(s) this PR fixes:

_(none — found while debugging a local dev environment issue caused by this; not tied to a filed issue)_

## Special notes for your reviewer:

This only changes the `sed` command's scope, not its replacement logic — the top-level version is still bumped exactly the same way as before. Verified against the actual current `frontend/package.json` by running both the old and new `sed` commands against a copy of it: the old command changes both `version` fields, the new one only changes the top-level one.

## Testing

This step only runs inside the release workflow itself, so it can't be exercised through the normal test suite. Verified by copying the real `frontend/package.json` and running the updated `sed` command against it locally (simulating a version bump), confirming only the top-level `version` field changes and `devEngines.packageManager.version` is left alone.

```
MINI='{
  "name": "mealie",
  "version": "3.24.0",
  "devEngines": {
    "packageManager": {
      "name": "pnpm",
      "version": "11",
      "onFail": "warn"
    }
  }
}'

diff <(echo "$MINI" | sed 's/\("version": "\)[^"]*"/\1TEST_VERSION"/') \
     <(echo "$MINI" | sed '0,/"version": "/{s/\("version": "\)[^"]*"/\1TEST_VERSION"/}')

```
<img width="730" height="259" alt="image" src="https://github.com/user-attachments/assets/016c1eef-8427-4c05-add3-b51cc48c2b69" />

## AI / LLM Assistance

Used an AI coding assistant to trace a local pnpm install failure back to this workflow's `sed` command, and to write and verify the fix.
