### PR TITLE
fix: translate recipe time units according to locale

### DIFF
--- a/frontend/app/lib/api/user/recipes/recipe.ts
+++ b/frontend/app/lib/api/user/recipes/recipe.ts
@@ -153,6 +153,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
   private streamRecipeCreate(streamRoute: string, payload: object | FormData, onProgress?: (message: string) => void): Promise<RequestResponse<string>> {
     return new Promise((resolve) => {
       const { token } = useMealieAuth();
+      const { locale } = useGlobalI18n();
       const isFormData = payload instanceof FormData;
 
       const sse = new SSE(streamRoute, {
@@ -160,6 +161,7 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
           // the browser has to set the multipart Content-Type itself, so it includes the boundary
           ...(isFormData ? {} : { "Content-Type": "application/json" }),
           ...(token.value ? { Authorization: `Bearer ${token.value}` } : {}),
+          "Accept-Language": locale.value,
         },
         payload: isFormData ? payload : JSON.stringify(payload),
         withCredentials: true,


### PR DESCRIPTION

## What this PR does / why we need it:

_(REQUIRED)_

Recipe time units (prep/cook/total time) were always displayed in English regardless
of the user's selected UI language, even when the language was set to e.g. German.

Root cause: time-unit strings ("30 minutes" / "30 Minuten") are translated once at
import time in `cleaner.py::pretty_print_timedelta`, using the `Translator` the
backend builds from the request's `Accept-Language` header. The normal REST API
client (`api-client.ts`) sets this header from `i18n.locale.value` on every request,
but recipe-from-URL import goes through a separate SSE-based streaming path
(`streamRecipeCreate` in `recipe.ts`) that builds its own headers from scratch and
never included `Accept-Language`. The backend fell back to `en-US`, and that English
string got baked into the recipe permanently.

- `frontend/app/lib/api/user/recipes/recipe.ts`: `streamRecipeCreate` now pulls the
  current locale via `useGlobalI18n()` (same source `api-client.ts` uses) and sends
  it as `Accept-Language` on the SSE request, matching the behavior of the regular
  axios client.

before:
<img width="596" height="512" alt="螢幕擷取畫面 2026-09-03 143647" src="https://github.com/user-attachments/assets/fa836aa0-1c77-43f4-a8be-275f1e579e49" />

after:
<img width="611" height="537" alt="螢幕擷取畫面 2026-09-03 143635" src="https://github.com/user-attachments/assets/05fb4ecd-3fe1-4a8d-ac9f-650cf53aad04" />

## Which issue(s) this PR fixes:

_(REQUIRED)_


Fixes #8235



## Testing


manually test with three URL provided by the bug issue.

## AI / LLM Assistance

_(REQUIRED)_

Used Claude Code to investigate and fix, but review and verified manually before submitting.
