### PR TITLE
fix: update recipe creation page translations on locale change

### DIFF
--- a/frontend/app/components/global/BaseOverflowButton.vue
+++ b/frontend/app/components/global/BaseOverflowButton.vue
@@ -158,23 +158,22 @@ const modelValue = defineModel({
   default: "",
 });
 
-const activeObj = ref<MenuItem>({
-  text: "DEFAULT",
-  value: "",
-});
+const activeObj = computed<MenuItem>(() =>
+  props.items.find(item => item.value === modelValue.value) ?? {
+    text: "DEFAULT",
+    value: "",
+  },
+);
 
 let startIndex = 0;
 props.items.forEach((item, index) => {
   if (item.value === modelValue.value) {
     startIndex = index;
-
-    activeObj.value = item;
   }
 });
 const itemGroup = ref(startIndex);
 
 function setValue(v: MenuItem) {
   modelValue.value = v.value || "";
-  activeObj.value = v;
 }
 </script>

--- a/frontend/app/components/global/ReportTable.vue
+++ b/frontend/app/components/global/ReportTable.vue
@@ -44,13 +44,13 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const router = useRouter();
 
-const headers = [
+const headers = computed(() => [
   { title: i18n.t("category.category"), value: "category", key: "category" },
   { title: i18n.t("general.name"), value: "name", key: "name" },
   { title: i18n.t("general.timestamp"), value: "timestamp", key: "timestamp" },
   { title: i18n.t("general.status"), value: "status", key: "status" },
   { title: i18n.t("general.delete"), value: "actions", key: "actions" },
-];
+]);
 
 function handleRowClick(item: ReportSummary) {
   if (item.status === "in-progress") {

--- a/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
+++ b/frontend/app/pages/g/[groupSlug]/r/create/bulk.vue
@@ -130,6 +130,7 @@
           <v-card-actions class="justify-center">
             <div style="width: 250px">
               <BaseButton
+                :text="$t('general.create')"
                 :disabled="bulkUrls.length === 0 || lockBulkImport"
                 rounded
                 block


### PR DESCRIPTION
## What this PR does / why we need it:
Some labels on the recipe creation page stay in the previous language after switching languages. They only update after refreshing the browser.

This PR changes three files:

- `BaseOverflowButton.vue`: Uses `computed` to get the selected item from the current menu items. This keeps the selected label up to date.
- `ReportTable.vue`: Uses `computed` for the table headers so they update when the language changes.
- `bulk.vue`: Passes translated text to the Create button.

### Before
<img width="1030" height="661" alt="Before" src="https://github.com/user-attachments/assets/8b3e5e8a-91bb-4a98-8c8b-383ada3810e4" />

### After
<img width="1054" height="665" alt="After" src="https://github.com/user-attachments/assets/5ba034e0-5f8e-4da5-a5fb-b0d851ae0387" />

## Which issue(s) this PR fixes:
Fixes #8272

## Testing
I ran task ui:check. It passed.

## AI / LLM Assistance
I used ChatGPT to analyze the problem and write the code. I reviewed the changes and ran the checks locally.