### PR TITLE
feat: Show calendar hint when adding to meal plan

### DIFF
--- a/frontend/app/components/Domain/Household/GroupMealPlanEntryDialog.vue
+++ b/frontend/app/components/Domain/Household/GroupMealPlanEntryDialog.vue
@@ -45,14 +45,7 @@
             </v-btn>
           </v-btn-toggle>
 
-          <v-date-picker
-            v-model="selectedDate"
-            class="mx-auto"
-            hide-header
-            show-adjacent-months
-            color="primary"
-            :first-day-of-week="firstDayOfWeek"
-          />
+          <MealPlanDatePicker v-model="selectedDate" :entry-type="entryType" />
 
           <v-select
             v-model="entryType"
@@ -140,7 +133,6 @@ import { format } from "date-fns";
 import RecipeSelector from "~/components/Domain/Recipe/RecipeSelector.vue";
 import { usePlanTypeOptions } from "~/composables/use-group-mealplan";
 import { buildRuleQueryFilter, useMealplanRules } from "~/composables/use-mealplan-rules";
-import { useHouseholdSelf } from "~/composables/use-households";
 import { validators } from "~/composables/use-validators";
 import type { CreatePlanEntry, PlanEntryType, ReadPlanEntry, UpdatePlanEntry } from "~/lib/api/types/meal-plan";
 import type { RecipeSummary } from "~/lib/api/types/recipe";
@@ -161,7 +153,6 @@ const emit = defineEmits<{
 
 const dialog = defineModel<boolean>({ required: true });
 
-const { household } = useHouseholdSelf();
 const { rules } = useMealplanRules();
 const planTypeOptions = usePlanTypeOptions();
 
@@ -176,7 +167,6 @@ const text = ref("");
 const ignoreRules = ref(false);
 
 const isRecipe = computed(() => entryMode.value === "recipe");
-const firstDayOfWeek = computed(() => household.value?.preferences?.firstDayOfWeek || 0);
 
 const applicableRuleFilter = computed(() => buildRuleQueryFilter(rules.value, selectedDate.value, entryType.value));
 const ruleQueryFilter = computed(() => ignoreRules.value ? null : applicableRuleFilter.value);

--- a/frontend/app/components/Domain/Mealplan/MealPlanAddRecipeDialog.vue
+++ b/frontend/app/components/Domain/Mealplan/MealPlanAddRecipeDialog.vue
@@ -1,0 +1,75 @@
+<template>
+  <BaseDialog
+    v-model="mealplannerDialog"
+    bottom-sheet
+    :title="$t('recipe.add-recipe-to-mealplan')"
+    color="primary"
+    :icon="$globals.icons.calendar"
+    can-confirm
+    @confirm="addRecipeToPlan"
+  >
+    <v-card-text>
+      <MealPlanDatePicker v-model="newMealdate" :entry-type="newMealType" />
+      <v-select
+        v-model="newMealType"
+        :return-object="false"
+        :items="planTypeOptions"
+        :label="$t('recipe.entry-type')"
+        item-title="text"
+        item-value="value"
+      />
+    </v-card-text>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { useUserApi } from "~/composables/api";
+import { alert } from "~/composables/use-toast";
+import type { PlanEntryType } from "~/lib/api/types/meal-plan";
+
+const props = defineProps<{
+  recipeId: string;
+}>();
+
+const mealplannerDialog = defineModel<boolean>({
+  default: false,
+});
+
+const i18n = useI18n();
+const api = useUserApi();
+const planTypeOptions = usePlanTypeOptions();
+const router = useRouter();
+
+const newMealType = ref<PlanEntryType>("dinner");
+const newMealdate = ref(new Date());
+
+const newMealdateString = computed(() => {
+  // Format the date to YYYY-MM-DD in the same timezone as newMealdate
+  const year = newMealdate.value.getFullYear();
+  const month = String(newMealdate.value.getMonth() + 1).padStart(2, "0");
+  const day = String(newMealdate.value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+});
+
+async function addRecipeToPlan() {
+  const { response } = await api.mealplans.createOne({
+    date: newMealdateString.value,
+    entryType: newMealType.value,
+    title: "",
+    text: "",
+    recipeId: props.recipeId,
+  });
+
+  if (response?.status === 201) {
+    alert.success(i18n.t("recipe.recipe-added-to-mealplan"), null, {
+      action: {
+        message: i18n.t("general.view"),
+        onClick: () => router.push("/household/mealplan/planner/view"),
+      },
+    });
+  }
+  else {
+    alert.error(i18n.t("recipe.failed-to-add-recipe-to-mealplan"));
+  }
+}
+</script>

--- a/frontend/app/components/Domain/Mealplan/MealPlanDatePicker.vue
+++ b/frontend/app/components/Domain/Mealplan/MealPlanDatePicker.vue
@@ -29,11 +29,11 @@
 </template>
 
 <script setup lang="ts">
-import { addMonths, format } from "date-fns";
+import { addMonths, format, isDate } from "date-fns";
 import type { DatePickerEventColorValue } from "vuetify/lib/components/VDatePicker/VDatePickerMonth.mjs";
 import type { PlanEntryType } from "~/lib/api/types/meal-plan";
 
-const selectedDate = defineModel<Date>();
+const selectedDate = defineModel<Date | [Date, Date]>();
 const props = defineProps<{
   entryType?: PlanEntryType;
 }>();
@@ -67,7 +67,9 @@ function hasMealPlanned(date: string): DatePickerEventColorValue {
   const planned = mealplans.value ?? [];
   const dateMatched = planned.filter(meal => meal.date === date);
   const typeMatched = dateMatched.filter(meal => !props.entryType || meal.entryType === props.entryType);
-  const isSelected = selectedDate.value && date === format(selectedDate.value, "yyyy-MM-dd");
+  const earlierDate = isDate(selectedDate.value) ? selectedDate.value : selectedDate.value?.[0];
+  const laterDate = isDate(selectedDate.value) ? selectedDate.value : selectedDate.value?.[1];
+  const isSelected = (earlierDate && date === format(earlierDate, "yyyy-MM-dd")) || (laterDate && date === format(laterDate, "yyyy-MM-dd"));
   if (!dateMatched.length) return false;
   if (typeMatched.length) return isSelected ? "primary-lighten-3" : "primary";
   return isSelected ? "grey-lighten-3" : "grey";

--- a/frontend/app/components/Domain/Mealplan/MealPlanDatePicker.vue
+++ b/frontend/app/components/Domain/Mealplan/MealPlanDatePicker.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-date-picker
+    v-model="selectedDate"
+    class="mx-auto"
+    hide-header
+    show-adjacent-months
+    color="primary"
+    :first-day-of-week="firstDayOfWeek"
+    :local="$i18n.locale"
+    :events="hasMealPlanned"
+    @update:month="updateMonth"
+    @update:year="updateYear"
+  >
+    <template #controls="{ yearText, monthYearText, prevMonth, nextMonth, disabled }">
+      <div class="d-flex justify-space-between w-100">
+        <v-btn :disabled="disabled.includes('prev-month')" :icon="$globals.icons.chevronLeft" flat density="comfortable" @click="prevMonth" />
+        <div class="text-center">
+          <div class="text-body-large">
+            {{ monthYearText.split(' ')[0] }}
+          </div>
+          <div class="text-body-small">
+            {{ yearText }}
+          </div>
+        </div>
+        <v-btn :disabled="disabled.includes('next-month')" :icon="$globals.icons.chevronRight" flat density="comfortable" @click="nextMonth" />
+      </div>
+    </template>
+  </v-date-picker>
+</template>
+
+<script setup lang="ts">
+import { addMonths, format } from "date-fns";
+import type { DatePickerEventColorValue } from "vuetify/lib/components/VDatePicker/VDatePickerMonth.mjs";
+import type { PlanEntryType } from "~/lib/api/types/meal-plan";
+
+const selectedDate = defineModel<Date>();
+const props = defineProps<{
+  entryType?: PlanEntryType;
+}>();
+
+const { household } = useHouseholdSelf();
+
+const target = ref(new Date());
+const range = computed(() => ({
+  start: addMonths(target.value, -1),
+  end: addMonths(target.value, 2),
+}));
+const { mealplans } = useMealplans(range);
+
+const firstDayOfWeek = computed(() => {
+  return household.value?.preferences?.firstDayOfWeek || 0;
+});
+
+function updateMonth(month: number) {
+  const copy = new Date(target.value);
+  copy.setMonth(month);
+  target.value = copy;
+}
+
+function updateYear(year: number) {
+  const copy = new Date(target.value);
+  copy.setFullYear(year);
+  target.value = copy;
+}
+
+function hasMealPlanned(date: string): DatePickerEventColorValue {
+  const planned = mealplans.value ?? [];
+  const dateMatched = planned.filter(meal => meal.date === date);
+  const typeMatched = dateMatched.filter(meal => !props.entryType || meal.entryType === props.entryType);
+  const isSelected = selectedDate.value && date === format(selectedDate.value, "yyyy-MM-dd");
+  if (!dateMatched.length) return false;
+  if (typeMatched.length) return isSelected ? "primary-lighten-3" : "primary";
+  return isSelected ? "grey-lighten-3" : "grey";
+}
+</script>

--- a/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeContextMenu/RecipeContextMenuContent.vue
@@ -37,35 +37,7 @@
       />
     </v-card-text>
   </BaseDialog>
-  <BaseDialog
-    v-model="mealplannerDialog"
-    bottom-sheet
-    :title="$t('recipe.add-recipe-to-mealplan')"
-    color="primary"
-    :icon="$globals.icons.calendar"
-    can-confirm
-    @confirm="addRecipeToPlan()"
-  >
-    <v-card-text>
-      <v-date-picker
-        v-model="newMealdate"
-        class="mx-auto mb-3"
-        hide-header
-        show-adjacent-months
-        color="primary"
-        :first-day-of-week="firstDayOfWeek"
-        :local="$i18n.locale"
-      />
-      <v-select
-        v-model="newMealType"
-        :return-object="false"
-        :items="planTypeOptions"
-        :label="$t('recipe.entry-type')"
-        item-title="text"
-        item-value="value"
-      />
-    </v-card-text>
-  </BaseDialog>
+  <MealPlanAddRecipeDialog v-model="mealplannerDialog" :recipe-id="recipeId" />
   <RecipeDialogAddToShoppingList
     v-if="shoppingLists && recipeRefWithScale"
     v-model="shoppingListDialog"
@@ -110,14 +82,11 @@ import RecipeDialogShare from "~/components/Domain/Recipe/RecipeDialogShare.vue"
 import { useUserApi } from "~/composables/api";
 import { useDownloader } from "~/composables/api/use-downloader";
 import { useAddToShoppingListDialog } from "~/composables/shopping-list-page/use-add-to-shopping-list-dialog";
-import { usePlanTypeOptions } from "~/composables/use-group-mealplan";
 import { useGroupRecipeActions } from "~/composables/use-group-recipe-actions";
 import { useGroupSelf } from "~/composables/use-groups";
-import { useHouseholdSelf } from "~/composables/use-households";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
 import { alert } from "~/composables/use-toast";
 import type { GroupRecipeActionOut, HouseholdSummary } from "~/lib/api/types/household";
-import type { PlanEntryType } from "~/lib/api/types/meal-plan";
 import type { Recipe } from "~/lib/api/types/recipe";
 import { isRecipeFullyPublic } from "~/lib/recipe/recipe-visibility";
 
@@ -198,30 +167,15 @@ const recipeDuplicateDialog = ref(false);
 const recipeName = ref(props.name);
 const loading = ref(false);
 const menuItems = ref<ContextMenuItem[]>([]);
-const newMealdate = ref(new Date());
-const newMealType = ref<PlanEntryType>("dinner");
-
-const newMealdateString = computed(() => {
-  // Format the date to YYYY-MM-DD in the same timezone as newMealdate
-  const year = newMealdate.value.getFullYear();
-  const month = String(newMealdate.value.getMonth() + 1).padStart(2, "0");
-  const day = String(newMealdate.value.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-});
 
 const i18n = useI18n();
 const auth = useMealieAuth();
 const { $globals } = useNuxtApp();
-const { household } = useHouseholdSelf();
 const { group, actions: groupActions } = useGroupSelf();
 const { isOwnGroup } = useLoggedInState();
 
 const route = useRoute();
 const groupSlug = computed(() => route.params.groupSlug as string || auth.user.value?.groupSlug || "");
-
-const firstDayOfWeek = computed(() => {
-  return household.value?.preferences?.firstDayOfWeek || 0;
-});
 
 const { share, isSupported: shareIsSupported } = useShare();
 const { copy, copied, isSupported: clipboardIsSupported } = useClipboard();
@@ -423,28 +377,6 @@ async function handleDownloadEvent() {
   download(api.recipes.share.getZipRedirectUrl(shareToken.id), `${props.slug}.zip`);
 }
 
-async function addRecipeToPlan() {
-  const { response } = await api.mealplans.createOne({
-    date: newMealdateString.value,
-    entryType: newMealType.value,
-    title: "",
-    text: "",
-    recipeId: props.recipeId,
-  });
-
-  if (response?.status === 201) {
-    alert.success(i18n.t("recipe.recipe-added-to-mealplan"), null, {
-      action: {
-        message: i18n.t("general.view"),
-        onClick: () => router.push("/household/mealplan/planner/view"),
-      },
-    });
-  }
-  else {
-    alert.error(i18n.t("recipe.failed-to-add-recipe-to-mealplan"));
-  }
-}
-
 async function duplicateRecipe() {
   const { data } = await api.recipes.duplicateOne(props.slug, recipeName.value);
   if (data && data.slug) {
@@ -515,6 +447,5 @@ function contextMenuEventHandler(eventKey: string) {
   loading.value = false;
 }
 
-const planTypeOptions = usePlanTypeOptions();
 const recipeActions = groupRecipeActionsStore.recipeActions;
 </script>

--- a/frontend/app/pages/household/mealplan/planner.vue
+++ b/frontend/app/pages/household/mealplan/planner.vue
@@ -29,7 +29,7 @@
         </template>
 
         <v-card>
-          <v-date-picker
+          <MealPlanDatePicker
             v-model="state.range"
             hide-header
             :multiple="'range'"


### PR DESCRIPTION
## What this PR does / why we need it:
When selecting a date for meal planning, dates that already have a meal planned will show up with a dot under it. 
This allows users a quick way to see what days need a plan, and which are already covered. 

| Before | After |
|--------|--------|
| <img width="506" height="609" alt="image" src="https://github.com/user-attachments/assets/3f171b9e-8ef3-4c77-98ba-5c11b631d670" /> | <img width="506" height="597" alt="image" src="https://github.com/user-attachments/assets/96f65dd7-52bf-489e-9905-8c60021f185f" /> | 

## Which issue(s) this PR fixes:
NA

## AI / LLM Assistance
No AI used