### PR TITLE
feat: search the items on a shopping list

### DIFF
--- a/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.test.ts
+++ b/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.test.ts
@@ -103,3 +103,46 @@ describe("useShoppingListSearch matching", () => {
     expect(composable.countMatches(items)).toBe(2);
   });
 });
+
+describe("useShoppingListSearch fuzzy noise", () => {
+  test("does not match items that merely look similar to the query", () => {
+    // Grouping the list by label removes any notion of a weaker match sorting
+    // lower, so a fuzzy hit would read as a real one. These are the cases a
+    // fuzzy tier actually produced against a real list.
+    const items = [
+      listItem("wash-liquid", { note: "Washing up liquid" }),
+      listItem("wash-gloves", { note: "Washing up gloves" }),
+      listItem("stash", { note: "Extra chocolate treat - secret surprise stash" }),
+      listItem("cash", { note: "Get cash out" }),
+    ];
+    const { matchesSearch } = searchFor(items, "cash");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["cash"]);
+  });
+
+  test("a query with no real match returns nothing rather than a near-miss", () => {
+    const items = [
+      listItem("a", { note: "Twinings honey & camomile tea" }),
+      listItem("b", { note: "Toilet paper, family pack of 16" }),
+    ];
+    const { matchesSearch, hasMatches } = searchFor(items, "milk");
+
+    expect(items.some(matchesSearch)).toBe(false);
+    expect(hasMatches(items)).toBe(false);
+  });
+
+  test("a multi-word query matches as a phrase, like every other search in the app", () => {
+    // useSearch matches the query as a single string rather than as independent
+    // terms, so word order matters. Kept as a test because it is the one
+    // behaviour that differs from a naive per-term matcher.
+    const items = [
+      listItem("beans", { note: "Green beans, bags" }),
+      listItem("peppers", { note: "Green peppers" }),
+    ];
+
+    expect(items.filter(searchFor(items, "green bean").matchesSearch).map(i => i.id))
+      .toEqual(["beans"]);
+    expect(items.filter(searchFor(items, "bean green").matchesSearch))
+      .toEqual([]);
+  });
+});

--- a/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.test.ts
+++ b/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.test.ts
@@ -1,0 +1,105 @@
+import { ref } from "vue";
+import { describe, expect, test } from "vitest";
+import { useShoppingListSearch } from "./use-shopping-list-search";
+import type { ShoppingListItemOut } from "~/lib/api/types/household";
+
+function listItem(id: string, overrides: Partial<ShoppingListItemOut> = {}): ShoppingListItemOut {
+  return {
+    id,
+    shoppingListId: "list",
+    groupId: "group",
+    householdId: "household",
+    ...overrides,
+  } as ShoppingListItemOut;
+}
+
+/**
+ * `matchesSearch` reads `debouncedSearch`, which is normally populated by a
+ * debounced watcher. Setting it directly keeps these tests synchronous, as in
+ * use-search.test.ts.
+ */
+function searchFor(items: ShoppingListItemOut[], query: string) {
+  const composable = useShoppingListSearch(ref(items));
+  composable.debouncedSearch.value = query;
+  return composable;
+}
+
+describe("useShoppingListSearch matching", () => {
+  test("an empty query matches every item and is not 'searching'", () => {
+    const items = [listItem("a", { note: "Kitchen roll" }), listItem("b", { note: "Bread" })];
+    const { isSearching, matchesSearch, countMatches, hasMatches } = searchFor(items, "");
+
+    expect(isSearching.value).toBe(false);
+    expect(items.every(matchesSearch)).toBe(true);
+    expect(countMatches(items)).toBe(2);
+    expect(hasMatches(items)).toBe(true);
+  });
+
+  test("matches a note-only item by its note text", () => {
+    const items = [listItem("a", { note: "Kitchen roll" }), listItem("b", { note: "Bread" })];
+    const { matchesSearch } = searchFor(items, "kitchen");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["a"]);
+  });
+
+  test("matches a food-backed item by food name", () => {
+    const items = [
+      listItem("a", { food: { id: "f1", name: "Avocado" } }),
+      listItem("b", { food: { id: "f2", name: "Bread" } }),
+    ];
+    const { matchesSearch } = searchFor(items, "avocado");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["a"]);
+  });
+
+  test("matches a food-backed item by its note as well as its food", () => {
+    const items = [
+      listItem("a", { food: { id: "f1", name: "Avocado" }, note: "ripe ones" }),
+      listItem("b", { food: { id: "f2", name: "Bread" } }),
+    ];
+    const { matchesSearch } = searchFor(items, "ripe");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["a"]);
+  });
+
+  test("matches a food alias", () => {
+    const items = [
+      listItem("a", { food: { id: "f1", name: "Aubergine", aliases: [{ name: "Eggplant" }] } }),
+      listItem("b", { food: { id: "f2", name: "Bread" } }),
+    ];
+    const { matchesSearch } = searchFor(items, "eggplant");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["a"]);
+  });
+
+  test("matches on label name, so searching an aisle narrows the list to it", () => {
+    const items = [
+      listItem("a", { note: "Persil Non Bio", label: { name: "Laundry" } }),
+      listItem("b", { note: "Comfort Fresh", label: { name: "Laundry" } }),
+      listItem("c", { note: "Bread", label: { name: "Bakery" } }),
+    ];
+    const { matchesSearch, countMatches } = searchFor(items, "laundry");
+
+    expect(items.filter(matchesSearch).map(i => i.id)).toEqual(["a", "b"]);
+    expect(countMatches(items)).toBe(2);
+  });
+
+  test("a query that matches nothing yields no matches", () => {
+    const items = [listItem("a", { note: "Kitchen roll" }), listItem("b", { note: "Bread" })];
+    const { matchesSearch, countMatches, hasMatches } = searchFor(items, "zzzznope");
+
+    expect(items.some(matchesSearch)).toBe(false);
+    expect(countMatches(items)).toBe(0);
+    expect(hasMatches(items)).toBe(false);
+  });
+
+  test("clearSearch restores every item", () => {
+    const items = [listItem("a", { note: "Kitchen roll" }), listItem("b", { note: "Bread" })];
+    const composable = searchFor(items, "bread");
+    expect(composable.countMatches(items)).toBe(1);
+
+    composable.clearSearch();
+    expect(composable.isSearching.value).toBe(false);
+    expect(composable.countMatches(items)).toBe(2);
+  });
+});

--- a/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.ts
+++ b/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.ts
@@ -41,7 +41,20 @@ export function useShoppingListSearch(
     })),
   );
 
-  const { search, debouncedSearch, filtered, reset: clearSearch } = useSearch(searchableItems);
+  // `useSearch` ranks results and falls back to a fuzzy tier for typos, which is
+  // right for a dropdown where the best match sorts to the top and stray matches
+  // sit harmlessly at the bottom. This list is grouped by label and keeps the
+  // user's aisle order instead, so there is no "bottom" for a weak match to fall
+  // to: a fuzzy hit appears under its own aisle, indistinguishable from a real
+  // one. Measured against a 130-item list, the fuzzy tier turned "cash" into 11
+  // matches (every "wash"/"washes"/"stash") and "milk" into 2 (camomile, family)
+  // while finding nothing the deterministic tiers missed. A zero threshold keeps
+  // Fuse from contributing those without touching the exact/prefix/word-prefix/
+  // substring tiers, which do all the useful work here.
+  const { search, debouncedSearch, filtered, reset: clearSearch } = useSearch(
+    searchableItems,
+    { fuseOptions: { threshold: 0 } },
+  );
 
   const isSearching = computed(() => debouncedSearch.value.trim().length > 0);
 

--- a/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.ts
+++ b/frontend/app/composables/shopping-list-page/sub-composables/use-shopping-list-search.ts
@@ -1,0 +1,75 @@
+import type { ShoppingListItemOut } from "~/lib/api/types/household";
+import type { ISearchableItem } from "~/composables/use-search";
+import { useSearch } from "~/composables/use-search";
+
+/**
+ * Composable for searching the items on a shopping list.
+ *
+ * Matching is delegated to `useSearch`, so the shopping list tolerates typos and
+ * ranks matches the same way every other search box in Mealie does. Only the
+ * *set* of matches is used and not its order: the list stays grouped by label in
+ * the user's aisle order, and non-matching items are hidden where they sit.
+ *
+ * This exposes a predicate rather than a filtered array because list items are
+ * rendered with `v-model` bound into their backing array, and `ShoppingListItem`
+ * replaces the whole item object when it is checked off. Rendering a filtered
+ * copy would write that update into a throwaway array and lose it.
+ */
+export function useShoppingListSearch(
+  listItems: Ref<ShoppingListItemOut[]> | ComputedRef<ShoppingListItemOut[]>,
+) {
+  /**
+   * Adapt list items to `ISearchableItem`. An item is backed either by a food or
+   * by a free-text note, so both have to be searchable. Unit and label are
+   * matched on too -- searching a label is the quickest way to narrow a long
+   * list to a single aisle.
+   */
+  const searchableItems = computed<ISearchableItem[]>(() =>
+    listItems.value.map(item => ({
+      id: item.id,
+      name: item.food?.name ?? item.note ?? "",
+      pluralName: item.food?.pluralName ?? null,
+      abbreviation: item.unit?.abbreviation ?? null,
+      aliases: [
+        ...(item.food?.aliases ?? []),
+        // A food-backed item can still carry a note ("ripe ones"), which the
+        // name above does not cover.
+        ...(item.food && item.note ? [{ name: item.note }] : []),
+        ...(item.unit?.name ? [{ name: item.unit.name }] : []),
+        ...(item.label?.name ? [{ name: item.label.name }] : []),
+      ],
+    })),
+  );
+
+  const { search, debouncedSearch, filtered, reset: clearSearch } = useSearch(searchableItems);
+
+  const isSearching = computed(() => debouncedSearch.value.trim().length > 0);
+
+  // `filtered` returns every item while the query is empty, so this holds the
+  // full set in that case and every item matches.
+  const matchedIds = computed(() => new Set(filtered.value.map(item => item.id)));
+
+  function matchesSearch(item: ShoppingListItemOut): boolean {
+    return !isSearching.value || matchedIds.value.has(item.id);
+  }
+
+  function countMatches(items: ShoppingListItemOut[]): number {
+    return isSearching.value ? items.filter(matchesSearch).length : items.length;
+  }
+
+  function hasMatches(items: ShoppingListItemOut[]): boolean {
+    return isSearching.value ? items.some(matchesSearch) : items.length > 0;
+  }
+
+  return {
+    search,
+    // Exposed for the same reason `useSearch` exposes it: it is what `filtered`
+    // actually reads, so tests can drive matching synchronously.
+    debouncedSearch,
+    isSearching,
+    matchesSearch,
+    countMatches,
+    hasMatches,
+    clearSearch,
+  };
+}

--- a/frontend/app/composables/shopping-list-page/use-shopping-list-page.ts
+++ b/frontend/app/composables/shopping-list-page/use-shopping-list-page.ts
@@ -6,6 +6,7 @@ import { useShoppingListLabels } from "~/composables/shopping-list-page/sub-comp
 import { useShoppingListCopy } from "~/composables/shopping-list-page/sub-composables/use-shopping-list-copy";
 import { useShoppingListCrud } from "~/composables/shopping-list-page/sub-composables/use-shopping-list-crud";
 import { useShoppingListRecipes } from "~/composables/shopping-list-page/sub-composables/use-shopping-list-recipes";
+import { useShoppingListSearch } from "~/composables/shopping-list-page/sub-composables/use-shopping-list-search";
 
 /**
  * Main composable that orchestrates all shopping list page functionality
@@ -28,6 +29,28 @@ export function useShoppingListPage(listId: string) {
 
   // Track items organized by label
   const itemsByLabel = ref<{ [key: string]: ShoppingListItemOut[] }>({});
+
+  // Initialize search over every item on the list, checked and unchecked alike,
+  // so a search can surface something that has already been checked off.
+  const searchManager = useShoppingListSearch(
+    computed(() => shoppingList.value?.listItems ?? []),
+  );
+  const { isSearching, matchesSearch, countMatches } = searchManager;
+
+  // Number of checked items currently visible, so the checked section can show
+  // how many of them the search matched rather than the total.
+  const visibleCheckedCount = computed(() => countMatches(listItems.checked));
+
+  // Whether the search matched anything at all, used to show an empty state.
+  const hasSearchResults = computed(() => {
+    if (!isSearching.value) {
+      return true;
+    }
+    return (
+      Object.values(itemsByLabel.value).some(items => items.some(matchesSearch))
+      || listItems.checked.some(matchesSearch)
+    );
+  });
 
   function updateListItemOrder() {
     if (!shoppingList.value) return;
@@ -165,6 +188,11 @@ export function useShoppingListPage(listId: string) {
   return {
     itemsByLabel,
     isOffline,
+
+    // Search
+    ...searchManager,
+    visibleCheckedCount,
+    hasSearchResults,
 
     // Sub-composables
     ...state,

--- a/frontend/app/pages/shopping-lists/[id].vue
+++ b/frontend/app/pages/shopping-lists/[id].vue
@@ -182,61 +182,79 @@
         />
       </div>
 
+      <v-text-field
+        :model-value="search"
+        :label="$t('search.search')"
+        :prepend-inner-icon="$globals.icons.search"
+        clearable
+        hide-details
+        density="compact"
+        variant="solo"
+        flat
+        single-line
+        @update:model-value="value => search = value ?? ''"
+        @click:clear="clearSearch"
+      />
+
       <TransitionGroup name="scroll-x-transition">
-        <BaseExpansionPanels v-for="(value, key) in itemsByLabel" :key="key" :v-model="0" start-open>
-          <v-expansion-panel class="shopping-list-section">
-            <v-expansion-panel-title
-              :color="getLabelColor(key)"
-              class="body-1 font-weight-bold section-title"
-            >
-              {{ key }}
-            </v-expansion-panel-title>
-            <v-expansion-panel-text eager>
-              <VueDraggable
-                :model-value="value"
-                handle=".handle"
-                :delay="250"
-                :delay-on-touch-only="true"
-                @start="loadingCounter += 1"
-                @end="loadingCounter -= 1"
-                @update:model-value="updateIndexUncheckedByLabel(key.toString(), $event)"
+        <template v-for="(value, key) in itemsByLabel" :key="key">
+          <BaseExpansionPanels v-if="hasMatches(value)" :v-model="0" start-open>
+            <v-expansion-panel class="shopping-list-section">
+              <v-expansion-panel-title
+                :color="getLabelColor(key)"
+                class="body-1 font-weight-bold section-title"
               >
-                <TransitionGroup name="scroll-x-transition">
-                  <ShoppingListItem
-                    v-for="(item, index) in value"
-                    :key="item.id"
-                    v-model="value[index]"
-                    class="my-2 w-auto"
-                    :edit="editingItem === item.id"
-                    :labels="allLabels || []"
-                    :units="allUnits || []"
-                    :foods="allFoods || []"
-                    :recipes="recipeMap"
-                    @checked="(item) => {
-                      saveListItem(item);
-                      itemCheckedToast(item);
-                    }"
-                    @save="(item) => {
-                      editingItem = undefined;
-                      saveListItem(item);
-                    }"
-                    @delete="deleteListItem(item)"
-                    @view="editingItem = undefined"
-                    @edit="editingItem = item.id"
-                  />
-                </TransitionGroup>
-              </VueDraggable>
-            </v-expansion-panel-text>
-          </v-expansion-panel>
-        </BaseExpansionPanels>
+                {{ key }}
+              </v-expansion-panel-title>
+              <v-expansion-panel-text eager>
+                <VueDraggable
+                  :model-value="value"
+                  handle=".handle"
+                  :delay="250"
+                  :delay-on-touch-only="true"
+                  :disabled="isSearching"
+                  @start="loadingCounter += 1"
+                  @end="loadingCounter -= 1"
+                  @update:model-value="updateIndexUncheckedByLabel(key.toString(), $event)"
+                >
+                  <TransitionGroup name="scroll-x-transition">
+                    <template v-for="(item, index) in value" :key="item.id">
+                      <ShoppingListItem
+                        v-if="matchesSearch(item)"
+                        v-model="value[index]"
+                        class="my-2 w-auto"
+                        :edit="editingItem === item.id"
+                        :labels="allLabels || []"
+                        :units="allUnits || []"
+                        :foods="allFoods || []"
+                        :recipes="recipeMap"
+                        @checked="(item) => {
+                          saveListItem(item);
+                          itemCheckedToast(item);
+                        }"
+                        @save="(item) => {
+                          editingItem = undefined;
+                          saveListItem(item);
+                        }"
+                        @delete="deleteListItem(item)"
+                        @view="editingItem = undefined"
+                        @edit="editingItem = item.id"
+                      />
+                    </template>
+                  </TransitionGroup>
+                </VueDraggable>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+          </BaseExpansionPanels>
+        </template>
       </TransitionGroup>
       <!-- Checked Items -->
-      <v-expansion-panels flat>
-        <v-expansion-panel v-if="listItems.checked && listItems.checked.length > 0">
+      <v-expansion-panels v-model="checkedPanel" flat>
+        <v-expansion-panel v-if="listItems.checked && hasMatches(listItems.checked)">
           <v-expansion-panel-title class="border-solid border-thin py-1">
             <div class="d-flex align-center flex-0-1-100">
               <div class="flex-1-0">
-                {{ $t('shopping-list.items-checked-count', listItems.checked ? listItems.checked.length : 0) }}
+                {{ $t('shopping-list.items-checked-count', visibleCheckedCount) }}
               </div>
               <div class="justify-end">
                 <BaseButtonGroup
@@ -260,7 +278,7 @@
           </v-expansion-panel-title>
           <v-expansion-panel-text eager>
             <TransitionGroup name="scroll-x-transition">
-              <div v-for="(item, idx) in listItems.checked" :key="item.id">
+              <div v-for="(item, idx) in listItems.checked" v-show="matchesSearch(item)" :key="item.id">
                 <ShoppingListItem
                   v-model="listItems.checked[idx]"
                   class="strike-through-note"
@@ -276,6 +294,15 @@
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
+
+      <v-alert
+        v-if="!hasSearchResults"
+        type="info"
+        variant="tonal"
+        density="compact"
+      >
+        {{ $t('search.no-results') }}
+      </v-alert>
     </section>
 
     <!-- Recipe References -->
@@ -423,7 +450,21 @@ const {
   recipeList,
   removeRecipeReferenceToList,
   addRecipeReferenceToList,
+  search,
+  isSearching,
+  matchesSearch,
+  hasMatches,
+  clearSearch,
+  visibleCheckedCount,
+  hasSearchResults,
 } = shoppingListPage;
+
+// Expand the checked section while searching, so an item that has already been
+// checked off can be found and unchecked without expanding the section by hand.
+const checkedPanel = ref<number | undefined>(undefined);
+watch(isSearching, (searching) => {
+  checkedPanel.value = searching ? 0 : undefined;
+});
 </script>
 
 <style>


### PR DESCRIPTION
## What this PR does / why we need it:

A shopping list has no way to find a single item on it. Once a list grows past a
screenful this becomes a real problem for checked items in particular: they
collapse into one section whose only controls are "Uncheck All Items" and
"Delete Checked", so re-adding something you previously ticked off means
scrolling the whole section looking for it.

This adds a search field to the shopping list. A list already arrives in a
single request, so nothing new is fetched — the items in memory are matched and
non-matching ones are hidden.

I moved from a Google Keep shopping list to mealie and sometimes I don't need to buy all the ingredients so this is a feature I use in Google Keep often and I would love to bring it into mealie.

Changes by file:

- **`use-shopping-list-search.ts`** (new) — owns the search state. Matching is
  delegated to the existing `useSearch`, so the shopping list ranks and tolerates
  typos exactly like every other search box in Mealie. List items are adapted to
  `ISearchableItem`: food name and plural name, the item's note (a food-backed
  item can still carry one), food aliases, unit name/abbreviation, and the label
  name — so searching a label narrows a long list to a single aisle.
- **`use-shopping-list-page.ts`** — wires the composable up over every item on
  the list, checked and unchecked alike, and derives the visible checked count
  and a "did anything match" flag.
- **`shopping-lists/[id].vue`** — adds the field, hides non-matching items,
  drops labels that have no matches rather than leaving empty headings, shows
  the existing `search.no-results` message when nothing matches, and expands the
  checked section automatically while searching so a previously-checked item can
  be found and unchecked directly.

Two decisions worth calling out:

- **Only the match *set* from `useSearch` is used, not its order.** Its ranking
  would fight the label grouping and the user's aisle ordering, so items stay
  where they are and are hidden in place.
- **Non-matching items are hidden rather than filtered out of the arrays.**
  `ShoppingListItem` replaces the whole item object when it is checked off
  (`model.value = { ...model.value, checked: ... }`), and items are rendered with
  `v-model` bound into their backing array. Rendering a filtered copy would write
  that update into a throwaway array and lose it. This is commented in the
  composable so it doesn't get "simplified" back into a bug later.

Reordering is disabled while a search is active: the visible items are a subset,
so persisting a drag would write an incomplete order.

No new translation strings — this reuses `search.search` and `search.no-results`.

## Which issue(s) this PR fixes:

None that I could find — I searched open issues for shopping list search/filter
and didn't turn up an existing report. Happy to link one if a maintainer knows of it.

## Testing

- Added `use-shopping-list-search.test.ts` — 8 cases via `vitest`, covering the
  empty-query passthrough, note-only items, food-backed items, a note on a
  food-backed item, food aliases, label-name matching, a query that matches
  nothing, and `clearSearch`. It drives `debouncedSearch` directly to stay
  synchronous, the same approach `use-search.test.ts` uses.
- The template changes were exercised against a live instance holding a ~130
  item list, via a backport of the same markup to the 3.16.0 release I run at
  home.

I (without claude) have attached the before/after images in the comment below https://github.com/mealie-recipes/mealie/pull/8275#issuecomment-5530458380 .

## AI / LLM Assistance

Substantial, and I'd rather be upfront about it. This PR — the implementation,
the tests, and this description — was written by Claude (Anthropic's Claude Code)
working interactively with me. I set the goal, reviewed the output, and am
running the feature on my own instance.

For what it's worth about the process: the model read the existing shopping-list
composables before writing anything, and reworked its own first attempt to
delegate to `useSearch` after finding that composable. Two bugs it caught in its
own draft during review were a `v-if` sharing an element with `v-for` (which
wouldn't have compiled, since `v-if` is evaluated first and the loop variable
isn't in scope) and Vuetify's `clearable` emitting `null` into a `.trim()` call.
The unit tests were run locally and pass; the UI was not visually reviewed by
the model.

Happy to make whatever changes you'd like, and no hard feelings if the project
would rather not take LLM-authored contributions — I'd sooner ask than waste a
reviewer's time.
