### PR TITLE
fix: remove unsupported partitioned cookie

### DIFF
--- a/frontend/app/composables/__tests__/use-token-cookie.test.ts
+++ b/frontend/app/composables/__tests__/use-token-cookie.test.ts
@@ -31,7 +31,7 @@ describe("getTokenCookieOptions", () => {
     vi.unstubAllGlobals();
   });
 
-  test("top-level https connection gets a lax, non-partitioned cookie", () => {
+  test("top-level https connection gets a lax cookie", () => {
     stubNuxtApp(true);
     setLocation("https:");
     setFramed(false);
@@ -40,10 +40,9 @@ describe("getTokenCookieOptions", () => {
 
     expect(options.secure).toBe(true);
     expect(options.sameSite).toBe("lax");
-    expect(options.partitioned).toBe(false);
   });
 
-  test("iframe-embedded https connection gets a none, partitioned cookie", () => {
+  test("iframe-embedded https connection gets a none cookie", () => {
     stubNuxtApp(true);
     setLocation("https:");
     setFramed(true);
@@ -52,10 +51,9 @@ describe("getTokenCookieOptions", () => {
 
     expect(options.secure).toBe(true);
     expect(options.sameSite).toBe("none");
-    expect(options.partitioned).toBe(true);
   });
 
-  test("insecure (http) connection stays lax and non-partitioned even when framed", () => {
+  test("insecure (http) connection stays lax even when framed", () => {
     stubNuxtApp(true);
     setLocation("http:");
     setFramed(true);
@@ -64,10 +62,9 @@ describe("getTokenCookieOptions", () => {
 
     expect(options.secure).toBe(false);
     expect(options.sameSite).toBe("lax");
-    expect(options.partitioned).toBe(false);
   });
 
-  test("non-production build stays lax and non-partitioned even when framed over https", () => {
+  test("non-production build stays lax even when framed over https", () => {
     stubNuxtApp(false);
     setLocation("https:");
     setFramed(true);
@@ -76,7 +73,14 @@ describe("getTokenCookieOptions", () => {
 
     expect(options.secure).toBe(false);
     expect(options.sameSite).toBe("lax");
-    expect(options.partitioned).toBe(false);
+  });
+
+  test("never asks for Partitioned, which the server cannot set", () => {
+    stubNuxtApp(true);
+    setLocation("https:");
+    setFramed(true);
+
+    expect(getTokenCookieOptions()).not.toHaveProperty("partitioned");
   });
 
   test("carries no max-age, since the server owns the cookie's lifetime", () => {

--- a/frontend/app/composables/use-token-cookie.ts
+++ b/frontend/app/composables/use-token-cookie.ts
@@ -3,7 +3,7 @@
  *
  * The server sets the cookie; the client only ever removes it, on logout or a dead session. A cookie
  * is matched for removal by name and path, but these have to line up with what the server sent for
- * the embedded (partitioned, SameSite=None) case to clear reliably.
+ * the embedded (SameSite=None) case to clear reliably.
  */
 export function getTokenCookieOptions() {
   const { $appInfo } = useNuxtApp();
@@ -14,7 +14,6 @@ export function getTokenCookieOptions() {
   return {
     secure: isSecureConnection,
     sameSite: (isEmbedded ? "none" : "lax") as "none" | "lax",
-    partitioned: isEmbedded,
   };
 }
 

--- a/frontend/app/plugins/axios.ts
+++ b/frontend/app/plugins/axios.ts
@@ -30,7 +30,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         config.headers.Authorization = `Bearer ${token}`;
       }
       // The server writes the session cookie now, but can't tell it's being framed — and an embedded
-      // deployment needs SameSite=None and a partitioned cookie. So the client flags it.
+      // deployment needs SameSite=None. So the client flags it.
       if (window.self !== window.top) {
         config.headers["X-Mealie-Embedded"] = "true";
       }

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -82,9 +82,9 @@ def request_is_https(request: Request) -> bool:
 def session_cookie_attrs(request: Request) -> dict:
     """Cookie attributes that have to match between setting and clearing the session cookie.
 
-    Mealie is sometimes embedded in another site, which needs `SameSite=None` and a partitioned
-    cookie. The server can't detect embedding, so the client flags it — and we only honour the flag
-    over HTTPS, since browsers reject `SameSite=None` without `Secure`.
+    Mealie is sometimes embedded in another site, which needs `SameSite=None`. The server can't
+    detect embedding, so the client flags it — and we only honour the flag over HTTPS, since
+    browsers reject `SameSite=None` without `Secure`.
     """
     secure = request_is_https(request)
     embedded = secure and request.headers.get("x-mealie-embedded", "").lower() == "true"
@@ -93,7 +93,6 @@ def session_cookie_attrs(request: Request) -> dict:
         "path": "/",
         "secure": secure,
         "samesite": "none" if embedded else "lax",
-        "partitioned": embedded,
     }
 
 
@@ -336,7 +335,7 @@ async def logout(
     accept_language: Annotated[str | None, Header()] = None,
 ):
     # Clearing a cookie only works when the attributes match the ones it was set with, which the old
-    # bare delete_cookie() call didn't manage for embedded (partitioned, SameSite=None) deployments.
+    # bare delete_cookie() call didn't manage for embedded (SameSite=None) deployments.
     response.set_cookie(SESSION_COOKIE_NAME, "", max_age=0, expires=0, **session_cookie_attrs(request))
 
     translator = get_locale_provider(accept_language)

--- a/tests/unit_tests/test_session_cookie.py
+++ b/tests/unit_tests/test_session_cookie.py
@@ -1,6 +1,9 @@
-from starlette.requests import Request
+from datetime import timedelta
 
-from mealie.routes.auth.auth import session_cookie_attrs
+from starlette.requests import Request
+from starlette.responses import Response
+
+from mealie.routes.auth.auth import SESSION_COOKIE_NAME, session_cookie_attrs, set_session_cookie
 
 
 def build_request(scheme: str = "http", headers: dict[str, str] | None = None) -> Request:
@@ -22,7 +25,6 @@ def test_plain_http_gets_an_insecure_lax_cookie():
 
     assert attrs["secure"] is False
     assert attrs["samesite"] == "lax"
-    assert attrs["partitioned"] is False
 
 
 def test_https_gets_a_secure_cookie():
@@ -44,11 +46,10 @@ def test_the_first_hop_of_a_forwarded_chain_decides():
     assert session_cookie_attrs(build_request(headers={"x-forwarded-proto": "http, https"}))["secure"] is False
 
 
-def test_embedded_over_https_relaxes_samesite_and_partitions():
+def test_embedded_over_https_relaxes_samesite():
     attrs = session_cookie_attrs(build_request(scheme="https", headers={"x-mealie-embedded": "true"}))
 
     assert attrs["samesite"] == "none"
-    assert attrs["partitioned"] is True
 
 
 def test_embedded_behind_an_untrusted_proxy_still_relaxes_samesite():
@@ -56,7 +57,6 @@ def test_embedded_behind_an_untrusted_proxy_still_relaxes_samesite():
     attrs = session_cookie_attrs(build_request(headers={"x-forwarded-proto": "https", "x-mealie-embedded": "true"}))
 
     assert attrs["samesite"] == "none"
-    assert attrs["partitioned"] is True
 
 
 def test_embedded_over_plain_http_stays_lax():
@@ -64,4 +64,28 @@ def test_embedded_over_plain_http_stays_lax():
     attrs = session_cookie_attrs(build_request(headers={"x-mealie-embedded": "true"}))
 
     assert attrs["samesite"] == "lax"
-    assert attrs["partitioned"] is False
+
+
+def test_no_attribute_starlette_cannot_emit():
+    """`Partitioned` needs Python 3.14; asking for it on 3.12 made every embedded login a 500."""
+    assert "partitioned" not in session_cookie_attrs(
+        build_request(scheme="https", headers={"x-mealie-embedded": "true"})
+    )
+
+
+def test_embedded_https_cookie_is_actually_sendable():
+    """The attribute dict alone can't catch a value Starlette rejects, so set the cookie for real."""
+    response = Response()
+    set_session_cookie(
+        response,
+        build_request(scheme="https", headers={"x-mealie-embedded": "true"}),
+        "token",
+        timedelta(hours=1),
+        remember_me=True,
+    )
+
+    set_cookie = next(v.decode() for k, v in response.raw_headers if k == b"set-cookie")
+    assert set_cookie.startswith(f"{SESSION_COOKIE_NAME}=token;")
+    assert "SameSite=none" in set_cookie
+    assert "Secure" in set_cookie
+    assert "Partitioned" not in set_cookie


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Partitioned cookies were introduced for embedded access, but that's not supported until Python 3.14. We can add it back in later when we eventually upgrade to 3.14, but for now it's best to just drop it since most embedded usecases still work fine without it.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/8277

## Testing

_(fill-in or delete this section)_

Updated tests as recommended in https://github.com/mealie-recipes/mealie/issues/8277.

## AI / LLM Assistance

_(REQUIRED)_

Fixed by Claude.
