### PR TITLE
fix: QueryFilter improvements

### DIFF
--- a/frontend/app/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/app/components/Domain/QueryFilterBuilder.vue
@@ -126,10 +126,12 @@
             />
             <v-number-input
               v-else-if="field.type === 'number'"
-              :model-value="field.value"
+              :model-value="field.value as number || 0"
               variant="underlined"
               control-variant="stacked"
               inset
+              :min="0"
+              :max="5"
               :precision="null"
               @update:model-value="setFieldValue(field, index, $event)"
             />

--- a/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -159,7 +159,6 @@
                           v-if="isOwnGroup"
                           v-model="state.settings.includeFoodsOnHand"
                           density="compact"
-                          size="small"
                           hide-details
                           class="my-auto"
                           :label="$t('recipe-finder.include-ingredients-on-hand')"
@@ -168,7 +167,6 @@
                           v-if="isOwnGroup"
                           v-model="state.settings.includeToolsOnHand"
                           density="compact"
-                          size="small"
                           hide-details
                           class="my-auto"
                           :label="$t('recipe-finder.include-tools-on-hand')"
@@ -606,8 +604,8 @@ const recipeSuggestions = computed<RecipeSuggestions>(() => {
 
 watchDebounced(
   [selectedFoods, selectedTools, state.settings], async () => {
-    // don't search for suggestions if no foods are selected
-    if (!selectedFoods.value.length) {
+    // don't search for suggestions if no filter are selected
+    if (!selectedFoods.value.length && !selectedTools.value.length && !state.settings.queryFilter) {
       recipeResponseItems.value = [];
       state.recipesReady = true;
       return;


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

This PR improves the filter search in several ways :

- On the recipe search page, you no longer need to select an ingredient to apply other filters. You can now use the “advanced” filters to find recipes even when you don't necessarily want to create a dedicated cookbook.
- The rating filter has been improved following #7966. As the only numerical filter, the rating ranges from 0 to 5.
- Warnings and deprecations have been fixed.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## AI / LLM Assistance

_(REQUIRED)_

None