### PR TITLE
fix: cascade group deletion to households and recipes

### DIFF
--- a/mealie/db/models/group/group.py
+++ b/mealie/db/models/group/group.py
@@ -35,7 +35,9 @@ class Group(SqlAlchemyBase, BaseMixins):
     id: FilterableColumn[GUID] = mapped_column(GUID, primary_key=True, default=GUID.generate)
     name: FilterableColumn[str] = mapped_column(sa.String, index=True, nullable=False, unique=True)
     slug: FilterableColumn[str | None] = mapped_column(sa.String, index=True, unique=True)
-    households: Mapped[list["Household"]] = orm.relationship("Household", back_populates="group")
+    households: Mapped[list["Household"]] = orm.relationship(
+        "Household", back_populates="group", cascade="all, delete-orphan"
+    )
     users: Mapped[list["User"]] = orm.relationship("User", back_populates="group")
     categories: Mapped[list[Category]] = orm.relationship(Category, secondary=group_to_categories, single_parent=True)
 
@@ -60,7 +62,9 @@ class Group(SqlAlchemyBase, BaseMixins):
     )
 
     # Recipes
-    recipes: Mapped[list["RecipeModel"]] = orm.relationship("RecipeModel", back_populates="group")
+    recipes: Mapped[list["RecipeModel"]] = orm.relationship(
+        "RecipeModel", back_populates="group", cascade="all, delete-orphan"
+    )
 
     # CRUD From Others
     common_args = {

--- a/tests/integration_tests/admin_tests/test_admin_group_actions.py
+++ b/tests/integration_tests/admin_tests/test_admin_group_actions.py
@@ -1,9 +1,11 @@
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 from mealie.core.config import get_app_settings
 from mealie.repos.repository_factory import AllRepositories
 from mealie.schema.group.ai_providers import AIProviderCreate, AIProviderSettingsUpdate
 from mealie.schema.user.user import GroupInDB
+from tests.fixtures.fixture_users import build_unique_user
 from tests.utils import api_routes
 from tests.utils.assertion_helpers import assert_ignore_keys
 from tests.utils.factories import random_bool, random_string
@@ -180,4 +182,21 @@ def test_admin_delete_group(unfiltered_database: AllRepositories, api_client: Te
     assert response.status_code == 200
 
     response = api_client.get(api_routes.admin_groups_item_id(group.id), headers=admin_user.token)
+    assert response.status_code == 404
+
+
+def test_admin_delete_group_with_recipes(session: Session, api_client: TestClient, admin_user: TestUser):
+    """https://github.com/mealie-recipes/mealie/issues/5007"""
+    user = build_unique_user(session, random_string(), api_client)
+
+    response = api_client.post(api_routes.recipes, json={"name": random_string()}, headers=user.token)
+    assert response.status_code == 201
+
+    response = api_client.delete(api_routes.admin_users_item_id(user.user_id), headers=admin_user.token)
+    assert response.status_code == 200
+
+    response = api_client.delete(api_routes.admin_groups_item_id(user.group_id), headers=admin_user.token)
+    assert response.status_code == 200
+
+    response = api_client.get(api_routes.admin_groups_item_id(user.group_id), headers=admin_user.token)
     assert response.status_code == 404


### PR DESCRIPTION
## What this PR does / why we need it:

Deleting a group fails with a 409 and the group can never be removed, if any recipe still belongs to it.

`Group.households` and `Group.recipes` in `mealie/db/models/group/group.py` were declared without a cascade, unlike every other relationship on that model. SQLAlchemy's default cascade does not include `delete`, so deleting a group de-associates the children by setting their foreign key to NULL instead of deleting them:

```sql
UPDATE recipes SET group_id = NULL, update_at = ? WHERE recipes.id = ?
```

`recipes.group_id` and `households.group_id` are both `nullable=False`, so that statement raises an IntegrityError, which `HttpRepo` maps to a 409. The group stays in the admin list permanently.

This adds `cascade="all, delete-orphan"` to both relationships. No schema change, so no migration is needed.

`Group.users` is deliberately left as it was. `admin_management_groups.py` already refuses to delete a group that still has users, and that guard should not be bypassed by a cascade.

## Which issue(s) this PR fixes:

Fixes #5007

## Special notes for your reviewer:

The behaviour change worth a second opinion is that deleting a group now hard deletes the households and recipes under it. A group that reaches the delete path already has no users, since the route rejects that case, so this seemed like the expected reading. If you would rather the API refuse the delete and report how many recipes are left behind, say so and I will rework it.

Worth knowing why this went unnoticed for so long. The admin group list disables the delete button while a group has households or users:

```vue
<v-btn :disabled="item && (item.households!.length > 0 || item.users!.length > 0)"
```

There is no equivalent guard for recipes. So the bug is only reachable after the user and the household have been deleted and an orphaned recipe is left behind, which is exactly the sequence described in the issue.

## Testing

Added `test_admin_delete_group_with_recipes`, which walks the sequence from the issue: create a user, create a recipe, delete the user, then delete the group. It fails on `mealie-next` and passes with this change.

Full backend suite run against both SQLite and Postgres. Also reproduced by hand in the browser against a dev instance, where the delete returns 409 and the group stays in the list before the change, and succeeds after it, leaving no orphaned recipe rows.

## AI / LLM Assistance

This pull request was developed with LLM assistance.
