### PR TITLE
fix: harden public filtering

### DIFF
--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -241,12 +241,9 @@ class RepositoryRecipes(HouseholdRepositoryGeneric[Recipe, RecipeModel]):
         q = q.filter_by(**fltr)
 
         if cookbook:
-            if pagination_result.query_filter and cookbook.query_filter_string:
-                pagination_result.query_filter = (
-                    f"({pagination_result.query_filter}) AND ({cookbook.query_filter_string})"
-                )
-            else:
-                pagination_result.query_filter = cookbook.query_filter_string
+            pagination_result.query_filter = QueryFilterBuilder.combine_filters(
+                pagination_result.query_filter, cookbook.query_filter_string
+            )
         else:
             category_ids = self._uuids_for_items(categories, Category)
             tag_ids = self._uuids_for_items(tags, Tag)

--- a/mealie/routes/explore/controller_public_cookbooks.py
+++ b/mealie/routes/explore/controller_public_cookbooks.py
@@ -8,6 +8,7 @@ from mealie.routes._base.base_controllers import BasePublicHouseholdExploreContr
 from mealie.schema.cookbook.cookbook import ReadCookBook
 from mealie.schema.make_dependable import make_dependable
 from mealie.schema.response.pagination import PaginationBase, PaginationQuery
+from mealie.services.query_filter.builder import QueryFilterBuilder
 
 router = APIRouter(prefix="/cookbooks")
 
@@ -25,10 +26,7 @@ class PublicCookbooksController(BasePublicHouseholdExploreController):
         search: str | None = None,
     ) -> PaginationBase[ReadCookBook]:
         public_filter = "(household.preferences.privateHousehold = FALSE AND public = TRUE)"
-        if q.query_filter:
-            q.query_filter = f"({q.query_filter}) AND {public_filter}"
-        else:
-            q.query_filter = public_filter
+        q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, public_filter)
 
         response = self.cross_household_cookbooks.page_all(
             pagination=q,

--- a/mealie/routes/explore/controller_public_households.py
+++ b/mealie/routes/explore/controller_public_households.py
@@ -5,6 +5,7 @@ from mealie.routes._base.base_controllers import BasePublicGroupExploreControlle
 from mealie.schema.household.household import HouseholdSummary
 from mealie.schema.make_dependable import make_dependable
 from mealie.schema.response.pagination import PaginationBase, PaginationQuery
+from mealie.services.query_filter.builder import QueryFilterBuilder
 
 router = APIRouter(prefix="/households")
 
@@ -20,10 +21,7 @@ class PublicHouseholdsController(BasePublicGroupExploreController):
         self, q: PaginationQuery = Depends(make_dependable(PaginationQuery))
     ) -> PaginationBase[HouseholdSummary]:
         public_filter = "(preferences.private_household = FALSE)"
-        if q.query_filter:
-            q.query_filter = f"({q.query_filter}) AND {public_filter}"
-        else:
-            q.query_filter = public_filter
+        q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, public_filter)
 
         response = self.households.page_all(pagination=q, override=HouseholdSummary)
         response.set_pagination_guides(self.get_explore_url_path(router.url_path_for("get_all")), q.model_dump())

--- a/mealie/routes/explore/controller_public_recipes.py
+++ b/mealie/routes/explore/controller_public_recipes.py
@@ -13,6 +13,7 @@ from mealie.schema.recipe import Recipe
 from mealie.schema.recipe.recipe import RecipeSummary
 from mealie.schema.recipe.recipe_suggestion import RecipeSuggestionQuery, RecipeSuggestionResponse
 from mealie.schema.response.pagination import PaginationBase, PaginationQuery, RecipeSearchQuery
+from mealie.services.query_filter.builder import QueryFilterBuilder
 
 router = APIRouter(prefix="/recipes")
 
@@ -59,10 +60,7 @@ class PublicRecipesController(BasePublicHouseholdExploreController):
                 raise COOKBOOK_NOT_FOUND_EXCEPTION
 
         public_filter = "(household.preferences.privateHousehold = FALSE AND settings.public = TRUE)"
-        if q.query_filter:
-            q.query_filter = f"({q.query_filter}) AND {public_filter}"
-        else:
-            q.query_filter = public_filter
+        q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, public_filter)
 
         pagination_response = self.cross_household_recipes.page_all(
             pagination=q,
@@ -99,10 +97,7 @@ class PublicRecipesController(BasePublicHouseholdExploreController):
         tools: list[UUID4] | None = Query(None),
     ) -> RecipeSuggestionResponse:
         public_filter = "(household.preferences.privateHousehold = FALSE AND settings.public = TRUE)"
-        if q.query_filter:
-            q.query_filter = f"({q.query_filter}) AND {public_filter}"
-        else:
-            q.query_filter = public_filter
+        q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, public_filter)
 
         recipes = self.cross_household_recipes.find_suggested_recipes(q, foods, tools)
         response = RecipeSuggestionResponse(items=recipes)

--- a/mealie/routes/households/controller_household_self_service.py
+++ b/mealie/routes/households/controller_household_self_service.py
@@ -12,6 +12,7 @@ from mealie.schema.household.household_statistics import HouseholdStatistics
 from mealie.schema.response.pagination import PaginationBase, PaginationQuery
 from mealie.schema.user.user import UserOut
 from mealie.services.household_services.household_service import HouseholdService
+from mealie.services.query_filter.builder import QueryFilterBuilder
 
 router = UserAPIRouter(prefix="/households", tags=["Households: Self Service"])
 
@@ -40,11 +41,7 @@ class HouseholdSelfServiceController(BaseUserController):
     def get_household_members(self, q: PaginationQuery = Depends()):
         """Returns all users belonging to the current household"""
 
-        qf_part = f"household_id={self.household_id}"
-        if q.query_filter:
-            q.query_filter = f"({q.query_filter}) AND {qf_part}"
-        else:
-            q.query_filter = qf_part
+        q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, f"household_id={self.household_id}")
 
         response = self.repos.users.page_all(q, override=UserOut)
 

--- a/mealie/routes/households/controller_mealplan.py
+++ b/mealie/routes/households/controller_mealplan.py
@@ -22,6 +22,7 @@ from mealie.services.event_bus_service.event_types import (
     EventOperation,
     EventTypes,
 )
+from mealie.services.query_filter.builder import QueryFilterBuilder
 
 router = APIRouter(prefix="/households/mealplans", tags=["Households: Mealplans"])
 
@@ -61,7 +62,7 @@ class GroupMealplanController(BaseCrudController):
             self.session, group_id=self.group_id, household_id=None
         ).recipes.by_user(self.user.id)
 
-        qf_string = " AND ".join([f"({rule.query_filter_string})" for rule in rules if rule.query_filter_string])
+        qf_string = QueryFilterBuilder.combine_filters(*[rule.query_filter_string for rule in rules])
         recipes_data = cross_household_recipes.page_all(
             pagination=PaginationQuery(
                 page=1,
@@ -91,11 +92,7 @@ class GroupMealplanController(BaseCrudController):
             else:
                 date_filter = f"date >= {start_date} AND date <= {end_date}"
 
-            if q.query_filter:
-                q.query_filter = f"({q.query_filter}) AND ({date_filter})"
-
-            else:
-                q.query_filter = date_filter
+            q.query_filter = QueryFilterBuilder.combine_filters(q.query_filter, date_filter)
 
         return self.repo.page_all(pagination=q)
 

--- a/mealie/services/query_filter/builder.py
+++ b/mealie/services/query_filter/builder.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from dateutil import parser as date_parser
 from dateutil.parser import ParserError
+from fastapi import HTTPException
 from humps import decamelize
 from sqlalchemy.ext.associationproxy import AssociationProxyInstance
 from sqlalchemy.orm import InstrumentedAttribute, Mapper
@@ -172,10 +173,7 @@ class QueryFilterBuilder:
         # parse filter string
         components = QueryFilterBuilder._break_filter_string_into_components(filter_string)
         base_components = QueryFilterBuilder._break_components_into_base_components(components)
-        if base_components.count(QueryFilterBuilder.l_group_sep) != base_components.count(
-            QueryFilterBuilder.r_group_sep
-        ):
-            raise ValueError("invalid query string: parenthesis are unbalanced")
+        QueryFilterBuilder._validate_parenthesis(base_components)
 
         # parse base components into a filter group
         self.filter_components = QueryFilterBuilder._parse_base_components_into_filter_components(base_components)
@@ -189,6 +187,46 @@ class QueryFilterBuilder:
         )
 
         return f"<<{joined}>>"
+
+    @staticmethod
+    def _validate_parenthesis(base_components: list[str | list[str]]) -> None:
+        """Validate that every group is opened before it's closed, and that all groups are closed."""
+
+        VALUE_ERROR = ValueError("invalid query string: parenthesis are unbalanced")
+
+        depth = 0
+        for base_component in base_components:
+            if base_component == QueryFilterBuilder.l_group_sep:
+                depth += 1
+            elif base_component == QueryFilterBuilder.r_group_sep:
+                depth -= 1
+                if depth < 0:
+                    raise VALUE_ERROR
+
+        if depth:
+            raise VALUE_ERROR
+
+    @classmethod
+    def combine_filters(cls, *filter_strings: str | None) -> str:
+        """
+        Combine filter strings into one filter string joined by `AND`, ignoring empty ones.
+
+        Validates each sub-filter individually, throwing an HTTPException if any are invalid.
+        """
+
+        parts: list[str] = []
+        for filter_string in filter_strings:
+            if not filter_string:
+                continue
+
+            try:
+                cls(filter_string)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+
+            parts.append(f"({filter_string})")
+
+        return " AND ".join(parts)
 
     @classmethod
     def _consolidate_group(

--- a/tests/integration_tests/public_explorer_tests/test_public_recipes.py
+++ b/tests/integration_tests/public_explorer_tests/test_public_recipes.py
@@ -150,6 +150,39 @@ def test_get_all_public_recipes_filtered(
     assert should_fetch is (str(random_recipe.id) in fetched_ids)
 
 
+def test_get_all_public_recipes_filter_cannot_escape_public_filter(
+    api_client: TestClient,
+    unique_user: TestUser,
+    random_recipe: Recipe,
+):
+    """A query filter must not be able to break out of its group and demote the mandatory public filter"""
+
+    database = unique_user.repos
+
+    group = database.groups.get_one(unique_user.group_id)
+    assert group and group.preferences
+
+    group.preferences.private_group = False
+    database.group_preferences.update(group.id, group.preferences)
+
+    household = database.households.get_one(unique_user.household_id)
+    assert household and household.preferences
+
+    household.preferences.private_household = False
+    household.preferences.recipe_public = True
+    database.household_preferences.update(household.id, household.preferences)
+
+    assert random_recipe.settings
+    random_recipe.settings.public = False
+    database.recipes.update(random_recipe.slug, random_recipe.model_dump())
+
+    response = api_client.get(
+        api_routes.explore_groups_group_slug_recipes(group.slug),
+        params={"queryFilter": 'name <> "zzz") OR (name <> "zzz"'},
+    )
+    assert response.status_code == 400
+
+
 @pytest.mark.parametrize("is_private_group", [True, False])
 @pytest.mark.parametrize("is_private_household", [True, False])
 @pytest.mark.parametrize("is_private_recipe", [True, False])

--- a/tests/unit_tests/repository_tests/test_pagination.py
+++ b/tests/unit_tests/repository_tests/test_pagination.py
@@ -1393,6 +1393,10 @@ def test_pagination_filter_advanced_frontend_sort(unique_user: TestUser):
     "qf",
     [
         pytest.param('(name="test name" AND useAbbreviation=f))', id="unbalanced parenthesis"),
+        pytest.param(
+            'name <> "test name") OR (useAbbreviation=f',
+            id="parenthesis closed before they're opened",
+        ),
         pytest.param('id="this is not a valid UUID"', id="invalid UUID"),
         pytest.param(
             'createdAt="this is not a valid datetime format"',


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Hardens our query filters to prevent injecting bad queries to get around public/private restrictions.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, see: GHSA-8865-m66j-f2g9

## Testing

_(fill-in or delete this section)_

Updated tests to reflect this.

## AI / LLM Assistance

_(REQUIRED)_

Solution by me, the human, wired into the repo by Claude.
