### PR TITLE
fix: recipe name normalization on update

### DIFF
--- a/mealie/db/models/recipe/recipe.py
+++ b/mealie/db/models/recipe/recipe.py
@@ -270,7 +270,7 @@ class RecipeModel(SqlAlchemyBase, BaseMixins):
 
 @event.listens_for(RecipeModel.name, "set")
 def receive_name(target: RecipeModel, value: str, oldvalue, initiator):
-    target.name_normalized = RecipeModel.normalize(value)
+    target.name_normalized = RecipeModel.normalize(value) if value else None
 
 
 @event.listens_for(RecipeModel.description, "set")


### PR DESCRIPTION
## What this PR does / why we need it

Fixes an issue where updating a recipe could result in a 500 Internal Server Error.

- Updated recipe name normalization to safely handle a None value during recipe updates.
- Prevents the normalization logic from attempting to normalize a missing recipe name.
- This addresses issue #4401.

## Which issue(s) this PR fixes

Fixes #4401

## Testing

The change was reviewed against the reported PUT update error in issue #4401. Automated tests were not run because the local pre-commit environment could not be initialized due to a Windows virtual-environment issue.