### PR TITLE
fix: return a 422 instead of a 500 when a recipe PUT omits the name

### DIFF
--- a/mealie/core/exceptions.py
+++ b/mealie/core/exceptions.py
@@ -38,6 +38,15 @@ class SlugError(Exception):
     pass
 
 
+class MissingRequiredData(Exception):
+    """
+    This exception is raised when a full-replacement update is missing data that the
+    resource cannot exist without.
+    """
+
+    pass
+
+
 class NoEntryFound(Exception):
     """
     This exception is raised when a user tries to access a resource that does not exist.

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -115,6 +115,14 @@ class RecipeController(BaseRecipeController):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ErrorResponse.respond(message=self.t("exceptions.recursive-recipe-link")),
             )
+        elif thrownType == exceptions.MissingRequiredData:
+            self.logger.error("Missing required data on recipe controller action")
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=ErrorResponse.respond(
+                    message=f"{ex}. PUT replaces the entire recipe; use PATCH to update only some fields."
+                ),
+            )
         elif thrownType == exceptions.SlugError:
             self.logger.error("Failed to generate a valid slug from recipe name")
             raise HTTPException(

--- a/mealie/services/recipe/recipe_service.py
+++ b/mealie/services/recipe/recipe_service.py
@@ -507,6 +507,13 @@ class RecipeService(RecipeServiceBase):
     def update_one(self, slug_or_id: str | UUID, update_data: Recipe) -> Recipe:
         recipe = self._pre_update_check(slug_or_id, update_data)
 
+        # A PUT replaces the whole recipe, so a body that omits the name would blank it out.
+        # Nothing downstream can cope with that, so reject it before the update rather than
+        # failing deeper in. This runs after the checks above so that a missing or forbidden
+        # recipe still answers 404 or 403 regardless of what the body contains.
+        if not update_data.name:
+            raise exceptions.MissingRequiredData("Recipe name is required")
+
         update_data = self._preserve_omitted_image(recipe, update_data)
         update_data = self._remove_non_existent_ingredient_references(update_data)
         update_data = self._resolve_ingredient_sub_recipes(update_data)

--- a/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_crud.py
@@ -1384,6 +1384,42 @@ def test_delete(api_client: TestClient, unique_user: TestUser):
     assert response.status_code == 200
 
 
+def test_update_missing_name_returns_error_not_500(api_client: TestClient, unique_user: TestUser):
+    """A PUT body without a name used to blank the name out and fail with a 500."""
+    name = random_string()
+    api_client.post(api_routes.recipes, json={"name": name}, headers=unique_user.token)
+
+    response = api_client.put(
+        api_routes.recipes_slug(name),
+        json={"recipeIngredient": [{"quantity": 2.0, "note": random_string()}]},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 422
+
+    # the recipe is left untouched
+    get_response = api_client.get(api_routes.recipes_slug(name), headers=unique_user.token)
+    assert get_response.status_code == 200
+    assert get_response.json()["name"] == name
+
+
+def test_patch_without_name_still_updates(api_client: TestClient, unique_user: TestUser):
+    """PATCH is the partial-update verb, so a body without a name must keep working."""
+    name = random_string()
+    api_client.post(api_routes.recipes, json={"name": name}, headers=unique_user.token)
+
+    note = random_string()
+    response = api_client.patch(
+        api_routes.recipes_slug(name),
+        json={"recipeIngredient": [{"quantity": 2.0, "note": note}]},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 200
+
+    recipe = api_client.get(api_routes.recipes_slug(name), headers=unique_user.token).json()
+    assert recipe["name"] == name
+    assert recipe["recipeIngredient"][0]["note"] == note
+
+
 def test_recipe_crud_404(api_client: TestClient, unique_user: TestUser):
     response = api_client.put(api_routes.recipes_slug("test"), json={"test": "stest"}, headers=unique_user.token)
     assert response.status_code == 404


### PR DESCRIPTION
## What this PR does / why we need it:

`PUT /api/recipes/{slug}` returns a 500 when the body leaves out the recipe name.

`Recipe` has no required fields, so a body containing only `recipeIngredient` validates
with `name=None`. `PUT` applies the model as a whole replacement — unlike `PATCH`, which
uses `model_dump(exclude_unset=True)` — so the `None` reaches the recipe model's name
normalisation and raises `TypeError: 'NoneType' object is not iterable` inside
`unidecode()`. `TypeError` is not one of the types `handle_exceptions` recognises, so it
falls through to the final `else` and is reported as a 500 "Unknown Error", even though
the request, not the server, is at fault.

I checked which fields actually cause this, since `PUT` supplies defaults for all of
them: `name` is the only one. A request carrying a valid name and omitting everything
else already fails with a 400.

Changes:

- `mealie/core/exceptions.py` — adds `MissingRequiredData`. I did not reuse
  `UnexpectedNone`, because it currently marks internal invariant failures ("Recipe not
  found", "Cannot find user"); mapping it to a 4xx would relabel genuine server faults as
  client errors.
- `mealie/services/recipe/recipe_service.py` — `update_one` rejects a body without a name
  before touching the database, so the stored recipe is left untouched. Putting the check
  in the service covers `PUT /{slug}` and `PUT ""`, which both call it. `patch_one` is a
  separate method and is unaffected, so partial updates via `PATCH` keep working.
- `mealie/routes/recipe/recipe_crud_routes.py` — maps the new exception to a 422 whose
  message names the missing field and points at `PATCH` for partial updates.

I also checked the two other callers of `update_one` (the image and asset upload
handlers); both pass a recipe loaded from the database, so they always carry a name.

Making `name` required on the schema would be the obvious fix, but `Recipe` is the request
body for both `PUT` and `PATCH`, so that would break partial updates — which is the
workaround suggested in the issue.

## Which issue(s) this PR fixes:

Fixes #4401

## Special notes for your reviewer:

**The status code is your call and I'd rather you picked it.** The issue asks for "a real
error, not a 500" without naming one. `handle_exceptions` answers 400 for its existing
domain errors ("Recipe already exists", recursive links, slug failures), so 400 would be
the consistent choice; I used 422 because this is a malformed body rather than a state
conflict, and separating the two seemed more useful to API clients. Happy to switch if you
prefer consistency within the controller.

Two smaller notes:

- `status.HTTP_422_UNPROCESSABLE_ENTITY` is deprecated in the Starlette version currently
  pinned, and the warning is raised as an error under the test settings, so I used
  `HTTP_422_UNPROCESSABLE_CONTENT`. There are no other uses of the old constant in the
  tree.
- A `PUT` carrying a valid name but omitting everything else answers 400 "Recipe already
  exists", which is confusing in its own right. That is outside this issue, so I have left
  it alone, but I'm happy to look at it separately if you think it is worth an issue.

For reference, #5788 attempted this last year and was closed by its author for lack of
time rather than being rejected.

## Testing

Two tests added next to the existing recipe CRUD tests:

- `test_update_missing_name_returns_error_not_500` — `PUT` with only `recipeIngredient`
  returns 422, and the stored recipe still has its original name. The second assertion
  matters: it catches a check placed too late to prevent the name being blanked.
- `test_patch_without_name_still_updates` — `PATCH` with the same partial body still
  returns 200 and applies the change, guarding the partial-update path against this fix.

Both were checked against the old behaviour by stashing the source changes: the first
then fails with the 500 and the `TypeError` above, while the second still passes,
confirming it guards the partial-update path rather than being green either way. With the
fix applied, both pass.

I also ran the other `update`/`patch` tests in that file, which pass. Two of them,
`test_read_update` and `test_update_with_empty_relationship`, fail when the file is run
with `-k`, but they fail identically with all of my changes stashed - they depend on
recipes created by earlier tests in the file - so they are unrelated to this change.

`ruff check`, `ruff format --check` and `mypy` are clean on the changed files.

## AI / LLM Assistance

I picked this issue, reproduced it locally against current `mealie-next` before starting,
and confirmed which fields actually trigger the 500 rather than assuming it was every
missing field. An LLM was used to trace the call path from the route down to the name
normalisation, to draft the fix and the two tests, and to run the checks described above.
I reviewed the diff. The decisions about where to put the check, not reusing
`UnexpectedNone`, keeping the scope to the reported issue, and leaving the status code
open for the reviewer were mine.