### PR TITLE
fix: import Recipe Keeper categories and yields

### DIFF
--- a/mealie/services/migrations/recipekeeper.py
+++ b/mealie/services/migrations/recipekeeper.py
@@ -77,12 +77,12 @@ class RecipeKeeperMigrator(BaseMigrator):
             MigrationAlias(key="prepTime", alias="prepTime", func=parse_iso8601_duration),
             MigrationAlias(key="image", alias="photo0"),
             MigrationAlias(key="tags", alias="recipeCourse", func=to_list),
-            MigrationAlias(key="recipe_category", alias="recipeCategory", func=to_list),
+            MigrationAlias(key="recipeCategory", alias="recipeCategory", func=to_list),
             MigrationAlias(key="notes", alias="recipeNotes"),
             MigrationAlias(key="nutrition", alias="nutrition", func=cleaner.clean_nutrition),
             MigrationAlias(key="rating", alias="recipeRating"),
             MigrationAlias(key="orgURL", alias="recipeSource"),
-            MigrationAlias(key="recipe_yield", alias="recipeYield"),
+            MigrationAlias(key="recipeYield", alias="recipeYield"),
         ]
 
     def _migrate(self) -> None:

--- a/tests/integration_tests/recipe_migration_tests/test_recipe_migrations.py
+++ b/tests/integration_tests/recipe_migration_tests/test_recipe_migrations.py
@@ -285,3 +285,29 @@ def test_bad_mealie_alpha_data_is_ignored(api_client: TestClient, unique_user: T
     report_entry = ReportEntryOut.model_validate(failed_item)
     assert report_entry.message == "Failed to import invalid-recipe.json"
     assert report_entry.exception == "JSONDecodeError: Expecting value: line 1 column 1 (char 0)"
+
+
+def test_recipekeeper_imports_categories_and_yield(api_client: TestClient, unique_user_fn_scoped: TestUser) -> None:
+    """Recipe Keeper categories and yields were dropped by the migrator's snake_case alias keys."""
+    unique_user = unique_user_fn_scoped
+
+    response = api_client.post(
+        api_routes.groups_migrations,
+        data={"migration_type": SupportedMigrations.recipekeeper.value},
+        files={"archive": test_data.migrations_recipekeeper.read_bytes()},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 200
+
+    def get(slug: str) -> Recipe:
+        return Recipe(**assert_deserialize(api_client.get(api_routes.recipes_slug(slug), headers=unique_user.token)))
+
+    # a bare number in recipeYield is a yield quantity
+    recipe = get("zucchini-bread")
+    assert [c.name for c in recipe.recipe_category or []] == ["Bread"]
+    assert recipe.recipe_yield_quantity == 16
+
+    # a number with a unit is a serving count
+    recipe = get("baked-salmon-fillets-dijon")
+    assert [c.name for c in recipe.recipe_category or []] == ["Fish"]
+    assert recipe.recipe_servings == 4


### PR DESCRIPTION
## What this PR does / why we need it:

Importing a Recipe Keeper export drops every category, and every recipe comes in without a
yield or serving count.

Both come from the same cause. The migrator rewrites the export's keys before the cleaner
runs:

    MigrationAlias(key="recipe_category", alias="recipeCategory", func=to_list),
    MigrationAlias(key="recipe_yield", alias="recipeYield"),

`cleaner.clean` reads both under their camelCase names — `recipe_data.get("recipeCategory", [])`
and likewise for the yield — so by the time it runs the keys have been renamed out from
under it and the values are silently discarded. Recipe Keeper is the only migrator doing
this: `myrecipebox` and `paprika` already use `key="recipeCategory"`, and `copymethat`,
`plantoeat`, `myrecipebox` and `paprika` all use `key="recipeYield"`.

Changes:

- `mealie/services/migrations/recipekeeper.py` — the two alias keys become `recipeCategory`
  and `recipeYield`, matching every other migrator.

No parsing step is needed for the yield, despite the suggestion in the issue. `cleaner`
already separates a bare quantity from a quantity with a unit, so `16` becomes a yield
quantity and `4 servings` becomes a serving count on its own once the value reaches it.

Against `tests/data/migrations/recipekeeper.zip`:

| recipe | `recipeYield` in export | before | after |
| --- | --- | --- | --- |
| Zucchini Bread | `16` | yield 0, no categories | yield quantity 16, `["Bread"]` |
| Baked Salmon Fillets Dijon | `4 servings` | servings 0, no categories | servings 4, `["Fish"]` |

## Which issue(s) this PR fixes:

Fixes #5820

## Special notes for your reviewer:

**One thing I found but did not change.** `parse_recipe_div` builds a dict keyed by
`itemprop`, so a recipe carrying more than one `recipeCategory` entry keeps only the last
one. Every recipe in the test archive has a single category, so this fix is enough for the
data I can verify against, and I did not want to change the parser's shape on a guess. A
commenter on the issue mentioned multi-category recipes, so I have asked them for an
example export. If you would rather I handled it here anyway, say so and I will — it would
mean collecting repeated `itemprop` values into a list rather than overwriting.

## Testing

Added `test_recipekeeper_imports_categories_and_yield`, which runs the real migration
through the API and checks both yield shapes present in the archive: `zucchini-bread`
(`16`, a bare quantity) and `baked-salmon-fillets-dijon` (`4 servings`, a quantity with a
unit), asserting the categories in each case. It fills in part of the existing
`# TODO: validate other types of content` in that file.

With the source change stashed, the new test fails on `assert [] == ["Bread"]`, so it
genuinely covers the defect. All 14 tests in `tests/integration_tests/recipe_migration_tests/`
pass with the fix, so the other ten migrators are unaffected.

`ruff check`, `ruff format --check` and `mypy` are clean.

## AI / LLM Assistance

I picked this issue and reproduced both symptoms locally against current `mealie-next`
before changing anything, including running the migrator's parser over the test archive to
confirm the values were being extracted correctly and lost later. An LLM was used to trace
where they were lost, to compare the alias keys against the other migrators, to draft the
change and the test, and to run the checks above. I reviewed the diff. The decisions about
scope — fixing the keys rather than adding the parsing step the issue suggested, and
raising the repeated-`itemprop` limitation with you instead of guessing at it — were mine.