### PR TITLE
fix: Allow submenus to be accessed via keyboard and mobile

### DIFF
--- a/frontend/app/components/global/BaseMenu.vue
+++ b/frontend/app/components/global/BaseMenu.vue
@@ -32,6 +32,8 @@
           :activator="child"
           :children="child.children"
           open-on-hover
+          open-on-focus
+          open-on-click
           submenu
           @menu="(childEvent) => $emit('menu', childEvent)"
         >

--- a/frontend/app/types/components.d.ts
+++ b/frontend/app/types/components.d.ts
@@ -16,6 +16,7 @@ import type BaseDialogContent from "@/components/global/BaseDialogContent.vue";
 import type BaseDivider from "@/components/global/BaseDivider.vue";
 import type BaseExpansionPanels from "@/components/global/BaseExpansionPanels.vue";
 import type BaseKeyValueEditor from "@/components/global/BaseKeyValueEditor.vue";
+import type BaseMenu from "@/components/global/BaseMenu.vue";
 import type BaseOverflowButton from "@/components/global/BaseOverflowButton.vue";
 import type BasePageTitle from "@/components/global/BasePageTitle.vue";
 import type ButtonLink from "@/components/global/ButtonLink.vue";
@@ -58,6 +59,7 @@ declare module "vue" {
     BaseDivider: typeof BaseDivider;
     BaseExpansionPanels: typeof BaseExpansionPanels;
     BaseKeyValueEditor: typeof BaseKeyValueEditor;
+    BaseMenu: typeof BaseMenu;
     BaseOverflowButton: typeof BaseOverflowButton;
     BasePageTitle: typeof BasePageTitle;
     ButtonLink: typeof ButtonLink;


### PR DESCRIPTION
## What this PR does / why we need it:
Previously #7946 added BaseMenu. Submenus of BaseMenu only used open-on-hover which means they were not accessible on mobile or via keyboard navigation. 

Now, submenus also use open-on-focus and open-on-click so they are accessible on mobile, desktop, and via keyboard navigation.  

## Which issue(s) this PR fixes:
NA

## Testing
Tested on smart phone for mobile and desktop for keyboard 

## AI / LLM Assistance
None