### PR TITLE
fix: limit one row for "to-many" relationship orderings

### DIFF
--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -4,13 +4,13 @@ import random
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from math import ceil
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException
 from pydantic import UUID4, BaseModel
 from sqlalchemy import ColumnElement, Select, case, delete, func, nulls_first, nulls_last, select
 from sqlalchemy.ext.associationproxy import AssociationProxyInstance
-from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.orm import InstrumentedAttribute, RelationshipProperty
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import sqltypes
 
@@ -25,7 +25,7 @@ from mealie.schema.response.pagination import (
     RequestQuery,
 )
 from mealie.schema.response.query_search import SearchFilter
-from mealie.services.query_filter.builder import NonFilterableValueError, QueryFilterBuilder
+from mealie.services.query_filter.builder import NonFilterableValueError, QueryFilterBuilder, RelationshipChain
 
 from ._utils import NOT_SET, NotSet
 
@@ -408,18 +408,50 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
 
         return query.offset((pagination.page - 1) * pagination.per_page), count, total_pages
 
+    def _aggregate_related_order_attr(
+        self, order_attr: ColumnElement, order_dir: OrderDirection, relationships: RelationshipChain
+    ) -> ColumnElement:
+        """
+        Reduce a related attribute to one value per record using a correlated subquery.
+
+        Joining a "to-many" relationship produces one row per related record, which duplicates records and
+        breaks LIMIT/OFFSET. Aggregating instead keeps one row per record, and picks the same related value
+        the ordering would have surfaced anyway: the lowest one when ascending, the highest when descending.
+        """
+        join_conditions: list[ColumnElement] = []
+        for relationship_attr, _ in relationships:
+            relationship = cast(RelationshipProperty, relationship_attr.property)
+            join_conditions.append(relationship.primaryjoin)
+            if relationship.secondary is not None:
+                join_conditions.append(relationship.secondaryjoin)
+
+        aggregate = func.max if order_dir is OrderDirection.desc else func.min
+        return select(aggregate(order_attr)).where(*join_conditions).correlate(self.model).scalar_subquery()
+
     def add_order_attr_to_query(
         self,
         query: Select,
         order_attr: InstrumentedAttribute,
         order_dir: OrderDirection,
         order_by_null: OrderByNullPosition | None,
+        relationships: RelationshipChain | None = None,
     ) -> Select:
-        order_attr = self.column_aliases.get(order_attr.key, order_attr)
+        if order_attr.key in self.column_aliases:
+            # aliases are already expressed in terms of the base model, so there's nothing left to traverse
+            order_attr = self.column_aliases[order_attr.key]
+            relationships = None
 
         # queries handle uppercase and lowercase differently, which is undesirable
         if isinstance(order_attr.type, sqltypes.String):
             order_attr = func.lower(order_attr)
+
+        if relationships:
+            if any(uselist for _, uselist in relationships):
+                order_attr = self._aggregate_related_order_attr(order_attr, order_dir, relationships)
+            else:
+                # "to-one" relationships can be joined directly, since they can't duplicate records
+                for relationship_attr, _ in relationships:
+                    query = query.join(relationship_attr, isouter=True)
 
         if order_dir is OrderDirection.asc:
             order_attr = order_attr.asc()
@@ -463,12 +495,13 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
                         order_by = order_by_val
                         order_dir = request_query.order_direction
 
-                    _, order_attr, query = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
-                        order_by, self.model, query=query
+                    relationships: RelationshipChain = []
+                    _, order_attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
+                        order_by, self.model, collect_relationships=relationships
                     )
 
                     query = self.add_order_attr_to_query(
-                        query, order_attr, order_dir, request_query.order_by_null_position
+                        query, order_attr, order_dir, request_query.order_by_null_position, relationships
                     )
 
                 except NonFilterableValueError as e:

--- a/mealie/repos/repository_generic.py
+++ b/mealie/repos/repository_generic.py
@@ -4,13 +4,13 @@ import random
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from math import ceil
-from typing import Any, cast
+from typing import Any
 
 from fastapi import HTTPException
 from pydantic import UUID4, BaseModel
 from sqlalchemy import ColumnElement, Select, case, delete, func, nulls_first, nulls_last, select
 from sqlalchemy.ext.associationproxy import AssociationProxyInstance
-from sqlalchemy.orm import InstrumentedAttribute, RelationshipProperty
+from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import sqltypes
 
@@ -408,26 +408,6 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
 
         return query.offset((pagination.page - 1) * pagination.per_page), count, total_pages
 
-    def _aggregate_related_order_attr(
-        self, order_attr: ColumnElement, order_dir: OrderDirection, relationships: RelationshipChain
-    ) -> ColumnElement:
-        """
-        Reduce a related attribute to one value per record using a correlated subquery.
-
-        Joining a "to-many" relationship produces one row per related record, which duplicates records and
-        breaks LIMIT/OFFSET. Aggregating instead keeps one row per record, and picks the same related value
-        the ordering would have surfaced anyway: the lowest one when ascending, the highest when descending.
-        """
-        join_conditions: list[ColumnElement] = []
-        for relationship_attr, _ in relationships:
-            relationship = cast(RelationshipProperty, relationship_attr.property)
-            join_conditions.append(relationship.primaryjoin)
-            if relationship.secondary is not None:
-                join_conditions.append(relationship.secondaryjoin)
-
-        aggregate = func.max if order_dir is OrderDirection.desc else func.min
-        return select(aggregate(order_attr)).where(*join_conditions).correlate(self.model).scalar_subquery()
-
     def add_order_attr_to_query(
         self,
         query: Select,
@@ -447,11 +427,12 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
 
         if relationships:
             if any(uselist for _, uselist in relationships):
-                order_attr = self._aggregate_related_order_attr(order_attr, order_dir, relationships)
+                order_attr = QueryFilterBuilder.aggregate_over_relationships(
+                    order_attr, relationships, self.model, descending=order_dir is OrderDirection.desc
+                )
             else:
-                # "to-one" relationships can be joined directly, since they can't duplicate records
-                for relationship_attr, _ in relationships:
-                    query = query.join(relationship_attr, isouter=True)
+                # "to-one" relationships can't duplicate records, so they're cheaper to join than to aggregate
+                query = QueryFilterBuilder.join_relationships(query, relationships)
 
         if order_dir is OrderDirection.asc:
             order_attr = order_attr.asc()
@@ -496,7 +477,7 @@ class RepositoryGeneric[Schema: MealieModel, Model: SqlAlchemyBase]:
                         order_dir = request_query.order_direction
 
                     relationships: RelationshipChain = []
-                    _, order_attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
+                    _, order_attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string(
                         order_by, self.model, collect_relationships=relationships
                     )
 

--- a/mealie/services/query_filter/builder.py
+++ b/mealie/services/query_filter/builder.py
@@ -11,7 +11,7 @@ from dateutil.parser import ParserError
 from fastapi import HTTPException
 from humps import decamelize
 from sqlalchemy.ext.associationproxy import AssociationProxyInstance
-from sqlalchemy.orm import InstrumentedAttribute, Mapper
+from sqlalchemy.orm import InstrumentedAttribute, Mapper, RelationshipProperty
 from sqlalchemy.sql import sqltypes
 
 from mealie.db.models._model_base import SqlAlchemyBase
@@ -257,12 +257,12 @@ class QueryFilterBuilder:
         attr_string: str,
         model: type[Model],
         *,
-        query: sa.Select | None = None,
         collect_relationships: RelationshipChain | None = None,
-    ) -> tuple[type[SqlAlchemyBase], InstrumentedAttribute, sa.Select | None]:
+    ) -> tuple[type[SqlAlchemyBase], InstrumentedAttribute]:
         """
         Take an attribute string and traverse a database model and its relationships to get the desired
-        model and model attribute. Optionally provide a query to apply the necessary table joins.
+        model and model attribute. Optionally collect the relationships traversed along the way, which can
+        then be expressed in a query with `join_relationships` or `aggregate_over_relationships`.
 
         If the attribute string is invalid, raises a `ValueError`.
 
@@ -284,15 +284,12 @@ class QueryFilterBuilder:
             try:
                 model_attr = getattr(current_model, attribute_link)
 
-                # proxied attributes can't be joined to the query directly, so we need to inspect the proxy
+                # proxied attributes can't be traversed directly, so we need to inspect the proxy
                 # and get the actual model and its attribute
                 if isinstance(model_attr, AssociationProxyInstance):
                     proxied_attribute_link = model_attr.target_collection
                     next_attribute_link = model_attr.value_attr
                     model_attr = getattr(current_model, proxied_attribute_link)
-
-                    if query is not None:
-                        query = query.join(model_attr, isouter=True)
 
                     mapper = sa.inspect(current_model)
                     relationship = mapper.relationships[proxied_attribute_link]
@@ -304,9 +301,6 @@ class QueryFilterBuilder:
                 # at the end of the chain there are no more relationships to inspect
                 if i == len(attribute_chain) - 1:
                     break
-
-                if query is not None:
-                    query = query.join(model_attr, isouter=True)
 
                 mapper = sa.inspect(current_model)
                 relationship = mapper.relationships[attribute_link]
@@ -323,7 +317,7 @@ class QueryFilterBuilder:
         if not getattr(model_attr, "info", {}).get("filterable"):
             raise NonFilterableValueError(model_attr)
 
-        return current_model, model_attr, query
+        return current_model, model_attr
 
     @staticmethod
     def _wrap_in_relationships(element: sa.ColumnElement, relationships: RelationshipChain) -> sa.ColumnElement:
@@ -337,6 +331,40 @@ class QueryFilterBuilder:
             element = relationship_attr.any(element) if uselist else relationship_attr.has(element)
 
         return element
+
+    @staticmethod
+    def join_relationships(query: sa.Select, relationships: RelationshipChain) -> sa.Select:
+        """
+        Join every relationship traversed by an attribute string onto a query.
+
+        Only safe for chains of "to-one" relationships: a "to-many" join duplicates a row per related record.
+        Use `aggregate_over_relationships` for those instead.
+        """
+        for relationship_attr, _ in relationships:
+            query = query.join(relationship_attr, isouter=True)
+
+        return query
+
+    @staticmethod
+    def aggregate_over_relationships[Model: SqlAlchemyBase](
+        element: sa.ColumnElement, relationships: RelationshipChain, model: type[Model], *, descending: bool
+    ) -> sa.ColumnElement:
+        """
+        Reduce a related attribute to one value per record using a correlated subquery.
+
+        Joining the relationships instead would duplicate a row per related record, which breaks LIMIT/OFFSET.
+        Aggregating keeps one row per record and picks the related value an ordering would have surfaced
+        anyway: the lowest one when ascending, the highest when descending.
+        """
+        join_conditions: list[sa.ColumnElement] = []
+        for relationship_attr, _ in relationships:
+            relationship = cast(RelationshipProperty, relationship_attr.property)
+            join_conditions.append(relationship.primaryjoin)
+            if relationship.secondary is not None:
+                join_conditions.append(relationship.secondaryjoin)
+
+        aggregate = sa.func.max if descending else sa.func.min
+        return sa.select(aggregate(element)).where(*join_conditions).correlate(model).scalar_subquery()
 
     @classmethod
     def _transform_model_attr(cls, model_attr: InstrumentedAttribute, model_attr_type: Any) -> InstrumentedAttribute:
@@ -417,7 +445,7 @@ class QueryFilterBuilder:
                 continue
 
             relationships: RelationshipChain = []
-            nested_model, model_attr, _ = self.get_model_and_model_attr_from_attr_string(
+            nested_model, model_attr = self.get_model_and_model_attr_from_attr_string(
                 component.attribute_name, model, collect_relationships=relationships
             )
             attr_map[i] = (nested_model, model_attr, relationships)

--- a/tests/unit_tests/repository_tests/test_pagination.py
+++ b/tests/unit_tests/repository_tests/test_pagination.py
@@ -1835,3 +1835,85 @@ def test_pagination_filter_not_in_related_field(unique_user: TestUser):
     result_ids = {recipe.id for recipe in database.recipes.page_all(query).items}
     assert excluded.id not in result_ids
     assert kept.id in result_ids
+
+
+def test_pagination_order_by_to_many_field_page_is_not_short(unique_user: TestUser):
+    """https://github.com/mealie-recipes/mealie/issues/8302"""
+    database = unique_user.repos
+    current_time = datetime.now(UTC)
+
+    tags = [
+        database.tags.create(TagSave(group_id=unique_user.group_id, name=name, slug=name))
+        for name in (random_string(10) for _ in range(3))
+    ]
+
+    for _ in range(5):
+        slug = random_string()
+        database.recipes.create(
+            Recipe(
+                user_id=unique_user.user_id,
+                group_id=unique_user.group_id,
+                name=slug,
+                slug=slug,
+                tags=tags,
+            )
+        )
+
+    query = PaginationQuery(
+        page=1,
+        per_page=5,
+        order_by="tags.name",
+        query_filter=f'created_at >= "{current_time.isoformat()}"',
+    )
+    result = database.recipes.page_all(query)
+    assert result.total == 5
+    assert len(result.items) == 5
+
+
+@pytest.mark.parametrize(
+    "order_direction",
+    [OrderDirection.asc, OrderDirection.desc],
+    ids=["order_ascending", "order_descending"],
+)
+def test_pagination_order_by_to_many_field(unique_user: TestUser, order_direction: OrderDirection):
+    """https://github.com/mealie-recipes/mealie/issues/8302"""
+    database = unique_user.repos
+    current_time = datetime.now(UTC)
+
+    tag_a, tag_b, tag_c, tag_d = [
+        database.tags.create(TagSave(group_id=unique_user.group_id, name=name, slug=name))
+        for name in (f"{letter}{random_string(10)}" for letter in "abcd")
+    ]
+
+    recipes = []
+    for tags in ([tag_a, tag_c], [tag_b, tag_d], []):
+        slug = random_string()
+        recipes.append(
+            database.recipes.create(
+                Recipe(
+                    user_id=unique_user.user_id,
+                    group_id=unique_user.group_id,
+                    name=slug,
+                    slug=slug,
+                    tags=tags,
+                )
+            )
+        )
+    recipe_ac, recipe_bd, recipe_untagged = recipes
+
+    query = PaginationQuery(
+        page=1,
+        per_page=-1,
+        order_by="tags.name",
+        order_direction=order_direction,
+        order_by_null_position=OrderByNullPosition.last,
+        query_filter=f'created_at >= "{current_time.isoformat()}"',
+    )
+    result_ids = [recipe.id for recipe in database.recipes.page_all(query).items]
+
+    if order_direction is OrderDirection.asc:
+        # ordered by each recipe's lowest tag name: a, then b
+        assert result_ids == [recipe_ac.id, recipe_bd.id, recipe_untagged.id]
+    else:
+        # ordered by each recipe's highest tag name: d, then c
+        assert result_ids == [recipe_bd.id, recipe_ac.id, recipe_untagged.id]

--- a/tests/unit_tests/repository_tests/test_query_filter_builder.py
+++ b/tests/unit_tests/repository_tests/test_query_filter_builder.py
@@ -107,7 +107,7 @@ def test_non_filterable_field_long_live_token_raises():
 
 def test_filterable_field_does_not_raise():
     """Filtering on a FilterableColumn field should not raise."""
-    model, attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("full_name", User)
+    model, attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("full_name", User)
     assert model is User
     assert attr is User.full_name
 
@@ -119,7 +119,7 @@ def test_filterable_field_does_not_raise():
 
 def test_deep_traversal_to_filterable_field_works():
     """Traversing a relationship to a FilterableColumn field should succeed."""
-    model, attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("user.full_name", RecipeModel)
+    model, attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("user.full_name", RecipeModel)
     assert model is User
     assert attr is User.full_name
 
@@ -154,6 +154,6 @@ def test_filter_query_user_password_raises():
 
 def test_association_proxy_resolving_to_filterable_field_works():
     """Single-hop association proxy (e.g. household_id) resolving to a FilterableColumn should succeed."""
-    model, attr, _ = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("household_id", RecipeModel)
+    model, attr = QueryFilterBuilder.get_model_and_model_attr_from_attr_string("household_id", RecipeModel)
     assert model is User
     assert attr is User.household_id


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes an API-exclusive bug with ordering by "to-many" relationships. See the issue for more details.

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes https://github.com/mealie-recipes/mealie/issues/8302

## Testing

_(fill-in or delete this section)_

Pytest

## AI / LLM Assistance

_(REQUIRED)_

Implemented by Claude