### PR TITLE
fix: inconsistent token usage

### DIFF
--- a/mealie/core/dependencies/dependencies.py
+++ b/mealie/core/dependencies/dependencies.py
@@ -20,7 +20,6 @@ from mealie.repos.all_repositories import get_repositories
 from mealie.schema.user import PrivateUser, TokenData
 from mealie.schema.user.user import DEFAULT_INTEGRATION_ID, GroupInDB
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
 oauth2_scheme_soft_fail = OAuth2PasswordBearer(tokenUrl="/api/auth/token", auto_error=False)
 app_dirs = get_app_dirs()
 settings = get_app_settings()
@@ -139,7 +138,10 @@ async def get_current_user(
     return user
 
 
-async def get_integration_id(token: str = Depends(oauth2_scheme)) -> str:
+async def get_integration_id(token: str = Depends(get_auth_token)) -> str:
+    # Shares get_current_user's token source, cookie fallback included. Reading the header directly
+    # would 401 every cookie-authenticated request to a BaseUserController route, which depends on
+    # both.
     try:
         decoded_token = jwt.decode(token, settings.SECRET, algorithms=[ALGORITHM])
         return decoded_token.get("integration_id", DEFAULT_INTEGRATION_ID)


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes a bug with cookie-only auth where the backend drops the `mealie.access_token`. This surfaced in a frontend race condition causing E2E tests to fail sometimes. In practice due to network latency this fixes itself due to retries, but in a test environment it's close to 50/50.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A, follow up to https://github.com/mealie-recipes/mealie/pull/8313

## Testing

_(fill-in or delete this section)_

Hard to test concretely, we'll see how E2E goes.

## AI / LLM Assistance

_(REQUIRED)_

Claude mostly autopiloted this fetching the logs and diagnosing.