### PR TITLE
fix: ingredient note spacing with swap icon

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
@@ -96,6 +96,13 @@ const parsedIng = computed(() => {
     white-space: normal;
     word-break: break-word;
   }
+
+  // the substitution button keeps a finger-sized tap target, but its box is taller than the
+  // line of text it sits on; left alone it sets the row's height and pushes the note down.
+  // it overflows the line instead of growing it
+  .v-btn--icon {
+    margin-block: calc((1.75rem - 48px) / 2);
+  }
 }
 
 .note {


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes the ingredient note spacing when substitutions are present and the swap icon renders.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Manually

## AI / LLM Assistance

_(REQUIRED)_

Claude wrote the fix