### PR TITLE
feat: pluralize substitutions if main ingredient is pluralized

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
@@ -10,11 +10,11 @@
     </template>
     <template v-if="parsedIng.note && !parsedIng.name">
       <SafeMarkdown class="text-bold d-inline" :source="parsedIng.note" />
-      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" />
+      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" :scale="scale" />
     </template>
     <template v-else-if="parsedIng.recipeLink">
       <SafeMarkdown class="text-bold d-inline" :source="parsedIng.recipeLink" />
-      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" />
+      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" :scale="scale" />
       <SafeMarkdown v-if="parsedIng.note" class="note" :source="parsedIng.note" />
     </template>
     <template v-else>
@@ -24,7 +24,7 @@
         :source="parsedIng.name"
       />
       <!-- sits before the note, which takes a full flex row of its own -->
-      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" />
+      <RecipeIngredientSubstitutions v-if="showSubstitutions" :ingredient="ingredient" :scale="scale" />
       <SafeMarkdown
         v-if="parsedIng.note"
         class="note"

--- a/frontend/app/components/Domain/Recipe/RecipeIngredientSubstitutions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredientSubstitutions.vue
@@ -34,7 +34,7 @@
             class="substitution"
           >
             <template v-if="substitution.substituteFood">
-              <span class="substitution-primary">{{ substitution.substituteFood.name }}</span>
+              <span class="substitution-primary">{{ substitutionFoodName(substitution, pluralFood) }}</span>
               <SafeMarkdown v-if="substitution.note" class="substitution-note" :source="substitution.note" />
             </template>
             <!-- with no food the note is the substitution itself, so it reads like one, the way
@@ -48,17 +48,25 @@
 </template>
 
 <script setup lang="ts">
-import { useIngredientSubstitutions } from "~/composables/recipes";
+import { substitutionFoodName, useFoodPlurality, useIngredientSubstitutions } from "~/composables/recipes";
 import type { IngredientFoodSubstitution, RecipeIngredient } from "~/lib/api/types/recipe";
 
 interface Props {
   ingredient: RecipeIngredient;
+  scale?: number;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  scale: 1,
+});
 
 const i18n = useI18n();
 const { recipeSubstitutions, foodSubstitutions, hasSubstitutions } = useIngredientSubstitutions(() => props.ingredient);
+
+// a substitute stands in for the food at this line's quantity and unit, so it takes the same
+// plural form the food itself does -- both sections alike, since they sit under the one line
+const { shouldPluralizeFood } = useFoodPlurality();
+const pluralFood = computed(() => shouldPluralizeFood(props.ingredient, props.scale));
 
 interface SubstitutionSection {
   key: string;

--- a/frontend/app/components/Domain/Recipe/RecipePrintView.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePrintView.vue
@@ -92,9 +92,9 @@
             />
             <!-- paper has nothing to tap, so what the menu holds on screen is spelled out here -->
             <SafeMarkdown
-              v-if="preferences.showSubstitutions && ingredientSubstitutionSummary(ingredient)"
+              v-if="preferences.showSubstitutions && substitutionSummary(ingredient)"
               class="substitution-body"
-              :source="$t('recipe.substitutions-with-value', { substitutions: ingredientSubstitutionSummary(ingredient) })"
+              :source="$t('recipe.substitutions-with-value', { substitutions: substitutionSummary(ingredient) })"
             />
           </div>
         </div>
@@ -225,7 +225,7 @@ import { useStaticRoutes } from "~/composables/api";
 import type { Recipe, RecipeIngredient, RecipeStep } from "~/lib/api/types/recipe";
 import type { NoUndefinedField } from "~/lib/api/types/non-generated";
 import { ImagePosition, useUserPrintPreferences } from "~/composables/use-users/preferences";
-import { ingredientSubstitutionSummary, useIngredientTextParser, useNutritionLabels } from "~/composables/recipes";
+import { ingredientSubstitutionSummary, useFoodPlurality, useIngredientTextParser, useNutritionLabels } from "~/composables/recipes";
 import { usePageState } from "~/composables/recipe-page/shared-state";
 import { useScaledAmount } from "~/composables/recipes/use-scaled-amount";
 
@@ -420,6 +420,13 @@ const { parseIngredientText } = useIngredientTextParser();
 
 function parseText(ingredient: RecipeIngredient) {
   return parseIngredientText(ingredient, props.scale);
+}
+
+const { shouldPluralizeFood } = useFoodPlurality();
+
+// the substitutes inflect with the line they stand in for, the same as on screen
+function substitutionSummary(ingredient: RecipeIngredient) {
+  return ingredientSubstitutionSummary(ingredient, shouldPluralizeFood(ingredient, props.scale));
 }
 </script>
 

--- a/frontend/app/composables/recipes/__tests__/use-ingredient-substitutions.test.ts
+++ b/frontend/app/composables/recipes/__tests__/use-ingredient-substitutions.test.ts
@@ -1,10 +1,11 @@
 import { ref } from "vue";
 import { describe, expect, test } from "vitest";
-import { ingredientSubstitutionSummary, useIngredientSubstitutions } from "../use-ingredient-substitutions";
+import { ingredientSubstitutionSummary, substitutionFoodName, useIngredientSubstitutions } from "../use-ingredient-substitutions";
 import type { IngredientFood, IngredientFoodSummary, RecipeIngredient } from "~/lib/api/types/recipe";
 
 const broth: IngredientFoodSummary = { id: "broth-id", name: "Chicken broth" };
 const pork: IngredientFoodSummary = { id: "pork-id", name: "Pork" };
+const shallot: IngredientFoodSummary = { id: "shallot-id", name: "Shallot", pluralName: "Shallots" };
 
 /** A food carrying its own substitutions, i.e. the ones that apply everywhere it is used. */
 function foodWithSubstitutions(): IngredientFood {
@@ -14,6 +15,23 @@ function foodWithSubstitutions(): IngredientFood {
     substitutions: [{ substituteFoodId: broth.id, substituteFood: broth }],
   };
 }
+
+describe("substitutionFoodName", () => {
+  test("inflects with the line the substitute stands in for", () => {
+    const substitution = { substituteFoodId: shallot.id, substituteFood: shallot };
+
+    expect(substitutionFoodName(substitution, true)).toStrictEqual("Shallots");
+    expect(substitutionFoodName(substitution, false)).toStrictEqual("Shallot");
+  });
+
+  test("falls back to the one name a food without a plural form has", () => {
+    expect(substitutionFoodName({ substituteFoodId: broth.id, substituteFood: broth }, true)).toStrictEqual("Chicken broth");
+  });
+
+  test("is empty for a substitution that is only a note", () => {
+    expect(substitutionFoodName({ note: "pork works" }, true)).toStrictEqual("");
+  });
+});
 
 describe("useIngredientSubstitutions", () => {
   test("keeps the two tiers apart", () => {
@@ -98,6 +116,18 @@ describe("ingredientSubstitutionSummary", () => {
   test("is empty when there is nothing to show, which is also the don't-render signal", () => {
     expect(ingredientSubstitutionSummary({})).toStrictEqual("");
     expect(ingredientSubstitutionSummary({ food: { id: "stock-id", name: "Chicken stock" } })).toStrictEqual("");
+  });
+
+  test("inflects the substitute foods when the line they replace is plural", () => {
+    const ingredient: RecipeIngredient = {
+      quantity: 2,
+      food: { id: "onion-id", name: "Onion", pluralName: "Onions" },
+      substitutions: [{ substituteFoodId: shallot.id, substituteFood: shallot, note: "milder" }],
+    };
+
+    const summary = ingredientSubstitutionSummary(ingredient, true);
+
+    expect(summary).toStrictEqual("Shallots (milder)");
   });
 
   test("skips a substitution carrying neither a food nor a note", () => {

--- a/frontend/app/composables/recipes/index.ts
+++ b/frontend/app/composables/recipes/index.ts
@@ -1,8 +1,8 @@
 export { useFraction } from "./use-fraction";
 export { useRecipe } from "./use-recipe";
 export { useRecipes, recentRecipes, allRecipes, useLazyRecipes } from "./use-recipes";
-export { useIngredientTextParser } from "./use-recipe-ingredients";
-export { useIngredientSubstitutions, ingredientSubstitutionSummary } from "./use-ingredient-substitutions";
+export { useFoodPlurality, useIngredientTextParser } from "./use-recipe-ingredients";
+export { useIngredientSubstitutions, ingredientSubstitutionSummary, substitutionFoodName } from "./use-ingredient-substitutions";
 export { useNutritionLabels } from "./use-recipe-nutrition";
 export { useTools } from "./use-recipe-tools";
 export { useRecipePermissions } from "./use-recipe-permissions";

--- a/frontend/app/composables/recipes/use-ingredient-substitutions.ts
+++ b/frontend/app/composables/recipes/use-ingredient-substitutions.ts
@@ -1,4 +1,5 @@
 import { computed } from "vue";
+import { useFoodName } from "./use-recipe-ingredients";
 import type { IngredientFood, IngredientFoodSubstitution, RecipeIngredient } from "~/lib/api/types/recipe";
 
 // the food is typed as a read-or-create union because either shape is accepted on input;
@@ -6,6 +7,14 @@ import type { IngredientFood, IngredientFoodSubstitution, RecipeIngredient } fro
 function foodSubstitutionsOf(ingredient: RecipeIngredient): IngredientFoodSubstitution[] {
   const food = ingredient.food as IngredientFood | null | undefined;
   return food?.substitutions || [];
+}
+
+/**
+ * The name a substitute food shows under, inflected to match the line it stands in for: a
+ * substitution for "2 onions" reads "shallots", not "shallot".
+ */
+export function substitutionFoodName(substitution: IngredientFoodSubstitution, usePluralFood = false): string {
+  return useFoodName(substitution.substituteFood || undefined, usePluralFood);
 }
 
 /**
@@ -28,10 +37,10 @@ export function useIngredientSubstitutions(ingredient: () => RecipeIngredient) {
  *
  * Returns "" when there are none, which is also the "don't render a line" signal.
  */
-export function ingredientSubstitutionSummary(ingredient: RecipeIngredient): string {
+export function ingredientSubstitutionSummary(ingredient: RecipeIngredient, usePluralFood = false): string {
   return [...(ingredient.substitutions || []), ...foodSubstitutionsOf(ingredient)]
     .map((substitution) => {
-      const food = substitution.substituteFood?.name;
+      const food = substitutionFoodName(substitution, usePluralFood);
       if (food && substitution.note) {
         return `${food} (${substitution.note})`;
       }

--- a/frontend/app/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/app/composables/recipes/use-recipe-ingredients.ts
@@ -1,7 +1,7 @@
 import DOMPurify from "isomorphic-dompurify";
 import { useFraction } from "./use-fraction";
 import { useLocales } from "../use-locales";
-import type { CreateIngredientFood, CreateIngredientUnit, IngredientFood, IngredientUnit, Recipe, RecipeIngredient } from "~/lib/api/types/recipe";
+import type { CreateIngredientFood, CreateIngredientUnit, IngredientFood, IngredientFoodSummary, IngredientUnit, Recipe, RecipeIngredient } from "~/lib/api/types/recipe";
 
 const { frac } = useFraction();
 
@@ -15,7 +15,7 @@ export function sanitizeIngredientHTML(rawHtml: string) {
   });
 }
 
-function useFoodName(food: CreateIngredientFood | IngredientFood | undefined, usePlural: boolean) {
+export function useFoodName(food: CreateIngredientFood | IngredientFood | IngredientFoodSummary | undefined, usePlural: boolean) {
   if (!food) {
     return "";
   }
@@ -79,16 +79,29 @@ function shouldUsePluralFood(quantity: number, hasUnit: boolean, pluralFoodHandl
   }
 }
 
-export function useIngredientTextParser() {
+/**
+ * The current locale's food pluralization rule, applied to one ingredient line. Anything that
+ * renders a food in place of that line's food -- a substitution, above all -- inflects with it,
+ * so the rule lives here rather than inside the text parser alone.
+ */
+export function useFoodPlurality() {
   const { locales, locale } = useLocales();
 
-  function useParsedIngredientText(ingredient: RecipeIngredient, scale = 1, includeFormating = true, groupSlug?: string): ParsedIngredientText {
-    const filteredLocales = locales.filter(lc => lc.value === locale.value);
-    const pluralFoodHandling = filteredLocales.length ? filteredLocales[0].pluralFoodHandling : "without-unit";
+  function shouldPluralizeFood(ingredient: RecipeIngredient, scale = 1): boolean {
+    const pluralFoodHandling = locales.find(lc => lc.value === locale.value)?.pluralFoodHandling || "without-unit";
+    return shouldUsePluralFood((ingredient.quantity || 0) * scale, !!ingredient.unit, pluralFoodHandling);
+  }
 
+  return { shouldPluralizeFood };
+}
+
+export function useIngredientTextParser() {
+  const { shouldPluralizeFood } = useFoodPlurality();
+
+  function useParsedIngredientText(ingredient: RecipeIngredient, scale = 1, includeFormating = true, groupSlug?: string): ParsedIngredientText {
     const { quantity, food, unit, note, referencedRecipe } = ingredient;
     const usePluralUnit = quantity !== undefined && ((quantity || 0) * scale > 1 || (quantity || 0) * scale === 0);
-    const usePluralFood = shouldUsePluralFood((quantity || 0) * scale, !!unit, pluralFoodHandling);
+    const usePluralFood = shouldPluralizeFood(ingredient, scale);
 
     let returnQty = "";
 


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Currently substitutions are always singular. Now they take the main ingredient's pluralization state and follow that.

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Manually tested and updated composable tests

## AI / LLM Assistance

_(REQUIRED)_

thx Claude
