### PR TITLE
feat: adjust ingredient spacing

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredientListItem.vue
@@ -65,7 +65,9 @@ const parsedIng = computed(() => {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.25em;
+  // column only: the note takes a flex row of its own, and it reads as belonging to the
+  // ingredient above it only if it sits tighter to that line than the rows sit to each other
+  column-gap: 0.25em;
   word-break: break-word;
   min-width: 0;
 
@@ -97,11 +99,22 @@ const parsedIng = computed(() => {
     word-break: break-word;
   }
 
-  // the substitution button keeps a finger-sized tap target, but its box is taller than the
-  // line of text it sits on; left alone it sets the row's height and pushes the note down.
-  // it overflows the line instead of growing it
+  // vuetify sizes an icon button for a toolbar, far taller than the line of text this one
+  // sits on; left alone it sets the row's height and pushes the note down. sized to the line
+  // instead, so the box, the icon glyph and the line are all the same height -- the glyph
+  // follows font-size, not the box, so it renders unchanged
   .v-btn--icon {
-    margin-block: calc((1.75rem - 48px) / 2);
+    line-height: inherit;
+    width: 1lh;
+    height: 1lh;
+
+    // the tap target stays finger-sized as a transparent halo over the rows either side,
+    // rather than a taller box that would push them apart
+    &::before {
+      content: "";
+      position: absolute;
+      inset: -0.75rem;
+    }
   }
 }
 

--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
@@ -26,7 +26,7 @@
         <v-divider v-if="showTitleEditor[index]" class="my-2" />
         <v-list-item
           density="compact"
-          class="pa-0"
+          class="px-0 py-1 ingredient-list-item"
           @click.stop="toggleChecked(index)"
         >
           <template #prepend>
@@ -103,5 +103,12 @@ function toggleChecked(index: number) {
 <style>
 .dense-markdown p {
   margin: auto !important;
+}
+
+/* vuetify clips both of these, which would swallow the substitution button's tap target
+   where it reaches past the line of text */
+.ingredient-list-item .v-list-item__content,
+.ingredient-list-item .v-list-item-title {
+  overflow: visible;
 }
 </style>


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

With the new substitution button the ingredient spacing looks wonky with notes. This tightens it up and makes sure the note is closer to the actual ingredient it belongs to.

Before:
<img width="326" height="449" alt="Screenshot 2026-09-06 at 5 38 38 PM" src="https://github.com/user-attachments/assets/f63618c5-46c1-409b-a4b7-422c426b37c9" />

After:
<img width="355" height="480" alt="Screenshot 2026-09-06 at 5 38 05 PM" src="https://github.com/user-attachments/assets/8b7193f5-2829-4468-9c49-3978f62d6a91" />


## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

Manually

## AI / LLM Assistance

_(REQUIRED)_

Claude wrote this PR
