### PR TITLE
fix: reject negative max_missing_foods/tools in recipe suggestions

### DIFF
--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -647,7 +647,8 @@
     "selected-tools": "Selected Tools",
     "other-filters": "Other Filters",
     "ready-to-make": "Ready to Make",
-    "almost-ready-to-make": "Almost Ready to Make"
+    "almost-ready-to-make": "Almost Ready to Make",
+    "max-missing-must-be-non-negative": "Must be 0 or greater"
   },
   "search": {
     "has-any": "Has Any",

--- a/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -138,6 +138,7 @@
                           v-model="state.settings.maxMissingFoods"
                           :precision="null"
                           :min="0"
+                          :rules="[(v: number) => v >= 0 || $t('recipe-finder.max-missing-must-be-non-negative')]"
                           control-variant="stacked"
                           inset
                           hide-details
@@ -147,6 +148,7 @@
                           v-model="state.settings.maxMissingTools"
                           :precision="null"
                           :min="0"
+                          :rules="[(v: number) => v >= 0 || $t('recipe-finder.max-missing-must-be-non-negative')]"
                           control-variant="stacked"
                           inset
                           hide-details
@@ -477,6 +479,21 @@ onMounted(() => {
     state.settings.includeToolsOnHand = false;
   }
 });
+
+// Clamp the max-missing fields so a negative value never reaches the API
+// even if the user bypasses the input's min/rules via paste or keyboard.
+// See https://github.com/mealie-recipes/mealie/issues/8238
+watch(
+  () => [state.settings.maxMissingFoods, state.settings.maxMissingTools],
+  ([foods, tools]) => {
+    if (typeof foods === "number" && foods < 0) {
+      state.settings.maxMissingFoods = 0;
+    }
+    if (typeof tools === "number" && tools < 0) {
+      state.settings.maxMissingTools = 0;
+    }
+  },
+);
 
 watch(
   () => state,

--- a/mealie/schema/recipe/recipe_suggestion.py
+++ b/mealie/schema/recipe/recipe_suggestion.py
@@ -1,3 +1,7 @@
+from typing import Annotated
+
+from pydantic import Field
+
 from mealie.schema._mealie.mealie_model import MealieModel
 from mealie.schema.recipe.recipe import RecipeSummary, RecipeTool
 from mealie.schema.recipe.recipe_ingredient import IngredientFood, IngredientFoodSummary
@@ -7,8 +11,8 @@ from mealie.schema.response.pagination import RequestQuery
 class RecipeSuggestionQuery(RequestQuery):
     limit: int = 10
 
-    max_missing_foods: int = 5
-    max_missing_tools: int = 5
+    max_missing_foods: Annotated[int, Field(ge=0)] = 5
+    max_missing_tools: Annotated[int, Field(ge=0)] = 5
 
     include_foods_on_hand: bool = True
     include_tools_on_hand: bool = True

--- a/tests/integration_tests/user_recipe_tests/test_recipe_suggestions.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_suggestions.py
@@ -775,3 +775,43 @@ def test_exact_matches_outrank_substitute_matches(api_client: TestClient, unique
     finally:
         for recipe in [exact_recipe, substituted_recipe]:
             unique_user.repos.recipes.delete(recipe.slug)
+
+
+def test_negative_max_missing_foods_rejected(api_client: TestClient, unique_user: TestUser):
+    """See https://github.com/mealie-recipes/mealie/issues/8238
+
+    A negative value for maxMissingFoods must be rejected by the API rather
+    than silently accepted. The frontend also clamps these values, but the
+    server is the source of truth.
+    """
+    response = api_client.get(
+        api_routes.recipes_suggestions,
+        params={"maxMissingFoods": -1},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 422
+
+
+def test_negative_max_missing_tools_rejected(api_client: TestClient, unique_user: TestUser):
+    """See https://github.com/mealie-recipes/mealie/issues/8238
+
+    A negative value for maxMissingTools must be rejected by the API rather
+    than silently accepted. The frontend also clamps these values, but the
+    server is the source of truth.
+    """
+    response = api_client.get(
+        api_routes.recipes_suggestions,
+        params={"maxMissingTools": -1},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 422
+
+
+def test_zero_max_missing_accepted(api_client: TestClient, unique_user: TestUser):
+    """A value of 0 is a valid lower bound and must continue to be accepted."""
+    response = api_client.get(
+        api_routes.recipes_suggestions,
+        params={"maxMissingFoods": 0, "maxMissingTools": 0},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
# Summary

Closes https://github.com/mealie-recipes/mealie/issues/8238.

The Recipe Finder accepted and retained negative values for the **Max Missing Ingredients** and **Max Missing Tools** settings. The `v-number-input :min="0"` attribute marked the field visually as invalid but did not clamp the typed value, so the negative number persisted in state and was forwarded to the API. The behavior between the two adjacent fields was inconsistent.

## Changes

- **Backend (`mealie/schema/recipe/recipe_suggestion.py`)** — `max_missing_foods` and `max_missing_tools` now use `Annotated[int, Field(ge=0)]`. FastAPI returns 422 for negative values, so the server is the source of truth regardless of what the client sends.
- **Frontend (`frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue`)** — both `v-number-input` fields now share an explicit `:rules` validation rule and a small `watch` that clamps negative values back to `0` before they reach the API.
- **i18n** — added `recipe-finder.max-missing-must-be-non-negative` (`"Must be 0 or greater"`) in `en-US`.
- **Tests (`tests/integration_tests/user_recipe_tests/test_recipe_suggestions.py`)** — added three integration tests:
  - `test_negative_max_missing_foods_rejected` — `maxMissingFoods=-1` returns 422.
  - `test_negative_max_missing_tools_rejected` — `maxMissingTools=-1` returns 422.
  - `test_zero_max_missing_accepted` — `0` remains a valid lower bound.

## Files

- `mealie/schema/recipe/recipe_suggestion.py` (+5/-1)
- `frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue` (+17/-0)
- `frontend/app/lang/messages/en-US.json` (+2/-1)
- `tests/integration_tests/user_recipe_tests/test_recipe_suggestions.py` (+40/-0)

Total: 4 files changed, 65 insertions(+), 3 deletions(-).
