### PR TITLE
fix: preserve recipe ingredient navigation state

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.test.ts
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.test.ts
@@ -1,0 +1,79 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { nextTick } from "vue";
+import RecipeIngredients from "./RecipeIngredients.vue";
+import type { RecipeIngredient } from "~/lib/api/types/recipe";
+import { useLocales } from "~/composables/use-locales";
+
+vi.mock("~/composables/use-locales");
+
+const ingredients = {
+  curryPaste: {
+    referenceId: "ingredient-curry-paste",
+    quantity: 1,
+    food: { id: "food-1", name: "curry paste" },
+  },
+  coconutMilk: {
+    referenceId: "ingredient-coconut-milk",
+    quantity: 1,
+    food: { id: "food-2", name: "coconut milk" },
+  },
+} satisfies Record<string, RecipeIngredient>;
+
+function mountIngredients(value: RecipeIngredient[], storageKey = "recipe-ingredients:test-recipe:checked") {
+  return mount(RecipeIngredients, {
+    props: {
+      value,
+      storageKey,
+    },
+    global: {
+      stubs: {
+        AppButtonCopy: true,
+        RecipeIngredientListItem: true,
+        VCheckbox: {
+          props: ["modelValue"],
+          emits: ["update:modelValue"],
+          template: `
+            <button
+              class="checkbox"
+              type="button"
+              :aria-pressed="modelValue ? 'true' : 'false'"
+              @click="$emit('update:modelValue', !modelValue)"
+            />
+          `,
+        },
+        VDivider: true,
+        VListItem: {
+          template: "<div class=\"list-item\" @click=\"$emit('click', $event)\"><slot name=\"prepend\" /><slot /></div>",
+        },
+        VListItemTitle: {
+          template: "<div><slot /></div>",
+        },
+      },
+    },
+  });
+}
+
+describe("RecipeIngredients", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.mocked(useLocales).mockReturnValue({
+      locales: [{ value: "en-US", pluralFoodHandling: "always" }],
+      locale: { value: "en-US", pluralFoodHandling: "always" },
+    } as any);
+  });
+
+  test("restores checked ingredients from session storage by reference id", async () => {
+    const firstWrapper = mountIngredients([ingredients.curryPaste, ingredients.coconutMilk]);
+    await firstWrapper.findAll(".checkbox")[0].trigger("click");
+    await nextTick();
+
+    expect(firstWrapper.findAll(".checkbox")[0].attributes("aria-pressed")).toBe("true");
+    firstWrapper.unmount();
+
+    const secondWrapper = mountIngredients([ingredients.coconutMilk, ingredients.curryPaste]);
+
+    expect(secondWrapper.findAll(".checkbox")[0].attributes("aria-pressed")).toBe("false");
+    expect(secondWrapper.findAll(".checkbox")[1].attributes("aria-pressed")).toBe("true");
+  });
+});

--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
@@ -31,11 +31,13 @@
         >
           <template #prepend>
             <v-checkbox
-              v-model="checked[index]"
+              :model-value="isChecked(index)"
               hide-details
               class="pt-0 my-auto py-auto"
               color="secondary"
               density="comfortable"
+              @click.stop
+              @update:model-value="setChecked(index, !!$event)"
             />
           </template>
           <v-list-item-title>
@@ -53,6 +55,7 @@
 
 <script setup lang="ts">
 import RecipeIngredientListItem from "./RecipeIngredientListItem.vue";
+import { useSessionStorage } from "@vueuse/core";
 import { useIngredientTextParser } from "~/composables/recipes";
 import type { RecipeIngredient } from "~/lib/api/types/recipe";
 
@@ -60,11 +63,13 @@ interface Props {
   value?: RecipeIngredient[];
   scale?: number;
   isCookMode?: boolean;
+  storageKey?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
   value: () => [],
   scale: 1,
   isCookMode: false,
+  storageKey: undefined,
 });
 
 const { parseIngredientText } = useIngredientTextParser();
@@ -73,7 +78,10 @@ function validateTitle(title?: string | null) {
   return !(title === undefined || title === "" || title === null);
 }
 
-const checked = ref(props.value.map(() => false));
+const transientChecked = ref<Record<string, boolean>>({});
+const sessionChecked = props.storageKey
+  ? useSessionStorage<Record<string, boolean>>(props.storageKey, {})
+  : null;
 const showTitleEditor = computed(() => props.value.map(x => validateTitle(x.title)));
 
 const ingredientCopyText = computed(() => {
@@ -94,9 +102,32 @@ const ingredientCopyText = computed(() => {
 });
 
 function toggleChecked(index: number) {
-  // TODO Find a better way to do this - $set is not available, and
-  // direct array modifications are not propagated for some reason
-  checked.value.splice(index, 1, !checked.value[index]);
+  setChecked(index, !isChecked(index));
+}
+
+function checkedState() {
+  return sessionChecked?.value ?? transientChecked.value;
+}
+
+function checkedKey(index: number) {
+  const referenceId = props.value[index]?.referenceId;
+  return referenceId ? `ref:${referenceId}` : `idx:${index}`;
+}
+
+function isChecked(index: number) {
+  return !!checkedState()[checkedKey(index)];
+}
+
+function setChecked(index: number, value: boolean) {
+  const state = checkedState();
+  state[checkedKey(index)] = value;
+
+  if (sessionChecked) {
+    sessionChecked.value = { ...state };
+  }
+  else {
+    transientChecked.value = { ...state };
+  }
 }
 </script>
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -77,7 +77,13 @@
               md="4"
               :class="$vuetify.display.mdAndUp ? 'border-e-thin' : null"
             >
-              <RecipePageIngredientToolsView v-if="!isEditForm" :recipe="recipe" :scale="scale" class="pr-2" />
+              <RecipePageIngredientToolsView
+                v-if="!isEditForm"
+                :recipe="recipe"
+                :scale="scale"
+                :ingredient-storage-key="ingredientStorageKey"
+                class="pr-2"
+              />
               <RecipePageOrganizers v-if="$vuetify.display.mdAndUp" v-model="recipe" class="pr-2" @item-selected="chipClicked" />
             </v-col>
             <!--
@@ -90,6 +96,7 @@
                 v-model:assets="recipe.assets"
                 :recipe="recipe"
                 :scale="scale"
+                :ingredient-storage-key="ingredientStorageKey"
               />
               <div v-if="isEditForm" class="d-flex">
                 <RecipeDialogBulkAdd class="ml-auto my-2 mr-1" @bulk-data="addStep" />
@@ -149,6 +156,7 @@
             :recipe="recipe"
             :scale="scale"
             :is-cook-mode="isCookMode"
+            :ingredient-storage-key="ingredientStorageKey"
           />
           <v-divider />
         </v-col>
@@ -168,6 +176,7 @@
             class="overflow-y-hidden px-4"
             :recipe="recipe"
             :scale="scale"
+            :ingredient-storage-key="ingredientStorageKey"
           />
         </v-col>
       </v-row>
@@ -182,6 +191,7 @@
         class="overflow-y-hidden mt-n5 px-2 px-md-4"
         :recipe="recipe"
         :scale="scale"
+        :ingredient-storage-key="ingredientStorageKey"
       />
 
       <div v-if="notLinkedIngredients.length > 0" class="px-2 px-md-4 pb-4">
@@ -192,6 +202,7 @@
             :value="notLinkedIngredients"
             :scale="scale"
             :is-cook-mode="isCookMode"
+            :storage-key="ingredientStorageKey"
           />
         </v-card>
       </div>
@@ -249,6 +260,7 @@ const route = useRoute();
 const { isOwnGroup } = useLoggedInState();
 
 const groupSlug = computed(() => (route.params.groupSlug as string) || auth.user?.value?.groupSlug || "");
+const ingredientStorageKey = computed(() => `recipe-ingredients:${recipe.value.id || recipe.value.slug}:checked`);
 
 const router = useRouter();
 const api = useUserApi();

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientToolsView.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientToolsView.vue
@@ -4,6 +4,7 @@
       :value="recipe.recipeIngredient"
       :scale="scale"
       :is-cook-mode="isCookMode"
+      :storage-key="ingredientStorageKey"
     />
     <div v-if="!isEditMode && recipe.tools && recipe.tools.length > 0">
       <h2 class="mt-4 text-h5 font-weight-medium opacity-80">
@@ -51,9 +52,11 @@ interface Props {
   recipe: NoUndefinedField<Recipe>;
   scale: number;
   isCookMode?: boolean;
+  ingredientStorageKey?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
   isCookMode: false,
+  ingredientStorageKey: undefined,
 });
 
 const { isOwnGroup } = useLoggedInState();

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -358,6 +358,7 @@
                             })"
                             :scale="scale"
                             :is-cook-mode="isCookMode"
+                            :storage-key="ingredientStorageKey"
                           />
                         </div>
                       </v-col>
@@ -418,6 +419,10 @@ const props = defineProps({
   scale: {
     type: Number,
     default: 1,
+  },
+  ingredientStorageKey: {
+    type: String,
+    default: undefined,
   },
 });
 

--- a/frontend/app/composables/recipes/__tests__/use-recipe-ingredients.test.ts
+++ b/frontend/app/composables/recipes/__tests__/use-recipe-ingredients.test.ts
@@ -7,6 +7,7 @@ vi.mock("~/composables/use-locales");
 
 let parseIngredientText: (ingredient: RecipeIngredient, scale?: number, includeFormating?: boolean) => string;
 let ingredientToParserString: (ingredient: RecipeIngredient) => string;
+let useParsedIngredientText: ReturnType<typeof useIngredientTextParser>["useParsedIngredientText"];
 
 describe("parseIngredientText", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("parseIngredientText", () => {
       locales: [{ value: "en-US", pluralFoodHandling: "always" }],
       locale: { value: "en-US", pluralFoodHandling: "always" },
     } as any);
-    ({ parseIngredientText, ingredientToParserString } = useIngredientTextParser());
+    ({ parseIngredientText, ingredientToParserString, useParsedIngredientText } = useIngredientTextParser());
   });
 
   const createRecipeIngredient = (overrides: Partial<RecipeIngredient>): RecipeIngredient => ({
@@ -61,6 +62,21 @@ describe("parseIngredientText", () => {
     const ingredient = createRecipeIngredient({ note: "<script>alert('foo')</script>" });
 
     expect(parseIngredientText(ingredient)).not.toContain("<script>");
+  });
+
+  test("referenced recipe links navigate in the current page", () => {
+    const ingredient = createRecipeIngredient({
+      referencedRecipe: {
+        id: "recipe-1",
+        name: "Curry Paste",
+        slug: "curry-paste",
+      },
+    });
+
+    const result = useParsedIngredientText(ingredient, 1, true, "home");
+
+    expect(result.recipeLink).toEqual("<a href=\"/g/home/r/curry-paste\">Curry Paste</a>");
+    expect(result.recipeLink).not.toContain("target=");
   });
 
   test("plural test : plural qty : use abbreviation", () => {

--- a/frontend/app/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/app/composables/recipes/use-recipe-ingredients.ts
@@ -45,7 +45,7 @@ function useRecipeLink(recipe: Recipe | undefined, groupSlug: string | undefined
     return undefined;
   }
 
-  return `<a href="/g/${groupSlug}/r/${recipe.slug}" target="_blank">${recipe.name}</a>`;
+  return `<a href="/g/${groupSlug}/r/${recipe.slug}">${recipe.name}</a>`;
 }
 
 type ParsedIngredientText = {


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, and is not marked as "required", then delete that section.

  PLEASE READ:
  -------------------------
  Mealie uses a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

Fixes an issue where clicking a referenced recipe from an ingredient opens a new tab via `target="_blank"`. In Android PWA contexts this can restart the app, leaving users unable to navigate back to the original recipe.

This PR changes referenced recipe ingredient links to navigate in the current page and preserves ingredient checkbox state in `sessionStorage` for the current tab session. When users navigate into a referenced recipe and then go back, their checked ingredient state is restored.


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Fixes #6511

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39

Be sure to include the word "fixes" otherwise the associated issue will not be closed.
-->

## Special notes for your reviewer:

Ingredient checked state is intentionally session-scoped only. It is not saved to the backend, synced across devices, or persisted after the tab/window is closed.

The state is keyed by `referenceId` when available, with an index fallback for ingredients without a reference id. Recipe page ingredient lists pass a shared storage key so the main ingredient list and cook-mode linked ingredient lists stay in sync.

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

- [x] `pnpm vitest run app/composables/recipes/__tests__/use-recipe-ingredients.test.ts app/components/Domain/Recipe/RecipeIngredients.test.ts`
- [x] `pnpm eslint app/composables/recipes/use-recipe-ingredients.ts app/composables/recipes/__tests__/use-recipe-ingredients.test.ts app/components/Domain/Recipe/RecipeIngredients.vue app/components/Domain/Recipe/RecipeIngredients.test.ts app/components/Domain/Recipe/RecipePage/RecipePage.vue app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientToolsView.vue app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue`
- [x] Manual test: clicking a referenced recipe navigates in the same PWA page
- [x] Manual test: navigating back restores checked ingredient state
<!--
  Describe how you tested this change.
-->

## AI / LLM Assistance

Use Codex  to add the test code.

<!--
  Describe to which degree an LLM was used in creating this pull request. Failure to accurately disclose LLM usage may result in
  review delays or closure of your PR.
-->
