### PR TITLE
fix: prevent random sort click-through

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeExplorerPage/RecipeExplorerPageParts/RecipeExplorerPageSearch.vue
@@ -53,7 +53,7 @@
                 :active="state.orderBy === v.value"
                 slim
                 density="comfortable"
-                @click="v.value === 'random' ? setRandomOrderByWrapper() : setOrderBy(v.value)"
+                @click.stop="v.value === 'random' ? setRandomOrderByWrapper() : setOrderBy(v.value)"
               >
                 <template #prepend>
                   <v-icon>{{ v.icon }}</v-icon>


### PR DESCRIPTION
## What this PR does / why we need it:

- Stops clicks on recipe explorer sort-menu items from propagating to controls underneath the overlay.
- Keeps users on the recipe list when they select the **Random** sort option.
- Preserves the separate **Random** button's existing behavior of opening a random recipe.

### Before

The **Random** option is selected from the sort menu:

<img width="1280" height="720" alt="Random option in the recipe sort menu" src="https://github.com/user-attachments/assets/df59c859-b227-4b7c-a0ff-c7b7a9735a6e" />

Instead of shuffling the list, Mealie opens a recipe detail page:

<img width="1280" height="720" alt="Recipe detail page opened unexpectedly" src="https://github.com/user-attachments/assets/4becbff8-9d8b-4df9-8743-a2c03a65f006" />

### After

Selecting **Random** updates the recipe list ordering and keeps the user on the recipe list:

<img width="1280" height="720" alt="Random selected in the sort menu after the fix" src="https://github.com/user-attachments/assets/7d9a4ea9-51bc-4342-a97f-12537831ba48" />

After the menu closes, the recipe list remains visible with **Random** selected:

<img width="1280" height="720" alt="Recipe list remains open after selecting Random" src="https://github.com/user-attachments/assets/ef70f67b-6933-452f-822c-9bfb5250e55d" />

The change does not alter the UI layout or styling.

## Which issue(s) this PR fixes:

Fixes #8324

## Testing

- Ran ESLint against RecipeExplorerPageSearch.vue.
- Ran the full frontend Vitest suite: 33 test files and 365 tests passed.
- Reproduced the original behavior on the official demo site.
- Verified the fix locally against the demo API: selecting **Random** keeps the URL on `/g/home` and leaves the recipe list visible.

## AI / LLM Assistance

OpenAI Codex assisted with the implementation. I reviewed and tested the final change.
