### PR TITLE
fix: prevent SSRF in recipe action triggers

### DIFF
--- a/mealie/routes/households/controller_group_recipe_actions.py
+++ b/mealie/routes/households/controller_group_recipe_actions.py
@@ -1,11 +1,12 @@
 from functools import cached_property
 
-import requests
+import httpx
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import UUID4
 
 from mealie.core.exceptions import NoEntryFound
+from mealie.pkgs.safehttp.transport import AsyncSafeTransport
 from mealie.routes._base.base_controllers import BaseUserController
 from mealie.routes._base.controller import controller
 from mealie.routes._base.mixins import HttpRepo
@@ -22,6 +23,19 @@ from mealie.schema.response.pagination import PaginationQuery
 from mealie.services.recipe.recipe_service import RecipeService
 
 router = APIRouter(prefix="/households/recipe-actions", tags=["Households: Recipe Actions"])
+
+
+async def _safe_post(url: str, payload: dict) -> None:
+    transport = AsyncSafeTransport(timeout=15)
+
+    async with httpx.AsyncClient(
+        transport=transport,
+        follow_redirects=True,
+    ) as client:
+        await client.post(
+            url,
+            json=payload,
+        )
 
 
 @controller(router)
@@ -79,7 +93,7 @@ class GroupRecipeActionController(BaseUserController):
             )
 
         if recipe_action.action_type == GroupRecipeActionType.post.value:
-            task_action = requests.post
+            task_action = _safe_post
         else:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
@@ -99,6 +113,5 @@ class GroupRecipeActionController(BaseUserController):
         bg_tasks.add_task(
             task_action,
             url=recipe_action.url,
-            json=jsonable_encoder(payload.model_dump()),
-            timeout=15,
+            payload=jsonable_encoder(payload.model_dump()),
         )

--- a/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
+++ b/tests/integration_tests/user_household_tests/test_group_recipe_actions.py
@@ -1,9 +1,10 @@
 from uuid import UUID, uuid4
 
 import pytest
-import requests
 from fastapi.testclient import TestClient
 
+from mealie.pkgs.safehttp.transport import InvalidDomainError
+from mealie.routes.households.controller_group_recipe_actions import _safe_post
 from mealie.schema.household.group_recipe_action import (
     CreateGroupRecipeAction,
     GroupRecipeActionOut,
@@ -17,8 +18,14 @@ from tests.utils.fixture_schemas import TestUser
 
 
 @pytest.fixture(autouse=True)
-def mock_requests_post(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: None)
+def mock_safe_post(monkeypatch: pytest.MonkeyPatch):
+    async def _mock_safe_post(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "mealie.routes.households.controller_group_recipe_actions._safe_post",
+        _mock_safe_post,
+    )
 
 
 def create_action(action_type: GroupRecipeActionType = GroupRecipeActionType.link) -> CreateGroupRecipeAction:
@@ -194,6 +201,15 @@ def test_group_recipe_actions_trigger_invalid_type(api_client: TestClient, uniqu
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_group_recipe_action_safe_post_blocks_private_ip():
+    with pytest.raises(InvalidDomainError):
+        await _safe_post(
+            "http://127.0.0.1:12345",
+            {"test": "payload"},
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**- What this PR does / why we need it:**

This PR fixes an SSRF risk in recipe action triggers.

Previously, recipe action POST requests were sent directly using `requests.post()`, which meant they bypassed Mealie's existing safe HTTP transport. This could allow recipe actions to make requests to local or private network addresses.

The change updates recipe action POST requests to use `httpx.AsyncClient` together with `AsyncSafeTransport`, so the same network safety checks already used elsewhere in Mealie are also applied here.

**Changes made:**

- Replaced direct `requests.post()` usage in `controller_group_recipe_actions.py`
- Added a small `_safe_post()` helper that uses `AsyncSafeTransport`
- Kept redirect handling enabled while still routing requests through the safe transport
- Updated the existing recipe action tests to mock the new helper
- Added a regression test to confirm that private IP addresses such as `127.0.0.1` are blocked

## Which issue(s) this PR fixes:

Fixes #7831

## Special notes for your reviewer:

The main area to review is the change from `requests.post()` to `httpx.AsyncClient` with `AsyncSafeTransport`.

I tried to keep the change small and reuse Mealie's existing safe HTTP implementation instead of adding a separate SSRF check.

## Testing

I tested the changes using the existing recipe action integration tests.

Commands run:

- `task py:format`
- `task py:lint`
- `task py:test -- tests/integration_tests/user_household_tests/test_group_recipe_actions.py`

Result:

- 23 tests passed
- Python lint checks passed
- Formatting completed successfully

A regression test was also added to verify that requests to a private/local IP address are rejected.

## AI / LLM Assistance

I used ChatGPT to help understand the issue, trace the relevant files, explain how `AsyncSafeTransport` works, and suggest an approach for the fix and regression test.

I reviewed the suggested changes, applied them manually, and ran the relevant formatting, linting, and tests locally before creating this PR.