### PR TITLE
fix: wrap long URLs in recipe card descriptions

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -171,6 +171,7 @@ const cursor = computed(() => showRecipeContent.value ? "pointer" : "auto");
   -webkit-line-clamp: 8;
   line-clamp: 8;
   overflow: hidden;
+  overflow-wrap: anywhere;
 }
 .recipe-card-footer {
   display: flex;


### PR DESCRIPTION
## What this PR does / why we need it:

Long URLs can make the recipe card description wider than the card. This causes the text to be cut off.

This PR adds `overflow-wrap: anywhere` to the recipe card description. Long URLs can wrap inside the card.

### Before

<img width="301" height="218" alt="Before" src="https://github.com/user-attachments/assets/4efb1210-a290-4400-a4fd-05ea923828f8" />

### After

<img width="308" height="218" alt="After" src="https://github.com/user-attachments/assets/03b7ee5e-2945-429e-b0b0-771c770a0136" />

## Which issue(s) this PR fixes:

Fixes #8329

## Testing

- Tested a recipe description containing a long URL.
- Checked a normal recipe description.
- Ran `task ui:check`.

## AI / LLM Assistance

I used ChatGPT to help investigate the CSS issue and review the solution. I made the final change.