### PR TITLE
fix: keep instruction section and step headings when importing

### DIFF
--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -150,6 +150,38 @@ def is_how_to_section(entry: typing.Any) -> bool:
     return isinstance(entry, dict) and "HowToSection" in (entry.get("@type"), entry.get("type"))
 
 
+def _step_heading(instruction: dict) -> str:
+    """Return the step's own heading, which Mealie stores as `summary`.
+
+    schema.org calls it `HowToStep.name`, but sites routinely fill that with a copy of the
+    text, or with the text truncated, so a name the text already opens with is dropped
+    rather than shown twice. This is the rule recipe_scrapers applies to the same field.
+    """
+    if summary := instruction.get("summary"):
+        return clean_string(summary)
+
+    name = instruction.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return ""
+
+    # compare the cleaned forms: a name carrying HTML entities would otherwise sail past
+    # the check against text that has already had them decoded
+    heading = clean_string(name).strip()
+    if not heading:
+        return ""
+
+    # sites also truncate the text into the name (yummly's "Step 1: Preheat oven to 425…"),
+    # and a heading cut off mid word is worse than no heading at all
+    if heading.endswith(("...", "\u2026")):
+        return ""
+
+    text = clean_string(instruction.get("text") or "")
+    if text.casefold().startswith(heading.rstrip(". \u2026").casefold()):
+        return ""
+
+    return heading
+
+
 def clean_instructions(steps_object: list | dict | str, default: list | None = None) -> list[dict]:
     """
     instructions attempts to parse the instructions field from a recipe and return a list of
@@ -197,7 +229,7 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
 
                 # a section heading lives on the first step of the section (RecipeStep.title),
                 # which is how the frontend groups the steps that follow it
-                if section_title := clean_string(entry.get("name", "")):
+                if section_title := clean_string(entry.get("name") or entry.get("Name") or ""):
                     section_steps = [section_steps[0] | {"title": section_title}, *section_steps[1:]]
 
                 instructions.extend(section_steps)
@@ -215,7 +247,7 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
             return [
                 {"text": _sanitize_instruction_text(instruction["text"])}
                 | ({"title": instruction["title"]} if instruction.get("title") else {})
-                | ({"summary": instruction["summary"]} if instruction.get("summary") else {})
+                | ({"summary": heading} if (heading := _step_heading(instruction)) else {})
                 for instruction in steps_object
                 if "text" in instruction and instruction["text"].strip()
             ]

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -3,7 +3,6 @@ import functools
 import html
 import json
 import numbers
-import operator
 import re
 import typing
 from datetime import datetime, timedelta
@@ -146,6 +145,11 @@ def clean_image(image: str | list | dict | None = None, default: str = NO_IMAGE)
             return [default]
 
 
+def is_how_to_section(entry: typing.Any) -> bool:
+    """schema.org groups steps with `@type: HowToSection`; some sites spell the key `type`."""
+    return isinstance(entry, dict) and "HowToSection" in (entry.get("@type"), entry.get("type"))
+
+
 def clean_instructions(steps_object: list | dict | str, default: list | None = None) -> list[dict]:
     """
     instructions attempts to parse the instructions field from a recipe and return a list of
@@ -155,14 +159,50 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
         TypeError: If the instructions field is not a supported type a TypeError is raised.
 
     Returns:
-        list[dict]: An ordered list of dictionaries with the keys `text`
+        list[dict]: An ordered list of dictionaries with the key `text`, plus `title` on the
+        first step of a named HowToSection, which is where Mealie stores a section heading
     """
     if not steps_object:
         return default or []
 
     match steps_object:
-        case [{"text": str()}]:  # Base Case
-            return steps_object
+        case [*_] if any(is_how_to_section(step) for step in steps_object):
+            # HowToSections should have the following layout,
+            # {
+            #  "@type": "HowToSection",
+            #  "name": "Section A",
+            #  "itemListElement": [
+            #    {
+            #      "@type": "HowToStep",
+            #      "text": "Instruction A"
+            #    },
+            # }
+            #
+            # Some sites (e.g. NYT Cooking) emit empty HowToSection placeholders
+            # with no itemListElement key, or use "item" per the schema.org spec.
+            # Use .get() with both fallbacks so those sections are skipped gracefully.
+            steps_object = typing.cast(list, steps_object)
+
+            instructions: list[dict] = []
+            for entry in steps_object:
+                if not is_how_to_section(entry):
+                    # a recipe can open with a few loose steps and only then start
+                    # grouping them, so both kinds share the one list
+                    instructions.extend(clean_instructions([entry]))
+                    continue
+
+                section_steps = clean_instructions(entry.get("itemListElement", entry.get("item", [])))
+                if not section_steps:
+                    continue
+
+                # a section heading lives on the first step of the section (RecipeStep.title),
+                # which is how the frontend groups the steps that follow it
+                if section_title := clean_string(entry.get("name", "")):
+                    section_steps = [section_steps[0] | {"title": section_title}, *section_steps[1:]]
+
+                instructions.extend(section_steps)
+
+            return instructions
         case [{"text": str()}, *_]:
             # The is the most common case. Most other operations eventually resolve to this
             # match case before being converted to a list of instructions
@@ -178,6 +218,15 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
                 for instruction in steps_object
                 if "text" in instruction and instruction["text"].strip()
             ]
+        case {"text": str()}:
+            # A single step is sometimes passed as a bare dict rather than a list of one
+            #
+            # {"@type": "HowToStep", "text": "Instruction A"}
+            #
+            return clean_instructions([steps_object])
+        case {"@type": "HowToSection"} | {"type": "HowToSection"}:
+            # Likewise, a recipe with only one section may pass that section on its own
+            return clean_instructions([steps_object])
         case {0: {"text": str()}} | {"0": {"text": str()}} | {1: {"text": str()}} | {"1": {"text": str()}}:
             # Some recipes have a dict with a string key representing the index, unsure if these can
             # be an int or not so we match against both. Additionally, we match against both 0 and 1 indexed
@@ -218,28 +267,6 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
             return [
                 {"text": _sanitize_instruction_text(instruction)} for instruction in steps_object if instruction.strip()
             ]
-        case [{"@type": "HowToSection"}, *_] | [{"type": "HowToSection"}, *_]:
-            # HowToSections should have the following layout,
-            # {
-            #  "@type": "HowToSection",
-            #  "itemListElement": [
-            #    {
-            #      "@type": "HowToStep",
-            #      "text": "Instruction A"
-            #    },
-            # }
-            #
-            # Some sites (e.g. NYT Cooking) emit empty HowToSection placeholders
-            # with no itemListElement key, or use "item" per the schema.org spec.
-            # Use .get() with both fallbacks so those sections are skipped gracefully.
-            steps_object = typing.cast(list[dict[str, str]], steps_object)
-            return clean_instructions(
-                functools.reduce(
-                    operator.concat,  # type: ignore
-                    [x.get("itemListElement", x.get("item", [])) for x in steps_object],
-                    [],
-                )
-            )
         case _:
             raise TypeError(f"Unexpected type for instructions: {type(steps_object)}, {steps_object}")
 

--- a/mealie/services/scraper/cleaner.py
+++ b/mealie/services/scraper/cleaner.py
@@ -215,6 +215,7 @@ def clean_instructions(steps_object: list | dict | str, default: list | None = N
             return [
                 {"text": _sanitize_instruction_text(instruction["text"])}
                 | ({"title": instruction["title"]} if instruction.get("title") else {})
+                | ({"summary": instruction["summary"]} if instruction.get("summary") else {})
                 for instruction in steps_object
                 if "text" in instruction and instruction["text"].strip()
             ]

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -42,19 +42,43 @@ from .fetch import (  # noqa: F401
 logger = get_logger()
 
 
-def carries_step_structure(instructions: Any) -> bool:
-    """Check whether structured instructions hold more than the scraper's flat text can carry.
+def _comparable(text: str) -> str:
+    return " ".join(str(text).split()).casefold()
 
-    That is a HowToSection grouping the steps, or a step that names itself with the fields
-    Mealie stores as a section heading (`title`) or a step heading (`summary`).
+
+def _is_stringified_mapping(text: str) -> bool:
+    """Detect a step dict that reached us as its own repr rather than as text.
+
+    recipe_scrapers stringifies the value when a site nests a single step where the spec
+    wants a list (hhursev/recipe-scrapers#2006), so this is never real instruction text and
+    must not count as content worth preserving.
     """
-    if isinstance(instructions, list):
-        return any(carries_step_structure(item) for item in instructions)
+    return text.strip().startswith(("{'", '{"'))
 
-    if cleaner.is_how_to_section(instructions):
-        return True
 
-    return isinstance(instructions, dict) and bool(instructions.get("title") or instructions.get("summary"))
+def prefer_structured_instructions(structured: list[dict], flat: list[dict]) -> bool:
+    """Decide whether the structured parse should replace the scraper's flattened text.
+
+    Two things have to hold. The structured parse must gain a heading, otherwise there is
+    nothing the flat text could not already express. And it must account for every piece of
+    text the flat parse produced, as either a step or a heading: a site specific scraper
+    reads the instructions off the page rather than out of the structured data, and its text
+    can differ from, or beat, what the page publishes as JSON-LD. That keeps the structured
+    data a refinement of the same content, never a replacement of better content.
+    """
+    headings = [step["title"] for step in structured if step.get("title")]
+    headings += [step["summary"] for step in structured if step.get("summary")]
+    if not headings:
+        return False
+
+    covered = {_comparable(step.get("text", "")) for step in structured}
+    covered |= {_comparable(heading) for heading in headings}
+
+    return all(
+        _comparable(step["text"]) in covered
+        for step in flat
+        if step.get("text") and not _is_stringified_mapping(step["text"])
+    )
 
 
 class ABCScraperStrategy(ABC):
@@ -148,7 +172,8 @@ class RecipeScraperPackage(ABCScraperStrategy):
             return value
 
         def get_instructions() -> list[RecipeStep]:
-            instructions = get_structured_instructions() or get_flat_instructions()
+            flat = get_flat_instructions()
+            instructions = pick_structured_instructions(flat) or flat
 
             self.logger.debug(f"Cleaned Instructions: (Type: {type(instructions)}) \n {instructions}")
 
@@ -160,15 +185,15 @@ class RecipeScraperPackage(ABCScraperStrategy):
             except TypeError:
                 return []
 
-        def get_structured_instructions() -> list[dict]:
-            """Parse the recipe's own structured data when it holds more than plain text.
+        def pick_structured_instructions(flat: list[dict]) -> list[dict]:
+            """Parse the recipe's own structured data, and use it only when it is strictly better.
 
-            recipe_scrapers renders instructions as text, which flattens HowToSections and
-            emits each section name as a line of its own (so headings arrive as bogus steps),
-            and drops a step's own heading entirely. Reading the schema data directly keeps
-            both. Only recipes carrying that structure take this path; everything else keeps
-            using the scraper's own parsing, which for a site specific scraper is the more
-            reliable source.
+            recipe_scrapers renders instructions as text, which flattens HowToSections and emits
+            each section name as a line of its own (so headings arrive as bogus steps), and drops
+            a step's own heading entirely. The structured data still holds both.
+
+            It is not always the better source though, so `prefer_structured_instructions`
+            decides: see there for when the scraper's own parsing wins instead.
             """
             try:
                 raw_instructions = scraped_data.schema.data.get("recipeInstructions")
@@ -176,18 +201,19 @@ class RecipeScraperPackage(ABCScraperStrategy):
                 self.logger.error("Error reading structured recipeInstructions")
                 return []
 
-            if not carries_step_structure(raw_instructions):
+            try:
+                structured = cleaner.clean_instructions(raw_instructions or [])
+            except TypeError:
+                self.logger.error("Error parsing structured instructions, falling back to the scraped text")
+                return []
+
+            if not prefer_structured_instructions(structured, flat):
                 return []
 
             self.logger.debug(
                 f"Scraped Structured Instructions: (Type: {type(raw_instructions)}) \n {raw_instructions}"
             )
-
-            try:
-                return cleaner.clean_instructions(raw_instructions)
-            except TypeError:
-                self.logger.error("Error parsing structured instructions, falling back to the scraped text")
-                return []
+            return structured
 
         def get_flat_instructions() -> list[dict]:
             instruction_as_text = try_get_default(

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -42,6 +42,14 @@ from .fetch import (  # noqa: F401
 logger = get_logger()
 
 
+def contains_how_to_section(instructions: Any) -> bool:
+    """Check whether schema.org instructions group any of their steps into HowToSections."""
+    if isinstance(instructions, list):
+        return any(contains_how_to_section(item) for item in instructions)
+
+    return cleaner.is_how_to_section(instructions)
+
+
 class ABCScraperStrategy(ABC):
     """
     Abstract class for all recipe parsers.
@@ -133,6 +141,42 @@ class RecipeScraperPackage(ABCScraperStrategy):
             return value
 
         def get_instructions() -> list[RecipeStep]:
+            instructions = get_sectioned_instructions() or get_flat_instructions()
+
+            self.logger.debug(f"Cleaned Instructions: (Type: {type(instructions)}) \n {instructions}")
+
+            try:
+                return [RecipeStep(title=x.get("title", ""), text=x.get("text")) for x in instructions]
+            except TypeError:
+                return []
+
+        def get_sectioned_instructions() -> list[dict]:
+            """Parse the recipe's own structured data when it groups steps into sections.
+
+            recipe_scrapers renders instructions as plain text, which flattens HowToSections
+            and emits each section name as a line of its own, so the section headings arrive
+            as bogus steps. Reading the schema data directly keeps them as step titles.
+            Only sectioned recipes take this path; everything else keeps using the scraper's
+            own parsing, which for a site specific scraper is the more reliable source.
+            """
+            try:
+                raw_instructions = scraped_data.schema.data.get("recipeInstructions")
+            except Exception:
+                self.logger.error("Error reading structured recipeInstructions")
+                return []
+
+            if not contains_how_to_section(raw_instructions):
+                return []
+
+            self.logger.debug(f"Scraped Sections: (Type: {type(raw_instructions)}) \n {raw_instructions}")
+
+            try:
+                return cleaner.clean_instructions(raw_instructions)
+            except TypeError:
+                self.logger.error("Error parsing HowToSections, falling back to the scraped instruction text")
+                return []
+
+        def get_flat_instructions() -> list[dict]:
             instruction_as_text = try_get_default(
                 scraped_data.instructions,
                 "recipeInstructions",
@@ -141,14 +185,7 @@ class RecipeScraperPackage(ABCScraperStrategy):
 
             self.logger.debug(f"Scraped Instructions: (Type: {type(instruction_as_text)}) \n {instruction_as_text}")
 
-            instruction_as_text = cleaner.clean_instructions(instruction_as_text)
-
-            self.logger.debug(f"Cleaned Instructions: (Type: {type(instruction_as_text)}) \n {instruction_as_text}")
-
-            try:
-                return [RecipeStep(title="", text=x.get("text")) for x in instruction_as_text]
-            except TypeError:
-                return []
+            return cleaner.clean_instructions(instruction_as_text)
 
         def get_notes() -> list[RecipeNote]:
             """Extract notes from schema.org recipe data and convert to RecipeNote objects"""

--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -42,12 +42,19 @@ from .fetch import (  # noqa: F401
 logger = get_logger()
 
 
-def contains_how_to_section(instructions: Any) -> bool:
-    """Check whether schema.org instructions group any of their steps into HowToSections."""
-    if isinstance(instructions, list):
-        return any(contains_how_to_section(item) for item in instructions)
+def carries_step_structure(instructions: Any) -> bool:
+    """Check whether structured instructions hold more than the scraper's flat text can carry.
 
-    return cleaner.is_how_to_section(instructions)
+    That is a HowToSection grouping the steps, or a step that names itself with the fields
+    Mealie stores as a section heading (`title`) or a step heading (`summary`).
+    """
+    if isinstance(instructions, list):
+        return any(carries_step_structure(item) for item in instructions)
+
+    if cleaner.is_how_to_section(instructions):
+        return True
+
+    return isinstance(instructions, dict) and bool(instructions.get("title") or instructions.get("summary"))
 
 
 class ABCScraperStrategy(ABC):
@@ -141,23 +148,27 @@ class RecipeScraperPackage(ABCScraperStrategy):
             return value
 
         def get_instructions() -> list[RecipeStep]:
-            instructions = get_sectioned_instructions() or get_flat_instructions()
+            instructions = get_structured_instructions() or get_flat_instructions()
 
             self.logger.debug(f"Cleaned Instructions: (Type: {type(instructions)}) \n {instructions}")
 
             try:
-                return [RecipeStep(title=x.get("title", ""), text=x.get("text")) for x in instructions]
+                return [
+                    RecipeStep(title=x.get("title", ""), summary=x.get("summary", ""), text=x.get("text"))
+                    for x in instructions
+                ]
             except TypeError:
                 return []
 
-        def get_sectioned_instructions() -> list[dict]:
-            """Parse the recipe's own structured data when it groups steps into sections.
+        def get_structured_instructions() -> list[dict]:
+            """Parse the recipe's own structured data when it holds more than plain text.
 
-            recipe_scrapers renders instructions as plain text, which flattens HowToSections
-            and emits each section name as a line of its own, so the section headings arrive
-            as bogus steps. Reading the schema data directly keeps them as step titles.
-            Only sectioned recipes take this path; everything else keeps using the scraper's
-            own parsing, which for a site specific scraper is the more reliable source.
+            recipe_scrapers renders instructions as text, which flattens HowToSections and
+            emits each section name as a line of its own (so headings arrive as bogus steps),
+            and drops a step's own heading entirely. Reading the schema data directly keeps
+            both. Only recipes carrying that structure take this path; everything else keeps
+            using the scraper's own parsing, which for a site specific scraper is the more
+            reliable source.
             """
             try:
                 raw_instructions = scraped_data.schema.data.get("recipeInstructions")
@@ -165,15 +176,17 @@ class RecipeScraperPackage(ABCScraperStrategy):
                 self.logger.error("Error reading structured recipeInstructions")
                 return []
 
-            if not contains_how_to_section(raw_instructions):
+            if not carries_step_structure(raw_instructions):
                 return []
 
-            self.logger.debug(f"Scraped Sections: (Type: {type(raw_instructions)}) \n {raw_instructions}")
+            self.logger.debug(
+                f"Scraped Structured Instructions: (Type: {type(raw_instructions)}) \n {raw_instructions}"
+            )
 
             try:
                 return cleaner.clean_instructions(raw_instructions)
             except TypeError:
-                self.logger.error("Error parsing HowToSections, falling back to the scraped instruction text")
+                self.logger.error("Error parsing structured instructions, falling back to the scraped text")
                 return []
 
         def get_flat_instructions() -> list[dict]:

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
@@ -293,20 +293,137 @@ instruction_test_cases = (
         input="Instruction A\r\nInstruction B\r\nInstruction C\r\n",
         expected=None,
     ),
+    CleanerCase(
+        test_id="how to sections with names",
+        input=[
+            {
+                "@type": "HowToSection",
+                "name": "Section A",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                    {"@type": "HowToStep", "text": "Instruction B"},
+                ],
+            },
+            {
+                "@type": "HowToSection",
+                "name": "Section B",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction C"},
+                ],
+            },
+        ],
+        expected=[
+            {"text": "Instruction A", "title": "Section A"},
+            {"text": "Instruction B"},
+            {"text": "Instruction C", "title": "Section B"},
+        ],
+    ),
+    CleanerCase(
+        test_id="how to sections with names using 'item' key",
+        input=[
+            {
+                "@type": "HowToSection",
+                "name": "Section A",
+                "item": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                    {"@type": "HowToStep", "text": "Instruction B"},
+                ],
+            },
+        ],
+        expected=[
+            {"text": "Instruction A", "title": "Section A"},
+            {"text": "Instruction B"},
+        ],
+    ),
+    CleanerCase(
+        test_id="how to section name is cleaned like any other string",
+        input=[
+            {
+                "@type": "HowToSection",
+                "name": "<p> Section&nbsp;A </p>",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                ],
+            },
+        ],
+        expected=[{"text": "Instruction A", "title": "Section A"}],
+    ),
+    CleanerCase(
+        test_id="empty how to section name is not stored as a title",
+        input=[
+            {
+                "@type": "HowToSection",
+                "name": "",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                ],
+            },
+        ],
+        expected=[{"text": "Instruction A"}],
+    ),
+    CleanerCase(
+        test_id="named how to section skipped when it has no steps",
+        input=[
+            {"@type": "HowToSection", "name": "Section A"},
+            {
+                "@type": "HowToSection",
+                "name": "Section B",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                ],
+            },
+        ],
+        expected=[{"text": "Instruction A", "title": "Section B"}],
+    ),
+    CleanerCase(
+        test_id="bare how to section dict wrapping a single step dict (rezeptwelt.de)",
+        input={
+            "@type": "HowToSection",
+            "name": "Section A",
+            "itemListElement": {"@type": "HowToStep", "text": "Instruction A"},
+        },
+        expected=[{"text": "Instruction A", "title": "Section A"}],
+    ),
+    CleanerCase(
+        test_id="loose steps mixed with sections in one list (cookbook.pfeiffer.net.au)",
+        input=[
+            {"@type": "HowToStep", "text": "Instruction A"},
+            {
+                "@type": "HowToSection",
+                "name": "Section B",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction B"},
+                    {"@type": "HowToStep", "text": "Instruction C"},
+                ],
+            },
+        ],
+        expected=[
+            {"text": "Instruction A"},
+            {"text": "Instruction B", "title": "Section B"},
+            {"text": "Instruction C"},
+        ],
+    ),
+    CleanerCase(
+        test_id="bare how to step dict",
+        input={"@type": "HowToStep", "text": "Instruction A"},
+        expected=[{"text": "Instruction A"}],
+    ),
 )
 
 
 @pytest.mark.parametrize("instructions", instruction_test_cases, ids=(x.test_id for x in instruction_test_cases))
 def test_cleaner_instructions(instructions: CleanerCase):
-    reuslt = cleaner.clean_instructions(instructions.input)
+    result = cleaner.clean_instructions(instructions.input)
 
-    expected = [
+    # most inputs boil down to the same three plain steps, so only cases that keep
+    # section titles carry an expectation of their own
+    expected = instructions.expected or [
         {"text": "Instruction A"},
         {"text": "Instruction B"},
         {"text": "Instruction C"},
     ]
 
-    assert reuslt == expected
+    assert result == expected
 
 
 ingredients_test_cases = (

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
@@ -428,6 +428,59 @@ instruction_test_cases = (
         expected=[{"text": "Instruction A", "title": "Section A", "summary": "Step heading A"}],
     ),
     CleanerCase(
+        test_id="capitalised section Name key (atelierdeschefs.fr)",
+        input=[
+            {
+                "@type": "HowToSection",
+                "Name": "Section A",
+                "itemListElement": [
+                    {"@type": "HowToStep", "text": "Instruction A"},
+                ],
+            },
+        ],
+        expected=[{"text": "Instruction A", "title": "Section A"}],
+    ),
+    CleanerCase(
+        test_id="step name becomes the step summary",
+        input=[
+            {"@type": "HowToStep", "name": "Mix", "text": "Instruction A"},
+            {"@type": "HowToStep", "text": "Instruction B"},
+        ],
+        expected=[
+            {"text": "Instruction A", "summary": "Mix"},
+            {"text": "Instruction B"},
+        ],
+    ),
+    CleanerCase(
+        test_id="step name repeating the text is not stored twice",
+        input=[
+            {"@type": "HowToStep", "name": "Instruction A", "text": "Instruction A"},
+            {"@type": "HowToStep", "name": "Instruction B, but truncat", "text": "Instruction B, but truncated"},
+        ],
+        expected=[
+            {"text": "Instruction A"},
+            {"text": "Instruction B, but truncated"},
+        ],
+    ),
+    CleanerCase(
+        test_id="step name repeating the text through html entities is not stored twice",
+        input=[
+            {"@type": "HowToStep", "name": "1. K&auml;...", "text": "1. K&auml;se in St&uuml;cken geben"},
+        ],
+        expected=[{"text": "1. Käse in Stücken geben"}],
+    ),
+    CleanerCase(
+        test_id="step name truncated from the text is not stored as a summary (yummly.com)",
+        input=[
+            {"@type": "HowToStep", "name": "Step 1: Preheat oven to 425\u2026", "text": "Preheat oven to 425 F."},
+            {"@type": "HowToStep", "name": "Mix", "text": "mix it all together"},
+        ],
+        expected=[
+            {"text": "Preheat oven to 425 F."},
+            {"text": "mix it all together"},
+        ],
+    ),
+    CleanerCase(
         test_id="bare how to step dict",
         input={"@type": "HowToStep", "text": "Instruction A"},
         expected=[{"text": "Instruction A"}],

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py
@@ -404,6 +404,30 @@ instruction_test_cases = (
         ],
     ),
     CleanerCase(
+        test_id="step summaries are preserved",
+        input=[
+            {"@type": "HowToStep", "summary": "Step heading A", "text": "Instruction A"},
+            {"@type": "HowToStep", "text": "Instruction B"},
+        ],
+        expected=[
+            {"text": "Instruction A", "summary": "Step heading A"},
+            {"text": "Instruction B"},
+        ],
+    ),
+    CleanerCase(
+        test_id="section headings and step summaries live side by side",
+        input=[
+            {
+                "@type": "HowToSection",
+                "name": "Section A",
+                "itemListElement": [
+                    {"@type": "HowToStep", "summary": "Step heading A", "text": "Instruction A"},
+                ],
+            },
+        ],
+        expected=[{"text": "Instruction A", "title": "Section A", "summary": "Step heading A"}],
+    ),
+    CleanerCase(
         test_id="bare how to step dict",
         input={"@type": "HowToStep", "text": "Instruction A"},
         expected=[{"text": "Instruction A"}],

--- a/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
@@ -3,7 +3,7 @@ import json
 from recipe_scrapers import scrape_html
 
 from mealie.lang.providers import get_locale_provider
-from mealie.services.scraper.scraper_strategies import RecipeScraperPackage, carries_step_structure
+from mealie.services.scraper.scraper_strategies import RecipeScraperPackage, prefer_structured_instructions
 
 SECTIONED_RECIPE = {
     "@context": "https://schema.org/",
@@ -153,13 +153,75 @@ def test_step_summaries_are_kept():
     ]
 
 
-def test_carries_step_structure():
-    assert carries_step_structure(SECTIONED_RECIPE["recipeInstructions"]) is True
-    assert carries_step_structure({"@type": "HowToSection", "itemListElement": []}) is True
-    assert carries_step_structure({"type": "HowToSection", "itemListElement": []}) is True
-    assert carries_step_structure([{"@type": "HowToStep", "summary": "A", "text": "B"}]) is True
-    assert carries_step_structure([{"@type": "HowToStep", "title": "A", "text": "B"}]) is True
-    assert carries_step_structure(FLAT_RECIPE["recipeInstructions"]) is False
-    assert carries_step_structure([{"@type": "HowToStep", "summary": "", "text": "B"}]) is False
-    assert carries_step_structure("Dice the onion.") is False
-    assert carries_step_structure(None) is False
+def test_structured_data_is_ignored_when_it_would_merge_steps(monkeypatch):
+    """Some sites put a whole method in one step, and only the scraper splits it up.
+
+    rezeptwelt.de publishes an unnamed section holding a single step whose text is the entire
+    method, while its own recipe_scrapers scraper reads the page and returns the steps
+    separately. Preferring the structured data there would replace readable steps with one
+    wall of text, so the scraper's own parsing has to win.
+    """
+    html = RecipeScraperPackage.ld_json_to_html(json.dumps(FLAT_RECIPE))
+    scraped_data = scrape_html(html, org_url="https://example.com", supported_only=False)
+    scraped_data.schema.data["recipeInstructions"] = [
+        {
+            "@type": "HowToSection",
+            "itemListElement": [
+                {"@type": "HowToStep", "name": "Salad", "text": "Boil the water.\nAdd the pasta.\nDrain it."}
+            ],
+        }
+    ]
+    monkeypatch.setattr(scraped_data, "instructions", lambda: "Boil the water.\nAdd the pasta.\nDrain it.")
+
+    strategy = RecipeScraperPackage(
+        "https://example.com",
+        get_locale_provider(),
+        repos=None,  # type: ignore[arg-type]
+    )
+    recipe, _ = strategy.clean_scraper(scraped_data, "https://example.com")
+    steps = recipe.recipe_instructions
+    assert steps is not None
+
+    assert [step.text for step in steps] == ["Boil the water.", "Add the pasta.", "Drain it."]
+
+
+def test_step_names_are_kept_as_step_summaries():
+    """schema.org names a step with `HowToStep.name`, which is Mealie's `summary`."""
+    recipe_data = dict(FLAT_RECIPE)
+    recipe_data["recipeInstructions"] = [
+        {"@type": "HowToStep", "name": "Mix", "text": "Whisk the eggs and the sugar."},
+        {"@type": "HowToStep", "text": "Fold in the flour."},
+    ]
+
+    steps = scrape(recipe_data).recipe_instructions
+    assert steps is not None
+
+    assert [(step.summary, step.text) for step in steps] == [
+        ("Mix", "Whisk the eggs and the sugar."),
+        ("", "Fold in the flour."),
+    ]
+
+
+def test_prefer_structured_instructions_needs_a_heading():
+    """Without a heading the structured data says nothing the flat text could not."""
+    structured = [{"text": "Dice the onion."}]
+    flat = [{"text": "Dice the onion."}]
+
+    assert prefer_structured_instructions(structured, flat) is False
+
+
+def test_prefer_structured_instructions_keeps_every_piece_of_flat_text():
+    structured = [{"text": "Dice the onion.", "title": "Prep"}, {"text": "Brown the beef."}]
+
+    # the flat text is the same content with the heading flattened into a line of its own
+    assert prefer_structured_instructions(structured, [{"text": "Prep"}, {"text": "Dice the onion."}]) is True
+    # ...but a scraper that read the page itself can produce text the structured data lacks
+    assert prefer_structured_instructions(structured, [{"text": "Dice the onion, finely."}]) is False
+
+
+def test_prefer_structured_instructions_ignores_a_stringified_step_dict():
+    """A site nesting one step where a list belongs makes recipe_scrapers hand back a repr."""
+    structured = [{"text": "Dice the onion.", "title": "Prep"}]
+    flat = [{"text": "{'@type': 'HowToStep', 'text': 'Dice the onion.'}"}]
+
+    assert prefer_structured_instructions(structured, flat) is True

--- a/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
@@ -3,7 +3,7 @@ import json
 from recipe_scrapers import scrape_html
 
 from mealie.lang.providers import get_locale_provider
-from mealie.services.scraper.scraper_strategies import RecipeScraperPackage, contains_how_to_section
+from mealie.services.scraper.scraper_strategies import RecipeScraperPackage, carries_step_structure
 
 SECTIONED_RECIPE = {
     "@context": "https://schema.org/",
@@ -131,10 +131,35 @@ def test_unparseable_sections_fall_back_to_the_scraper(monkeypatch):
     assert [step.text for step in steps] == ["Dice the onion.", "Brown the beef."]
 
 
-def test_contains_how_to_section():
-    assert contains_how_to_section(SECTIONED_RECIPE["recipeInstructions"]) is True
-    assert contains_how_to_section({"@type": "HowToSection", "itemListElement": []}) is True
-    assert contains_how_to_section({"type": "HowToSection", "itemListElement": []}) is True
-    assert contains_how_to_section(FLAT_RECIPE["recipeInstructions"]) is False
-    assert contains_how_to_section("Dice the onion.") is False
-    assert contains_how_to_section(None) is False
+def test_step_summaries_are_kept():
+    """`summary` is Mealie's own step heading, and pasted JSON is where it comes from.
+
+    recipe_scrapers renders instructions as plain text, so the key is gone before the
+    cleaner runs and a pasted Mealie export or AI generated recipe lost its step headings
+    (mealie-recipes/mealie#6406). The structured data still has them.
+    """
+    recipe_data = dict(FLAT_RECIPE)
+    recipe_data["recipeInstructions"] = [
+        {"@type": "HowToStep", "summary": "Sear the beef", "text": "Sear for 2 minutes a side."},
+        {"@type": "HowToStep", "text": "Deglaze with the wine."},
+    ]
+
+    steps = scrape(recipe_data).recipe_instructions
+    assert steps is not None
+
+    assert [(step.summary, step.text) for step in steps] == [
+        ("Sear the beef", "Sear for 2 minutes a side."),
+        ("", "Deglaze with the wine."),
+    ]
+
+
+def test_carries_step_structure():
+    assert carries_step_structure(SECTIONED_RECIPE["recipeInstructions"]) is True
+    assert carries_step_structure({"@type": "HowToSection", "itemListElement": []}) is True
+    assert carries_step_structure({"type": "HowToSection", "itemListElement": []}) is True
+    assert carries_step_structure([{"@type": "HowToStep", "summary": "A", "text": "B"}]) is True
+    assert carries_step_structure([{"@type": "HowToStep", "title": "A", "text": "B"}]) is True
+    assert carries_step_structure(FLAT_RECIPE["recipeInstructions"]) is False
+    assert carries_step_structure([{"@type": "HowToStep", "summary": "", "text": "B"}]) is False
+    assert carries_step_structure("Dice the onion.") is False
+    assert carries_step_structure(None) is False

--- a/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py
@@ -1,0 +1,140 @@
+import json
+
+from recipe_scrapers import scrape_html
+
+from mealie.lang.providers import get_locale_provider
+from mealie.services.scraper.scraper_strategies import RecipeScraperPackage, contains_how_to_section
+
+SECTIONED_RECIPE = {
+    "@context": "https://schema.org/",
+    "@type": "Recipe",
+    "name": "Sectioned Recipe",
+    "recipeIngredient": ["1 onion", "1 lb beef"],
+    "recipeInstructions": [
+        {
+            "@type": "HowToSection",
+            "name": "Prep Work",
+            "itemListElement": [
+                {"@type": "HowToStep", "text": "Dice the onion."},
+                {"@type": "HowToStep", "text": "Mince the garlic."},
+            ],
+        },
+        {
+            "@type": "HowToSection",
+            "name": "Cooking",
+            "itemListElement": [
+                {"@type": "HowToStep", "text": "Brown the beef."},
+            ],
+        },
+    ],
+}
+
+FLAT_RECIPE = {
+    "@context": "https://schema.org/",
+    "@type": "Recipe",
+    "name": "Flat Recipe",
+    "recipeIngredient": ["1 onion"],
+    "recipeInstructions": [
+        {"@type": "HowToStep", "text": "Dice the onion."},
+        {"@type": "HowToStep", "text": "Brown the beef."},
+    ],
+}
+
+
+def scrape(recipe_data: dict):
+    """Parse a schema.org Recipe the way the html-or-json route does."""
+    html = RecipeScraperPackage.ld_json_to_html(json.dumps(recipe_data))
+    scraped_data = scrape_html(html, org_url="https://example.com", supported_only=False)
+
+    strategy = RecipeScraperPackage(
+        "https://example.com",
+        get_locale_provider(),
+        repos=None,  # type: ignore[arg-type]
+    )
+    recipe, _ = strategy.clean_scraper(scraped_data, "https://example.com")
+    return recipe
+
+
+def test_how_to_section_names_are_kept_as_step_titles():
+    """Section headings must survive an import as `RecipeStep.title`.
+
+    recipe_scrapers flattens `HowToSection` into newline separated text and emits each
+    section name as a line of its own, so importing a sectioned recipe used to turn every
+    heading into a bogus instruction step (mealie-recipes/mealie#6887). The structured
+    data is read directly instead, and the heading is stored on the first step of its
+    section, which is how the frontend groups steps.
+    """
+    steps = scrape(SECTIONED_RECIPE).recipe_instructions
+    assert steps is not None
+
+    assert [(step.title, step.text) for step in steps] == [
+        ("Prep Work", "Dice the onion."),
+        ("", "Mince the garlic."),
+        ("Cooking", "Brown the beef."),
+    ]
+
+
+def test_section_names_are_not_imported_as_instruction_steps():
+    steps = scrape(SECTIONED_RECIPE).recipe_instructions
+    assert steps is not None
+
+    assert "Prep Work" not in [step.text for step in steps]
+    assert "Cooking" not in [step.text for step in steps]
+
+
+def test_recipes_without_sections_are_untouched():
+    """Sites without sections must keep using the scraper's own instruction parsing."""
+    steps = scrape(FLAT_RECIPE).recipe_instructions
+    assert steps is not None
+
+    assert [(step.title, step.text) for step in steps] == [
+        ("", "Dice the onion."),
+        ("", "Brown the beef."),
+    ]
+
+
+def test_single_step_section_is_imported():
+    """A section holding one step as a bare dict, rather than a list, is a real shape.
+
+    rezeptwelt.de publishes recipes this way, and it used to reach the database as a
+    stringified Python dict (see `tests/utils/recipe_data.py`).
+    """
+    recipe_data = dict(SECTIONED_RECIPE)
+    recipe_data["recipeInstructions"] = {
+        "@type": "HowToSection",
+        "name": "Prep Work",
+        "itemListElement": {"@type": "HowToStep", "text": "Dice the onion."},
+    }
+
+    steps = scrape(recipe_data).recipe_instructions
+    assert steps is not None
+
+    assert [(step.title, step.text) for step in steps] == [("Prep Work", "Dice the onion.")]
+
+
+def test_unparseable_sections_fall_back_to_the_scraper(monkeypatch):
+    """A section shape the cleaner cannot parse must not lose the scraper's own output."""
+    html = RecipeScraperPackage.ld_json_to_html(json.dumps(FLAT_RECIPE))
+    scraped_data = scrape_html(html, org_url="https://example.com", supported_only=False)
+    scraped_data.schema.data["recipeInstructions"] = [{"@type": "HowToSection", "itemListElement": 12}]
+    monkeypatch.setattr(scraped_data, "instructions", lambda: "Dice the onion.\nBrown the beef.")
+
+    strategy = RecipeScraperPackage(
+        "https://example.com",
+        get_locale_provider(),
+        repos=None,  # type: ignore[arg-type]
+    )
+    recipe, _ = strategy.clean_scraper(scraped_data, "https://example.com")
+    steps = recipe.recipe_instructions
+    assert steps is not None
+
+    assert [step.text for step in steps] == ["Dice the onion.", "Brown the beef."]
+
+
+def test_contains_how_to_section():
+    assert contains_how_to_section(SECTIONED_RECIPE["recipeInstructions"]) is True
+    assert contains_how_to_section({"@type": "HowToSection", "itemListElement": []}) is True
+    assert contains_how_to_section({"type": "HowToSection", "itemListElement": []}) is True
+    assert contains_how_to_section(FLAT_RECIPE["recipeInstructions"]) is False
+    assert contains_how_to_section("Dice the onion.") is False
+    assert contains_how_to_section(None) is False

--- a/tests/utils/recipe_data.py
+++ b/tests/utils/recipe_data.py
@@ -35,7 +35,7 @@ def get_recipe_test_cases():
             html_file=test_data.html_schinken_kase_waffeln_ohne_viel_schnickschnack,
             expected_slug="schinken-kase-waffeln-ohne-viel-schnickschnack",
             num_ingredients=7,
-            num_steps=1,  # Malformed JSON Data, can't parse steps just get one string
+            num_steps=1,  # a single HowToSection wrapping one step, titled 'Waffelteig'
         ),
         RecipeSiteTestCase(
             url="https://cookpad.com/us/recipes/5544853-sous-vide-smoked-beef-ribs",


### PR DESCRIPTION
## What this PR does / why we need it:

Recipes whose instructions carry headings lose them on import. A `HowToSection` grouping steps loses the grouping and each section heading arrives as a bogus instruction step, and a step that names itself loses that name. `RecipeStep` already has fields for both, `title` for the section heading ("This is the section title!!!" in `mealie/schema/recipe/recipe_step.py`) and `summary` for the step's own heading, and the recipe page already renders both, so all that was missing was carrying them across.

There are two places they get dropped, and fixing only one of them changes nothing for the import paths people actually use.

- `mealie/services/scraper/cleaner.py` - `clean_instructions()` flattened every `HowToSection` into a bare list of steps and discarded `name`. The section branch is now reached whenever any entry in the list is a section rather than only when the first one is, because sites do mix loose steps and sections in the same list (a recipe that opens with a couple of ungrouped steps and only then starts grouping them); the old pattern matched such a list as a plain list of steps and silently dropped every section in it. It now keeps the name as `title` on the **first** step of each section, which is how the frontend groups the steps that follow, and fills a step's `summary` from either the `summary` key Mealie writes itself or schema.org's `HowToStep.name`. Sites fill that name with a copy of the step text as often as with a real heading, so a name the text already opens with is dropped (the rule recipe_scrapers applies to the same field, compared case insensitively and after decoding entities), and so is a name truncated mid word, which is what yummly.com publishes ("Step 1: Preheat oven to 425…"). Section names are run through `clean_string()` like any other scraped string, and are read from `Name` as well as `name`, which is the spelling atelierdeschefs.fr publishes. The single element base case was removed because the list case below it already matches a one element list, and returning the object untouched skipped sanitization. Two shapes that used to raise `TypeError` are now handled: a lone section passed as a bare dict, and a single step passed as a bare dict (rezeptwelt.de publishes recipes this way, which is why `tests/utils/recipe_data.py` carried a "can't parse steps" comment; that recipe now imports as one real step titled "Waffelteig" instead of a stringified Python dict).
- `mealie/services/scraper/scraper_strategies.py` - `clean_scraper()` asked `recipe_scrapers` for `instructions()` first, which renders instructions as plain text and emits each section name as a line of its own, so the cleaner never saw a `HowToSection` on the URL or the html-or-json path at all. Both parses now run and `prefer_structured_instructions()` picks between them, and `RecipeStep(title="", ...)` no longer hardcodes the headings away.

The picking rule is the part worth reviewing. The structured parse is used only when it gains a heading, and only when every piece of text the scraper's own parse produced is still accounted for, as either a step or a heading. That second condition matters because a site specific scraper reads the instructions off the page instead of out of the JSON-LD, and its text can differ from, or beat, what the page publishes: Cookomix, Magimix, SunBasket and ThePlantBasedSchool all produce better text than their own structured data. The rule keeps the structured data a refinement of the same content and never a replacement for better content. The single exception is a step dict that reached us as its own `repr`, which happens when a site nests one step where the spec wants a list (hhursev/recipe-scrapers#2006); that is not instruction text, so it does not count as content to preserve.

### Before

Importing a recipe with four `HowToSection`s (cookbook.pfeiffer.net.au/biryani-chicken-rajasthani) turns every heading into a step of its own, so "to marinate" is step 1 and the real first step is step 2:

![sections-before.png](https://github.com/user-attachments/assets/70593532-6553-4b6a-9aed-999ccd26c66a)

The same thing in the JSON from #6887, pasted into "Import from HTML or JSON":

```
[{"text": "Prep Work"}, {"text": "Dice the onion."}, {"text": "Mince the garlic."}, {"text": "Cooking"}, {"text": "Brown the beef."}]
```

### After

The headings become section titles on the first step of each section, which the recipe page renders as a section banner, and the steps are numbered as the site numbers them:

![sections-after.png](https://github.com/user-attachments/assets/b4053d72-5e5f-4d03-8aa7-fe44a68eebad)

Same import, as JSON:

```
[{"title": "Prep Work", "text": "Dice the onion."}, {"text": "Mince the garlic."}, {"title": "Cooking", "text": "Brown the beef."}]
```

The same applies to a step's own heading. Pasting a schema.org recipe whose steps carry `summary`, which is what Mealie's own JSON editor and AI generated recipes produce, drops every heading and the cards fall back to "Step: N":

![summary-before.png](https://github.com/user-attachments/assets/d252e179-426f-4bd6-9011-a740d9546d2f)

After, the step keeps the heading it was given:

![summary-after.png](https://github.com/user-attachments/assets/1a353a57-0669-499c-bc36-10f2489248d3)

A recipe exported from Mealie and pasted straight back in now keeps its section headings, its step headings and its text exactly, **provided the pasted JSON declares `@context`/`@type`**. Mealie's export does not, and `recipe_scrapers` rejects it as "no schema found" before any of this code runs, so the round trip in #6887 still needs that separate fix. Not addressed here.

## Which issue(s) this PR fixes:

Contributes to #6887: both instruction rows of its table, `recipeInstructions[].title` and `recipeInstructions[].summary`. Also covers the instruction half of #6406. The remaining rows of #6887 (categories, tools) and the recipe saving problems in #7785 (identity fields on update, organizers by name, the `PUT /api/recipes/undefined` slug bug) are deliberately left alone here.

## Special notes for your reviewer:

The judgement call worth a second opinion is `prefer_structured_instructions()`, described above. Restricting the structured read to the generic wild mode scraper was the obvious alternative, but measuring it against the corpus showed that would give up 250 of the 258 improved pages to avoid 11 regressions, where the content comparison avoids all 11 and gives up only those same 11.

Related, not addressed here: when `instructions()` raises and `try_get_default` falls back to the raw structured data, an unparseable shape still raises `TypeError` out of `clean_scraper`. That behaviour predates this PR and is unchanged by it. Upstream `recipe_scrapers` has an open issue for the shapes that trigger it (hhursev/recipe-scrapers#2006).

There is no grouped instruction API in `recipe_scrapers` to lean on: `ingredient_groups()` exists, the instruction equivalent has been open as hhursev/recipe-scrapers#1225 since 2024, and hhursev/recipe-scrapers#2046 shows the flattening is intentional there, so reading the schema data directly is the practical route.

## Testing

- `tests/unit_tests/services_tests/scraper_tests/test_cleaner_parts.py` - fifteen new `clean_instructions` cases: named sections, the `item` key spelling, name cleaning, an empty name, a named section with no steps, loose steps mixed with sections in one list, a bare section dict wrapping a single step dict, a bare step dict, a preserved step summary, a section heading and step summary side by side, the capitalised `Name` key some sites use, a `HowToStep.name` becoming a step summary, a name that merely repeats the text being dropped, the same repetition hidden behind HTML entities, and a name truncated mid word. The shared expectation was made per case so sectioned cases can assert their own output.
- `tests/unit_tests/services_tests/scraper_tests/test_scraper_strategies.py` (new) - drives `RecipeScraperPackage.clean_scraper()` over schema.org JSON the way the html-or-json route does: section headings become step titles, headings are not imported as steps, step names and summaries survive, flat recipes are untouched, a single step section dict imports, an unparseable section falls back to the scraper's own output, and a site whose scraper splits a one step method keeps that split. `prefer_structured_instructions()` is also unit tested directly.
- `task py:test` (full suite), `task py:lint`, `task py:mypy` and `ruff format --check` all pass locally.
- Swept the whole `recipe_scrapers` fixture corpus, 1104 real pages across ~600 sites, driving each page through its own site scraper and comparing the shipped output with this branch. **255 pages gain headings (445 section headings, 541 step headings), no page loses a single piece of instruction text, and no heading merely repeats or truncates its own step.** Two earlier versions of the picking rule did lose text, on 16 and then 11 pages, and an earlier version of the heading rules produced 16 junk headings, which is what the sweep was for.
- Checked against live pages as well as the synthetic fixtures. `cookbook.pfeiffer.net.au/biryani-chicken-rajasthani` goes from 21 steps (4 of them headings) to 17 steps under 4 headings; `amateurprochef.com` (6 sections, one of them an empty placeholder with no `itemListElement`) goes from 16 steps to 10 under 5 headings, the placeholder skipped; `leukerecepten.nl` (a site with its own scraper, one section) keeps all 8 steps and gains the heading; `cookbook.pfeiffer.net.au/chicken-pepper` is the mixed list case above, going from 9 steps to 7 with both loose steps intact.

## AI / LLM Assistance

Investigation, implementation, tests and this description were produced with LLM assistance (Claude Code), reviewed by me, and validated by running the test suite, linter and type checker locally.
