### PR TITLE
fix: auto_init merges model_config.exclude with default {"id"} instead of replacing it

### DIFF
--- a/mealie/db/models/_model_utils/auto_init.py
+++ b/mealie/db/models/_model_utils/auto_init.py
@@ -39,7 +39,15 @@ def _get_config(relation_cls: type[SqlAlchemyBase]) -> AutoInitConfig:
         return cfg
     # Map all matching attributes in Config to all AutoInitConfig attributes
     for attr in class_config:
-        if attr in cfgKeys:
+        if attr not in cfgKeys:
+            continue
+
+        if attr == "exclude":
+            # A model's own `exclude` adds to the default exclusions (e.g. "id")
+            # rather than replacing them -- otherwise a model that declares
+            # `exclude` loses primary-key protection during `auto_init`.
+            cfg.exclude = cfg.exclude | set(class_config[attr])
+        else:
             setattr(cfg, attr, class_config[attr])
 
     return cfg

--- a/tests/unit_tests/test_auto_init_config.py
+++ b/tests/unit_tests/test_auto_init_config.py
@@ -1,0 +1,41 @@
+from pydantic import ConfigDict
+
+from mealie.db.models._model_utils.auto_init import _get_config
+
+
+class _NoConfig:
+    pass
+
+
+class _CustomExcludeOnly:
+    model_config = ConfigDict(exclude={"households_with_ingredient_food"})
+
+
+class _CustomExcludeWithId:
+    model_config = ConfigDict(exclude={"id", "recipe"})
+
+
+class _OtherConfigKeyOnly:
+    model_config = ConfigDict(get_attr="slug")
+
+
+def test_get_config_defaults_to_excluding_id_when_no_model_config():
+    cfg = _get_config(_NoConfig)
+    assert cfg.exclude == {"id"}
+
+
+def test_get_config_merges_custom_exclude_with_default_id_exclusion():
+    """Regression test for GH issue #8088."""
+    cfg = _get_config(_CustomExcludeOnly)
+    assert cfg.exclude == {"id", "households_with_ingredient_food"}
+
+
+def test_get_config_does_not_duplicate_id_when_custom_exclude_already_has_it():
+    cfg = _get_config(_CustomExcludeWithId)
+    assert cfg.exclude == {"id", "recipe"}
+
+
+def test_get_config_preserves_default_exclude_for_unrelated_config_keys():
+    cfg = _get_config(_OtherConfigKeyOnly)
+    assert cfg.get_attr == "slug"
+    assert cfg.exclude == {"id"}


### PR DESCRIPTION
## Summary

Fixes #8088.

`_get_config()` in `mealie/db/models/_model_utils/auto_init.py` replaced `AutoInitConfig`'s default primary-key exclusion (`{"id"}`) with a model's own `model_config.exclude`, instead of merging the two. Any model declaring `model_config = ConfigDict(exclude={...})` without separately re-listing `"id"` loses primary-key protection during `BaseMixins.update()`, which re-invokes `__init__(**kwargs)` on an already-persisted row. Every `Create*`/`Save*` schema for these models carries an `id` field defaulting to `None` when the client doesn't send one, so `auto_init` then does `setattr(self, "id", None)` on a live row — nulling its primary key mid-update and failing the next flush with a `NOT NULL` constraint violation.

Confirmed concretely on `IngredientFoodModel`: any `PUT /api/foods/{id}` that changes anything fails this way. `RecipeToolModel`, `GroupModel`, `HouseholdModel`, `UserModel`, and `ReportModel` declare `exclude` the same vulnerable way. `RecipeInstructionModel` and `ShoppingListItemModel`/`ShoppingListModel` already work around this ad hoc by manually re-adding `"id"` to their own `exclude` — this fixes it at the source so no model needs to remember to do that, per the suggestion in the issue's follow-up comment.

## Fix

`_get_config()` now unions a model's own `exclude` with the default instead of replacing it wholesale. Every other `AutoInitConfig` attribute keeps its existing replace-on-match behavior.

## Tests

Added `tests/unit_tests/test_auto_init_config.py` — direct unit coverage of `_get_config()`:
- No `model_config` → default `{"id"}` exclusion still applies.
- Custom `exclude` → merged with `{"id"}`, not replacing it.
- Custom `exclude` that already includes `"id"` → no duplication.
- An unrelated config key (`get_attr`) → default `exclude` untouched.

This was requested explicitly in the issue's follow-up comment, alongside independent confirmation of the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)