### PR TITLE
Fix: parse Instagram OpenGraph recipe titles correctly

### DIFF
--- a/mealie/services/scraper/scraper_strategies.py
+++ b/mealie/services/scraper/scraper_strategies.py
@@ -542,6 +542,40 @@ class RecipeScraperOpenGraph(ABCScraperStrategy):
     async def get_html(self, url: str) -> str:
         return self.raw_html or await safe_scrape_html(url)
 
+    @staticmethod
+    def extract_recipe_name(title: str) -> str:
+        """Extract a recipe name from social-media Open Graph titles.
+
+        Instagram may put the account name and the entire post caption into
+        og:title. In that case, extract the likely recipe title instead of
+        using the full caption as the recipe name.
+        """
+        title = cleaner.clean_string(title)
+
+        instagram_match = re.search(
+            r"\bon Instagram:\s*(.+)",
+            title,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+
+        if not instagram_match:
+            return title
+
+        caption = instagram_match.group(1).strip().strip("\"'")
+
+        section_match = re.search(
+            r"\s+(?=(?:follow\b|ingredients?\b|instructions?\b|method\b|directions?\b))",
+            caption,
+            flags=re.IGNORECASE,
+        )
+
+        if section_match:
+            caption = caption[:section_match.start()]
+
+        recipe_name = caption.strip().strip("\"' -")
+
+        return recipe_name or title
+
     def get_recipe_fields(self, html) -> dict | None:
         """
         Get the recipe fields from the Open Graph data.
@@ -560,14 +594,16 @@ class RecipeScraperOpenGraph(ABCScraperStrategy):
         except Exception:
             return None
 
+        title = og_field(properties, "og:title")
+        recipe_name = self.extract_recipe_name(title)
         return {
-            "name": og_field(properties, "og:title"),
+            "name": recipe_name,
             "description": og_field(properties, "og:description"),
             "image": og_field(properties, "og:image"),
             "recipeYield": "",
             "recipeIngredient": ["Could not detect ingredients"],
             "recipeInstructions": [{"text": "Could not detect instructions"}],
-            "slug": slugify(og_field(properties, "og:title")),
+            "slug": slugify(recipe_name),
             "orgURL": self.url or og_field(properties, "og:url"),
             "categories": [],
             "tags": og_fields(properties, "og:article:tag"),

--- a/tests/unit_tests/services_tests/scraper_tests/test_cleaner.py
+++ b/tests/unit_tests/services_tests/scraper_tests/test_cleaner.py
@@ -60,6 +60,50 @@ def test_html_with_recipe_data():
     assert url_validation_regex.match(recipe_data["image"])
 
 
+def test_open_graph_extracts_recipe_name_from_instagram_caption():
+    """Regression test for GH #6427.
+
+    Instagram may include the account name and full post caption in og:title.
+    The scraper should extract the recipe title instead of using the entire
+    caption as the recipe name.
+    """
+    html = """
+    <html>
+      <head>
+        <meta
+          property="og:title"
+          content='Jess &amp; Dan Saunders | VEGAN PUNKS on Instagram: "DOUBLE TOFU STUFFED FLATBREADS Follow @vegan_punks for more of the good stuff and grab the recipe below. Ingredients Makes 6 For the dough 350g plain flour. Instructions 1. Mix the dough."'
+        />
+        <meta
+          property="og:description"
+          content="A vegan stuffed flatbread recipe."
+        />
+        <meta
+          property="og:image"
+          content="https://example.com/image.jpg"
+        />
+        <meta
+          property="og:url"
+          content="https://www.instagram.com/reel/example/"
+        />
+      </head>
+    </html>
+    """
+
+    translator = get_locale_provider()
+    strategy = RecipeScraperOpenGraph(
+        "https://www.instagram.com/reel/example/",
+        translator,
+        None,  # type: ignore[arg-type]
+    )
+
+    recipe_data = strategy.get_recipe_fields(html)
+
+    assert recipe_data is not None
+    assert recipe_data["name"] == "DOUBLE TOFU STUFFED FLATBREADS"
+    assert recipe_data["slug"] == "double-tofu-stuffed-flatbreads"
+
+
 def test_clean_scraper_preserves_notes():
     """Regression test: notes must survive the RecipeScraperPackage pipeline (previously dropped silently)."""
     ld_json = json.dumps(
@@ -88,3 +132,11 @@ def test_clean_scraper_preserves_notes():
     assert recipe.notes[0].text == "Keep refrigerated up to 3 days"
     assert recipe.notes[1].title == "Variation"
     assert recipe.notes[1].text == "Add chili flakes for extra heat"
+
+
+def test_open_graph_preserves_normal_title():
+    title = "Healthy Pasta Bake - BBC Food"
+
+    result = RecipeScraperOpenGraph.extract_recipe_name(title)
+
+    assert result == title


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes an issue in the OpenGraph recipe scraper where Instagram posts can produce extremely long recipe names and slugs.

Instagram may include the account name and the full post caption in the `og:title` metadata. Previously, `RecipeScraperOpenGraph` used the complete `og:title` value directly as the recipe name and as the input for generating the recipe slug. For posts with long captions, this could result in an excessively long recipe URL and make the imported recipe difficult or impossible to open.

This PR changes the OpenGraph parsing behavior for Instagram-style titles:

- Added `extract_recipe_name()` to `RecipeScraperOpenGraph`.
- Detects titles containing the Instagram-specific `on Instagram:` pattern.
- Extracts the caption portion after `on Instagram:`.
- Uses common caption section markers such as `Follow`, `Ingredients`, `Instructions`, `Method`, and `Directions` to identify where the likely recipe title ends.
- Uses the extracted recipe name for both the recipe `name` and generated `slug`.
- Leaves normal non-Instagram OpenGraph titles unchanged.
- Added regression tests covering both the Instagram case and normal OpenGraph title behavior.

The parsing approach was chosen instead of simply truncating the generated slug because the underlying problem is that the scraper is interpreting the entire Instagram caption as the recipe title. Extracting the likely recipe name addresses the source of the problem while preserving the existing behavior for normal OpenGraph titles.


## Which issue(s) this PR fixes:

Fixes #6427


## Special notes for your reviewer:

The main change is contained in `RecipeScraperOpenGraph.extract_recipe_name()` in `mealie/services/scraper/scraper_strategies.py`.

The implementation is intentionally limited to OpenGraph titles matching the Instagram-style `on Instagram:` pattern so that existing behavior for normal OpenGraph titles is preserved.

I would particularly appreciate feedback on the title extraction logic and the selected caption section markers (`Follow`, `Ingredients`, `Instructions`, `Method`, and `Directions`), especially if there are additional Instagram title formats that should be considered.


## Testing

Added regression tests in `tests/unit_tests/services_tests/scraper_tests/test_cleaner.py`.

The tests cover:

- An Instagram-style `og:title` containing the account name, recipe title, social-media text, ingredients, and instructions.
- Verification that the extracted recipe name is `DOUBLE TOFU STUFFED FLATBREADS`.
- Verification that the generated slug is `double-tofu-stuffed-flatbreads`.
- A normal OpenGraph title (`Healthy Pasta Bake - BBC Food`) to verify that non-Instagram titles remain unchanged.

The targeted regression tests were executed in the Mealie Docker environment using Python 3.12 and pytest.

Result:

`2 passed`


## AI / LLM Assistance

AI/LLM assistance was used during the investigation and development of this fix.

The LLM was used to:

- Help trace the recipe import flow and identify `RecipeScraperOpenGraph` as the relevant fallback scraper.
- Discuss the root cause of the issue and possible approaches to handling Instagram `og:title` values.
- Help diagnose local testing and Docker environment issues encountered while running the tests.
- Review Git diffs and help prepare the changes for the pull request.

I reviewed the suggested implementation, applied the changes to the codebase, inspected the resulting behavior, and manually ran the targeted regression tests in the project environment.