### PR TITLE
feat: add delete action to recipe cards

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeCard.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCard.vue
@@ -81,8 +81,9 @@
                 :menu-icon="$globals.icons.dotsVertical"
                 :name="name"
                 :recipe-id="recipeId"
+                :recipe="recipe"
                 :use-items="{
-                  delete: false,
+                  delete: true,
                   edit: false,
                   download: true,
                   mealplanner: true,
@@ -109,8 +110,10 @@ import RecipeContextMenu from "./RecipeContextMenu/RecipeContextMenu.vue";
 import RecipeCardImage from "./RecipeCardImage.vue";
 import RecipeCardRating from "./RecipeCardRating.vue";
 import { useLoggedInState } from "~/composables/use-logged-in-state";
+import type { Recipe } from "~/lib/api/types/recipe";
 
 interface Props {
+  recipe?: Recipe;
   name: string;
   slug: string;
   description?: string | null;

--- a/frontend/app/components/Domain/Recipe/RecipeCardSection.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeCardSection.vue
@@ -117,6 +117,7 @@
             :xl="3"
           >
             <RecipeCard
+              :recipe="recipe"
               :name="recipe.name!"
               :description="recipe.description!"
               :slug="recipe.slug!"
@@ -124,6 +125,7 @@
               :image="recipe.image!"
               :tags="recipe.tags!"
               :recipe-id="recipe.id!"
+              @delete="removeRecipe"
             />
           </v-col>
         </v-row>
@@ -336,6 +338,11 @@ async function initRecipes() {
   page.value = page.value + 1;
 
   emit(REPLACE_RECIPES_EVENT, newRecipes);
+}
+
+function removeRecipe(slug: string) {
+  const updatedRecipes = props.recipes.filter(recipe => recipe.slug !== slug);
+  emit(REPLACE_RECIPES_EVENT, updatedRecipes);
 }
 
 const infiniteScroll = useThrottleFn(async () => {


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a Delete action to the context menu on recipe cards.

Previously, deleting a recipe was less convenient because users generally needed to open the recipe before accessing the delete option. Recipe cards already provide a context menu for common actions such as downloading, sharing, and adding recipes to the meal planner or shopping list, so adding Delete to the same menu makes recipe management more convenient and reduces unnecessary navigation.

This PR:

- Enables the existing Delete action in the recipe card context menu.
- Passes the recipe data required by the existing delete functionality.
- Reuses the existing delete confirmation flow rather than introducing a new deletion mechanism.
- Removes the deleted recipe from the current recipe card list immediately after deletion, without requiring a manual page refresh.

The change is intentionally small and reuses the existing `RecipeContextMenu` deletion behavior.

## Which issue(s) this PR fixes:

No linked issue. This is a small usability improvement to make deleting recipes directly from recipe cards more convenient.

## Special notes for your reviewer:

The main changes are in:

- `frontend/app/components/Domain/Recipe/RecipeCard.vue`
- `frontend/app/components/Domain/Recipe/RecipeCardSection.vue`

`RecipeCard.vue` enables the existing Delete menu item and forwards the deletion event.

`RecipeCardSection.vue` handles the deletion event by updating the displayed recipe list so that the deleted card disappears immediately.

No new delete API or confirmation dialog was introduced; the implementation reuses the existing recipe deletion functionality.

## Testing

Tested manually in the local Mealie Docker environment.

Verified that:

- The Delete option appears in the recipe card context menu.
- Selecting Delete uses the existing confirmation flow.
- Confirming the deletion successfully deletes the recipe.
- The deleted recipe card disappears from the current list immediately without refreshing the page.
- The deleted recipe remains absent after refreshing the page.
- Other existing recipe card context menu actions remain available.

## AI / LLM Assistance

AI/LLM assistance was used during the development of this change.

The LLM was used to:

- Help inspect the existing recipe card and context menu structure.
- Trace the existing recipe deletion flow and related events.
- Help diagnose why a deleted recipe card initially remained visible until the page was refreshed.
- Review the final Git diff and help resolve a merge conflict after updating to the latest `mealie-next` branch.


I reviewed the suggested changes, applied them to the codebase, and manually tested the final functionality in the local Mealie environment.