### PR TITLE
fix: default the recipe name when an AI import returns a blank one

### DIFF
--- a/mealie/lang/messages/en-US.json
+++ b/mealie/lang/messages/en-US.json
@@ -8,6 +8,7 @@
         "recipe-image-deleted": "Recipe image deleted",
         "recipe-defaults": {
             "ingredient-note": "1 Cup Flour",
+            "name": "New Recipe",
             "step-text": "Recipe steps as well as other fields in the recipe page support markdown syntax.\n\n**Add a link**\n\n[My Link](https://demo.mealie.io)\n"
         },
         "servings-text": {

--- a/mealie/services/recipe/import_workflow/recipe_conversion.py
+++ b/mealie/services/recipe/import_workflow/recipe_conversion.py
@@ -1,5 +1,6 @@
 from pydantic.alias_generators import to_camel
 
+from mealie.core.exceptions import SlugError
 from mealie.schema.openai.recipe import OpenAIRecipe
 from mealie.schema.recipe.recipe import Recipe, create_recipe_slug
 from mealie.schema.recipe.recipe_ingredient import RecipeIngredient
@@ -9,6 +10,31 @@ from mealie.schema.recipe.recipe_step import RecipeStep
 from mealie.services.scraper import cleaner
 
 from .context import WorkflowContext
+
+DEFAULT_RECIPE_NAME_KEY = "recipe.recipe-defaults.name"
+DEFAULT_RECIPE_NAME = "New Recipe"
+DEFAULT_RECIPE_SLUG = "new-recipe"
+
+
+def resolve_name_and_slug(ctx: WorkflowContext, name: str) -> tuple[str, str]:
+    """
+    Returns a recipe name and its slug, falling back to a default name when the provider's name
+    is missing or unsluggable.
+
+    A provider occasionally returns an empty or punctuation-only name, which has no valid slug.
+    That shouldn't fail the whole import, since the rest of the recipe is usually fine and the
+    user can rename it after the fact.
+    """
+
+    candidates = [name, ctx.translator.t(DEFAULT_RECIPE_NAME_KEY, DEFAULT_RECIPE_NAME)]
+    for candidate in candidates:
+        try:
+            return candidate, create_recipe_slug(candidate)
+        except SlugError:
+            continue
+
+    # the translated default has no valid slug in this locale, so fall back to an ASCII one
+    return candidates[-1], DEFAULT_RECIPE_SLUG
 
 
 def convert_nutrition(openai_recipe: OpenAIRecipe) -> Nutrition | None:
@@ -30,6 +56,7 @@ def to_recipe(ctx: WorkflowContext, openai_recipe: OpenAIRecipe) -> Recipe:
     """
 
     compiled = ctx.compiled_source
+    name, slug = resolve_name_and_slug(ctx, openai_recipe.name)
 
     # callers that persist the recipe themselves assign its owner, so only set it when known
     owner = (
@@ -40,8 +67,8 @@ def to_recipe(ctx: WorkflowContext, openai_recipe: OpenAIRecipe) -> Recipe:
 
     return Recipe(
         **owner,
-        name=openai_recipe.name,
-        slug=create_recipe_slug(openai_recipe.name),
+        name=name,
+        slug=slug,
         description=openai_recipe.description,
         recipe_yield=openai_recipe.recipe_yield,
         total_time=openai_recipe.total_time,

--- a/tests/unit_tests/services_tests/test_recipe_import_workflow.py
+++ b/tests/unit_tests/services_tests/test_recipe_import_workflow.py
@@ -17,6 +17,11 @@ from mealie.services.openai.content import (
 from mealie.services.recipe.import_workflow.compilers import DEFAULT_SOURCE_COMPILERS
 from mealie.services.recipe.import_workflow.compilers.base import SourceCompiler, SourceType
 from mealie.services.recipe.import_workflow.context import WorkflowInput
+from mealie.services.recipe.import_workflow.recipe_conversion import (
+    DEFAULT_RECIPE_NAME,
+    DEFAULT_RECIPE_SLUG,
+    resolve_name_and_slug,
+)
 from mealie.services.recipe.import_workflow.steps.compile_source import CompileSourceStep
 from mealie.services.recipe.import_workflow.workflow import DEFAULT_WORKFLOW_STEPS
 
@@ -253,3 +258,45 @@ async def test_a_compiler_returning_nothing_also_hands_over():
 
     assert compiled is not None
     assert compiled.content == "from the second url compiler"
+
+
+class StubTranslator:
+    """Translator is a Protocol with a single method, so a stub is enough here."""
+
+    def __init__(self, translation: str | None = None) -> None:
+        self.translation = translation
+
+    def t(self, key, default=None, **kwargs) -> str:
+        return self.translation if self.translation is not None else (default or key)
+
+
+class NameContext:
+    """Only the part of WorkflowContext that `resolve_name_and_slug` touches."""
+
+    def __init__(self, translator=None) -> None:
+        self.translator = translator or get_locale_provider("en-US")
+
+
+def test_a_usable_name_is_kept():
+    assert resolve_name_and_slug(NameContext(), "Grilled Cheese") == ("Grilled Cheese", "grilled-cheese")
+
+
+@pytest.mark.parametrize("name", ["", "   ", "!!!", "🍞🧀"])
+def test_an_unsluggable_name_falls_back_to_the_default(name: str):
+    """A provider returning a junk name shouldn't throw away an otherwise good recipe."""
+
+    assert resolve_name_and_slug(NameContext(), name) == (DEFAULT_RECIPE_NAME, DEFAULT_RECIPE_SLUG)
+
+
+def test_the_default_name_is_translated():
+    name, slug = resolve_name_and_slug(NameContext(StubTranslator("Neues Rezept")), "")
+
+    assert (name, slug) == ("Neues Rezept", "neues-rezept")
+
+
+def test_an_unsluggable_translation_falls_back_to_an_ascii_slug():
+    """slugify can come back empty for a script it can't transliterate."""
+
+    name, slug = resolve_name_and_slug(NameContext(StubTranslator("🍲")), "")
+
+    assert (name, slug) == ("🍲", DEFAULT_RECIPE_SLUG)


### PR DESCRIPTION
## What this PR does / why we need it:

An AI import fails outright when the provider returns a recipe whose name is empty or contains only
characters that don't survive slugification. `to_recipe` passes the name straight to
`create_recipe_slug`, which raises `SlugError` on an empty slug, and nothing in the workflow catches
it — so the whole import is lost even though the ingredients and instructions usually came back
intact.

```
File ".../import_workflow/recipe_conversion.py", line 44, in to_recipe
    slug=create_recipe_slug(openai_recipe.name),
File ".../schema/recipe/recipe.py", line 55, in create_recipe_slug
    raise SlugError("Recipe name cannot be empty or contain only special characters")
mealie.core.exceptions.SlugError: Recipe name cannot be empty or contain only special characters
```

`OpenAIRecipe.name` is typed `str`, so a provider can't return `None` — but an empty string passes
validation fine, and a junk title shouldn't cost the user the rest of the recipe.

- `mealie/services/recipe/import_workflow/recipe_conversion.py` — add `resolve_name_and_slug`, which
  returns the provider's name when it slugifies, and otherwise falls back to a translated default.
- `mealie/lang/messages/en-US.json` — add `recipe.recipe-defaults.name`, alongside the existing
  `ingredient-note` and `step-text` defaults. Only `en-US` is touched; the other locales are
  Crowdin-managed.
- `tests/unit_tests/services_tests/test_recipe_import_workflow.py` — unit tests for each branch.

Three decisions worth calling out:

- **Scoped to the AI import path, not `create_recipe_slug` itself.** Raising is arguably correct for
  manual creation, and other callers depend on that behaviour.
- **There's a third fallback to an ASCII slug.** Once the default name is translated you can't assume
  it slugifies — `slugify` can return empty for scripts it can't transliterate. Without that fallback
  the patch would swap one crash for a rarer, stranger one.
- **`t(key, default)` rather than `t(key)`**, so this keeps working in a locale whose file hasn't
  picked the key up from Crowdin yet. Verified: de-DE and fr-FR currently fall through to
  "New Recipe" rather than rendering a raw key.

It lives in `to_recipe` because, per that function's own docstring, it's shared by every step that
produces a draft recipe — so this also covers a recipe that imported fine and then came back from the
translation step with a blank name.

## Which issue(s) this PR fixes:

No open issue matches this traceback, so there's nothing to close. For context:

- Discussion #6986 — maintainer note on self-hosted models and AI import reliability. A self-hosted
  OpenAI-compatible endpoint is what surfaced this, but the crash is a missing guard in Mealie: any
  provider returning a junk title should degrade gracefully.
- Issue #3505 — blank names via *manual* creation (a different code path). Relevant because a
  maintainer there suggested the empty-name case is best handled where slugs are created, since slugs
  already clean strings. That's the principle this follows.

## Special notes for your reviewer:

There's an existing string `recipe.import-errors.provider-returned-nothing` ("The AI provider did not
return a recipe"), and a reasonable objection is that a blank name means the provider failed, so the
user should get that error rather than a silent "New Recipe".

The argument for defaulting: the ingredients and instructions typically survive intact, so discarding
the whole import over a missing title throws away good data the user would have to re-import to
recover, and renaming is one click. Mealie also already defaults a blank name to "New Recipe"
elsewhere (`create_one` in the recipe repository, per #3505), so this is consistent with existing
behaviour rather than new precedent.

If you'd rather have the error path, the change is small either way — swap the fallback for a raised
import error using that existing string. Happy to do that instead.

## Testing

Seven unit tests covering: a normal name passing through with its expected slug; empty and
whitespace-only names; a punctuation-only name; an emoji-only name; a translated default; and a
stub translator returning an unsluggable string, which exercises the ASCII fallback.

Verified end to end as well, not just at the unit level: the stock 3.25.1 image reproduces the
traceback above, and with the patch applied the same input yields `name="New Recipe"`,
`slug="new-recipe"` with both ingredients and both instructions preserved — checked across en-US,
de-DE and fr-FR.

Full `tests/unit_tests` suite passes. Ruff (format + lint) and mypy are clean.

## AI / LLM Assistance

This PR was written by Claude Code (Claude Opus 5) working from my direction, and I've reviewed it
before submitting. The bug came from my own instance — a self-hosted OpenAI-compatible endpoint
returning a recipe with no title — and I supplied the traceback and the intended approach, including
the decision to scope the change to the import path rather than to `create_recipe_slug`. The
implementation, the tests, and the before/after verification against a real container were produced
in that session.
