### PR TITLE
fix: apply a submitted API key when updating an AI provider

### DIFF
--- a/mealie/repos/repository_ai_provider.py
+++ b/mealie/repos/repository_ai_provider.py
@@ -27,7 +27,11 @@ class GroupRepositoryAIProvider(GroupRepositoryGeneric[AIProviderOut, AIProvider
 
     def update(self, match_value: str | int | UUID4, new_data: AIProviderCreate | dict):
         if isinstance(new_data, AIProviderCreate):
+            # api_key is excluded from the schema's dump, so carry it over by hand, the same
+            # way create does. Without this every update looks like it omitted the key.
+            api_key = new_data.api_key
             new_data = new_data.model_dump()
+            new_data["api_key"] = api_key
 
         # Merge existing API key into new data
         if not new_data.get("api_key"):

--- a/tests/integration_tests/user_group_tests/test_group_ai_providers.py
+++ b/tests/integration_tests/user_group_tests/test_group_ai_providers.py
@@ -76,6 +76,53 @@ def test_update_provider(api_client: TestClient, unique_user: TestUser):
         api_client.delete(api_routes.groups_ai_providers_providers_provider_id(provider.id), headers=unique_user.token)
 
 
+def test_update_provider_rotates_the_api_key(api_client: TestClient, unique_user: TestUser):
+    """A submitted key must actually replace the stored one.
+
+    The key is write-only, so the response can't confirm this; read it back off the repository.
+    """
+    provider = unique_user.repos.group_ai_providers.create(
+        AIProviderCreate(name=random_string(), model="gpt-4o", api_key="original-key")
+    )
+
+    try:
+        response = api_client.put(
+            api_routes.groups_ai_providers_providers_provider_id(provider.id),
+            json={"name": provider.name, "model": provider.model, "apiKey": "rotated-key"},
+            headers=unique_user.token,
+        )
+        assert response.status_code == 200
+
+        stored = unique_user.repos.group_ai_providers.get_one(provider.id)
+        assert stored is not None
+        assert stored.api_key == "rotated-key"
+    finally:
+        api_client.delete(api_routes.groups_ai_providers_providers_provider_id(provider.id), headers=unique_user.token)
+
+
+def test_update_provider_without_an_api_key_keeps_the_stored_one(api_client: TestClient, unique_user: TestUser):
+    """Editing other fields must not wipe the key, since the client never receives it to resend."""
+
+    provider = unique_user.repos.group_ai_providers.create(
+        AIProviderCreate(name=random_string(), model="gpt-4o", api_key="original-key")
+    )
+
+    try:
+        response = api_client.put(
+            api_routes.groups_ai_providers_providers_provider_id(provider.id),
+            json={"name": provider.name, "model": "gpt-4-turbo"},
+            headers=unique_user.token,
+        )
+        assert response.status_code == 200
+        assert response.json()["model"] == "gpt-4-turbo"
+
+        stored = unique_user.repos.group_ai_providers.get_one(provider.id)
+        assert stored is not None
+        assert stored.api_key == "original-key"
+    finally:
+        api_client.delete(api_routes.groups_ai_providers_providers_provider_id(provider.id), headers=unique_user.token)
+
+
 def test_delete_provider(api_client: TestClient, unique_user: TestUser):
     provider = unique_user.repos.group_ai_providers.create(
         AIProviderCreate(name=random_string(), model="gpt-4o", api_key="test-key")


### PR DESCRIPTION
## What this PR does / why we need it:

An AI provider's API key can't be changed after the provider is created. Submitting a new key
appears to succeed — the update returns 200 and the other edited fields are saved — but the
provider keeps authenticating with its original key. The only way to correct a mistyped or
rotated key today is to delete the provider and create it again, and nothing in the UI or the
response indicates the submitted key was dropped.

`AIProviderCreate.api_key` is declared `Field("", exclude=True)`, so it is absent from
`model_dump()`. `GroupRepositoryAIProvider.update` dumps the schema and then treats the now-missing
key as "the client didn't send one", so its merge-the-stored-key branch fires on every update and
writes the old key back over the submitted one. `create` already works around the exclusion by
carrying the key across the dump by hand; this does the same in `update`.

- `mealie/repos/repository_ai_provider.py` — preserve `api_key` across `model_dump()` in `update`,
  mirroring what `create` does.
- `tests/integration_tests/user_group_tests/test_group_ai_providers.py` — two regression tests, one
  per branch of the merge behaviour.

Preserving the stored key when the update omits one is deliberate and unchanged: the key is
write-only, so `GroupAIProviderDialog` never receives it to send back, and leaving the field blank
while editing other fields must not wipe it.

No API, schema, or migration changes; the fix is three lines inside the repository.

## Which issue(s) this PR fixes:

No open issue that I could confirm matches this. #7957 ("Gemini OpenAI-compatible endpoint
authentication fails when using API key field") may share this root cause — if the reporter had
ever saved that provider and later corrected the key, they would have been authenticating with the
original value — but I haven't been able to verify that against their setup, so I'm not claiming it
closes that issue. Happy to add a `Fixes` line if a maintainer confirms the link.

## Special notes for your reviewer:

The write-once behaviour is easy to miss because it's invisible from the API surface — `api_key` is
excluded from every response, so no existing test could observe that the update was dropped. The new
tests read the key back off the repository rather than the response for that reason.

Introduced alongside the provider CRUD in #7650; this is not a regression from a recent change.

Worth deciding separately: `update` silently ignoring an unusable field is the kind of thing that
would be better caught at the schema boundary. I kept the fix minimal rather than reworking how
`exclude=True` interacts with the repository layer, but I'm happy to take that further if you'd
prefer a more structural fix.

## Testing

- `test_update_provider_rotates_the_api_key` — creates a provider, PUTs a new key, asserts the
  stored key changed. Fails on `mealie-next` without the fix, passes with it.
- `test_update_provider_without_an_api_key_keeps_the_stored_one` — PUTs an update with no key,
  asserts the original survives. Passes both with and without the fix; it guards the behaviour this
  change must not break.

Also ran the surrounding suites against the change: `tests/integration_tests/user_group_tests/test_group_ai_providers.py`,
`tests/integration_tests/admin_tests/test_admin_ai_providers.py`,
`tests/unit_tests/schema_tests/test_ai_providers.py` and
`tests/unit_tests/services_tests/test_openai_service.py` — all pass. Ruff (format + lint) and mypy
are clean.

## AI / LLM Assistance

This PR was written by Claude Code (Claude Opus 5) working from my direction, and I've reviewed it
before submitting. The bug was found while debugging a 401 from a self-hosted OpenAI-compatible
endpoint on my own instance: I kept re-entering the API key with no effect, and tracing the update
path through `repository_ai_provider.py` explained why. The diagnosis, the fix and the tests were
produced in that session; the failing-without-the-fix / passing-with-it check above was run to
confirm the tests actually exercise the bug rather than just passing.
