### PR TITLE
fix: skip mounted directories during backup restore

### DIFF
--- a/mealie/services/backups_v2/backup_v2.py
+++ b/mealie/services/backups_v2/backup_v2.py
@@ -77,15 +77,25 @@ class BackupV2(BaseService):
 
     def _copy_data(self, data_path: Path) -> None:
         for f in data_path.iterdir():
+            destination = self.directories.DATA_DIR / f.name
+
             if f.is_file():
                 if f.name not in self.RESTORE_FILES:
                     continue
 
-                shutil.copyfile(f, self.directories.DATA_DIR / f.name)
+                shutil.copyfile(f, destination)
                 continue
 
-            shutil.rmtree(self.directories.DATA_DIR / f.name)
-            shutil.copytree(f, self.directories.DATA_DIR / f.name)
+            if destination.is_mount():
+                self.logger.warning(
+                    f"Skipping mounted data directory during restore: {destination}"
+                )
+                continue
+
+            if destination.exists():
+                shutil.rmtree(destination)
+
+            shutil.copytree(f, destination)
 
         # since we copied a new .secret, AppSettings has the wrong secret info
         self.logger.info("invalidating appsettings cache")

--- a/tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py
+++ b/tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py
@@ -1,5 +1,7 @@
 import statistics
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
@@ -61,6 +63,24 @@ def test_database_restore():
 
     for s1, s2 in zip(snapshop_1, snapshop_2, strict=False):
         assert snapshop_1[s1].sort(key=dict_sorter) == snapshop_2[s2].sort(key=dict_sorter)
+
+
+def test_copy_data_skips_mounted_directories(tmp_path: Path):
+    backup_v2 = BackupV2()
+
+    source_dir = tmp_path / "source"
+    mounted_dir = source_dir / "mealie-pgdata"
+    mounted_dir.mkdir(parents=True)
+
+    with (
+        patch.object(Path, "is_mount", return_value=True),
+        patch("mealie.services.backups_v2.backup_v2.shutil.rmtree") as mock_rmtree,
+        patch("mealie.services.backups_v2.backup_v2.shutil.copytree") as mock_copytree,
+    ):
+        backup_v2._copy_data(source_dir)
+
+    mock_rmtree.assert_not_called()
+    mock_copytree.assert_not_called()
 
 
 def _5ab195a474eb_add_normalized_search_properties(session: Session):


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes #5524, where restoring a backup can fail when the backup contains a directory whose destination is a mounted directory inside Mealie's data directory.

The issue occurs in `BackupV2._copy_data()`. The original implementation removes each destination directory with `shutil.rmtree()` before copying the restored directory into place. If the destination is a mount point, such as `/app/data/mealie-pgdata`, attempting to remove it can raise:

`OSError: [Errno 16] Device or resource busy`

This interrupts the restore process and may leave the application in an inconsistent state because database restoration has already started before the data directory is restored.

Changes made in this PR:

* **`mealie/services/backups_v2/backup_v2.py`**

  * Creates the destination path once for each item being restored.
  * Checks `Path.is_mount()` before removing a destination directory.
  * Logs a warning and skips the directory if the destination is a mount point.
  * Only calls `shutil.rmtree()` when the non-mounted destination actually exists.
  * Keeps the existing restore behaviour for normal files and directories.

* **`tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py`**

  * Adds `test_copy_data_skips_mounted_directories`.
  * Simulates a mounted destination directory.
  * Verifies that mounted directories are neither removed with `shutil.rmtree()` nor overwritten with `shutil.copytree()`.

The mount-point check is based on the destination path rather than a specific directory name such as `mealie-pgdata`, so the protection also applies to other mounted directories that may exist inside the Mealie data directory.

## Which issue(s) this PR fixes:

Fixes #5524

## Special notes for your reviewer:

The main change is in `BackupV2._copy_data()`. In particular, review of the `Path.is_mount()` check and the decision to skip mounted destinations would be appreciated.

The intention is to keep this fix limited to preventing restore operations from deleting or overwriting mounted directories while preserving the existing behaviour for regular directories.

## Testing

A regression test, `test_copy_data_skips_mounted_directories`, was added to reproduce the relevant behaviour in isolation.

The test:

* creates a temporary backup data directory containing a directory representing `mealie-pgdata`;
* mocks `Path.is_mount()` so the corresponding destination is treated as a mount point;
* mocks `shutil.rmtree()` and `shutil.copytree()`;
* verifies that neither operation is performed on the mounted destination.

The regression test was first run against the original implementation. It failed as expected because the original code attempted to remove the mounted destination:

`AssertionError: Expected 'rmtree' to not have been called. Called 1 times.`

After applying the mount-point check, the same regression test passed:

`1 passed`

The complete `backup_v2` unit test file was also run to check for regressions in the existing backup and restore functionality:

`4 passed in 145.52s`

Tests were run using Python 3.12 and pytest 9.1.1 in the project's Docker/Linux environment.

## AI / LLM Assistance

AI/LLM assistance was used to help analyse the reported error, discuss possible implementation approaches

The code changes were reviewed locally, and the regression test and existing `backup_v2` tests were executed locally to verify the behaviour before submission.
