### PR TITLE
fix: get_empty()/merge() missing legacy cookbook/plan-rule checks for tags & categories

### DIFF
--- a/mealie/repos/repository_factory.py
+++ b/mealie/repos/repository_factory.py
@@ -26,14 +26,19 @@ from mealie.db.models.household.shopping_list import (
     ShoppingListRecipeReference,
 )
 from mealie.db.models.household.webhooks import GroupWebhooksModel
-from mealie.db.models.recipe.category import Category, recipes_to_categories
+from mealie.db.models.recipe.category import (
+    Category,
+    cookbooks_to_categories,
+    plan_rules_to_categories,
+    recipes_to_categories,
+)
 from mealie.db.models.recipe.comment import RecipeComment
 from mealie.db.models.recipe.ingredient import IngredientFoodModel, IngredientUnitModel
 from mealie.db.models.recipe.labels import MultiPurposeLabel
 from mealie.db.models.recipe.recipe import RecipeModel
 from mealie.db.models.recipe.recipe_timeline import RecipeTimelineEvent
 from mealie.db.models.recipe.shared import RecipeShareTokenModel
-from mealie.db.models.recipe.tag import Tag, recipes_to_tags
+from mealie.db.models.recipe.tag import Tag, cookbooks_to_tags, plan_rules_to_tags, recipes_to_tags
 from mealie.db.models.recipe.tool import Tool
 from mealie.db.models.users import LongLiveToken, User
 from mealie.db.models.users.password_reset import PasswordResetModel
@@ -101,24 +106,68 @@ class RepositoryCategories(GroupRepositoryGeneric[CategoryOut, Category]):
         return q.options(with_expression(Category.recipe_count, count_sq))
 
     def get_empty(self) -> Sequence[Category]:
-        stmt = select(Category).filter(~Category.recipes.any())
+        # a category is only "unused" if it's absent from recipes AND from cookbook filters
+        # AND from meal plan rules; Category has no ORM relationship to the cookbook/plan-rule
+        # join tables, so those are checked via EXISTS subqueries instead of .any()
+        used_in_cookbooks = (
+            select(cookbooks_to_categories.c.cookbook_id)
+            .where(cookbooks_to_categories.c.category_id == Category.id)
+            .correlate(Category)
+            .exists()
+        )
+        used_in_plan_rules = (
+            select(plan_rules_to_categories.c.group_plan_rule_id)
+            .where(plan_rules_to_categories.c.category_id == Category.id)
+            .correlate(Category)
+            .exists()
+        )
+        stmt = select(Category).filter(~Category.recipes.any(), ~used_in_cookbooks, ~used_in_plan_rules)
 
         return self.session.execute(stmt).scalars().all()
 
     def merge(self, from_category: UUID4, to_category: UUID4) -> CategoryOut | None:
-        already_in_to = select(recipes_to_categories.c.recipe_id).where(
+        already_in_to_recipes = select(recipes_to_categories.c.recipe_id).where(
             recipes_to_categories.c.category_id == to_category
+        )
+        already_in_to_cookbooks = select(cookbooks_to_categories.c.cookbook_id).where(
+            cookbooks_to_categories.c.category_id == to_category
+        )
+        already_in_to_plan_rules = select(plan_rules_to_categories.c.group_plan_rule_id).where(
+            plan_rules_to_categories.c.category_id == to_category
         )
 
         try:
             self.session.execute(
                 update(recipes_to_categories)
                 .where(recipes_to_categories.c.category_id == from_category)
-                .where(recipes_to_categories.c.recipe_id.not_in(already_in_to))
+                .where(recipes_to_categories.c.recipe_id.not_in(already_in_to_recipes))
                 .values(category_id=to_category)
             )
             self.session.execute(
                 delete(recipes_to_categories).where(recipes_to_categories.c.category_id == from_category)
+            )
+
+            # cookbook filters and meal plan rules also reference categories, so any row
+            # still pointing at from_category needs to move to to_category before from_category
+            # is deleted, de-duplicating against rows that already reference to_category
+            self.session.execute(
+                update(cookbooks_to_categories)
+                .where(cookbooks_to_categories.c.category_id == from_category)
+                .where(cookbooks_to_categories.c.cookbook_id.not_in(already_in_to_cookbooks))
+                .values(category_id=to_category)
+            )
+            self.session.execute(
+                delete(cookbooks_to_categories).where(cookbooks_to_categories.c.category_id == from_category)
+            )
+
+            self.session.execute(
+                update(plan_rules_to_categories)
+                .where(plan_rules_to_categories.c.category_id == from_category)
+                .where(plan_rules_to_categories.c.group_plan_rule_id.not_in(already_in_to_plan_rules))
+                .values(category_id=to_category)
+            )
+            self.session.execute(
+                delete(plan_rules_to_categories).where(plan_rules_to_categories.c.category_id == from_category)
             )
 
             from_model = self._query_one(from_category)
@@ -143,20 +192,55 @@ class RepositoryTags(GroupRepositoryGeneric[TagOut, Tag]):
         return q.options(with_expression(Tag.recipe_count, count_sq))
 
     def get_empty(self) -> Sequence[Tag]:
-        stmt = select(Tag).filter(~Tag.recipes.any())
+        # a tag is only "unused" if it's absent from recipes AND from cookbook filters AND
+        # from meal plan rules; Tag has no ORM relationship to the cookbook/plan-rule join
+        # tables, so those are checked via EXISTS subqueries instead of .any()
+        used_in_cookbooks = (
+            select(cookbooks_to_tags.c.cookbook_id).where(cookbooks_to_tags.c.tag_id == Tag.id).correlate(Tag).exists()
+        )
+        used_in_plan_rules = (
+            select(plan_rules_to_tags.c.plan_rule_id)
+            .where(plan_rules_to_tags.c.tag_id == Tag.id)
+            .correlate(Tag)
+            .exists()
+        )
+        stmt = select(Tag).filter(~Tag.recipes.any(), ~used_in_cookbooks, ~used_in_plan_rules)
         return self.session.execute(stmt).scalars().all()
 
     def merge(self, from_tag: UUID4, to_tag: UUID4) -> TagOut | None:
-        already_in_to = select(recipes_to_tags.c.recipe_id).where(recipes_to_tags.c.tag_id == to_tag)
+        already_in_to_recipes = select(recipes_to_tags.c.recipe_id).where(recipes_to_tags.c.tag_id == to_tag)
+        already_in_to_cookbooks = select(cookbooks_to_tags.c.cookbook_id).where(cookbooks_to_tags.c.tag_id == to_tag)
+        already_in_to_plan_rules = select(plan_rules_to_tags.c.plan_rule_id).where(
+            plan_rules_to_tags.c.tag_id == to_tag
+        )
 
         try:
             self.session.execute(
                 update(recipes_to_tags)
                 .where(recipes_to_tags.c.tag_id == from_tag)
-                .where(recipes_to_tags.c.recipe_id.not_in(already_in_to))
+                .where(recipes_to_tags.c.recipe_id.not_in(already_in_to_recipes))
                 .values(tag_id=to_tag)
             )
             self.session.execute(delete(recipes_to_tags).where(recipes_to_tags.c.tag_id == from_tag))
+
+            # cookbook filters and meal plan rules also reference tags, so any row still
+            # pointing at from_tag needs to move to to_tag before from_tag is deleted,
+            # de-duplicating against rows that already reference to_tag
+            self.session.execute(
+                update(cookbooks_to_tags)
+                .where(cookbooks_to_tags.c.tag_id == from_tag)
+                .where(cookbooks_to_tags.c.cookbook_id.not_in(already_in_to_cookbooks))
+                .values(tag_id=to_tag)
+            )
+            self.session.execute(delete(cookbooks_to_tags).where(cookbooks_to_tags.c.tag_id == from_tag))
+
+            self.session.execute(
+                update(plan_rules_to_tags)
+                .where(plan_rules_to_tags.c.tag_id == from_tag)
+                .where(plan_rules_to_tags.c.plan_rule_id.not_in(already_in_to_plan_rules))
+                .values(tag_id=to_tag)
+            )
+            self.session.execute(delete(plan_rules_to_tags).where(plan_rules_to_tags.c.tag_id == from_tag))
 
             from_model = self._query_one(from_tag)
             self.session.delete(from_model)

--- a/tests/integration_tests/category_tag_tool_tests/test_organizers_legacy_filter_references.py
+++ b/tests/integration_tests/category_tag_tool_tests/test_organizers_legacy_filter_references.py
@@ -1,0 +1,301 @@
+"""
+Integration tests for:
+- GET /organizers/categories/empty, GET /organizers/tags/empty
+- POST /organizers/categories/merge, POST /organizers/tags/merge
+
+Categories and tags can also be referenced by two legacy join tables that have no ORM
+relationship configured on the Category/Tag models and no FK ondelete cascade:
+cookbooks_to_{categories,tags} (cookbook filters) and plan_rules_to_{categories,tags}
+(meal plan rules). Deleting a category/tag with rows in either table raises a
+ForeignKeyViolation, same failure mode as the food/shopping-list-item bug.
+
+These join tables are populated only by the deprecated `categories`/`tags` relationships on
+CookBook/GroupMealPlanRules - the current API (query_filter_string) never writes them - so
+existing rows can only come from data created before that migration. To exercise this path,
+the tests insert rows into the join tables directly via the ORM session instead of the API.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy import insert, select
+from sqlalchemy.orm import Session
+
+from mealie.db.models.recipe.category import cookbooks_to_categories, plan_rules_to_categories
+from mealie.db.models.recipe.tag import cookbooks_to_tags, plan_rules_to_tags
+from tests.utils import api_routes
+from tests.utils.factories import random_string
+from tests.utils.fixture_schemas import TestUser
+
+CATEGORIES_MERGE = "/api/organizers/categories/merge"
+TAGS_MERGE = "/api/organizers/tags/merge"
+
+
+def _create_category(api_client: TestClient, user: TestUser) -> dict:
+    response = api_client.post(api_routes.organizers_categories, json={"name": random_string(10)}, headers=user.token)
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_tag(api_client: TestClient, user: TestUser) -> dict:
+    response = api_client.post(api_routes.organizers_tags, json={"name": random_string(10)}, headers=user.token)
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_cookbook(api_client: TestClient, user: TestUser) -> dict:
+    response = api_client.post(api_routes.households_cookbooks, json={"name": random_string(10)}, headers=user.token)
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_plan_rule(api_client: TestClient, user: TestUser) -> dict:
+    response = api_client.post(
+        api_routes.households_mealplans_rules,
+        json={"day": "unset", "entryType": "unset"},
+        headers=user.token,
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _link_cookbook_to_category(session: Session, cookbook_id: str, category_id: str) -> None:
+    session.execute(insert(cookbooks_to_categories).values(cookbook_id=cookbook_id, category_id=category_id))
+    session.commit()
+
+
+def _link_cookbook_to_tag(session: Session, cookbook_id: str, tag_id: str) -> None:
+    session.execute(insert(cookbooks_to_tags).values(cookbook_id=cookbook_id, tag_id=tag_id))
+    session.commit()
+
+
+def _link_plan_rule_to_category(session: Session, plan_rule_id: str, category_id: str) -> None:
+    session.execute(insert(plan_rules_to_categories).values(group_plan_rule_id=plan_rule_id, category_id=category_id))
+    session.commit()
+
+
+def _link_plan_rule_to_tag(session: Session, plan_rule_id: str, tag_id: str) -> None:
+    session.execute(insert(plan_rules_to_tags).values(plan_rule_id=plan_rule_id, tag_id=tag_id))
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Categories — empty / direct delete
+# ---------------------------------------------------------------------------
+
+
+def test_category_empty_excludes_category_used_by_cookbook_filter(api_client: TestClient, unique_user: TestUser):
+    category = _create_category(api_client, unique_user)
+    cookbook = _create_cookbook(api_client, unique_user)
+    _link_cookbook_to_category(unique_user.repos.session, cookbook["id"], category["id"])
+
+    response = api_client.get(api_routes.organizers_categories_empty, headers=unique_user.token)
+    assert response.status_code == 200
+    ids = [c["id"] for c in response.json()]
+    assert category["id"] not in ids
+
+    # a direct delete attempt must fail cleanly (not an unhandled 500)
+    delete_response = api_client.delete(
+        api_routes.organizers_categories_item_id(category["id"]), headers=unique_user.token
+    )
+    assert delete_response.status_code < 500
+
+    unique_user.repos.session.execute(
+        cookbooks_to_categories.delete().where(cookbooks_to_categories.c.cookbook_id == cookbook["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_cookbooks_item_id(cookbook["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_categories_item_id(category["id"]), headers=unique_user.token)
+
+
+def test_category_empty_excludes_category_used_by_plan_rule(api_client: TestClient, unique_user: TestUser):
+    category = _create_category(api_client, unique_user)
+    plan_rule = _create_plan_rule(api_client, unique_user)
+    _link_plan_rule_to_category(unique_user.repos.session, plan_rule["id"], category["id"])
+
+    response = api_client.get(api_routes.organizers_categories_empty, headers=unique_user.token)
+    assert response.status_code == 200
+    ids = [c["id"] for c in response.json()]
+    assert category["id"] not in ids
+
+    delete_response = api_client.delete(
+        api_routes.organizers_categories_item_id(category["id"]), headers=unique_user.token
+    )
+    assert delete_response.status_code < 500
+
+    unique_user.repos.session.execute(
+        plan_rules_to_categories.delete().where(plan_rules_to_categories.c.group_plan_rule_id == plan_rule["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_mealplans_rules_item_id(plan_rule["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_categories_item_id(category["id"]), headers=unique_user.token)
+
+
+# ---------------------------------------------------------------------------
+# Tags — empty / direct delete
+# ---------------------------------------------------------------------------
+
+
+def test_tag_empty_excludes_tag_used_by_cookbook_filter(api_client: TestClient, unique_user: TestUser):
+    tag = _create_tag(api_client, unique_user)
+    cookbook = _create_cookbook(api_client, unique_user)
+    _link_cookbook_to_tag(unique_user.repos.session, cookbook["id"], tag["id"])
+
+    response = api_client.get(api_routes.organizers_tags_empty, headers=unique_user.token)
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()]
+    assert tag["id"] not in ids
+
+    delete_response = api_client.delete(api_routes.organizers_tags_item_id(tag["id"]), headers=unique_user.token)
+    assert delete_response.status_code < 500
+
+    unique_user.repos.session.execute(
+        cookbooks_to_tags.delete().where(cookbooks_to_tags.c.cookbook_id == cookbook["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_cookbooks_item_id(cookbook["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_tags_item_id(tag["id"]), headers=unique_user.token)
+
+
+def test_tag_empty_excludes_tag_used_by_plan_rule(api_client: TestClient, unique_user: TestUser):
+    tag = _create_tag(api_client, unique_user)
+    plan_rule = _create_plan_rule(api_client, unique_user)
+    _link_plan_rule_to_tag(unique_user.repos.session, plan_rule["id"], tag["id"])
+
+    response = api_client.get(api_routes.organizers_tags_empty, headers=unique_user.token)
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()]
+    assert tag["id"] not in ids
+
+    delete_response = api_client.delete(api_routes.organizers_tags_item_id(tag["id"]), headers=unique_user.token)
+    assert delete_response.status_code < 500
+
+    unique_user.repos.session.execute(
+        plan_rules_to_tags.delete().where(plan_rules_to_tags.c.plan_rule_id == plan_rule["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_mealplans_rules_item_id(plan_rule["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_tags_item_id(tag["id"]), headers=unique_user.token)
+
+
+# ---------------------------------------------------------------------------
+# Categories — merge
+# ---------------------------------------------------------------------------
+
+
+def test_category_merge_reassigns_cookbook_filter_and_dedupes_overlap(api_client: TestClient, unique_user: TestUser):
+    from_cat = _create_category(api_client, unique_user)
+    to_cat = _create_category(api_client, unique_user)
+    cookbook = _create_cookbook(api_client, unique_user)
+
+    # one cookbook already references both, to exercise the de-duplication path
+    _link_cookbook_to_category(unique_user.repos.session, cookbook["id"], from_cat["id"])
+    _link_cookbook_to_category(unique_user.repos.session, cookbook["id"], to_cat["id"])
+
+    response = api_client.post(
+        CATEGORIES_MERGE, json={"fromId": from_cat["id"], "toId": to_cat["id"]}, headers=unique_user.token
+    )
+    assert response.status_code == 200
+
+    rows = unique_user.repos.session.execute(
+        select(cookbooks_to_categories.c.category_id).where(cookbooks_to_categories.c.cookbook_id == cookbook["id"])
+    ).all()
+    category_ids = [str(r[0]) for r in rows]
+    assert category_ids.count(to_cat["id"]) == 1
+    assert from_cat["id"] not in category_ids
+
+    unique_user.repos.session.execute(
+        cookbooks_to_categories.delete().where(cookbooks_to_categories.c.cookbook_id == cookbook["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_cookbooks_item_id(cookbook["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_categories_item_id(to_cat["id"]), headers=unique_user.token)
+
+
+def test_category_merge_reassigns_plan_rule_and_dedupes_overlap(api_client: TestClient, unique_user: TestUser):
+    from_cat = _create_category(api_client, unique_user)
+    to_cat = _create_category(api_client, unique_user)
+    plan_rule = _create_plan_rule(api_client, unique_user)
+
+    _link_plan_rule_to_category(unique_user.repos.session, plan_rule["id"], from_cat["id"])
+    _link_plan_rule_to_category(unique_user.repos.session, plan_rule["id"], to_cat["id"])
+
+    response = api_client.post(
+        CATEGORIES_MERGE, json={"fromId": from_cat["id"], "toId": to_cat["id"]}, headers=unique_user.token
+    )
+    assert response.status_code == 200
+
+    rows = unique_user.repos.session.execute(
+        select(plan_rules_to_categories.c.category_id).where(
+            plan_rules_to_categories.c.group_plan_rule_id == plan_rule["id"]
+        )
+    ).all()
+    category_ids = [str(r[0]) for r in rows]
+    assert category_ids.count(to_cat["id"]) == 1
+    assert from_cat["id"] not in category_ids
+
+    unique_user.repos.session.execute(
+        plan_rules_to_categories.delete().where(plan_rules_to_categories.c.group_plan_rule_id == plan_rule["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_mealplans_rules_item_id(plan_rule["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_categories_item_id(to_cat["id"]), headers=unique_user.token)
+
+
+# ---------------------------------------------------------------------------
+# Tags — merge
+# ---------------------------------------------------------------------------
+
+
+def test_tag_merge_reassigns_cookbook_filter_and_dedupes_overlap(api_client: TestClient, unique_user: TestUser):
+    from_tag = _create_tag(api_client, unique_user)
+    to_tag = _create_tag(api_client, unique_user)
+    cookbook = _create_cookbook(api_client, unique_user)
+
+    _link_cookbook_to_tag(unique_user.repos.session, cookbook["id"], from_tag["id"])
+    _link_cookbook_to_tag(unique_user.repos.session, cookbook["id"], to_tag["id"])
+
+    response = api_client.post(
+        TAGS_MERGE, json={"fromId": from_tag["id"], "toId": to_tag["id"]}, headers=unique_user.token
+    )
+    assert response.status_code == 200
+
+    rows = unique_user.repos.session.execute(
+        select(cookbooks_to_tags.c.tag_id).where(cookbooks_to_tags.c.cookbook_id == cookbook["id"])
+    ).all()
+    tag_ids = [str(r[0]) for r in rows]
+    assert tag_ids.count(to_tag["id"]) == 1
+    assert from_tag["id"] not in tag_ids
+
+    unique_user.repos.session.execute(
+        cookbooks_to_tags.delete().where(cookbooks_to_tags.c.cookbook_id == cookbook["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_cookbooks_item_id(cookbook["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_tags_item_id(to_tag["id"]), headers=unique_user.token)
+
+
+def test_tag_merge_reassigns_plan_rule_and_dedupes_overlap(api_client: TestClient, unique_user: TestUser):
+    from_tag = _create_tag(api_client, unique_user)
+    to_tag = _create_tag(api_client, unique_user)
+    plan_rule = _create_plan_rule(api_client, unique_user)
+
+    _link_plan_rule_to_tag(unique_user.repos.session, plan_rule["id"], from_tag["id"])
+    _link_plan_rule_to_tag(unique_user.repos.session, plan_rule["id"], to_tag["id"])
+
+    response = api_client.post(
+        TAGS_MERGE, json={"fromId": from_tag["id"], "toId": to_tag["id"]}, headers=unique_user.token
+    )
+    assert response.status_code == 200
+
+    rows = unique_user.repos.session.execute(
+        select(plan_rules_to_tags.c.tag_id).where(plan_rules_to_tags.c.plan_rule_id == plan_rule["id"])
+    ).all()
+    tag_ids = [str(r[0]) for r in rows]
+    assert tag_ids.count(to_tag["id"]) == 1
+    assert from_tag["id"] not in tag_ids
+
+    unique_user.repos.session.execute(
+        plan_rules_to_tags.delete().where(plan_rules_to_tags.c.plan_rule_id == plan_rule["id"])
+    )
+    unique_user.repos.session.commit()
+    api_client.delete(api_routes.households_mealplans_rules_item_id(plan_rule["id"]), headers=unique_user.token)
+    api_client.delete(api_routes.organizers_tags_item_id(to_tag["id"]), headers=unique_user.token)


### PR DESCRIPTION

## What this PR does / why we need it:

Fixes a gap in `get_empty()` and `merge()` for Tags and Categories: both only ever checked recipe associations, but tags/categories can also be referenced by two legacy join tables with no `ondelete` cascade and no ORM relationship configured — `cookbooks_to_{categories,tags}` and `plan_rules_to_{categories,tags}`.

As a result:
- **Delete Unused** could offer a tag/category as "unused" (since it correctly had zero recipe associations) even though it was still referenced by a cookbook filter or meal plan rule — attempting the delete then failed with a raw `ForeignKeyViolation` `IntegrityError`.
- **Merge** only reassigned the recipes association table from `from_id` to `to_id`, leaving any cookbook filter or meal plan rule still pointing at the now-deleted `from_id`.

Fixed both:
- `get_empty()` now also excludes tags/categories referenced by either join table, via `EXISTS` subqueries (no ORM relationship exists to reuse `.has()`/`.any()` here, unlike the recipes association).
- `merge()` now reassigns `cookbook_id`/`plan_rule_id` rows from `from_id` to `to_id` in both join tables before deleting `from_id`, de-duplicating against rows that already reference `to_id` — same pattern already used for the recipes association table.

**Scope note:** these join tables are only populated by the deprecated `categories`/`tags` fields on `CookBook`/`GroupMealPlanRules`; current API schemas (`CreateCookBook`, `PlanRulesCreate`) only expose `query_filter_string`. So this only affects installs with pre-migration data still sitting in those tables, not anything created through the current API. Direct delete (outside Delete Unused) already failed cleanly with a 400/409, not an unhandled 500 — this fix makes Delete Unused and merge correctly account for these references instead of surfacing a raw database error.

Found while fixing an analogous gap in `RepositoryFood.get_empty()` (foods vs. shopping list items) in #8225.

## Which issue(s) this PR fixes:

N/A — no tracked issue; found during work on #8225.

## Special notes for your reviewer:

This is a fix to code from #7829, unrelated to the currently-open #8225 — opened as its own PR to keep scope separate, per the project's one-PR-at-a-time preference. Currently opened as a draft since I'm at my open-PR limit; happy to mark ready for review once a slot frees up, or sooner if you'd like to look at it now regardless.

## Testing:

- `DB_ENGINE=sqlite uv run pytest` — full suite, 2709 passed, 16 skipped (expected: long-running scraper/parser tests, LDAP tests requiring an external service).
- New test file `test_organizers_legacy_filter_references.py` (8 tests) covering, for both Tags and Categories: `get_empty()` correctly excludes items referenced by a cookbook filter or plan rule, direct delete of such an item fails cleanly (not a 500) when still referenced, and merge correctly reassigns cookbook/plan-rule references to the target with overlap de-duplication. Since the current API can't create these legacy rows anymore, tests insert them directly via the test session.

## AI / LLM Assistance:

Claude Code was used to generate the implementation, following the existing pattern used for the recipes association table in the same repo methods. All code was reviewed, and I ran the full test suite myself.