### PR TITLE
fix: prevent stale recipe edits from overwriting newer changes

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeImageUploadBtn.vue
@@ -81,6 +81,7 @@
 </template>
 
 <script setup lang="ts">
+import { useImageEdit } from "~/composables/recipe-page/use-image-edit";
 import { alert } from "~/composables/use-toast";
 import { useUserApi } from "~/composables/api";
 
@@ -98,6 +99,7 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const api = useUserApi();
+const editImage = useImageEdit();
 
 const url = ref("");
 const loading = ref(false);
@@ -112,7 +114,8 @@ function uploadImage(fileObject: File) {
 async function deleteImage() {
   loading.value = true;
   try {
-    await api.recipes.deleteImage(props.slug);
+    const result = await editImage(config => api.recipes.deleteImage(props.slug, config));
+    if (!result || result.error) return;
     emit(DELETE_EVENT);
     menu.value = false;
   }
@@ -127,7 +130,8 @@ async function deleteImage() {
 
 async function getImageFromURL() {
   loading.value = true;
-  const { data } = await api.recipes.updateImagebyURL(props.slug, url.value);
+  const result = await editImage(config => api.recipes.updateImagebyURL(props.slug, url.value, config));
+  const data = result?.data;
   if (data?.image) {
     emit(REFRESH_EVENT, data.image);
   }

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -14,6 +14,9 @@
         {{ $t("general.discard-changes-description") }}
       </v-card-text>
     </BaseDialog>
+    <v-alert v-if="saveConflict" type="warning" role="alert" class="mb-4">
+      {{ $t("recipe.edit-conflict") }}
+    </v-alert>
     <RecipePageParseDialog
       :model-value="isParsing"
       :ingredients="recipe.recipeIngredient"
@@ -224,6 +227,7 @@ import type { ComponentPublicInstance } from "vue";
 import { invoke, until } from "@vueuse/core";
 import type { RouteLocationNormalized } from "vue-router";
 import RecipeIngredients from "../RecipeIngredients.vue";
+import { createImageEdit, imageEditKey } from "~/composables/recipe-page/use-image-edit";
 import RecipePageEditorToolbar from "./RecipePageParts/RecipePageEditorToolbar.vue";
 import RecipePageFooter from "./RecipePageParts/RecipePageFooter.vue";
 import RecipePageHeader from "./RecipePageParts/RecipePageHeader.vue";
@@ -302,6 +306,9 @@ onUnmounted(() => toolbarObserver?.disconnect());
  */
 const originalRecipe = ref<Recipe | null>(null);
 const discardDialog = ref(false);
+const saveConflict = ref(false);
+const saving = ref(false);
+provide(imageEditKey, createImageEdit({ recipe, originalRecipe, saving, saveConflict }));
 const pendingRoute = ref<RouteLocationNormalized | null>(null);
 
 invoke(async () => {
@@ -419,7 +426,24 @@ watch(isParsing, () => {
  */
 
 async function saveRecipe() {
-  const { data, error } = await api.recipes.updateOne(recipe.value.slug, recipe.value);
+  if (saving.value) return false;
+  saving.value = true;
+  saveConflict.value = false;
+  let result;
+  try {
+    result = await api.recipes.updateOne(originalRecipe.value?.id ?? recipe.value.slug, {
+      ...recipe.value,
+      updatedAt: originalRecipe.value?.updatedAt,
+    }, { suppressErrorAlertStatuses: [409] });
+  }
+  finally {
+    saving.value = false;
+  }
+  const { data, error } = result;
+  if (error) {
+    saveConflict.value = error.response?.status === 409;
+    return false;
+  }
   if (!error) {
     if (data?.slug && data.slug !== route.params.slug) {
       isNavigatingAfterRename.value = true;
@@ -433,12 +457,13 @@ async function saveRecipe() {
       router.replace(`/g/${groupSlug.value}/r/` + data.slug);
     }
   }
+  return true;
 }
 
 async function saveParsedIngredients(ingredients: NoUndefinedField<RecipeIngredient[]>) {
   const returnToEdit = isEditMode.value;
   recipe.value.recipeIngredient = ingredients;
-  await saveRecipe();
+  if (!await saveRecipe()) return;
   toggleIsParsing(false);
   if (returnToEdit) {
     setMode(PageMode.EDIT);

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageEditorToolbar.vue
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useImageEdit } from "~/composables/recipe-page/use-image-edit";
 import { usePageState, usePageUser } from "~/composables/recipe-page/shared-state";
 import type { NoUndefinedField } from "~/lib/api/types/non-generated";
 import type { Recipe } from "~/lib/api/types/recipe";
@@ -51,6 +52,7 @@ const recipe = defineModel<NoUndefinedField<Recipe>>({ required: true });
 
 const { user } = usePageUser();
 const api = useUserApi();
+const editImage = useImageEdit();
 const { imageKey } = usePageState(recipe.value.slug);
 
 const canEditOwner = computed(() => {
@@ -73,7 +75,7 @@ async function uploadImage(fileObject: File) {
   if (!recipe.value || !recipe.value.slug) {
     return;
   }
-  const newVersion = await api.recipes.updateImage(recipe.value.slug, fileObject);
+  const newVersion = await editImage(config => api.recipes.updateImage(recipe.value.slug, fileObject, config));
   if (newVersion?.data?.image) {
     recipe.value.image = newVersion.data.image;
   }

--- a/frontend/app/composables/recipe-page/use-image-edit.test.ts
+++ b/frontend/app/composables/recipe-page/use-image-edit.test.ts
@@ -1,0 +1,52 @@
+import { ref } from "vue";
+import type { AxiosResponse } from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { createImageEdit } from "./use-image-edit";
+import type { Recipe } from "~/lib/api/types/recipe";
+
+function state() {
+  return {
+    recipe: ref({ updatedAt: "old", description: "unsaved draft" } as Recipe),
+    originalRecipe: ref<Recipe | null>({ updatedAt: "old", description: "original" } as Recipe),
+    saving: ref(false),
+    saveConflict: ref(false),
+  };
+}
+
+describe("image edits during a recipe edit", () => {
+  it("sends the original version and adopts only the response version without replacing the draft", async () => {
+    const s = state();
+    const response = { headers: { "x-recipe-updated-at": "new" } } as AxiosResponse;
+    const request = vi.fn().mockResolvedValue({ data: { image: "image" }, error: null, response });
+    await createImageEdit(s)(request);
+    expect(request).toHaveBeenCalledWith({ headers: { "X-Recipe-Updated-At": "old" }, suppressErrorAlertStatuses: [409] });
+    expect(s.originalRecipe.value?.updatedAt).toBe("new");
+    expect(s.recipe.value.updatedAt).toBe("new");
+    expect(s.recipe.value.description).toBe("unsaved draft");
+    expect(s.saving.value).toBe(false);
+  });
+
+  it("keeps the draft and version and exposes a conflict for a rejected request", async () => {
+    const s = state();
+    await createImageEdit(s)(vi.fn().mockResolvedValue({ data: null, response: null, error: { response: { status: 409 } } }));
+    expect(s.saveConflict.value).toBe(true);
+    expect(s.originalRecipe.value?.updatedAt).toBe("old");
+    expect(s.recipe.value.description).toBe("unsaved draft");
+    expect(s.saving.value).toBe(false);
+  });
+
+  it("does not start a second write while saving", async () => {
+    const s = state();
+    s.saving.value = true;
+    const request = vi.fn();
+    await createImageEdit(s)(request);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("releases the saving flag after a transport exception", async () => {
+    const s = state();
+    await expect(createImageEdit(s)(vi.fn().mockRejectedValue(new Error("offline")))).rejects.toThrow("offline");
+    expect(s.saving.value).toBe(false);
+    expect(s.originalRecipe.value?.updatedAt).toBe("old");
+  });
+});

--- a/frontend/app/composables/recipe-page/use-image-edit.ts
+++ b/frontend/app/composables/recipe-page/use-image-edit.ts
@@ -1,0 +1,45 @@
+import { inject } from "vue";
+import type { InjectionKey, Ref } from "vue";
+import type { AxiosRequestConfig } from "axios";
+import type { RequestResponse } from "~/lib/api/types/non-generated";
+import type { Recipe } from "~/lib/api/types/recipe";
+
+export type ImageEdit = <T>(request: (config?: AxiosRequestConfig) => Promise<RequestResponse<T>>) => Promise<RequestResponse<T> | undefined>;
+export const imageEditKey: InjectionKey<ImageEdit> = Symbol("recipe-image-edit");
+
+export function createImageEdit({ recipe, originalRecipe, saving, saveConflict }: {
+  recipe: Ref<Recipe>;
+  originalRecipe: Ref<Recipe | null>;
+  saving: Ref<boolean>;
+  saveConflict: Ref<boolean>;
+}): ImageEdit {
+  return async (request) => {
+    if (saving.value) return;
+    saving.value = true;
+    saveConflict.value = false;
+    try {
+      const result = await request({
+        headers: { "X-Recipe-Updated-At": originalRecipe.value?.updatedAt },
+        suppressErrorAlertStatuses: [409],
+      });
+      if (result.error) {
+        saveConflict.value = result.error.response?.status === 409;
+      }
+      else {
+        const timestamp = result.response?.headers["x-recipe-updated-at"];
+        if (typeof timestamp === "string" && originalRecipe.value) {
+          originalRecipe.value.updatedAt = timestamp;
+          recipe.value.updatedAt = timestamp;
+        }
+      }
+      return result;
+    }
+    finally {
+      saving.value = false;
+    }
+  };
+}
+
+export function useImageEdit(): ImageEdit {
+  return inject(imageEditKey, request => request());
+}

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -405,6 +405,7 @@
     "an-error-occurred": "An error occurred"
   },
   "recipe": {
+    "edit-conflict": "This recipe has been updated elsewhere. Your changes have not been saved. Copy your changes, then refresh to load the latest version.",
     "add-to-favorites": "Add to Favorites",
     "api-extras": "API Extras",
     "calories": "Calories",

--- a/frontend/app/lib/api/user/recipes/recipe.ts
+++ b/frontend/app/lib/api/user/recipes/recipe.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from "axios";
 import { SSE } from "sse.js";
 import type { ReadyStateEvent, SSEvent } from "sse.js";
 import { BaseCRUDAPI } from "../../base/base-clients";
@@ -130,20 +131,20 @@ export class RecipeAPI extends BaseCRUDAPI<CreateRecipe, Recipe, Recipe> {
     return await this.requests.post<RecipeAsset>(routes.recipesRecipeSlugAssets(recipeSlug), formData);
   }
 
-  updateImage(slug: string, fileObject: File) {
+  updateImage(slug: string, fileObject: File, config?: AxiosRequestConfig) {
     const formData = new FormData();
     formData.append("image", fileObject);
     formData.append("extension", fileObject.name.split(".").pop() ?? "");
 
-    return this.requests.put<UpdateImageResponse, FormData>(routes.recipesRecipeSlugImage(slug), formData);
+    return this.requests.put<UpdateImageResponse, FormData>(routes.recipesRecipeSlugImage(slug), formData, config);
   }
 
-  updateImagebyURL(slug: string, url: string) {
-    return this.requests.post<UpdateImageResponse>(routes.recipesRecipeSlugImage(slug), { url });
+  updateImagebyURL(slug: string, url: string, config?: AxiosRequestConfig) {
+    return this.requests.post<UpdateImageResponse>(routes.recipesRecipeSlugImage(slug), { url }, config);
   }
 
-  deleteImage(slug: string) {
-    return this.requests.delete<string>(routes.recipesRecipeSlugImage(slug));
+  deleteImage(slug: string, config?: AxiosRequestConfig) {
+    return this.requests.delete<string>(routes.recipesRecipeSlugImage(slug), config);
   }
 
   async testCreateOneUrl(url: string, useOpenAI = false) {

--- a/frontend/app/plugins/axios.ts
+++ b/frontend/app/plugins/axios.ts
@@ -7,6 +7,7 @@ import { isSafeRedirectTarget } from "~/lib/validators/redirect";
 declare module "axios" {
   interface AxiosRequestConfig {
     suppressAlert?: boolean;
+    suppressErrorAlertStatuses?: number[];
   }
 }
 
@@ -95,7 +96,8 @@ export default defineNuxtPlugin((nuxtApp) => {
         }
       }
 
-      if (error?.response?.data?.detail?.message) {
+      const suppressed = error.config?.suppressErrorAlertStatuses?.includes(error.response?.status);
+      if (error?.response?.data?.detail?.message && !suppressed) {
         alert.error(error.response.data.detail.message as string);
       };
 

--- a/mealie/core/exceptions.py
+++ b/mealie/core/exceptions.py
@@ -22,6 +22,10 @@ class PermissionDenied(Exception):
     pass
 
 
+class RecipeEditConflict(Exception):
+    """The recipe changed since the client read it."""
+
+
 class RecursiveRecipe(Exception):
     """
     This exception is raised when a recipe references itself, either directly or indirectly.

--- a/mealie/repos/repository_recipes.py
+++ b/mealie/repos/repository_recipes.py
@@ -1,6 +1,7 @@
 import re as re
-from collections.abc import Iterable, Sequence
-from datetime import UTC, datetime
+from collections.abc import Generator, Iterable, Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
 from typing import Self
 from uuid import UUID
 
@@ -8,6 +9,7 @@ import sqlalchemy as sa
 from pydantic import UUID4
 from sqlalchemy.exc import IntegrityError
 
+from mealie.core.exceptions import RecipeEditConflict
 from mealie.db.models.household import Household, HouseholdToRecipe
 from mealie.db.models.recipe.category import Category
 from mealie.db.models.recipe.ingredient import RecipeIngredientModel, RecipeIngredientSubstitutionModel
@@ -196,21 +198,76 @@ class RepositoryRecipes(RecipeSuggestionMixin, HouseholdRepositoryGeneric[Recipe
         additional_ids = self.session.execute(sa.select(model.id).filter(model.slug.in_(slugs))).scalars().all()
         return ids + additional_ids
 
-    def update(self, match_value: str | int | UUID4, new_data: dict | Recipe) -> Recipe:
-        new_data = new_data if isinstance(new_data, dict) else new_data.model_dump()
+    @contextmanager
+    def update_transaction(self) -> Generator[None, None, None]:
+        """Keep bulk recipe writes in a single transaction."""
+        previous = self.session.info.get("defer_recipe_commit", False)
+        self.session.info["defer_recipe_commit"] = True
+        try:
+            yield
+            if not previous:
+                self.session.commit()
+        except Exception:
+            self.session.rollback()
+            raise
+        finally:
+            self.session.info["defer_recipe_commit"] = previous
+
+    def reserve_update(self, match_value: str | int | UUID4, expected: datetime | None = None) -> datetime:
+        """Compare-and-swap before changing any recipe content or relationships.
+
+        Missing preconditions retain legacy API behavior. Supplied timestamps are
+        always enforced, including for PATCH and bulk updates.
+        """
         entry = self._query_one(match_value=match_value)
+        previous = entry.update_at
+        timestamp = datetime.now(UTC)
+        if previous is not None:
+            timestamp = max(timestamp, previous + timedelta(microseconds=1))
+        expected = expected if expected is not None else previous
+        result = self.session.execute(
+            sa.update(RecipeModel)
+            .where(
+                RecipeModel.id == entry.id, RecipeModel.group_id == entry.group_id, RecipeModel.update_at == expected
+            )
+            .values(update_at=timestamp)
+            .execution_options(synchronize_session=False)
+        )
+        if result.rowcount != 1:
+            raise RecipeEditConflict()
+        # Keep the ORM flush from replacing our reserved timestamp via onupdate.
+        entry.update_at = timestamp
+        return timestamp
 
-        if new_name := new_data.get("name"):
-            new_data["slug"] = entry.slug if new_name == entry.name else create_recipe_slug(new_name)
+    def update(self, match_value: str | int | UUID4, new_data: dict | Recipe) -> Recipe:
+        new_data = dict(new_data) if isinstance(new_data, dict) else new_data.model_dump()
+        entry = self._query_one(match_value=match_value)
+        expected = new_data.pop("updated_at", None)
+        try:
+            timestamp = self.reserve_update(match_value, expected)
+        except Exception:
+            self.session.rollback()
+            raise
+        new_data["update_at"] = timestamp
 
-        # Handle explicit group_id injection for related items that require it
-        for organizer_field in ["tags", "recipe_category", "tools"]:
-            for organizer in new_data.get(organizer_field, []):
-                organizer["group_id"] = self.group_id
+        try:
+            if new_name := new_data.get("name"):
+                new_data["slug"] = entry.slug if new_name == entry.name else create_recipe_slug(new_name)
 
-        entry.update(session=self.session, **new_data)
-        self.session.commit()
-        return self.schema.model_validate(entry)
+            # Handle explicit group_id injection for related items that require it
+            for organizer_field in ["tags", "recipe_category", "tools"]:
+                for organizer in new_data.get(organizer_field, []):
+                    organizer["group_id"] = self.group_id
+
+            entry.update(session=self.session, **new_data)
+            self.session.flush()
+            result = self.schema.model_validate(entry)
+            if not self.session.info.get("defer_recipe_commit", False):
+                self.session.commit()
+            return result
+        except Exception:
+            self.session.rollback()
+            raise
 
     def page_all(  # type: ignore
         self,

--- a/mealie/routes/recipe/recipe_crud_routes.py
+++ b/mealie/routes/recipe/recipe_crud_routes.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections import defaultdict
 from collections.abc import AsyncIterable, Awaitable, Callable
+from datetime import datetime
 from shutil import copyfileobj
 from typing import Annotated
 from uuid import UUID
@@ -13,10 +14,12 @@ from fastapi import (
     Depends,
     File,
     Form,
+    Header,
     HTTPException,
     Path,
     Query,
     Request,
+    Response,
     status,
 )
 from fastapi.datastructures import UploadFile
@@ -28,7 +31,6 @@ from mealie.core import exceptions
 from mealie.core.dependencies import (
     get_temporary_zip_path,
 )
-from mealie.pkgs import cache
 from mealie.repos.all_repositories import get_repositories
 from mealie.routes._base import controller
 from mealie.routes._base.routers import MealieCrudRoute, UserAPIRouter
@@ -94,6 +96,14 @@ class RecipeController(BaseRecipeController):
     def handle_exceptions(self, ex: Exception) -> None:
         thrownType = type(ex)
 
+        if thrownType == exceptions.RecipeEditConflict:
+            self.session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=ErrorResponse.respond(
+                    message="This recipe has been updated. Copy your changes, then refresh before saving."
+                ),
+            )
         if thrownType == exceptions.PermissionDenied:
             self.logger.error("Permission Denied on recipe controller action")
             raise HTTPException(
@@ -641,9 +651,13 @@ class RecipeController(BaseRecipeController):
         updated_by_group_and_household: defaultdict[UUID4, defaultdict[UUID4, list[Recipe]]] = defaultdict(
             lambda: defaultdict(list)
         )
-        for recipe in data:
-            r = self.service.update_one(recipe.id, recipe)  # type: ignore
-            updated_by_group_and_household[r.group_id][r.household_id].append(r)
+        try:
+            with self.group_recipes.update_transaction():
+                for recipe in data:
+                    r = self.service.update_one(recipe.id, recipe)  # type: ignore
+                    updated_by_group_and_household[r.group_id][r.household_id].append(r)
+        except Exception as e:
+            self.handle_exceptions(e)
 
         all_updated: list[Recipe] = []
         if updated_by_group_and_household:
@@ -689,9 +703,13 @@ class RecipeController(BaseRecipeController):
         updated_by_group_and_household: defaultdict[UUID4, defaultdict[UUID4, list[Recipe]]] = defaultdict(
             lambda: defaultdict(list)
         )
-        for recipe in data:
-            r = self.service.patch_one(recipe.id, recipe)  # type: ignore
-            updated_by_group_and_household[r.group_id][r.household_id].append(r)
+        try:
+            with self.group_recipes.update_transaction():
+                for recipe in data:
+                    r = self.service.patch_one(recipe.id, recipe)  # type: ignore
+                    updated_by_group_and_household[r.group_id][r.household_id].append(r)
+        except Exception as e:
+            self.handle_exceptions(e)
 
         all_updated: list[Recipe] = []
         if updated_by_group_and_household:
@@ -756,8 +774,20 @@ class RecipeController(BaseRecipeController):
     # Image and Assets
 
     @router.post("/{slug}/image", response_model=UpdateImageResponse, tags=["Recipe: Images and Assets"])
-    async def scrape_image_url(self, slug: str, url: ScrapeRecipe):
-        recipe = self.mixins.get_one(slug)
+    async def scrape_image_url(
+        self,
+        slug: str,
+        url: ScrapeRecipe,
+        response: Response,
+        expected: datetime | None = Header(None, alias="X-Recipe-Updated-At"),
+    ):
+        recipe = self.service.get_one(slug)
+        if not self.service.can_update([recipe.slug]):
+            self.handle_exceptions(exceptions.PermissionDenied())
+        try:
+            timestamp = self.group_recipes.reserve_update(slug, expected)
+        except Exception as e:
+            self.handle_exceptions(e)
         data_service = RecipeDataService(recipe.id)
 
         try:
@@ -781,23 +811,43 @@ class RecipeController(BaseRecipeController):
                 detail=ErrorResponse.respond("Image could not be downloaded"),
             )
 
-        recipe.image = cache.cache_key.new_key()
-        self.service.update_one(recipe.slug, recipe)
-        return UpdateImageResponse(image=recipe.image)
+        image = self.group_recipes.update_image(recipe.slug)
+        response.headers["X-Recipe-Updated-At"] = timestamp.isoformat()
+        return UpdateImageResponse(image=image)
 
     @router.put("/{slug}/image", response_model=UpdateImageResponse, tags=["Recipe: Images and Assets"])
-    def update_recipe_image(self, slug: str, image: bytes = File(...), extension: str = Form(...)):
+    def update_recipe_image(
+        self,
+        slug: str,
+        response: Response,
+        image: bytes = File(...),
+        extension: str = Form(...),
+        expected: datetime | None = Header(None, alias="X-Recipe-Updated-At"),
+    ):
         try:
+            if not self.service.can_update([slug]):
+                raise exceptions.PermissionDenied()
+            timestamp = self.group_recipes.reserve_update(slug, expected)
             new_version = self.service.update_recipe_image(slug, image, extension)
+            response.headers["X-Recipe-Updated-At"] = timestamp.isoformat()
             return UpdateImageResponse(image=new_version)
         except Exception as e:
             self.handle_exceptions(e)
             return None
 
     @router.delete("/{slug}/image", tags=["Recipe: Images and Assets"])
-    def delete_recipe_image(self, slug: str):
+    def delete_recipe_image(
+        self,
+        slug: str,
+        response: Response,
+        expected: datetime | None = Header(None, alias="X-Recipe-Updated-At"),
+    ):
         try:
+            if not self.service.can_update([slug]):
+                raise exceptions.PermissionDenied()
+            timestamp = self.group_recipes.reserve_update(slug, expected)
             self.service.delete_recipe_image(slug)
+            response.headers["X-Recipe-Updated-At"] = timestamp.isoformat()
             return SuccessResponse.respond(message=self.t("recipe.recipe-image-deleted"))
         except Exception as e:
             self.handle_exceptions(e)

--- a/tests/integration_tests/user_recipe_tests/test_recipe_edit_conflicts.py
+++ b/tests/integration_tests/user_recipe_tests/test_recipe_edit_conflicts.py
@@ -1,0 +1,146 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.utils import api_routes
+from tests.utils.factories import random_string
+from tests.utils.fixture_schemas import TestUser
+
+
+def create_recipe(client: TestClient, user: TestUser) -> dict:
+    response = client.post(api_routes.recipes, json={"name": random_string()}, headers=user.token)
+    assert response.status_code == 201
+    return client.get(api_routes.recipes_slug(response.json()), headers=user.token).json()
+
+
+@pytest.mark.parametrize("method", ["put", "patch"])
+def test_stale_recipe_edit(api_client: TestClient, unique_user: TestUser, method: str):
+    original = create_recipe(api_client, unique_user)
+    url = api_routes.recipes_slug(original["slug"])
+    first = deepcopy(original)
+    first["description"] = "first editor"
+    saved = getattr(api_client, method)(url, json=first, headers=unique_user.token)
+    assert saved.status_code == 200
+    assert saved.json()["updatedAt"] != original["updatedAt"]
+    stale = deepcopy(original)
+    stale["description"] = "stale editor"
+    rejected = getattr(api_client, method)(url, json=stale, headers=unique_user.token)
+    assert rejected.status_code == 409
+    current = api_client.get(url, headers=unique_user.token).json()
+    assert current["description"] == "first editor"
+    assert current["updatedAt"] == saved.json()["updatedAt"]
+    current["description"] = "refreshed editor"
+    assert getattr(api_client, method)(url, json=current, headers=unique_user.token).status_code == 200
+
+
+@pytest.mark.parametrize("method", ["put", "patch"])
+def test_legacy_updates_without_timestamp(api_client: TestClient, unique_user: TestUser, method: str):
+    original = create_recipe(api_client, unique_user)
+    payload = deepcopy(original)
+    payload.pop("updatedAt")
+    payload["description"] = "legacy client"
+    response = getattr(api_client, method)(
+        api_routes.recipes_slug(original["slug"]), json=payload, headers=unique_user.token
+    )
+    assert response.status_code == 200
+    assert response.json()["updatedAt"] != original["updatedAt"]
+
+
+@pytest.mark.parametrize("method", ["put", "patch"])
+def test_bulk_conflict_rolls_back(api_client: TestClient, unique_user: TestUser, method: str):
+    first = create_recipe(api_client, unique_user)
+    second = create_recipe(api_client, unique_user)
+    changed = deepcopy(second)
+    changed["description"] = "already updated"
+    assert (
+        api_client.put(api_routes.recipes_slug(second["slug"]), json=changed, headers=unique_user.token).status_code
+        == 200
+    )
+    first_change = deepcopy(first)
+    first_change["description"] = "must roll back"
+    response = getattr(api_client, method)(api_routes.recipes, json=[first_change, second], headers=unique_user.token)
+    assert response.status_code == 409
+    after = api_client.get(api_routes.recipes_slug(first["slug"]), headers=unique_user.token).json()
+    assert after["description"] == first["description"]
+    assert after["updatedAt"] == first["updatedAt"]
+
+
+def test_image_version_and_stale_delete(api_client: TestClient, unique_user: TestUser):
+    original = create_recipe(api_client, unique_user)
+    url = api_routes.recipes_slug(original["slug"])
+    headers = {**unique_user.token, "X-Recipe-Updated-At": original["updatedAt"]}
+    deleted = api_client.delete(url + "/image", headers=headers)
+    assert deleted.status_code == 200
+    timestamp = deleted.headers["X-Recipe-Updated-At"]
+    current = api_client.get(url, headers=unique_user.token).json()
+    from datetime import datetime
+
+    assert datetime.fromisoformat(timestamp) == datetime.fromisoformat(current["updatedAt"])
+    assert api_client.delete(url + "/image", headers=headers).status_code == 409
+    current["description"] = "save after own image edit"
+    current["updatedAt"] = timestamp
+    assert api_client.put(url, json=current, headers=unique_user.token).status_code == 200
+
+
+def test_relationship_only_edit_advances_time(api_client: TestClient, unique_user: TestUser):
+    recipe = create_recipe(api_client, unique_user)
+    response = api_client.patch(
+        api_routes.recipes_slug(recipe["slug"]),
+        headers=unique_user.token,
+        json={"updatedAt": recipe["updatedAt"], "notes": [{"title": "Note", "text": "New note"}]},
+    )
+    assert response.status_code == 200
+    assert response.json()["updatedAt"] != recipe["updatedAt"]
+
+
+def test_simultaneous_edit_only_one_wins(api_client: TestClient, unique_user: TestUser, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    from mealie.app import app
+    from mealie.repos.repository_recipes import RepositoryRecipes
+
+    original = create_recipe(api_client, unique_user)
+    barrier = Barrier(2)
+    reserve = RepositoryRecipes.reserve_update
+
+    def synchronized_reserve(self, match_value, expected=None):
+        barrier.wait(timeout=10)
+        return reserve(self, match_value, expected)
+
+    monkeypatch.setattr(RepositoryRecipes, "reserve_update", synchronized_reserve)
+
+    def save(description):
+        payload = {**original, "description": description}
+        with TestClient(app) as client:
+            return client.put(api_routes.recipes_slug(original["slug"]), headers=unique_user.token, json=payload)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(save, ["editor A", "editor B"]))
+    assert sorted(response.status_code for response in responses) == [200, 409]
+    winner = next(response.json() for response in responses if response.status_code == 200)
+    actual = api_client.get(api_routes.recipes_slug(original["slug"]), headers=unique_user.token).json()
+    assert actual["description"] == winner["description"]
+    assert actual["updatedAt"] == winner["updatedAt"]
+
+
+def test_image_upload_returns_exact_version(api_client: TestClient, unique_user: TestUser, test_image_jpg):
+    recipe = create_recipe(api_client, unique_user)
+    url = api_routes.recipes_slug(recipe["slug"])
+    headers = {**unique_user.token, "X-Recipe-Updated-At": recipe["updatedAt"]}
+    response = api_client.put(
+        url + "/image",
+        headers=headers,
+        data={"extension": "jpg"},
+        files={"image": ("test.jpg", test_image_jpg.read_bytes(), "image/jpeg")},
+    )
+    assert response.status_code == 200
+    current = api_client.get(url, headers=unique_user.token).json()
+    from datetime import datetime
+
+    assert datetime.fromisoformat(response.headers["X-Recipe-Updated-At"]) == datetime.fromisoformat(
+        current["updatedAt"]
+    )
+    assert api_client.delete(url + "/image", headers=headers).status_code == 409
+    assert api_client.get(url, headers=unique_user.token).json()["image"] == current["image"]


### PR DESCRIPTION
## What this PR does / why we need it:

When two users edit the same recipe, a later save can silently overwrite changes saved by the other user. This PR adds timestamp-based optimistic concurrency checks.

- `repository_recipes.py`: atomically checks `updatedAt` before updating a recipe and rolls back bulk updates if a conflict occurs.
- `exceptions.py` and `recipe_crud_routes.py`: introduce a recipe conflict exception, return HTTP 409, and support timestamp preconditions for image operations.
- `RecipePage.vue`: submits the original timestamp and preserves unsaved drafts when saving fails.
- `use-image-edit.ts`, image components, and the recipe API client: coordinate image updates with the editor’s timestamp without replacing its draft.
- `axios.ts` and `en-US.json`: display a persistent conflict warning and suppress the duplicate toast for handled 409 responses.
- Backend and frontend tests cover stale updates, bulk rollback, concurrent requests, and image-edit version handling.

The implementation uses the existing update timestamp, so no database migration or additional dependency is required.
<img width="865" height="604" alt="图片" src="https://github.com/user-attachments/assets/ac6e550d-9e88-4b4d-90a4-30ac7e2fd4b0" />

## Which issue(s) this PR fixes:

Related to #6633.

## Special notes for your reviewer:

Feedback would be particularly useful on the concurrency contract and backward compatibility:

- Clients that omit timestamps retain existing behavior and are not protected against stale writes.
- Saving unchanged content still advances the timestamp and can cause another editor’s save to conflict.
- Image downloads hold a database write transaction; the performance implications should be reviewed.

## Testing

- Passed 71 backend tests across the recipe CRUD, image assets, and new conflict test modules using an isolated Linux container with SQLite.
- Concurrent API requests using the same timestamp resulted in one successful save and one HTTP 409 response.
- Passed four frontend tests covering image-edit timestamp synchronization, draft preservation, duplicate-request prevention, and error recovery.
- Passed Ruff, targeted ESLint checks, and `git diff --check`.
- Successfully generated the production frontend using Node.js 24 and pnpm.
- Manually tested two browser sessions in Docker and observed a stale save returning HTTP 409 after the other session saved.

## AI / LLM Assistance

GPT-6 assisted with implementation, regression tests, and this PR description. I reviewed the AI-generated implementation and code, manually reproduced the issue, and tested the two-user editing scenario in Docker.