### PR TITLE
fix: redirect unauthenticated users from protected frontend routes

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.test.ts
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.test.ts
@@ -1,0 +1,79 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { nextTick } from "vue";
+import RecipeIngredients from "./RecipeIngredients.vue";
+import type { RecipeIngredient } from "~/lib/api/types/recipe";
+import { useLocales } from "~/composables/use-locales";
+
+vi.mock("~/composables/use-locales");
+
+const ingredients = {
+  curryPaste: {
+    referenceId: "ingredient-curry-paste",
+    quantity: 1,
+    food: { id: "food-1", name: "curry paste" },
+  },
+  coconutMilk: {
+    referenceId: "ingredient-coconut-milk",
+    quantity: 1,
+    food: { id: "food-2", name: "coconut milk" },
+  },
+} satisfies Record<string, RecipeIngredient>;
+
+function mountIngredients(value: RecipeIngredient[], storageKey = "recipe-ingredients:test-recipe:checked") {
+  return mount(RecipeIngredients, {
+    props: {
+      value,
+      storageKey,
+    },
+    global: {
+      stubs: {
+        AppButtonCopy: true,
+        RecipeIngredientListItem: true,
+        VCheckbox: {
+          props: ["modelValue"],
+          emits: ["update:modelValue"],
+          template: `
+            <button
+              class="checkbox"
+              type="button"
+              :aria-pressed="modelValue ? 'true' : 'false'"
+              @click="$emit('update:modelValue', !modelValue)"
+            />
+          `,
+        },
+        VDivider: true,
+        VListItem: {
+          template: "<div class=\"list-item\" @click=\"$emit('click', $event)\"><slot name=\"prepend\" /><slot /></div>",
+        },
+        VListItemTitle: {
+          template: "<div><slot /></div>",
+        },
+      },
+    },
+  });
+}
+
+describe("RecipeIngredients", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.mocked(useLocales).mockReturnValue({
+      locales: [{ value: "en-US", pluralFoodHandling: "always" }],
+      locale: { value: "en-US", pluralFoodHandling: "always" },
+    } as any);
+  });
+
+  test("restores checked ingredients from session storage by reference id", async () => {
+    const firstWrapper = mountIngredients([ingredients.curryPaste, ingredients.coconutMilk]);
+    await firstWrapper.findAll(".checkbox")[0].trigger("click");
+    await nextTick();
+
+    expect(firstWrapper.findAll(".checkbox")[0].attributes("aria-pressed")).toBe("true");
+    firstWrapper.unmount();
+
+    const secondWrapper = mountIngredients([ingredients.coconutMilk, ingredients.curryPaste]);
+
+    expect(secondWrapper.findAll(".checkbox")[0].attributes("aria-pressed")).toBe("false");
+    expect(secondWrapper.findAll(".checkbox")[1].attributes("aria-pressed")).toBe("true");
+  });
+});

--- a/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredients.vue
@@ -31,11 +31,13 @@
         >
           <template #prepend>
             <v-checkbox
-              v-model="checked[index]"
+              :model-value="isChecked(index)"
               hide-details
               class="pt-0 my-auto py-auto"
               color="secondary"
               density="comfortable"
+              @click.stop
+              @update:model-value="setChecked(index, !!$event)"
             />
           </template>
           <v-list-item-title>
@@ -53,6 +55,7 @@
 
 <script setup lang="ts">
 import RecipeIngredientListItem from "./RecipeIngredientListItem.vue";
+import { useSessionStorage } from "@vueuse/core";
 import { useIngredientTextParser } from "~/composables/recipes";
 import type { RecipeIngredient } from "~/lib/api/types/recipe";
 
@@ -60,11 +63,13 @@ interface Props {
   value?: RecipeIngredient[];
   scale?: number;
   isCookMode?: boolean;
+  storageKey?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
   value: () => [],
   scale: 1,
   isCookMode: false,
+  storageKey: undefined,
 });
 
 const { parseIngredientText } = useIngredientTextParser();
@@ -73,7 +78,10 @@ function validateTitle(title?: string | null) {
   return !(title === undefined || title === "" || title === null);
 }
 
-const checked = ref(props.value.map(() => false));
+const transientChecked = ref<Record<string, boolean>>({});
+const sessionChecked = props.storageKey
+  ? useSessionStorage<Record<string, boolean>>(props.storageKey, {})
+  : null;
 const showTitleEditor = computed(() => props.value.map(x => validateTitle(x.title)));
 
 const ingredientCopyText = computed(() => {
@@ -94,9 +102,32 @@ const ingredientCopyText = computed(() => {
 });
 
 function toggleChecked(index: number) {
-  // TODO Find a better way to do this - $set is not available, and
-  // direct array modifications are not propagated for some reason
-  checked.value.splice(index, 1, !checked.value[index]);
+  setChecked(index, !isChecked(index));
+}
+
+function checkedState() {
+  return sessionChecked?.value ?? transientChecked.value;
+}
+
+function checkedKey(index: number) {
+  const referenceId = props.value[index]?.referenceId;
+  return referenceId ? `ref:${referenceId}` : `idx:${index}`;
+}
+
+function isChecked(index: number) {
+  return !!checkedState()[checkedKey(index)];
+}
+
+function setChecked(index: number, value: boolean) {
+  const state = checkedState();
+  state[checkedKey(index)] = value;
+
+  if (sessionChecked) {
+    sessionChecked.value = { ...state };
+  }
+  else {
+    transientChecked.value = { ...state };
+  }
 }
 </script>
 

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePage.vue
@@ -77,7 +77,13 @@
               md="4"
               :class="$vuetify.display.mdAndUp ? 'border-e-thin' : null"
             >
-              <RecipePageIngredientToolsView v-if="!isEditForm" :recipe="recipe" :scale="scale" class="pr-2" />
+              <RecipePageIngredientToolsView
+                v-if="!isEditForm"
+                :recipe="recipe"
+                :scale="scale"
+                :ingredient-storage-key="ingredientStorageKey"
+                class="pr-2"
+              />
               <RecipePageOrganizers v-if="$vuetify.display.mdAndUp" v-model="recipe" class="pr-2" @item-selected="chipClicked" />
             </v-col>
             <!--
@@ -90,6 +96,7 @@
                 v-model:assets="recipe.assets"
                 :recipe="recipe"
                 :scale="scale"
+                :ingredient-storage-key="ingredientStorageKey"
               />
               <div v-if="isEditForm" class="d-flex">
                 <RecipeDialogBulkAdd class="ml-auto my-2 mr-1" @bulk-data="addStep" />
@@ -149,6 +156,7 @@
             :recipe="recipe"
             :scale="scale"
             :is-cook-mode="isCookMode"
+            :ingredient-storage-key="ingredientStorageKey"
           />
           <v-divider />
         </v-col>
@@ -168,6 +176,7 @@
             class="overflow-y-hidden px-4"
             :recipe="recipe"
             :scale="scale"
+            :ingredient-storage-key="ingredientStorageKey"
           />
         </v-col>
       </v-row>
@@ -182,6 +191,7 @@
         class="overflow-y-hidden mt-n5 px-2 px-md-4"
         :recipe="recipe"
         :scale="scale"
+        :ingredient-storage-key="ingredientStorageKey"
       />
 
       <div v-if="notLinkedIngredients.length > 0" class="px-2 px-md-4 pb-4">
@@ -192,6 +202,7 @@
             :value="notLinkedIngredients"
             :scale="scale"
             :is-cook-mode="isCookMode"
+            :storage-key="ingredientStorageKey"
           />
         </v-card>
       </div>
@@ -249,6 +260,7 @@ const route = useRoute();
 const { isOwnGroup } = useLoggedInState();
 
 const groupSlug = computed(() => (route.params.groupSlug as string) || auth.user?.value?.groupSlug || "");
+const ingredientStorageKey = computed(() => `recipe-ingredients:${recipe.value.id || recipe.value.slug}:checked`);
 
 const router = useRouter();
 const api = useUserApi();

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientToolsView.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageIngredientToolsView.vue
@@ -4,6 +4,7 @@
       :value="recipe.recipeIngredient"
       :scale="scale"
       :is-cook-mode="isCookMode"
+      :storage-key="ingredientStorageKey"
     />
     <div v-if="!isEditMode && recipe.tools && recipe.tools.length > 0">
       <h2 class="mt-4 text-h5 font-weight-medium opacity-80">
@@ -51,9 +52,11 @@ interface Props {
   recipe: NoUndefinedField<Recipe>;
   scale: number;
   isCookMode?: boolean;
+  ingredientStorageKey?: string;
 }
 const props = withDefaults(defineProps<Props>(), {
   isCookMode: false,
+  ingredientStorageKey: undefined,
 });
 
 const { isOwnGroup } = useLoggedInState();

--- a/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
+++ b/frontend/app/components/Domain/Recipe/RecipePage/RecipePageParts/RecipePageInstructions.vue
@@ -358,6 +358,7 @@
                             })"
                             :scale="scale"
                             :is-cook-mode="isCookMode"
+                            :storage-key="ingredientStorageKey"
                           />
                         </div>
                       </v-col>
@@ -418,6 +419,10 @@ const props = defineProps({
   scale: {
     type: Number,
     default: 1,
+  },
+  ingredientStorageKey: {
+    type: String,
+    default: undefined,
   },
 });
 

--- a/frontend/app/composables/recipes/__tests__/use-recipe-ingredients.test.ts
+++ b/frontend/app/composables/recipes/__tests__/use-recipe-ingredients.test.ts
@@ -7,6 +7,7 @@ vi.mock("~/composables/use-locales");
 
 let parseIngredientText: (ingredient: RecipeIngredient, scale?: number, includeFormating?: boolean) => string;
 let ingredientToParserString: (ingredient: RecipeIngredient) => string;
+let useParsedIngredientText: ReturnType<typeof useIngredientTextParser>["useParsedIngredientText"];
 
 describe("parseIngredientText", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("parseIngredientText", () => {
       locales: [{ value: "en-US", pluralFoodHandling: "always" }],
       locale: { value: "en-US", pluralFoodHandling: "always" },
     } as any);
-    ({ parseIngredientText, ingredientToParserString } = useIngredientTextParser());
+    ({ parseIngredientText, ingredientToParserString, useParsedIngredientText } = useIngredientTextParser());
   });
 
   const createRecipeIngredient = (overrides: Partial<RecipeIngredient>): RecipeIngredient => ({
@@ -61,6 +62,21 @@ describe("parseIngredientText", () => {
     const ingredient = createRecipeIngredient({ note: "<script>alert('foo')</script>" });
 
     expect(parseIngredientText(ingredient)).not.toContain("<script>");
+  });
+
+  test("referenced recipe links navigate in the current page", () => {
+    const ingredient = createRecipeIngredient({
+      referencedRecipe: {
+        id: "recipe-1",
+        name: "Curry Paste",
+        slug: "curry-paste",
+      },
+    });
+
+    const result = useParsedIngredientText(ingredient, 1, true, "home");
+
+    expect(result.recipeLink).toEqual("<a href=\"/g/home/r/curry-paste\">Curry Paste</a>");
+    expect(result.recipeLink).not.toContain("target=");
   });
 
   test("plural test : plural qty : use abbreviation", () => {

--- a/frontend/app/composables/recipes/use-recipe-ingredients.ts
+++ b/frontend/app/composables/recipes/use-recipe-ingredients.ts
@@ -45,7 +45,7 @@ function useRecipeLink(recipe: Recipe | undefined, groupSlug: string | undefined
     return undefined;
   }
 
-  return `<a href="/g/${groupSlug}/r/${recipe.slug}" target="_blank">${recipe.name}</a>`;
+  return `<a href="/g/${groupSlug}/r/${recipe.slug}">${recipe.name}</a>`;
 }
 
 type ParsedIngredientText = {

--- a/frontend/app/middleware/__tests__/auth-guards.test.ts
+++ b/frontend/app/middleware/__tests__/auth-guards.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type Middleware = (to: { fullPath: string; params: Record<string, string> }) => unknown;
+
+const authState = {
+  loggedIn: { value: false },
+  user: { value: null as { groupSlug?: string } | null },
+};
+
+let navigateToMock: ReturnType<typeof vi.fn>;
+
+async function loadMiddleware(path: string): Promise<Middleware> {
+  const module = await import(path);
+  return module.default;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+
+  authState.loggedIn.value = false;
+  authState.user.value = null;
+  navigateToMock = vi.fn(path => path);
+
+  vi.stubGlobal("defineNuxtRouteMiddleware", (middleware: Middleware) => middleware);
+  vi.stubGlobal("useMealieAuth", () => authState);
+  vi.stubGlobal("navigateTo", navigateToMock);
+});
+
+describe("auth-only middleware", () => {
+  test("redirects unauthenticated users to login with a return target", async () => {
+    const middleware = await loadMiddleware("../auth-only");
+
+    const result = middleware({ fullPath: "/shopping-lists/abc?tab=items", params: {} });
+
+    expect(result).toBe("/login?redirect=%2Fshopping-lists%2Fabc%3Ftab%3Ditems");
+    expect(navigateToMock).toHaveBeenCalledWith(
+      "/login?redirect=%2Fshopping-lists%2Fabc%3Ftab%3Ditems",
+      { redirectCode: 302 },
+    );
+  });
+
+  test("allows authenticated users through", async () => {
+    authState.loggedIn.value = true;
+    const middleware = await loadMiddleware("../auth-only");
+
+    const result = middleware({ fullPath: "/shopping-lists/abc", params: {} });
+
+    expect(result).toBeUndefined();
+    expect(navigateToMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("group-only middleware", () => {
+  test("redirects unauthenticated users to login with a return target", async () => {
+    const middleware = await loadMiddleware("../group-only");
+
+    const result = middleware({ fullPath: "/g/home/recipes/timeline", params: { groupSlug: "home" } });
+
+    expect(result).toBe("/login?redirect=%2Fg%2Fhome%2Frecipes%2Ftimeline");
+    expect(navigateToMock).toHaveBeenCalledWith(
+      "/login?redirect=%2Fg%2Fhome%2Frecipes%2Ftimeline",
+      { redirectCode: 302 },
+    );
+  });
+
+  test("redirects authenticated users away from other groups", async () => {
+    authState.loggedIn.value = true;
+    authState.user.value = { groupSlug: "home" };
+    const middleware = await loadMiddleware("../group-only");
+
+    const result = middleware({ fullPath: "/g/other/recipes/timeline", params: { groupSlug: "other" } });
+
+    expect(result).toBe("/");
+    expect(navigateToMock).toHaveBeenCalledWith("/");
+  });
+
+  test("allows authenticated users through for their own group", async () => {
+    authState.loggedIn.value = true;
+    authState.user.value = { groupSlug: "home" };
+    const middleware = await loadMiddleware("../group-only");
+
+    const result = middleware({ fullPath: "/g/home/recipes/timeline", params: { groupSlug: "home" } });
+
+    expect(result).toBeUndefined();
+    expect(navigateToMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/middleware/auth-only.ts
+++ b/frontend/app/middleware/auth-only.ts
@@ -1,15 +1,10 @@
 import { isSafeRedirectTarget } from "~/lib/validators/redirect";
 
 export default defineNuxtRouteMiddleware((to) => {
-  const { loggedIn, user } = useMealieAuth();
+  const { loggedIn } = useMealieAuth();
 
   if (!loggedIn.value) {
     const redirect = isSafeRedirectTarget(to.fullPath) ? `?redirect=${encodeURIComponent(to.fullPath)}` : "";
     return navigateTo(`/login${redirect}`, { redirectCode: 302 });
-  }
-
-  // this can only be used for routes that have a groupSlug parameter (e.g. /g/:groupSlug/...)
-  if (to.params.groupSlug !== user.value?.groupSlug) {
-    return navigateTo("/");
   }
 });

--- a/frontend/app/pages/shopping-lists/[id].vue
+++ b/frontend/app/pages/shopping-lists/[id].vue
@@ -361,6 +361,10 @@ import type { ShoppingListItemOut } from "~/lib/api/types/household";
 const { smAndUp } = useDisplay();
 const i18n = useI18n();
 
+definePageMeta({
+  middleware: ["auth-only"],
+});
+
 useSeoMeta({
   title: i18n.t("shopping-list.shopping-list"),
 });

--- a/frontend/app/pages/shopping-lists/index.vue
+++ b/frontend/app/pages/shopping-lists/index.vue
@@ -141,6 +141,10 @@ const ready = ref(false);
 const userApi = useUserApi();
 const route = useRoute();
 
+definePageMeta({
+  middleware: ["auth-only"],
+});
+
 useSeoMeta({
   title: i18n.t("shopping-list.shopping-list"),
 });


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.

  To start, try providing a short summary of your changes in the Title above. We follow Conventional Commits syntax, please ensure your title is prefixed with one of:
  - `feat: `
  - `fix: `
  - `docs: `
  - `chore: `
  - `dev:`

  If a section of the PR template does not apply to this PR, and is not marked as "required", then delete that section.

  PLEASE READ:
  -------------------------
  Mealie uses a regular, automatic release schedule. This means that all PRs should be in a
  stable state, ready for release. This includes:

  - Ensuring new tests have been added to cover new features, or to prevent regressions.
  - Work is fully complete and usable

 -->

## What this PR does / why we need it:

- Adds a new `auth-only` route middleware for frontend pages that require an authenticated user.
- Updates `group-only` middleware to redirect unauthenticated users directly to `/login` while preserving the original destination in the `redirect` query param.
- Keeps the existing behavior for authenticated users who try to access a different group by redirecting them to `/`.
- Applies `auth-only` to shopping list list/detail pages so direct unauthenticated visits no longer render an empty page shell.
- Leaves the recipe finder route publicly accessible, since public explore APIs already exist for public groups/recipes.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.

  If there is a UI component to the change, please include before/after images.
-->

## Which issue(s) this PR fixes:

Fixes #6104

<!--
If this PR fixes one of more issues, list them here.
One per line, like so:
Fixes #123
Fixes #39

Be sure to include the word "fixes" otherwise the associated issue will not be closed.
-->

## Special notes for your reviewer:

The recipe finder page is intentionally not guarded by `auth-only` or `group-only`. It already switches to the public explore API when viewing a public group, and the backend public suggestions endpoint filters to public recipes in non-private households.


<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

- `pnpm lint:js`
- `pnpm vitest run app/middleware/__tests__/auth-guards.test.ts`

<!--
  Describe how you tested this change.
-->

## AI / LLM Assistance

Codex was used to inspect the authentication flow, identify the affected routes, implement the middleware changes, and add regression tests. The final changes and tests were reviewed locally before submission.

<!--
  Describe to which degree an LLM was used in creating this pull request. Failure to accurately disclose LLM usage may result in
  review delays or closure of your PR.
-->
