### PR TITLE
fix: reset upload loading state after file picker closes

### DIFF
--- a/frontend/app/components/global/AppButtonUpload.test.ts
+++ b/frontend/app/components/global/AppButtonUpload.test.ts
@@ -1,0 +1,108 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { nextTick } from "vue";
+import AppButtonUpload from "./AppButtonUpload.vue";
+
+vi.mock("~/composables/api", () => ({
+  useUserApi: () => ({
+    upload: {
+      file: vi.fn(),
+    },
+  }),
+}));
+
+function mountUpload() {
+  return mount(AppButtonUpload, {
+    props: {
+      url: "none",
+      post: false,
+    },
+    global: {
+      stubs: {
+        VForm: {
+          template: "<form><slot /></form>",
+        },
+        VBtn: {
+          props: ["loading"],
+          emits: ["click"],
+          template: `
+            <button
+              class="upload-button"
+              type="button"
+              :data-loading="loading ? 'true' : 'false'"
+              @click="$emit('click')"
+            >
+              <slot />
+            </button>
+          `,
+        },
+        VIcon: {
+          template: "<span><slot /></span>",
+        },
+      },
+    },
+  });
+}
+
+describe("AppButtonUpload", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("stops loading when the file picker closes without selecting a file", async () => {
+    vi.stubGlobal("useNuxtApp", () => ({
+      $globals: {
+        icons: {
+          upload: "upload",
+        },
+      },
+    }));
+
+    const wrapper = mountUpload();
+
+    const input = wrapper.find("input[type=\"file\"]");
+    const clickSpy = vi.spyOn(input.element as HTMLInputElement, "click")
+      .mockImplementation(() => {});
+
+    await wrapper.find(".upload-button").trigger("click");
+    await nextTick();
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(wrapper.find(".upload-button").attributes("data-loading")).toBe("true");
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await nextTick();
+
+    expect(wrapper.find(".upload-button").attributes("data-loading")).toBe("false");
+
+    wrapper.unmount();
+  });
+
+  test("stops loading when the window regains focus", async () => {
+    vi.stubGlobal("useNuxtApp", () => ({
+      $globals: {
+        icons: {
+          upload: "upload",
+        },
+      },
+    }));
+
+    const wrapper = mountUpload();
+
+    const input = wrapper.find("input[type=\"file\"]");
+    vi.spyOn(input.element as HTMLInputElement, "click")
+      .mockImplementation(() => {});
+
+    await wrapper.find(".upload-button").trigger("click");
+    await nextTick();
+
+    expect(wrapper.find(".upload-button").attributes("data-loading")).toBe("true");
+
+    window.dispatchEvent(new Event("focus"));
+    await nextTick();
+
+    expect(wrapper.find(".upload-button").attributes("data-loading")).toBe("false");
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/app/components/global/AppButtonUpload.vue
+++ b/frontend/app/components/global/AppButtonUpload.vue
@@ -140,13 +140,22 @@ function onFileChanged(e: Event) {
 
 function onButtonClick() {
   isSelecting.value = true;
-  window.addEventListener(
-    "focus",
-    () => {
-      isSelecting.value = false;
-    },
-    { once: true },
-  );
+
+  function resetSelecting() {
+    isSelecting.value = false;
+    window.removeEventListener("focus", resetSelecting);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  }
+
+  function onVisibilityChange() {
+    if (document.visibilityState === "visible") {
+      resetSelecting();
+    }
+  }
+
+  window.addEventListener("focus", resetSelecting);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
   uploader.value?.click();
 }
 </script>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it

This PR fixes an issue where the upload button can remain stuck in a loading state after the user opens the system file picker and then closes or cancels it without selecting a file.

This behavior is related to `AppButtonUpload`. When the upload button is clicked, the component sets `isSelecting` to `true`, which causes the button to display its loading state while the system file picker is open.

Previously, the component relied only on the window `focus` event to reset `isSelecting` to `false` after returning from the file picker. However, the `focus` event is not always sufficient for detecting that the user has returned to the application. In those cases, `isSelecting` remains `true`, leaving the upload button in a permanent loading state and preventing the user from attempting another upload normally.

The fix keeps the existing `focus` handling and adds a `visibilitychange` listener as an additional fallback. When the document becomes visible again, the component resets `isSelecting` to `false`.

A shared `resetSelecting()` function is used by both event paths. It also removes the registered `focus` and `visibilitychange` listeners once the selecting state has been reset, avoiding unnecessary listeners remaining after the file picker has closed.

This keeps the existing behavior for environments where the `focus` event works correctly while providing an additional way to recover the upload state when the page becomes visible again.

## Which issue(s) this PR fixes

Fixes #4770

## Testing

A new `AppButtonUpload.test.ts` test file was added to cover the loading-state behavior.

Two cases are tested:

1. **File picker closes without selecting a file**
   - The upload button is clicked.
   - The component enters the loading state (`isSelecting = true`).
   - A `visibilitychange` event is triggered to simulate returning to the page.
   - The test verifies that the loading state is reset.

2. **Window regains focus**
   - The upload button is clicked.
   - The component enters the loading state.
   - A window `focus` event is triggered.
   - The test verifies that the original focus-based behavior still resets the loading state correctly.

The regression test was also run before applying the fix and failed because the loading state remained active after `visibilitychange`. After adding the fallback, both tests pass.

Test command:

`corepack pnpm test:ci AppButtonUpload.test.ts`

Result:

`2 tests passed`

ESLint was also run against both modified files:

`corepack pnpm exec eslint app/components/global/AppButtonUpload.vue app/components/global/AppButtonUpload.test.ts`

Result:

`Passed with no lint errors`

## AI / LLM Assistance

AI/LLM assistance was used to help investigate the issue, suggest the implementation. The changes were reviewed locally and validated with ESLint and Vitest.