### PR TITLE
fix: correct type mismatches in ShoppingListItem and RecipeDataAliasManagerDialog

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.vue
@@ -96,12 +96,14 @@ function saveAliases() {
   const seenAliasNames: string[] = [];
   const keepAliases: GenericAlias[] = [];
   aliases.value.forEach((alias) => {
+    const abbreviation = "abbreviation" in props.data ? props.data.abbreviation : undefined;
+    const pluralAbbreviation = "pluralAbbreviation" in props.data ? props.data.pluralAbbreviation : undefined;
     if (
       !alias.name
       || alias.name === props.data.name
       || alias.name === props.data.pluralName
-      || alias.name === props.data.abbreviation
-      || alias.name === props.data.pluralAbbreviation
+      || alias.name === abbreviation
+      || alias.name === pluralAbbreviation
       || seenAliasNames.includes(alias.name)
     ) {
       return;

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListAddItemForm.vue
@@ -66,14 +66,14 @@
 
 <script setup lang="ts">
 import { useShoppingListItemEditor } from "~/composables/shopping-list-page/use-shopping-list-item-editor";
-import type { ShoppingListItemCreate, ShoppingListItemOut } from "~/lib/api/types/household";
+import type { ShoppingListItemOut } from "~/lib/api/types/household";
 import type { MultiPurposeLabelOut } from "~/lib/api/types/labels";
 import type { IngredientFood, IngredientUnit } from "~/lib/api/types/recipe";
 import ShoppingListItemDetails from "./ShoppingListItemDetails.vue";
 import { onClickOutside } from "@vueuse/core";
 
 // modelValue as reactive v-model
-const listItem = defineModel<ShoppingListItemCreate | ShoppingListItemOut>({ required: true });
+const listItem = defineModel<ShoppingListItemOut>({ required: true });
 
 defineProps({
   labels: {

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
@@ -57,12 +57,12 @@
 
 <script setup lang="ts">
 import { useShoppingListItemEditor } from "~/composables/shopping-list-page/use-shopping-list-item-editor";
-import type { ShoppingListItemCreate, ShoppingListItemOut } from "~/lib/api/types/household";
+import type { ShoppingListItemOut } from "~/lib/api/types/household";
 import type { MultiPurposeLabelOut } from "~/lib/api/types/labels";
 import type { IngredientUnit } from "~/lib/api/types/recipe";
 
 // modelValue as reactive v-model
-const listItem = defineModel<ShoppingListItemCreate | ShoppingListItemOut>({ required: true });
+const listItem = defineModel<ShoppingListItemOut>({ required: true });
 
 defineProps({
   labels: {

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListItemEditor.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListItemEditor.vue
@@ -51,13 +51,13 @@
 
 <script setup lang="ts">
 import { useShoppingListItemEditor } from "~/composables/shopping-list-page/use-shopping-list-item-editor";
-import type { ShoppingListItemCreate, ShoppingListItemOut } from "~/lib/api/types/household";
+import type { ShoppingListItemOut } from "~/lib/api/types/household";
 import type { MultiPurposeLabelOut } from "~/lib/api/types/labels";
 import type { IngredientFood, IngredientUnit } from "~/lib/api/types/recipe";
 import ShoppingListItemDetails from "./ShoppingListItemDetails.vue";
 
 // modelValue as reactive v-model
-const listItem = defineModel<ShoppingListItemCreate | ShoppingListItemOut>({ required: true });
+const listItem = defineModel<ShoppingListItemOut>({ required: true });
 
 defineProps({
   labels: {

--- a/frontend/app/composables/shopping-list-page/use-shopping-list-item-editor.ts
+++ b/frontend/app/composables/shopping-list-page/use-shopping-list-item-editor.ts
@@ -1,8 +1,8 @@
 import type { ModelRef } from "vue";
-import type { ShoppingListItemOut, ShoppingListItemCreate, IngredientFood } from "~/lib/api/types/household";
+import type { ShoppingListItemOut, IngredientFood } from "~/lib/api/types/household";
 import { useFoodData, useFoodStore, useUnitData, useUnitStore } from "../store";
 
-export function useShoppingListItemEditor(listItem: ModelRef<ShoppingListItemOut | ShoppingListItemCreate, string, ShoppingListItemOut | ShoppingListItemCreate, ShoppingListItemOut | ShoppingListItemCreate>) {
+export function useShoppingListItemEditor(listItem: ModelRef<ShoppingListItemOut, string, ShoppingListItemOut, ShoppingListItemOut>) {
   const foodStore = useFoodStore();
   const foodData = useFoodData();
 


### PR DESCRIPTION

## What this PR does / why we need it:

Fixes two cases where a component's declared TypeScript type didn't match the data it actually receives at runtime. Found by running `vue-tsc --noEmit` locally (the project's CI does not currently run a type-check step, so these went unnoticed).

- **ShoppingList editor components** (`ShoppingListAddItemForm.vue`, `ShoppingListItemDetails.vue`, `ShoppingListItemEditor.vue`, and the `useShoppingListItemEditor` composable): the `v-model` was typed as `ShoppingListItemCreate | ShoppingListItemOut`, but every call site only ever passes a `ShoppingListItemOut` (e.g. `createListItemData` in `pages/shopping-lists/[id].vue` is declared `ref<ShoppingListItemOut>`). Since `labelId` only exists on `ShoppingListItemOut`, the stale union type made TypeScript reject valid property access. Narrowed the model type to `ShoppingListItemOut` to match actual usage.
- **`RecipeDataAliasManagerDialog.vue`**: `saveAliases()` compared `alias.name` against `props.data.abbreviation` / `props.data.pluralAbbreviation`, but `props.data` is typed `IngredientFood | IngredientUnit`, and only `IngredientUnit` has those two fields. Narrowed the access with an `in` check so both union branches type-check; behavior is unchanged since the missing-field case already evaluated to `undefined` at runtime.

Both fixes are type-only corrections — no runtime behavior changes.

screenshot for reference below:
<img width="1152" height="273" alt="螢幕擷取畫面 2026-09-05 151922" src="https://github.com/user-attachments/assets/c60c5e4d-dc96-4a88-87c0-18b8c8fc1a07" />

<img width="995" height="282" alt="螢幕擷取畫面 2026-09-05 151849" src="https://github.com/user-attachments/assets/5234b54a-653c-4d6c-986a-647a54c79a1c" />


## Which issue(s) this PR fixes:

Not tied to an existing issue; found via a local `vue-tsc --noEmit` audit (the CI pipeline doesn't currently run type-checking).


## Testing

- `vue-tsc --noEmit` (typescript@5.9.3, vue-tsc@2.2.0) confirms both sets of errors are resolved.
- `pnpm lint:js` passes.
- `pnpm exec vitest run` — all 380 tests pass, including the shopping-list composable tests most relevant to this change.
- No runtime/UI behavior change (type-only fixes), so no manual UI testing beyond the above.


## AI / LLM Assistance

Used Claude Code (Anthropic) throughout: to run and interpret `vue-tsc` output, diagnose the root cause of each type mismatch, implement the fixes, and verify them against lint/tests. All changes were reviewed and validated by me before submitting.

