### PR TITLE
fix: make TypeScript generation deterministic

### DIFF
--- a/dev/code-generation/gen_ts_types.py
+++ b/dev/code-generation/gen_ts_types.py
@@ -1,9 +1,14 @@
 import re
 import subprocess
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from importlib import import_module
 from pathlib import Path
 
 from jinja2 import Template
+from pydantic import BaseModel
 from pydantic2ts import generate_typescript_defs
+from pydantic2ts.cli.script import extract_pydantic_models
 from utils import log
 
 # ============================================================
@@ -30,6 +35,20 @@ export {};
 
 CWD = Path(__file__).parent
 PROJECT_DIR = Path(__file__).parent.parent.parent
+
+
+@contextmanager
+def forbid_extra_fields(models: Iterable[type[BaseModel]]) -> Iterator[None]:
+    model_configs = {model: model.model_config.copy() for model in models}
+    try:
+        for model in model_configs:
+            if model.model_config.get("extra") != "allow":
+                model.model_config["extra"] = "forbid"
+        yield
+    finally:
+        for model, config in model_configs.items():
+            model.model_config.clear()
+            model.model_config.update(config)
 
 
 def generate_global_components_types() -> None:
@@ -172,14 +191,8 @@ def generate_typescript_types() -> None:  # noqa: C901
         with open(file, "w") as f:
             f.writelines(lines)
 
-    def path_to_module(path: Path):
-        str_path: str = str(path)
-
-        str_path = str_path.removeprefix(str(PROJECT_DIR))
-        str_path = str_path.removeprefix("/")
-        str_path = str_path.replace("/", ".")
-
-        return str_path
+    def path_to_module(path: Path) -> str:
+        return ".".join(path.relative_to(PROJECT_DIR).parts)
 
     schema_path = PROJECT_DIR / "mealie" / "schema"
     types_dir = PROJECT_DIR / "frontend" / "app" / "lib" / "api" / "types"
@@ -190,7 +203,7 @@ def generate_typescript_types() -> None:  # noqa: C901
     skipped_dirs: list[Path] = []
     failed_modules: list[Path] = []
 
-    out_paths: list[Path] = []
+    generator_inputs = []
     for module in schema_path.iterdir():
         if module.is_dir() and module.stem in ignore_dirs:
             skipped_dirs.append(module)
@@ -205,12 +218,23 @@ def generate_typescript_types() -> None:  # noqa: C901
 
         try:
             path_as_module = path_to_module(module)
-            generate_typescript_defs(path_as_module, str(out_path), exclude=("MealieModel"))  # type: ignore
-            clean_output_file(out_path)
-            out_paths.append(out_path)
+            models = extract_pydantic_models(import_module(path_as_module))
+            generator_inputs.append((module, path_as_module, out_path, models))
         except Exception:
             failed_modules.append(module)
             log.exception(f"Module Error: {module}")
+
+    out_paths: list[Path] = []
+    models = {model for *_, module_models in generator_inputs for model in module_models}
+    with forbid_extra_fields(models):
+        for module, path_as_module, out_path, _ in generator_inputs:
+            try:
+                generate_typescript_defs(path_as_module, str(out_path), exclude=("MealieModel"))  # type: ignore
+                clean_output_file(out_path)
+                out_paths.append(out_path)
+            except Exception:
+                failed_modules.append(module)
+                log.exception(f"Module Error: {module}")
 
     # Run ESLint --fix on the files to clean up any formatting issues
     subprocess.run(

--- a/tests/unit_tests/test_code_generation.py
+++ b/tests/unit_tests/test_code_generation.py
@@ -1,0 +1,18 @@
+import importlib
+from pathlib import Path
+
+from pydantic import create_model
+from pydantic2ts.cli.script import generate_json_schema_v2
+
+
+def test_type_generation_restores_model_config(monkeypatch) -> None:
+    code_generation_dir = Path(__file__).parents[2] / "dev" / "code-generation"
+    monkeypatch.syspath_prepend(str(code_generation_dir))
+    gen_ts_types = importlib.import_module("gen_ts_types")
+    model = create_model("UnconfiguredModel", value=(str, ...))
+
+    with gen_ts_types.forbid_extra_fields([model]):
+        assert model.model_config["extra"] == "forbid"
+        generate_json_schema_v2([model])
+
+    assert model.model_config == {}


### PR DESCRIPTION
## What this PR does / why we need it:

### Problem / Context

`pydantic2ts` temporarily changes every exported Pydantic model's `extra` setting to `forbid`, but it does not restore models whose original setting was unset. Shared models therefore retain state from whichever schema module was generated first, making later TypeScript output depend on module processing order.

### Changes

- Load each schema module before generation so all exported models are known up front.
- Keep non-`allow` models closed for the complete generation pass, then restore every original model config even when generation fails.
- Build dotted module names from `Path.parts`, which also makes the preload work with Windows paths.
- Add a regression covering the dependency's config mutation and restoration.

### User impact

Generated TypeScript definitions no longer gain or lose index signatures based on schema-module order, so `task dev:generate` produces stable output and avoids unrelated generated-file changes.

## Which issue(s) this PR fixes:

Fixes #8222

## Verification

- Regression test: 1 passed; the test failed on the base revision because the preservation boundary did not exist.
- Ruff lint and format checks: passed for both changed files.
- MyPy: passed for `dev/code-generation/gen_ts_types.py`.
- Complete TypeScript generator: passed for all 12 schema modules; generated definitions matched the committed files with no semantic diff.
- `git diff --check`: passed.
- The repository-wide pytest bootstrap was attempted but cannot import the locked `python-ldap` dependency on Windows because its native extension requires MSVC/OpenLDAP.

## AI / LLM Assistance

AI assistance was used to help investigate the generator state leak, implement the fix, and draft the regression test. I reviewed the complete diff and independently ran all verification listed above.