### PR TITLE
fix: remove stacked variant on number inputs

### DIFF
--- a/frontend/app/components/Domain/Group/GroupAIProviderDialog.vue
+++ b/frontend/app/components/Domain/Group/GroupAIProviderDialog.vue
@@ -59,7 +59,6 @@
           type="number"
           :min="0"
           hide-details
-          control-variant="stacked"
           density="compact"
           variant="outlined"
           class="mb-4"

--- a/frontend/app/components/Domain/QueryFilterBuilder.vue
+++ b/frontend/app/components/Domain/QueryFilterBuilder.vue
@@ -128,7 +128,6 @@
               v-else-if="field.type === 'number'"
               :model-value="field.value as number || 0"
               variant="underlined"
-              control-variant="stacked"
               inset
               :min="0"
               :max="5"
@@ -176,7 +175,6 @@
               :model-value="parseRelativeDateOffset(field.value)"
               :suffix="$t('query-filter.dates.days-ago', parseRelativeDateOffset(field.value))"
               variant="underlined"
-              control-variant="stacked"
               density="compact"
               inset
               :min="0"

--- a/frontend/app/components/Domain/Recipe/RecipeIngredientEditor.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeIngredientEditor.vue
@@ -41,9 +41,8 @@
               :min="0"
               hide-details
               inset
-              control-variant="stacked"
               density="compact"
-              :style="$vuetify.display.mdAndDown ? '' : 'flex: 1 0 50px;'"
+              :style="$vuetify.display.mdAndDown ? '' : 'flex: 3 0 50px;'"
               :placeholder="$t('recipe.quantity')"
               @keypress="quantityFilter"
             />
@@ -54,7 +53,7 @@
               auto-select-first
               hide-details
               density="compact"
-              :style="$vuetify.display.mdAndDown ? '' : 'flex: 2 0 50px;'"
+              :style="$vuetify.display.mdAndDown ? '' : 'flex: 4 0 50px;'"
               variant="filled"
               return-object
               :items="filteredUnits"
@@ -106,7 +105,7 @@
               auto-select-first
               hide-details
               density="compact"
-              :style="$vuetify.display.mdAndDown ? '' : 'flex: 4 0 50px;'"
+              :style="$vuetify.display.mdAndDown ? '' : 'flex: 7 0 50px;'"
               variant="filled"
               return-object
               :items="filteredFoods"
@@ -157,7 +156,7 @@
               auto-select-first
               hide-details
               density="compact"
-              :style="$vuetify.display.mdAndDown ? '' : 'flex: 4 0 50px;'"
+              :style="$vuetify.display.mdAndDown ? '' : 'flex: 7 0 50px;'"
               variant="filled"
               return-object
               :items="search.data.value || []"
@@ -172,7 +171,7 @@
               v-model="model.note"
               hide-details
               density="compact"
-              :style="$vuetify.display.mdAndDown ? '' : 'flex: 4 0 50px;'"
+              :style="$vuetify.display.mdAndDown ? '' : 'flex: 7 0 50px;'"
               variant="filled"
               :placeholder="$t('recipe.notes')"
               class=""

--- a/frontend/app/components/Domain/Recipe/RecipeNutrition.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeNutrition.vue
@@ -17,7 +17,6 @@
             density="compact"
             autocomplete="off"
             variant="underlined"
-            control-variant="stacked"
             inset
             :precision="null"
             :min="0"

--- a/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
+++ b/frontend/app/components/Domain/ShoppingList/ShoppingListItemDetails.vue
@@ -6,8 +6,7 @@
       :label="$t('form.quantity-label-abbreviated')"
       :min="0"
       :precision="null"
-      control-variant="stacked"
-      style="flex: 1"
+      style="flex: 5"
       inset
     />
     <InputLabelType
@@ -17,7 +16,7 @@
       :label="$t('recipe.unit')"
       :icon="$globals.icons.units"
       :menu-props="{ location: menuDirection }"
-      style="flex: 3"
+      style="flex: 7"
       create
       @create="createAssignUnit"
     />

--- a/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
+++ b/frontend/app/pages/g/[groupSlug]/recipes/finder/index.vue
@@ -138,7 +138,6 @@
                           v-model="state.settings.maxMissingFoods"
                           :precision="null"
                           :min="0"
-                          control-variant="stacked"
                           inset
                           hide-details
                           :label="$t('recipe-finder.max-missing-ingredients')"
@@ -147,7 +146,6 @@
                           v-model="state.settings.maxMissingTools"
                           :precision="null"
                           :min="0"
-                          control-variant="stacked"
                           inset
                           hide-details
                           :label="$t('recipe-finder.max-missing-tools')"

--- a/frontend/app/pages/household/mealplan/planner.vue
+++ b/frontend/app/pages/household/mealplan/planner.vue
@@ -41,7 +41,6 @@
             <v-number-input
               v-model="numberOfDaysPast"
               :min="0"
-              control-variant="stacked"
               inset
               :label="$t('meal-plan.numberOfDaysPast-label')"
               :hint="$t('meal-plan.numberOfDaysPast-hint')"
@@ -53,7 +52,6 @@
             <v-number-input
               v-model="numberOfDays"
               :min="1"
-              control-variant="stacked"
               inset
               :label="$t('meal-plan.numberOfDays-label')"
               :hint="$t('meal-plan.numberOfDays-hint')"


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

This PR removes the "stacked" attribute from numeric fields, which displays the increase and decrease buttons side by side.
Stacked buttons have the drawback of being less accessible due to their small size, especially with "compact" fields such as those for ingredients.

The size of some fields has been slightly adjusted

## Which issue(s) this PR fixes:

_(REQUIRED)_

None

## AI / LLM Assistance

_(REQUIRED)_

`Ctrl + F`
