### PR TITLE
fix: prevent creating shopping lists with empty names and disable submit button

### DIFF
--- a/frontend/app/pages/shopping-lists/index.vue
+++ b/frontend/app/pages/shopping-lists/index.vue
@@ -9,11 +9,12 @@
       :title="$t('shopping-list.create-shopping-list')"
       :icon="$globals.icons.formatListCheck"
       can-submit
+      :submit-disabled="!isCreateNameValid"
       @submit="createOne"
     >
       <v-card-text>
         <v-text-field
-          v-model="state.createName"
+          v-model.trim="state.createName"
           autofocus
           :label="$t('shopping-list.new-list')"
         />
@@ -157,6 +158,7 @@ const state = reactive({
   ownerDialog: false,
   ownerTarget: ref<ShoppingListOut | null>(null),
 });
+const isCreateNameValid = computed(() => state.createName.trim().length > 0);
 
 const { data: shoppingLists } = useAsyncData(useAsyncKey(), async () => {
   return await fetchShoppingLists();
@@ -208,7 +210,8 @@ async function refresh() {
 }
 
 async function createOne() {
-  const { data } = await userApi.shopping.lists.createOne({ name: state.createName });
+  if (!isCreateNameValid.value) return;
+  const { data } = await userApi.shopping.lists.createOne({ name: state.createName.trim() });
 
   if (data) {
     refresh();


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes the issue where users could create a shopping list with an empty or whitespace-only name.

- Modified `frontend/app/pages/shopping-lists/index.vue`.
- Added a computed property `isCreateNameValid` to check if the trimmed input is non-empty.
- Bound `:submit-disabled` to keep the create button greyed out (disabled) when the input is invalid, and green when valid.
- Applied `v-model.trim` to the input field and added a guard clause in `createOne` to prevent empty names from being submitted to the API.

## Which issue(s) this PR fixes:

Fixes #8362 

## Testing

Tested locally in the browser. Verified that:
1. The create button remains disabled (grayed out) when the input is empty or contains only spaces.
2. The create button becomes enabled (green) once valid text is entered.
3. Pressing Enter does not submit an empty shopping list.

 **1.Disabled state (Empty/Whitespace-only input)**
<img width="786" height="336" alt="image" src="https://github.com/user-attachments/assets/c783c2e0-0202-45bc-a1cb-e28ab0c1758f" />

 **2.Enabled state (Valid input)**
<img width="786" height="345" alt="image" src="https://github.com/user-attachments/assets/e425e8ff-f8a8-4076-989e-986fc3910eee" />

 **3.Creation Result**
<img width="865" height="534" alt="image" src="https://github.com/user-attachments/assets/695f8915-282d-439f-ab88-34d72661a658" />


## AI / LLM Assistance

NA
