### PR TITLE
fix: Show permission error ,when food creation fails

### DIFF
--- a/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
+++ b/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
@@ -286,7 +286,7 @@ export function useParseIngredientsDialog(
       }
 
       if (!newUnit) {
-        alert.error(i18n.t("events.something-went-wrong"));
+        alert.error(i18n.t("general.cant-create-permission"));
         return;
       }
 

--- a/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
+++ b/frontend/app/composables/recipes/use-parse-ingredients-dialog.ts
@@ -318,7 +318,7 @@ export function useParseIngredientsDialog(
       }
 
       if (!newFood) {
-        alert.error(i18n.t("events.something-went-wrong"));
+        alert.error(i18n.t("general.cant-create-permission"));
         return;
       }
 

--- a/frontend/app/lang/messages/en-US.json
+++ b/frontend/app/lang/messages/en-US.json
@@ -176,7 +176,8 @@
     "date-created": "Date Created",
     "date-updated": "Date Updated",
     "key": "Key",
-    "value": "Value"
+    "value": "Value",
+    "cant-create-permission": "Can't create. Please contact your administrator to get permission."
   },
   "group": {
     "create-group": "Create Group",


### PR DESCRIPTION
## What this PR does / why we need it:

Replaces the generic `"Something Went Wrong!"` error alert with a clear permission denied message when creating missing foods fails due to insufficient user privileges during ingredient parsing.

* `frontend/app/lang/messages/en-US.json`: Added `cant-create-permission` under `general`.
* `frontend/app/composables/recipes/use-parse-ingredients-dialog.ts`: Updated `createMissingFood` to display the permission error on failure.
 * Updated `createMissingUnit` in `use-parse-ingredients-dialog.ts` to use `general.cant-create-permission`.
> **Note**: Front-end handling for units relies on backend permission checks introduced in #8181 (`mealie/routes/unit_and_foods/units.py`).

## Which issue(s) this PR fixes:

Fixes #8368
Depends on #8181

## Special notes for your reviewer:

None.    

## Testing

1. Logged in as a user without **Organize** permission (unable to create foods).
2. Parsed recipe ingredients and clicked to create a missing food.
3. Verified the permission error message appears instead of the generic alert.

**Visual Changes**

**Food**
Before:
<img width="1567" height="702" alt="image" src="https://github.com/user-attachments/assets/773a05ae-8b11-428f-9917-60cd8cc305a8" />

After:
<img width="1573" height="719" alt="image" src="https://github.com/user-attachments/assets/5aaefede-c193-4b02-8126-deb6973d3ec5" />

**Units:**
After: 
<img width="1535" height="719" alt="295e75d0c74fb28ba8d8e599306711bf" src="https://github.com/user-attachments/assets/0f59a9cd-6c76-40db-b16e-9f541219f6e7" />


## AI / LLM Assistance

NA