### PR TITLE
fix: recognize Facebook reel share URLs as videos

### DIFF
--- a/mealie/services/openai/transcription.py
+++ b/mealie/services/openai/transcription.py
@@ -3,6 +3,7 @@ import re
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TypedDict
+from urllib.parse import urlsplit
 
 from mealie.core import exceptions
 from mealie.core.config import get_app_settings
@@ -33,13 +34,30 @@ def get_yt_dlp_extractors() -> list:
     return [ie for ie in yt_dlp.extractor.gen_extractors() if ie.working() and not isinstance(ie, GenericIE)]
 
 
+def _is_facebook_reel_share_url(url: str) -> bool:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return False
+
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname in {"facebook.com", "www.facebook.com", "m.facebook.com"}
+        and re.fullmatch(r"/share/r/[A-Za-z0-9]+/?", parsed.path) is not None
+    )
+
+
 def is_video_url(url: str) -> bool:
     """Whether yt-dlp recognizes the URL as something it can download."""
 
     if not url:
         return False
 
-    return any(ie.suitable(url) for ie in get_yt_dlp_extractors())
+    if any(ie.suitable(url) for ie in get_yt_dlp_extractors()):
+        return True
+
+    # These links need yt-dlp's generic redirect handling before its Facebook extractor.
+    return _is_facebook_reel_share_url(url)
 
 
 def parse_subtitle_content(subtitle_content: str) -> str:

--- a/tests/unit_tests/services_tests/test_transcription.py
+++ b/tests/unit_tests/services_tests/test_transcription.py
@@ -1,6 +1,68 @@
+from unittest.mock import Mock
+
 import pytest
 
 import mealie.services.openai.transcription as transcription_module
+from mealie.services.recipe.import_workflow.compilers.transcription import TranscriptionCompiler
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://facebook.com/share/r/1DWziuVHRi/",
+        "https://www.facebook.com/share/r/1DWziuVHRi/",
+        "https://m.facebook.com/share/r/1DWziuVHRi/",
+        "https://www.facebook.com/share/r/1DWziuVHRi?mibextid=test",
+        "http://www.facebook.com/share/r/1DWziuVHRi/",
+    ],
+)
+def test_is_video_url_accepts_facebook_reel_shares(monkeypatch: pytest.MonkeyPatch, url: str):
+    monkeypatch.setattr(transcription_module, "get_yt_dlp_extractors", lambda: [])
+
+    assert transcription_module.is_video_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "https://example.com/share/r/1DWziuVHRi/",
+        "https://notfacebook.com/share/r/1DWziuVHRi/",
+        "https://www.facebook.com.example.com/share/r/1DWziuVHRi/",
+        "https://www.facebook.com@elsewhere.example/share/r/1DWziuVHRi/",
+        "https://www.facebook.com/share/p/1DWziuVHRi/",
+        "https://www.facebook.com/share/r/",
+        "https://www.facebook.com/share/r/1DWziuVHRi/extra",
+        "ftp://www.facebook.com/share/r/1DWziuVHRi/",
+        "https://[invalid/share/r/1DWziuVHRi/",
+    ],
+)
+def test_is_video_url_rejects_non_reel_shares(monkeypatch: pytest.MonkeyPatch, url: str):
+    monkeypatch.setattr(transcription_module, "get_yt_dlp_extractors", lambda: [])
+
+    assert not transcription_module.is_video_url(url)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.facebook.com/share/r/1DWziuVHRi/", True),
+        ("https://www.facebook.com/reel/1433866715330175/", True),
+        ("https://www.youtube.com/watch?v=BaW_jenozKc", True),
+        ("https://example.com/recipe", False),
+    ],
+)
+def test_is_video_url_with_real_extractors(url: str, expected: bool):
+    assert transcription_module.is_video_url(url) is expected
+
+
+@pytest.mark.parametrize("audio_enabled", [True, False])
+def test_facebook_reel_share_transcription_eligibility(audio_enabled: bool):
+    ctx = Mock()
+    ctx.input.url = "https://www.facebook.com/share/r/1DWziuVHRi/"
+    ctx.ai.provider_settings.audio_provider_enabled = audio_enabled
+
+    assert TranscriptionCompiler(ctx).can_compile() is audio_enabled
 
 
 class _SettingsStub:


### PR DESCRIPTION
## What this PR does / why we need it:

Facebook Reel share links such as https://www.facebook.com/share/r/1DWziuVHRi/ currently fail is_video_url(), so the transcription compiler skips them before yt-dlp can follow the redirect.

Adds a narrow fallback for HTTP(S) /share/r/<id> links on facebook.com, www.facebook.com, and m.facebook.com. Existing extractor matching stays first, and the generic extractor remains excluded from normal video detection. Redirects and downloading remain delegated to yt-dlp.

Adds 21 test cases covering accepted links, unrelated/lookalike domains, invalid paths and URLs, real extractors, and transcription eligibility with the audio provider enabled or disabled. Existing cookiefile tests are retained.

## Which issue(s) this PR fixes:

Fixes #8367

## Testing

- task py:test -- tests/unit_tests/services_tests: 320 passed.
- Targeted transcription, recipe import workflow, and OpenAI service tests: 74 passed.
- task py:lint and Ruff check for the changed test file: passed.
- task py:mypy: passed for 464 source files.
- uv run --frozen ruff format --check .: 697 files already formatted.
- git diff --check: passed.
- With locked yt-dlp 2026.8.19, the issue URL returns False under the original detection expression and True after this fix.
- Live yt-dlp --simulate --no-playlist --socket-timeout 15 --retries 1 https://www.facebook.com/share/r/1DWziuVHRi/ succeeded: generic extractor -> redirect to reel 1433866715330175 -> Facebook extractor -> video format identified.

Additional checks: task py:check passed formatting, lint and mypy; its full pytest run was manually interrupted after 244 passed, so the full suite is not claimed as passing. task ui:check was attempted but dependency installation hit registry DNS failures and was stopped. No frontend files change.

Environment: macOS arm64 / CPython 3.12.14. Dependencies installed from the committed lockfile. ffmpeg is unavailable, so live verification used simulation; MP3 conversion and end-to-end AI transcription/import were not run.

## AI / LLM Assistance

OpenAI Codex assisted with the implementation. I reviewed the final diff.