### PR TITLE
fix: pin all resolved addresses in one curl RESOLVE entry so IPv4 fallback works

### DIFF
--- a/mealie/pkgs/safehttp/transport.py
+++ b/mealie/pkgs/safehttp/transport.py
@@ -74,6 +74,10 @@ def _matches(host: str, ips: Sequence[IPAddress], hosts: set[str], networks: lis
     return False
 
 
+def _resolve_address(ip: IPAddress) -> str:
+    return f"[{ip}]" if isinstance(ip, ipaddress.IPv6Address) else str(ip)
+
+
 class _SafeTransportMixin:
     """
     Shared SSRF protection for the sync and async curl transports.
@@ -161,7 +165,7 @@ class _SafeTransportMixin:
         if literal is not None:
             # curl connects straight to the literal address; nothing to pin.
             return None
-        return [f"{host}:{port}:{ip}" for ip in ips]
+        return [f"{host}:{port}:{','.join(_resolve_address(ip) for ip in ips)}"]
 
     def _warn(self, request: httpx.Request, reason: str) -> None:
         if self._log:

--- a/tests/unit_tests/pkgs/safehttp/test_transport.py
+++ b/tests/unit_tests/pkgs/safehttp/test_transport.py
@@ -69,7 +69,14 @@ def test_pin_covers_all_resolved_addresses(monkeypatch):
     _patch_resolver(monkeypatch, ["93.184.216.34", "93.184.216.35"])
     transport = AsyncSafeTransport()
     resolve = transport._validate(_request("http://example.test/"))
-    assert resolve == ["example.test:80:93.184.216.34", "example.test:80:93.184.216.35"]
+    assert resolve == ["example.test:80:93.184.216.34,93.184.216.35"]
+
+
+def test_pin_brackets_ipv6_addresses(monkeypatch):
+    _patch_resolver(monkeypatch, ["2606:4700:4700::1111", "93.184.216.34"])
+    transport = AsyncSafeTransport()
+    resolve = transport._validate(_request("https://example.test/"))
+    assert resolve == ["example.test:443:[2606:4700:4700::1111],93.184.216.34"]
 
 
 def test_rejects_when_any_resolved_address_is_unsafe(monkeypatch):
@@ -172,6 +179,19 @@ async def test_async_transport_pins_connection_to_validated_ip(monkeypatch):
     with _LocalServer() as server:
         # host does not really resolve to localhost; the resolver + pin make it so
         _patch_resolver(monkeypatch, ["127.0.0.1"])
+        transport = AsyncSafeTransport(allow_hosts=["pinned.example"])
+        async with httpx.AsyncClient(transport=transport) as client:
+            resp = await client.get(f"http://pinned.example:{server.port}/")
+        assert resp.status_code == 200
+        assert resp.text == "OK"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ips", [["127.0.0.1", "2001:db8::1"], ["2001:db8::1", "127.0.0.1"]])
+async def test_async_transport_falls_back_to_reachable_pinned_address(monkeypatch, ips: list[str]):
+    with _LocalServer() as server:
+        # a dual-stack host in a container without IPv6 connectivity
+        _patch_resolver(monkeypatch, ips)
         transport = AsyncSafeTransport(allow_hosts=["pinned.example"])
         async with httpx.AsyncClient(transport=transport) as client:
             resp = await client.get(f"http://pinned.example:{server.port}/")


### PR DESCRIPTION
## What this PR does / why we need it:

Recipe imports fail with `curl: (7) Failed to connect ... after 0 ms` on hosts that resolve to both IPv6 and IPv4 addresses when the container has no IPv6 connectivity (very common for Cloudflare-fronted recipe sites behind Docker's default IPv4-only network).

Cause: `_SafeTransportMixin._validate()` returns one `CURLOPT_RESOLVE` entry per address (`host:port:ipA`, `host:port:ipB`, ...). curl treats each `HOST:PORT:ADDRESS` entry as a full replacement of the DNS-cache entry for that host+port, so only the **last** address survives and curl never tries the others. When the last one is an IPv6 address, the connection fails immediately with no fallback. (The pre-existing `_patch_resolver` tests only used a single IPv4 address, so this never showed up.)

Fix (`mealie/pkgs/safehttp/transport.py`):
- Emit a single `HOST:PORT:ADDR1,ADDR2,...` entry — the multi-address form curl documents — so curl's own address-family fallback (Happy Eyeballs) works while the connection is still pinned to exactly the addresses we validated. SSRF / DNS-rebinding protection is unchanged: every address is still validated before pinning, and curl still can't re-resolve.
- IPv6 addresses are wrapped in `[...]` as the curl docs require for the multi-address form.

Tests (`tests/unit_tests/pkgs/safehttp/test_transport.py`):
- updated `test_pin_covers_all_resolved_addresses` to the single-entry shape
- new `test_pin_brackets_ipv6_addresses`
- new `test_async_transport_falls_back_to_reachable_pinned_address` (parametrised: IPv4 first / IPv6 first) — resolves a host to an unreachable documentation-range IPv6 address plus `127.0.0.1` and asserts the request to a local server still succeeds

## Which issue(s) this PR fixes:

Fixes #8375

## Special notes for your reviewer:

I did not go the IPv4-only route suggested as a workaround in the issue, since that would break IPv6-only hosts. Letting curl pick among the validated addresses keeps both the pin and dual-stack behaviour.

## Testing

Reproduced against curl_cffi 0.16.2 with a local HTTP server: pinning `['h:port:127.0.0.1', 'h:port:2001:db8::1']` fails with curl error 7 (only the last entry is used), while `['h:port:[2001:db8::1],127.0.0.1']` connects fine.

```
uv run pytest tests/unit_tests/pkgs/safehttp/ -q        # 81 passed
ruff check / ruff format --check / mypy on the touched files   # clean
```

RED→GREEN: with the fix stashed, `test_pin_brackets_ipv6_addresses` and the fallback case where the IPv6 address comes last fail (curl error 7, since only the last RESOLVE entry is used); with the fix all 81 tests pass.

## AI / LLM Assistance

This PR was prepared with an AI assistant (Claude) under my direction; I reviewed the diff and ran the tests myself.
