### PR TITLE
fix: webhooks dont fire around midnight

### DIFF
--- a/mealie/services/event_bus_service/event_bus_listeners.py
+++ b/mealie/services/event_bus_service/event_bus_listeners.py
@@ -2,12 +2,12 @@ import contextlib
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Generator
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from fastapi.encoders import jsonable_encoder
 from pydantic import UUID4
-from sqlalchemy import and_, or_, select, true
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -175,10 +175,7 @@ class WebhookEventListener(EventListenerBase):
         # Webhooks store a time of day, not a datetime, so we compare against the window's time of day.
         # This means the window can wrap around midnight UTC, which inverts the comparison.
         time_filter: ColumnElement[bool]
-        if end_dt - start_dt >= timedelta(days=1):
-            # the window covers every time of day
-            time_filter = true()
-        elif start_time <= end_time:
+        if start_time <= end_time:
             time_filter = and_(
                 GroupWebhooksModel.scheduled_time > start_time,
                 GroupWebhooksModel.scheduled_time <= end_time,

--- a/mealie/services/event_bus_service/event_bus_listeners.py
+++ b/mealie/services/event_bus_service/event_bus_listeners.py
@@ -2,13 +2,14 @@ import contextlib
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Generator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from fastapi.encoders import jsonable_encoder
 from pydantic import UUID4
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select, true
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from mealie.db.db_setup import session_context
 from mealie.db.models.household.webhooks import GroupWebhooksModel
@@ -168,11 +169,31 @@ class WebhookEventListener(EventListenerBase):
 
     def get_scheduled_webhooks(self, start_dt: datetime, end_dt: datetime) -> list[ReadWebhook]:
         """Fetches all scheduled webhooks from the database"""
+        start_time = start_dt.astimezone(UTC).time()
+        end_time = end_dt.astimezone(UTC).time()
+
+        # Webhooks store a time of day, not a datetime, so we compare against the window's time of day.
+        # This means the window can wrap around midnight UTC, which inverts the comparison.
+        time_filter: ColumnElement[bool]
+        if end_dt - start_dt >= timedelta(days=1):
+            # the window covers every time of day
+            time_filter = true()
+        elif start_time <= end_time:
+            time_filter = and_(
+                GroupWebhooksModel.scheduled_time > start_time,
+                GroupWebhooksModel.scheduled_time <= end_time,
+            )
+        else:
+            # the window spans midnight UTC
+            time_filter = or_(
+                GroupWebhooksModel.scheduled_time > start_time,
+                GroupWebhooksModel.scheduled_time <= end_time,
+            )
+
         with self.ensure_session() as session:
             stmt = select(GroupWebhooksModel).where(
                 GroupWebhooksModel.enabled == True,  # noqa: E712 - required for SQLAlchemy comparison
-                GroupWebhooksModel.scheduled_time > start_dt.astimezone(UTC).time(),
-                GroupWebhooksModel.scheduled_time <= end_dt.astimezone(UTC).time(),
+                time_filter,
                 GroupWebhooksModel.group_id == self.group_id,
                 GroupWebhooksModel.household_id == self.household_id,
             )

--- a/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
+++ b/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
@@ -109,32 +109,6 @@ def test_get_scheduled_webhooks_filter_query_spanning_midnight(unique_user_fn_sc
     assert out_of_range.id not in result_ids
 
 
-def test_get_scheduled_webhooks_filter_query_full_day(unique_user_fn_scoped: TestUser):
-    """A query window of a day or more should match webhooks at every time of day."""
-
-    unique_user = unique_user_fn_scoped
-    database = unique_user.repos
-
-    created = [
-        database.webhooks.create(
-            webhook_factory(
-                group_id=unique_user.group_id,
-                household_id=unique_user.household_id,
-                scheduled_time=datetime(2026, 1, 1, hour, 0, tzinfo=UTC),
-            )
-        )
-        for hour in (0, 6, 12, 18, 23)
-    ]
-
-    start = datetime(2026, 1, 1, 9, 30, tzinfo=UTC)
-    end = start + timedelta(days=1)
-
-    event_bus_listener = WebhookEventListener(UUID(unique_user.group_id), UUID(unique_user.household_id))
-    results = event_bus_listener.get_scheduled_webhooks(start, end)
-
-    assert {result.id for result in results} == {webhook.id for webhook in created}
-
-
 def test_event_listener_get_meals_by_date_range(unique_user: TestUser):
     """
     Test that WebhookEventListener correctly uses the get_meals_by_date_range method
@@ -168,32 +142,25 @@ def test_event_listener_get_meals_by_date_range(unique_user: TestUser):
         }
     )
 
-    webhook_data = EventWebhookData(
-        webhook_start_dt=start_date,
-        webhook_end_dt=end_date,
-        document_type=EventDocumentType.mealplan,
-        operation="create",
-    )
-    event = Event(
-        event_type=EventTypes.webhook_task,
-        document_data=webhook_data,
-        message=EventBusMessage(title="Test event message"),
-        integration_id="00000000-0000-0000-0000-000000000000",
-    )
-
-    event_bus_listener = WebhookEventListener(UUID(unique_user.group_id), UUID(unique_user.household_id))
-    subscribers = event_bus_listener.get_scheduled_webhooks(start_date, end_date)
-
-    event_bus_listener.publish_to_subscribers(event, subscribers)
-
-    assert event.document_data.webhook_body is not None
-    meals = event.document_data.webhook_body
-    assert len(meals) == 2
-
-    assert any(meal.title == "Meal 1" for meal in meals)
-    assert any(meal.title == "Meal 2" for meal in meals)
-
     try:
+        webhook_data = EventWebhookData(
+            webhook_start_dt=start_date,
+            webhook_end_dt=end_date,
+            document_type=EventDocumentType.mealplan,
+            operation="create",
+        )
+        event = Event(
+            event_type=EventTypes.webhook_task,
+            document_data=webhook_data,
+            message=EventBusMessage(title="Test event message"),
+            integration_id="00000000-0000-0000-0000-000000000000",
+        )
+
+        event_bus_listener = WebhookEventListener(UUID(unique_user.group_id), UUID(unique_user.household_id))
+        subscribers = event_bus_listener.get_scheduled_webhooks(start_date, end_date)
+
+        event_bus_listener.publish_to_subscribers(event, subscribers)
+
         assert event.document_data.webhook_body is not None
         meals = event.document_data.webhook_body
         assert len(meals) == 2

--- a/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
+++ b/tests/unit_tests/services_tests/scheduler/tasks/test_post_webhook.py
@@ -78,6 +78,63 @@ def test_get_scheduled_webhooks_filter_query(unique_user: TestUser):
                 break
 
 
+def test_get_scheduled_webhooks_filter_query_spanning_midnight(unique_user_fn_scoped: TestUser):
+    """
+    Webhooks store a time of day, so a query window that crosses midnight UTC must still match
+    webhooks scheduled on either side of it.
+    """
+
+    unique_user = unique_user_fn_scoped
+    database = unique_user.repos
+
+    def webhook_at(hour: int, minute: int) -> SaveWebhook:
+        return webhook_factory(
+            group_id=unique_user.group_id,
+            household_id=unique_user.household_id,
+            scheduled_time=datetime(2026, 1, 1, hour, minute, tzinfo=UTC),
+        )
+
+    before_midnight = database.webhooks.create(webhook_at(23, 58))
+    after_midnight = database.webhooks.create(webhook_at(0, 2))
+    out_of_range = database.webhooks.create(webhook_at(12, 0))
+
+    start = datetime(2026, 1, 1, 23, 55, tzinfo=UTC)
+    end = datetime(2026, 1, 2, 0, 5, tzinfo=UTC)
+
+    event_bus_listener = WebhookEventListener(UUID(unique_user.group_id), UUID(unique_user.household_id))
+    results = event_bus_listener.get_scheduled_webhooks(start, end)
+
+    result_ids = {result.id for result in results}
+    assert result_ids == {before_midnight.id, after_midnight.id}
+    assert out_of_range.id not in result_ids
+
+
+def test_get_scheduled_webhooks_filter_query_full_day(unique_user_fn_scoped: TestUser):
+    """A query window of a day or more should match webhooks at every time of day."""
+
+    unique_user = unique_user_fn_scoped
+    database = unique_user.repos
+
+    created = [
+        database.webhooks.create(
+            webhook_factory(
+                group_id=unique_user.group_id,
+                household_id=unique_user.household_id,
+                scheduled_time=datetime(2026, 1, 1, hour, 0, tzinfo=UTC),
+            )
+        )
+        for hour in (0, 6, 12, 18, 23)
+    ]
+
+    start = datetime(2026, 1, 1, 9, 30, tzinfo=UTC)
+    end = start + timedelta(days=1)
+
+    event_bus_listener = WebhookEventListener(UUID(unique_user.group_id), UUID(unique_user.household_id))
+    results = event_bus_listener.get_scheduled_webhooks(start, end)
+
+    assert {result.id for result in results} == {webhook.id for webhook in created}
+
+
 def test_event_listener_get_meals_by_date_range(unique_user: TestUser):
     """
     Test that WebhookEventListener correctly uses the get_meals_by_date_range method


### PR DESCRIPTION
## What this PR does / why we need it:

_(REQUIRED)_

Fixes a logic bug where webhooks fail to fire around midnight. If our time range overlaps midnight, then the query fails since webhooks are a time rather than a datetime.

This bug also [causes CI to fail](https://github.com/mealie-recipes/mealie/actions/runs/34726266746/job/103640799181) 5 minutes out of the day 🙃 

## Which issue(s) this PR fixes:

_(REQUIRED)_

N/A

## Testing

_(fill-in or delete this section)_

pytest

## AI / LLM Assistance

_(REQUIRED)_

Diagnosed/fixed by Claude