### PR TITLE
fix: discard alias edits when the alias manager dialog is cancelled

### DIFF
--- a/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.test.ts
+++ b/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.test.ts
@@ -1,0 +1,105 @@
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, describe, expect, test } from "vitest";
+import { nextTick } from "vue";
+import RecipeDataAliasManagerDialog from "./RecipeDataAliasManagerDialog.vue";
+import type { IngredientFood } from "~/lib/api/types/recipe";
+
+const wrappers: VueWrapper[] = [];
+
+function mountDialog(data: IngredientFood) {
+  const wrapper = mount(RecipeDataAliasManagerDialog, {
+    props: {
+      data,
+      modelValue: true,
+    },
+    global: {
+      mocks: {
+        $globals: {
+          icons: {
+            edit: "edit",
+            check: "check",
+            delete: "delete",
+            create: "create",
+          },
+        },
+      },
+      stubs: {
+        BaseDialog: {
+          template: `
+            <div>
+              <slot />
+              <slot name="custom-card-action" />
+              <button class="dialog-submit" type="button" @click="$emit('submit')" />
+              <button class="dialog-cancel" type="button" @click="$emit('cancel')" />
+            </div>
+          `,
+        },
+        BaseButton: {
+          template: "<button type=\"button\"><slot /></button>",
+        },
+        BaseButtonGroup: {
+          template: "<div />",
+        },
+        VCardText: {
+          template: "<div><slot /></div>",
+        },
+        VContainer: {
+          template: "<div><slot /></div>",
+        },
+        VRow: {
+          template: "<div><slot /></div>",
+        },
+        VCol: {
+          template: "<div><slot /></div>",
+        },
+        VTextField: {
+          props: ["modelValue"],
+          template: "<input :value=\"modelValue\" @input=\"$emit('update:modelValue', $event.target.value)\">",
+        },
+      },
+    },
+  });
+
+  wrappers.push(wrapper);
+
+  return wrapper;
+}
+
+describe("RecipeDataAliasManagerDialog", () => {
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+    wrappers.length = 0;
+  });
+
+  test("cancel discards alias edits", async () => {
+    const data = {
+      id: "1",
+      name: "abalone",
+      aliases: [{ name: "alias-original" }],
+    } as IngredientFood;
+    const wrapper = mountDialog(data);
+
+    await wrapper.find("input").setValue("alias-cancelled");
+    await wrapper.find(".dialog-cancel").trigger("click");
+    await nextTick();
+
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+    expect(wrapper.emitted("submit")).toBeUndefined();
+    expect(data.aliases).toEqual([{ name: "alias-original" }]);
+  });
+
+  test("confirm emits the edited aliases", async () => {
+    const data = {
+      id: "1",
+      name: "abalone",
+      aliases: [{ name: "alias-original" }],
+    } as IngredientFood;
+    const wrapper = mountDialog(data);
+
+    await wrapper.find("input").setValue("alias-renamed");
+    await wrapper.find(".dialog-submit").trigger("click");
+    await nextTick();
+
+    expect(wrapper.emitted("submit")).toEqual([[[{ name: "alias-renamed" }]]]);
+  });
+});

--- a/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.vue
+++ b/frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.vue
@@ -76,9 +76,9 @@ function deleteAlias(index: number) {
   aliases.value.splice(index, 1);
 }
 
-const aliases = ref<GenericAlias[]>(props.data.aliases || []);
+const aliases = ref<GenericAlias[]>([]);
 function initAliases() {
-  aliases.value = [...props.data.aliases || []];
+  aliases.value = (props.data.aliases || []).map(alias => ({ ...alias }));
   if (!aliases.value.length) {
     createAlias();
   }


### PR DESCRIPTION
## What this PR does / why we need it:

In Data Management → Foods (and Units) → Edit → **Manage Aliases**, renaming an alias and clicking **Cancel** did not discard the rename: reopening the dialog showed the cancelled name.

Cause: `RecipeDataAliasManagerDialog` seeded its local `aliases` ref with the parent form's alias objects (`ref(props.data.aliases)` / `[...props.data.aliases]` — a shallow copy of the array, same objects). `v-model="alias.name"` therefore wrote straight into `editForm.data.aliases`, so the parent already held the edit before Confirm/Cancel was ever pressed.

Fix (`frontend/app/components/Domain/Recipe/RecipeDataAliasManagerDialog.vue`):
- copy each alias object on init (`.map(alias => ({ ...alias }))`) so the dialog works on its own draft; only `saveAliases` → `submit` hands the result back to the parent.
- start the ref empty and let `initAliases()` populate it (it already ran on setup and on every dialog open).

Test (`RecipeDataAliasManagerDialog.test.ts`): mounts the dialog with a stubbed `BaseDialog`, edits the alias field, then asserts that Cancel leaves `data.aliases` untouched and that Confirm still emits the edited aliases.

## Which issue(s) this PR fixes:

Fixes #8382

## Testing

```
cd frontend
pnpm vitest run app/components/Domain/Recipe/RecipeDataAliasManagerDialog.test.ts   # 2 passed
pnpm vitest run                                                                       # 37 files, 393 tests passed
pnpm eslint <touched files>                                                           # clean
```

RED→GREEN: with the `.vue` change stashed, `cancel discards alias edits` fails with `expected [ { name: 'alias-cancelled' } ] to deeply equal [ { name: 'alias-original' } ]` — the exact symptom from the issue; with the fix both tests pass.

## AI / LLM Assistance

Prepared with an AI assistant (Claude) under my direction; I reviewed the diff and ran the tests.
