### PR TITLE
fix: import recipe notes from Paprika archives

### DIFF
--- a/mealie/services/migrations/paprika.py
+++ b/mealie/services/migrations/paprika.py
@@ -7,8 +7,6 @@ import zipfile
 from gzip import GzipFile
 from pathlib import Path
 
-from mealie.schema.recipe import RecipeNote
-
 from ._migration_base import BaseMigrator
 from .utils.migration_alias import MigrationAlias
 
@@ -53,7 +51,8 @@ class PaprikaMigrator(BaseMigrator):
             MigrationAlias(
                 key="notes",
                 alias="notes",
-                func=lambda x: [z for z in [RecipeNote(title="", text=x) if x else None] if z],
+                # the cleaner only accepts strings and dicts, so a RecipeNote here is silently dropped
+                func=lambda x: [{"title": "", "text": x}] if x else [],
             ),
             MigrationAlias(
                 key="recipeCategory",

--- a/tests/integration_tests/recipe_migration_tests/test_recipe_migrations.py
+++ b/tests/integration_tests/recipe_migration_tests/test_recipe_migrations.py
@@ -1,5 +1,8 @@
+import json
 import os
 from dataclasses import dataclass, field
+from gzip import GzipFile
+from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
@@ -311,3 +314,39 @@ def test_recipekeeper_imports_categories_and_yield(api_client: TestClient, uniqu
     recipe = get("baked-salmon-fillets-dijon")
     assert [c.name for c in recipe.recipe_category or []] == ["Fish"]
     assert recipe.recipe_servings == 4
+
+
+def test_paprika_imports_notes(api_client: TestClient, unique_user_fn_scoped: TestUser) -> None:
+    """Paprika exports carry recipe notes in a `notes` string, which must survive the import."""
+    unique_user = unique_user_fn_scoped
+    note_text = "Burnt brandy is brandy that has been flamed to burn off the alcohol."
+
+    recipe_json = json.dumps(
+        {
+            "name": "Paprika Notes Test",
+            "ingredients": "1 cup flour\n2 eggs",
+            "directions": "Mix everything together.",
+            "notes": note_text,
+        }
+    ).encode()
+
+    archive = BytesIO()
+    with ZipFile(archive, "w") as zip_file:
+        gzipped = BytesIO()
+        with GzipFile(fileobj=gzipped, mode="wb") as gz:
+            gz.write(recipe_json)
+        zip_file.writestr("paprika-notes-test.paprikarecipe", gzipped.getvalue())
+
+    response = api_client.post(
+        api_routes.groups_migrations,
+        data={"migration_type": SupportedMigrations.paprika.value},
+        files={"archive": archive.getvalue()},
+        headers=unique_user.token,
+    )
+    assert response.status_code == 200
+
+    response = api_client.get(api_routes.recipes_slug("paprika-notes-test"), headers=unique_user.token)
+    recipe = Recipe(**assert_deserialize(response))
+
+    assert recipe.notes
+    assert recipe.notes[0].text == note_text


### PR DESCRIPTION
## What this PR does / why we need it:

Recipes imported from a Paprika archive always came in with no notes, even when the export carried them. The Paprika migrator maps the export's `notes` string into a `RecipeNote` object, but every import path then goes through the shared `clean_notes()` helper in `mealie/services/scraper/cleaner.py`, which only accepts `str` and `dict` and silently `continue`s past anything else — so each note was dropped without an error or a log line. Paprika is the only migrator that emitted model objects here; the other seven all pass strings, which is why only Paprika was affected. This changes the Paprika alias to emit a plain dict, matching what the cleaner expects and what the other migrators already do, and drops the now-unused `RecipeNote` import.

## Which issue(s) this PR fixes:

Related to #7929 — that issue also reports ingredient-grouping headers being treated as ingredients, which this PR does not address, so it should stay open. (The trailing-newline half of that issue was already fixed by #8213.) The missing-notes problem specifically was reported in [this comment](https://github.com/mealie-recipes/mealie/issues/7929#issuecomment-3121775386).

## Special notes for your reviewer:

I fixed this on the migrator side rather than in `clean_notes()` deliberately: the cleaner is shared by every import path (scraper, all migrators), so widening its accepted types is a larger blast radius than bringing the one outlier back in line with the existing convention. That said, a cleaner that silently discards data it doesn't recognise is arguably worth hardening separately — happy to follow up if you'd prefer that direction instead.

## Testing

Added `test_paprika_imports_notes`, which builds a minimal Paprika archive in memory (a gzipped `.paprikarecipe` inside a zip) with a `notes` field, runs it through the real migration endpoint, and asserts the note survives. Verified it actually catches the bug: the test fails on `mealie-next` without the one-line change and passes with it. Also confirmed against the real Paprika 3 export attached to the issue, and ran the full `tests/integration_tests/recipe_migration_tests/` suite (15 passed), plus `ruff check`, `ruff format --check`, and `mypy` on the touched files.

<img width="937" height="122" alt="image" src="https://github.com/user-attachments/assets/6f4d766d-1c27-44cb-ab09-92c59e7c57a7" />

<img width="1388" height="771" alt="image" src="https://github.com/user-attachments/assets/62553739-e484-4172-91a8-4877696ea0fc" />

After the fix — the Paprika export's notes now come through. Note the ingredient "60ml burnt brandy (see note)" referring to this exact note, which was previously dropped entirely.



## AI / LLM Assistance

Used Claude Code to trace where the notes were being dropped (export file → migrator alias → shared cleaner), write the fix and the regression test, and verify the before/after behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
